### PR TITLE
Adding vLLM Client to inference perf runner

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
       - name: Do Linting and Type Checks
         run: |
           make check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,10 +13,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+      - name: Set up Python PDM
+        uses: pdm-project/setup-pdm@v4
       - name: Do Linting and Type Checks
         run: |
           make check

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ type-check:
 # Check for and install dependencies
 .PHONY: all-deps
 all-deps:
+	pip install pdm
 	@echo "Creating virtual environment if it doesn't exist..."
 	@if [ ! -d $(VENV) ]; then \
 	    pdm venv create --with venv 3.12; \

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ type-check:
 # Check for and install dependencies
 .PHONY: all-deps
 all-deps:
-	pip install pdm
 	@echo "Creating virtual environment if it doesn't exist..."
 	@if [ ! -d $(VENV) ]; then \
 	    pdm venv create --with venv 3.12; \

--- a/inference_perf/client/__init__.py
+++ b/inference_perf/client/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from .base import ModelServerClient
 from .mock_client import MockModelServerClient
+from .vllm_client import vLLMModelServerClient
 
 
-__all__ = ["ModelServerClient", "MockModelServerClient"]
+__all__ = ["ModelServerClient", "MockModelServerClient", "vLLMModelServerClient"]

--- a/inference_perf/client/base.py
+++ b/inference_perf/client/base.py
@@ -27,5 +27,5 @@ class ModelServerClient(ABC):
         self.reportgen = reportgen
 
     @abstractmethod
-    def process_request(self, data: InferenceData) -> None:
+    async def process_request(self, data: InferenceData) -> None:
         raise NotImplementedError

--- a/inference_perf/client/mock_client.py
+++ b/inference_perf/client/mock_client.py
@@ -12,16 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from inference_perf.datagen import InferenceData
-from inference_perf.reportgen import ReportGenerator
+from inference_perf.reportgen import ReportGenerator, RequestMetric
 from .base import ModelServerClient
+import asyncio
 
 
 class MockModelServerClient(ModelServerClient):
-    def __init__(self, uri: str) -> None:
-        self.uri = uri
+    def __init__(self) -> None:
+        pass
 
     def set_report_generator(self, reportgen: ReportGenerator) -> None:
         self.reportgen = reportgen
 
     async def process_request(self, data: InferenceData) -> None:
         print("Processing request - " + data.system_prompt)
+        await asyncio.sleep(3)
+        self.reportgen.collect_request_metrics(
+            RequestMetric(
+                prompt_tokens=0,
+                completion_tokens=0,
+                time_taken=3,
+            )
+        )

--- a/inference_perf/client/mock_client.py
+++ b/inference_perf/client/mock_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from inference_perf.datagen import InferenceData
-from inference_perf.reportgen import ReportGenerator, Metric
+from inference_perf.reportgen import ReportGenerator
 from .base import ModelServerClient
 
 
@@ -25,4 +25,3 @@ class MockModelServerClient(ModelServerClient):
 
     async def process_request(self, data: InferenceData) -> None:
         print("Processing request - " + data.system_prompt)
-        self.reportgen.collect_metrics(Metric(name=data.system_prompt))

--- a/inference_perf/client/mock_client.py
+++ b/inference_perf/client/mock_client.py
@@ -30,7 +30,7 @@ class MockModelServerClient(ModelServerClient):
         self.reportgen.collect_request_metrics(
             RequestMetric(
                 prompt_tokens=0,
-                completion_tokens=0,
-                time_taken=3,
+                output_tokens=0,
+                time_per_request=3,
             )
         )

--- a/inference_perf/client/vllm_client.py
+++ b/inference_perf/client/vllm_client.py
@@ -46,8 +46,8 @@ class vLLMModelServerClient(ModelServerClient):
                         self.reportgen.collect_request_metrics(
                             RequestMetric(
                                 prompt_tokens=usage["prompt_tokens"],
-                                completion_tokens=usage["completion_tokens"],
-                                time_taken=end - start,
+                                output_tokens=usage["completion_tokens"],
+                                time_per_request=end - start,
                             )
                         )
                     else:

--- a/inference_perf/loadgen/load_timer.py
+++ b/inference_perf/loadgen/load_timer.py
@@ -48,7 +48,7 @@ class ConstantLoadTimer(LoadTimer):
 
         # Given a rate, yield a time to wait before the next request
         while True:
-            next_time += self._rand.exponential(1 / self._rate)
+            next_time += self._rand.uniform(0, 1 / self._rate)
             yield next_time
 
 
@@ -73,7 +73,6 @@ class PoissonLoadTimer(LoadTimer):
 
             # Schedule the requests over the next second
             timer = ConstantLoadTimer(req_count)
-            times = timer.start_timer(next_time)
             for _ in range(req_count):
-                next_time = next(times)
+                next_time = next(timer.start_timer(next_time))
                 yield next_time

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from inference_perf.loadgen import LoadGenerator, LoadType
 from inference_perf.datagen import MockDataGenerator
