### PR TITLE
Containerize the benchmark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.9.20-slim-bookworm as dev
+
+RUN apt-get update -y \
+    && apt-get install -y python3-pip
+
+# Install PDM
+RUN pip3 install --upgrade pip
+RUN pip3 install pdm
+
+# Set working directory
+WORKDIR /workspace
+
+# Copy project files
+COPY . /workspace
+
+# Install dependencies using PDM
+RUN pdm install
+
+# Run inference-perf (example, adjust as needed)
+CMD ["pdm", "run", "inference-perf", "--config_file", "config.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM python:3.9.20-slim-bookworm as dev
+FROM python:3.12.9-slim-bookworm as dev
 
 RUN apt-get update -y \
     && apt-get install -y python3-pip
 
-# Install PDM
+# Upgrade pip
 RUN pip3 install --upgrade pip
-RUN pip3 install pdm
 
 # Set working directory
 WORKDIR /workspace
@@ -13,8 +12,8 @@ WORKDIR /workspace
 # Copy project files
 COPY . /workspace
 
-# Install dependencies using PDM
-RUN pdm install
+# Install dependencies
+RUN pip install -e .
 
-# Run inference-perf (example, adjust as needed)
-CMD ["pdm", "run", "inference-perf", "--config_file", "config.yml"]
+# Run inference-perf
+CMD ["inference-perf", "--config_file", "config.yml"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project is currently in development.
 
 ## Getting Started
 
+### Run locally
+
 [PDM Python Package Manager](https://pdm-project.org/latest/) is utilized in this repository for dependecy management.
 
 - Setup virtual environment with `pdm` and install dependencies
@@ -20,6 +22,21 @@ This project is currently in development.
 
     ```
     pdm run inference-perf --config_file config.yml
+    ```
+
+### Run in a Docker container
+
+- Build the container
+
+    ```
+    docker build -t inference-perf .
+    ```
+
+- Run the container
+
+    ```
+    docker run -it --rm -v $(pwd)/config.yml:/workspace/config.yml inference-perf
+
     ```
 
 ## Contributing


### PR DESCRIPTION
This change adds a Dockerfile to build and run the benchmark within a container. The change updates the README with the instructions as well.

Fixes https://github.com/kubernetes-sigs/inference-perf/issues/39