### PR TITLE
Add random data generator

### DIFF
--- a/examples/vllm/config-random.yml
+++ b/examples/vllm/config-random.yml
@@ -1,0 +1,37 @@
+load:
+  type: constant
+  stages:
+  - rate: 1
+    duration: 30
+api: completion
+server:
+  type: vllm
+  model_name: HuggingFaceTB/SmolLM2-135M-Instruct
+  base_url: http://0.0.0.0:8000
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: HuggingFaceTB/SmolLM2-135M-Instruct
+data:
+  type: random
+  input_distribution:
+    min: 10
+    max: 100
+    mean: 50
+    std: 10
+    total_count: 100
+  output_distribution:
+    min: 10
+    max: 512
+    mean: 256
+    std: 100
+    total_count: 100
+metrics:
+  type: prometheus
+  prometheus:
+    url: http://localhost:9090
+    scrape_interval: 15
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -28,6 +28,7 @@ class DataGenType(Enum):
     Mock = "mock"
     ShareGPT = "shareGPT"
     Synthetic = "synthetic"
+    Random = "random"
 
 
 # Represents the distribution for input prompts and output generations.
@@ -41,7 +42,7 @@ class Distribution(BaseModel):
 
 class DataConfig(BaseModel):
     type: DataGenType = DataGenType.Mock
-    # Distributions are only supported for synthetic dataset at this moment
+    # Distributions are only supported for synthetic/random dataset at this moment
     input_distribution: Optional[Distribution] = Distribution()
     output_distribution: Optional[Distribution] = Distribution()
 

--- a/inference_perf/datagen/__init__.py
+++ b/inference_perf/datagen/__init__.py
@@ -15,10 +15,12 @@ from .base import DataGenerator
 from .mock_datagen import MockDataGenerator
 from .hf_sharegpt_datagen import HFShareGPTDataGenerator
 from .synthetic_datagen import SyntheticDataGenerator
+from .random_datagen import RandomDataGenerator
 
 __all__ = [
     "DataGenerator",
     "MockDataGenerator",
     "HFShareGPTDataGenerator",
     "SyntheticDataGenerator",
+    "RandomDataGenerator",
 ]

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -1,0 +1,98 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+from inference_perf.apis import InferenceAPIData, CompletionAPIData
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from inference_perf.utils.distribution import generate_distribution
+from .base import DataGenerator, IODistribution
+from typing import Generator, List
+from inference_perf.config import APIType
+
+# Random data generator generates random tokens from the model's
+# vocabulary for the desired input and output distribution.
+class RandomDataGenerator(DataGenerator):
+    def __init__(
+        self,
+        apiType: APIType,
+        ioDistribution: IODistribution,
+        tokenizer: CustomTokenizer,
+    ) -> None:
+        super().__init__(apiType, ioDistribution, tokenizer)
+
+        if self.ioDistribution is None:
+            raise ValueError("IODistribution is required for RandomDataGenerator")
+
+        self.input_lengths = generate_distribution(
+            self.ioDistribution.input.min,
+            self.ioDistribution.input.max,
+            self.ioDistribution.input.mean,
+            self.ioDistribution.input.std_dev,
+            self.ioDistribution.input.total_count,
+        )
+        self.output_lengths = generate_distribution(
+            self.ioDistribution.output.min,
+            self.ioDistribution.output.max,
+            self.ioDistribution.output.mean,
+            self.ioDistribution.output.std_dev,
+            self.ioDistribution.output.total_count,
+        )
+
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for RandomDataGenerator")
+
+        hf_tokenizer = self.tokenizer.get_tokenizer()
+        if hasattr(hf_tokenizer, "vocab_size") and hf_tokenizer.vocab_size is not None:
+            self.vocab_size: int = hf_tokenizer.vocab_size
+        elif hasattr(hf_tokenizer, "get_vocab") and callable(hf_tokenizer.get_vocab):
+            self.vocab_size = len(hf_tokenizer.get_vocab())
+        else:
+            try:
+                self.vocab_size = len(hf_tokenizer)
+            except TypeError as e:
+                raise ValueError(
+                    "Tokenizer does not have a 'vocab_size' attribute, 'get_vocab()' method, "
+                    "or support len() for vocabulary size. Cannot use random token generation."
+                ) from e
+        if self.vocab_size <= 0:
+            raise ValueError(f"Tokenizer vocabulary size must be positive, got {self.vocab_size}.")
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Completion]
+
+    def is_io_distribution_supported(self) -> bool:
+        return True
+
+    def get_data(self) -> Generator[InferenceAPIData, None, None]:
+        i = 0
+
+        while True:
+            if self.tokenizer is None:
+                raise ValueError("Tokenizer is required for RandomDataGenerator")
+
+            if self.apiType == APIType.Completion:
+                prompt_text: str
+                if self.input_lengths[i] <= 0:
+                    random_token_ids_list = []
+                else:
+                    random_token_ids = np.random.randint(0, self.vocab_size, size=self.input_lengths[i], dtype=np.int64)
+                    random_token_ids_list = random_token_ids.tolist()
+                prompt_text = self.tokenizer.get_tokenizer().decode(random_token_ids_list)
+
+                yield CompletionAPIData(
+                    prompt=prompt_text,
+                    max_tokens=self.output_lengths[i],
+                )
+                i += 1
+            else:
+                raise Exception(f"Unsupported API type: {self.apiType}. RandomDataGenerator only supports Completion.")

