### PR TITLE
Add the option to ignore end of sequence

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,7 @@ server:
   type: vllm
   model_name: HuggingFaceTB/SmolLM2-135M-Instruct
   base_url: http://0.0.0.0:8000
+  ignore_eos: true
 tokenizer:
   pretrained_model_name_or_path: HuggingFaceTB/SmolLM2-135M-Instruct
 data:

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -108,6 +108,7 @@ class ModelServerClientConfig(BaseModel):
     type: ModelServerType = ModelServerType.VLLM
     model_name: str
     base_url: str
+    ignore_eos: bool
 
 
 class CustomTokenizerConfig(BaseModel):

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -84,6 +84,7 @@ def main_cli() -> None:
                 uri=config.server.base_url,
                 model_name=config.server.model_name,
                 tokenizer=tokenizer,
+                ignore_eos=config.server.ignore_eos,
             )
     else:
         raise Exception("model server client config missing")

--- a/inference_perf/prompts/base.py
+++ b/inference_perf/prompts/base.py
@@ -66,7 +66,7 @@ class InferenceData(ABC, BaseModel):
 
     @abstractmethod
     def to_payload(
-        self, model_name: str, max_tokens: int
+        self, model_name: str, max_tokens: int, ignore_eos: bool
     ) -> dict[str, Any]:  # Defines the HTTP request body for this request type
         raise NotImplementedError
 

--- a/inference_perf/prompts/chat.py
+++ b/inference_perf/prompts/chat.py
@@ -31,11 +31,12 @@ class LlmChatCompletionInferenceData(InferenceData):
     def get_route(self) -> str:
         return "/v1/chat/completions"
 
-    def to_payload(self, model_name: str, max_tokens: int) -> dict[str, Any]:
+    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool) -> dict[str, Any]:
         return {
             "model": model_name,
             "messages": [{"role": m.role, "content": m.content} for m in self.messages],
             "max_tokens": max_tokens,
+            "ignore_eos": ignore_eos,
         }
 
     async def process_response(self, res: aiohttp.ClientResponse, tokenizer: CustomTokenizer) -> ResponseData:

--- a/inference_perf/prompts/completion.py
+++ b/inference_perf/prompts/completion.py
@@ -27,13 +27,14 @@ class LlmCompletionInferenceData(InferenceData):
     def get_route(self) -> str:
         return "/v1/completions"
 
-    def to_payload(self, model_name: str, max_tokens: int) -> dict[str, Any]:
+    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool) -> dict[str, Any]:
         if self.max_tokens == 0:
             self.max_tokens = max_tokens
         return {
             "model": model_name,
             "prompt": self.prompt,
             "max_tokens": self.max_tokens,
+            "ignore_eos": ignore_eos,
         }
 
     async def process_response(self, res: aiohttp.ClientResponse, tokenizer: CustomTokenizer) -> ResponseData:


### PR DESCRIPTION
This change adds the option to ignore end of sequence on responses produced by the model server. This allows us to set max_tokens and get close to the expected tokens.

Fixes https://github.com/kubernetes-sigs/inference-perf/issues/82

With ignore_eos=true and max_tokens=1000
```
    "output_len": {
      "mean": 914.1739130434783,
      "min": 681.0,
      "p10": 770.8,
      "p50": 979.0,
      "p90": 992.8,
      "max": 996.0
    },
```

With ignore_eos=false and max_tokens=1000
```
    "output_len": {
      "mean": 337.625,
      "min": 4.0,
      "p10": 45.300000000000004,
      "p50": 328.5,
      "p90": 697.9000000000002,
      "max": 892.0
    },
```