### PR TITLE
k6 based load generator and local runner setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 # Ignore all venv directories
 .venv/
 **/.venv/
+
+# pycache
+__pycache__
+
+# tmp files
+tmp/*
+!tmp/.gitkeep

--- a/inference_perf/loadgen/__init__.py
+++ b/inference_perf/loadgen/__init__.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .load_generator import LoadGenerator
+
+__all__ = ["LoadGenerator"]

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -11,3 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from jinja2 import Template
+import os
+
+
+class LoadGenerator:
+    def __init__(self) -> None:
+        templates_path = os.path.dirname(os.path.realpath(__file__))
+        with open(templates_path + "/templates/script.js.j2") as tmpfile:
+            self.template = Template(tmpfile.read())
+
+    def generate(self, **kwargs: str) -> str:
+        return self.template.render(kwargs)

--- a/inference_perf/loadgen/templates/script.js.j2
+++ b/inference_perf/loadgen/templates/script.js.j2
@@ -1,0 +1,11 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export const options = {
+  iterations: 10,
+};
+
+export default function () {
+  http.get('{{ url }}');
+  sleep(1);
+}

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -11,3 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from loadgen import LoadGenerator
+import subprocess
+
+
+class InferencePerfRunner:
+    # Configuration and benchmarking setup
+    def __init__(self) -> None:
+        self.load_script = LoadGenerator().generate(url="http://test.k6.io")
+
+    # Local testing with k6 executable
+    def run_local(self) -> None:
+        filename = "tmp/script.js"
+        with open(filename, "w") as scriptfile:
+            scriptfile.write(self.load_script)
+
+        subprocess.run(["k6", "run", filename])
+
+    # Distributed testing with Kubernetes
+    def run_distributed_k8s(self) -> None:
+        pass
+
+
+if __name__ == "__main__":
+    InferencePerfRunner().run_local()

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -1,1 +1,2 @@
 aiohttp
+jinja2


### PR DESCRIPTION
Based on proposal #2 

This PR is aimed as an example to showcase how k6 can be leveraged for load generation and runner capabilities. An example template script is generated for local testing. 

This PR is also aimed at showcasing the ability to easily configure benchmarking setup configurations like http vs grpc, local run vs distributed run.

Instructions for local performance benchmarking run:
Note: Install k6 as per [docs](https://grafana.com/docs/k6/latest/set-up/install-k6/)
```
python inference_perf/main.py
```