--- a/inference_perf/utils/distribution.py
+++ b/inference_perf/utils/distribution.py
@@ -1,0 +1,60 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+from numpy.typing import NDArray
+
+
+def generate_distribution(min: int, max: int, mean: float, std_dev: float, total_count: int) -> NDArray[np.int_]:
+    """
+    Generates an array of lengths in integer adhering to the specified distribution constraints.
+
+    Args:
+        min: The minimum allowed length.
+        max: The maximum allowed length.
+        mean: The target mean of the distribution.
+        std_dev: The target standard deviation of the distribution.
+        total_count: The total number of lengths to generate.
+
+    Returns:
+        A numpy array of integers representing lengths for input prompts or output generations.
+
+    Raises:
+        ValueError: If constraints are impossible (e.g., min_val > max_val).
+    """
+    if min > max:
+        raise ValueError("Minimum value cannot be greater than maximum value.")
+    if total_count <= 0:
+        raise ValueError("Total count must be a positive integer.")
+    if std_dev < 0:
+        raise ValueError("Standard deviation cannot be negative.")
+    if mean < min or mean > max:
+        raise ValueError("Mean cannot be outside min and max range.")
+
+    # Generate floating-point numbers from a normal distribution
+    # Use a large enough intermediate pool if std_dev is high relative to range
+    # to increase chances of getting values within bounds after generation.
+    # This is a heuristic; perfect adherence isn't guaranteed.
+    generated_numbers = np.random.normal(loc=mean, scale=std_dev, size=total_count)
+
+    # Clip the numbers to the specified min/max range
+    clipped_numbers = np.clip(generated_numbers, min, max)
+
+    # Round to the nearest integer and convert type
+    generated_lengths = np.round(clipped_numbers).astype(int)
+
+    # Ensure integer values are strictly within bounds after rounding
+    # (e.g., rounding 4.6 when max is 4 could result in 5 without this)
+    generated_lengths = np.clip(generated_lengths, min, max)
+
+    return generated_lengths


### PR DESCRIPTION
This change adds a random data generator to generate prompts by using the model tokenizer's vocabulary and generating random tokens. This is useful when you need to benchmark with any desirable input or output distribution without a lot of overlap in prompts.

Fixes https://github.com/kubernetes-sigs/inference-perf/issues/92