-from inference_perf.client import ModelServerClient, vLLMModelServerClient
+from inference_perf.client import ModelServerClient, MockModelServerClient
 from inference_perf.reportgen import ReportGenerator, MockReportGenerator
 import asyncio
 
@@ -34,7 +34,8 @@ class InferencePerfRunner:
 
 def main_cli() -> None:
     # Define Model Server Client
-    client = vLLMModelServerClient(uri="http://0.0.0.0:8000", model_name="gpt2")
+    client = MockModelServerClient()
+    # client = vLLMModelServerClient(uri="http://0.0.0.0:8000", model_name="openai-community/gpt2")
 
     # Define LoadGenerator
     loadgen = LoadGenerator(MockDataGenerator(), LoadType.CONSTANT, rate=2, duration=5)

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -15,6 +15,7 @@ from inference_perf.loadgen import LoadGenerator, LoadType
 from inference_perf.datagen import MockDataGenerator
 from inference_perf.client import ModelServerClient, vLLMModelServerClient
 from inference_perf.reportgen import ReportGenerator, MockReportGenerator
+import asyncio
 
 
 class InferencePerfRunner:
@@ -25,15 +26,15 @@ class InferencePerfRunner:
         self.client.set_report_generator(self.reportgen)
 
     def run(self) -> None:
-        self.loadgen.run(self.client)
+        asyncio.run(self.loadgen.run(self.client))
 
     def generate_report(self) -> None:
-        self.reportgen.generate_report()
+        asyncio.run(self.reportgen.generate_report())
 
 
 def main_cli() -> None:
     # Define Model Server Client
-    client = vLLMModelServerClient(uri="http://0.0.0.0:8000")
+    client = vLLMModelServerClient(uri="http://0.0.0.0:8000", model_name="gpt2")
 
     # Define LoadGenerator
     loadgen = LoadGenerator(MockDataGenerator(), LoadType.CONSTANT, rate=2, duration=5)

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from inference_perf.loadgen import LoadGenerator, LoadType
 from inference_perf.datagen import MockDataGenerator
-from inference_perf.client import ModelServerClient, MockModelServerClient
+from inference_perf.client import ModelServerClient, vLLMModelServerClient
 from inference_perf.reportgen import ReportGenerator, MockReportGenerator
 import asyncio
 
@@ -34,8 +34,7 @@ class InferencePerfRunner:
 
 def main_cli() -> None:
     # Define Model Server Client
-    client = MockModelServerClient()
-    # client = vLLMModelServerClient(uri="http://0.0.0.0:8000", model_name="openai-community/gpt2")
+    client = vLLMModelServerClient(uri="http://0.0.0.0:8000", model_name="openai-community/gpt2")
 
     # Define LoadGenerator
     loadgen = LoadGenerator(MockDataGenerator(), LoadType.CONSTANT, rate=2, duration=5)

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from inference_perf.loadgen import LoadGenerator, LoadType
 from inference_perf.datagen import MockDataGenerator
-from inference_perf.client import ModelServerClient, MockModelServerClient
+from inference_perf.client import ModelServerClient, vLLMModelServerClient
 from inference_perf.reportgen import ReportGenerator, MockReportGenerator
 
 
@@ -33,7 +33,7 @@ class InferencePerfRunner:
 
 def main_cli() -> None:
     # Define Model Server Client
-    client = MockModelServerClient(uri="0.0.0.0:0")
+    client = vLLMModelServerClient(uri="http://0.0.0.0:8000")
 
     # Define LoadGenerator
     loadgen = LoadGenerator(MockDataGenerator(), LoadType.CONSTANT, rate=2, duration=5)

--- a/inference_perf/reportgen/__init__.py
+++ b/inference_perf/reportgen/__init__.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .base import ReportGenerator, Metric
+from .base import ReportGenerator, RequestMetric
 from .mock_reportgen import MockReportGenerator
 
 
-__all__ = ["ReportGenerator", "Metric", "MockReportGenerator"]
+__all__ = ["ReportGenerator", "RequestMetric", "MockReportGenerator"]

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -16,8 +16,17 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 
-class Metric(BaseModel):
-    name: str
+class MetricsSummary(BaseModel):
+    total_requests: int
+    avg_prompt_tokens: float
+    avg_completion_tokens: float
+    avg_latency: float
+
+
+class RequestMetric(BaseModel):
+    prompt_tokens: int
+    completion_tokens: int
+    time_taken: float
 
 
 class ReportGenerator(ABC):
@@ -26,9 +35,9 @@ class ReportGenerator(ABC):
         pass
 
     @abstractmethod
-    def collect_metrics(self, metric: Metric) -> None:
+    def collect_request_metrics(self, metric: RequestMetric) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def generate_report(self) -> None:
+    async def generate_report(self) -> None:
         raise NotImplementedError

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -19,14 +19,14 @@ from typing import Tuple
 class MetricsSummary(BaseModel):
     total_requests: int
     avg_prompt_tokens: float
-    avg_completion_tokens: float
-    avg_latency: float
+    avg_output_tokens: float
+    avg_time_per_request: float
 
 
 class RequestMetric(BaseModel):
     prompt_tokens: int
