### PR TITLE
Add output distribution to synthetic data generator

### DIFF
--- a/examples/vllm/config-synthetic.yml
+++ b/examples/vllm/config-synthetic.yml
@@ -1,7 +1,10 @@
 load:
   type: constant
+  interval: 15
   stages:
   - rate: 1
+    duration: 30
+  - rate: 2
     duration: 30
 api: completion
 server:
@@ -18,3 +21,19 @@ data:
     mean: 50
     std: 10
     total_count: 100
+  output_distribution:
+    min: 10
+    max: 100
+    mean: 50
+    std: 10
+    total_count: 100
+metrics:
+  type: prometheus
+  prometheus:
+    url: http://localhost:9090
+    scrape_interval: 15
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true

--- a/examples/vllm/vllm_server.ipynb
+++ b/examples/vllm/vllm_server.ipynb
@@ -60,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a configuration file for the test using `shareGPT` data and run the constant rate test for `30s`"
+    "Create a configuration file for the test using `shareGPT` data and run the constant rate test for `30s`. You can also use the synthetic dataset if you prefer by running with the `config-synthetic.yml` file instead."
    ]
   },
   {

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -28,7 +28,7 @@ class vLLMModelServerClient(ModelServerClient):
         super().__init__(api_type)
         self.model_name = model_name
         self.uri = uri
-        self.max_completion_tokens = 30
+        self.max_completion_tokens = 30  # default to use when not set at the request level
         self.tokenizer = tokenizer
         self.request_metrics: List[RequestMetric] = list()
         self.prompt_metrics_collector_reporter = RequestLifecycleMetricsCollectorReporter()

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -36,6 +36,13 @@ class SyntheticDataGenerator(DataGenerator):
             self.ioDistribution.input.std_dev,
             self.ioDistribution.input.total_count,
         )
+        self.output_lengths = self.generate_distribution(
+            self.ioDistribution.output.min,
+            self.ioDistribution.output.max,
+            self.ioDistribution.output.mean,
+            self.ioDistribution.output.std_dev,
+            self.ioDistribution.output.total_count,
+        )
         base_prompt = "Pick as many lines as you can from these poem lines:\n"
         self.token_ids = self.tokenizer.get_tokenizer().encode(base_prompt + self.get_sonnet_data())
 
@@ -52,7 +59,8 @@ class SyntheticDataGenerator(DataGenerator):
                 raise ValueError("Tokenizer is required for SyntheticDataGenerator")
             if self.apiType == APIType.Completion:
                 yield LlmCompletionInferenceData(
-                    prompt=self.tokenizer.get_tokenizer().decode(self.token_ids[: self.input_lengths[i]])
+                    prompt=self.tokenizer.get_tokenizer().decode(self.token_ids[: self.input_lengths[i]]),
+                    max_tokens=self.output_lengths[i],
                 )
                 i += 1
             else:

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -105,8 +105,10 @@ def main_cli() -> None:
         elif config.data.type == DataGenType.Synthetic:
             if config.data.input_distribution is None:
                 raise Exception("SyntheticDataGenerator requires 'input_distribution' to be configured")
+            if config.data.output_distribution is None:
+                raise Exception("SyntheticDataGenerator requires 'output_distribution' to be configured")
 
-            io_distribution = IODistribution(input=config.data.input_distribution)
+            io_distribution = IODistribution(input=config.data.input_distribution, output=config.data.output_distribution)
             datagen = SyntheticDataGenerator(config.api, ioDistribution=io_distribution, tokenizer=tokenizer)
         else:
             datagen = MockDataGenerator(config.api)

--- a/inference_perf/prompts/completion.py
+++ b/inference_perf/prompts/completion.py
@@ -22,15 +22,18 @@ from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 class LlmCompletionInferenceData(InferenceData):
     prompt: str
+    max_tokens: int = 0
 
     def get_route(self) -> str:
         return "/v1/completions"
 
     def to_payload(self, model_name: str, max_tokens: int) -> dict[str, Any]:
+        if self.max_tokens == 0:
+            self.max_tokens = max_tokens
         return {
             "model": model_name,
             "prompt": self.prompt,
-            "max_tokens": max_tokens,
+            "max_tokens": self.max_tokens,
         }
 
     async def process_response(self, res: aiohttp.ClientResponse, tokenizer: CustomTokenizer) -> ResponseData:


### PR DESCRIPTION
This change makes the output distribution configurable for synthetic data generator similar to input distribution. When specified, the output distribution will follow a normal distribution based on the provided mean and standard deviation. Fixes https://github.com/kubernetes-sigs/inference-perf/issues/65. 