-    completion_tokens: int
-    time_taken: float
+    output_tokens: int
+    time_per_request: float
 
 
 class ReportGenerator(ABC):

--- a/inference_perf/reportgen/mock_reportgen.py
+++ b/inference_perf/reportgen/mock_reportgen.py
@@ -24,12 +24,15 @@ class MockReportGenerator(ReportGenerator):
         self.metrics.append(metric)
 
     async def generate_report(self) -> None:
-        print("\n\nGenerating Report ..")
-        summary = MetricsSummary(
-            total_requests=len(self.metrics),
-            avg_prompt_tokens=statistics.mean([x.prompt_tokens for x in self.metrics]),
-            avg_completion_tokens=statistics.mean([x.completion_tokens for x in self.metrics]),
-            avg_latency=statistics.mean([x.time_taken for x in self.metrics]),
-        )
+        if len(self.metrics) > 0:
+            print("\n\nGenerating Report ..")
+            summary = MetricsSummary(
+                total_requests=len(self.metrics),
+                avg_prompt_tokens=statistics.mean([x.prompt_tokens for x in self.metrics]),
+                avg_completion_tokens=statistics.mean([x.completion_tokens for x in self.metrics]),
+                avg_latency=statistics.mean([x.time_taken for x in self.metrics]),
+            )
 
-        print(summary.model_dump())
+            print(summary.model_dump())
+        else:
+            print("Report generation failed")

--- a/inference_perf/reportgen/mock_reportgen.py
+++ b/inference_perf/reportgen/mock_reportgen.py
@@ -11,17 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .base import ReportGenerator, Metric
+from .base import ReportGenerator, RequestMetric, MetricsSummary
 from typing import List
+import statistics
 
 
 class MockReportGenerator(ReportGenerator):
     def __init__(self) -> None:
-        self.metrics: List[Metric] = []
+        self.metrics: List[RequestMetric] = []
 
-    def collect_metrics(self, metric: Metric) -> None:
+    def collect_request_metrics(self, metric: RequestMetric) -> None:
         self.metrics.append(metric)
 
-    def generate_report(self) -> None:
+    async def generate_report(self) -> None:
         print("\n\nGenerating Report ..")
-        print("Report: Total Requests = " + str(len(self.metrics)))
+        summary = MetricsSummary(
+            total_requests=len(self.metrics),
+            avg_prompt_tokens=statistics.mean([x.prompt_tokens for x in self.metrics]),
+            avg_completion_tokens=statistics.mean([x.completion_tokens for x in self.metrics]),
+            avg_latency=statistics.mean([x.time_taken for x in self.metrics]),
+        )
+
+        print(summary.model_dump())

--- a/inference_perf/reportgen/mock_reportgen.py
+++ b/inference_perf/reportgen/mock_reportgen.py
@@ -31,8 +31,8 @@ class MockReportGenerator(ReportGenerator):
             summary = MetricsSummary(
                 total_requests=len(self.metrics),
                 avg_prompt_tokens=statistics.mean([x.prompt_tokens for x in self.metrics]),
-                avg_completion_tokens=statistics.mean([x.completion_tokens for x in self.metrics]),
-                avg_latency=statistics.mean([x.time_taken for x in self.metrics]),
+                avg_output_tokens=statistics.mean([x.output_tokens for x in self.metrics]),
+                avg_time_per_request=statistics.mean([x.time_per_request for x in self.metrics]),
             )
 
             self.printer.pprint(summary.model_dump())

--- a/inference_perf/reportgen/mock_reportgen.py
+++ b/inference_perf/reportgen/mock_reportgen.py
@@ -14,11 +14,13 @@
 from .base import ReportGenerator, RequestMetric, MetricsSummary
 from typing import List
 import statistics
+from pprint import PrettyPrinter
 
 
 class MockReportGenerator(ReportGenerator):
     def __init__(self) -> None:
         self.metrics: List[RequestMetric] = []
+        self.printer = PrettyPrinter(indent=4)
 
     def collect_request_metrics(self, metric: RequestMetric) -> None:
         self.metrics.append(metric)
@@ -33,6 +35,6 @@ class MockReportGenerator(ReportGenerator):
                 avg_latency=statistics.mean([x.time_taken for x in self.metrics]),
             )
 
-            print(summary.model_dump())
+            self.printer.pprint(summary.model_dump())
         else:
             print("Report generation failed")


### PR DESCRIPTION
Fixes #14 

Updated run returns using a test model.

Steps to reproduce:
- Run vLLM as a docker container - [instructions](https://docs.vllm.ai/en/stable/deployment/docker.html)
- Load [GPT2](https://huggingface.co/openai-community/gpt2) model `openai-community/gpt2`
- Run inference-perf as per getting started [directions](https://github.com/kubernetes-sigs/inference-perf?tab=readme-ov-file#getting-started)
```
Run started
Run completed


Generating Report ..
    'avg_completion_tokens': 28.714285714285715,
    'avg_latency': 0.12395962485710957,
    'avg_prompt_tokens': 2.5714285714285716,
    'total_requests': 21
 ```