### PR TITLE
Multi-stage report generation for Prometheus Metrics

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -23,3 +23,6 @@ report:
     summary: true
     per_stage: true
     per_request: false
+  prometheus:
+    summary: true
+    per_stage: false

--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -13,13 +13,17 @@
 # limitations under the License.
 from abc import ABC, abstractmethod
 from inference_perf.client.modelserver.base import ModelServerClient
+from inference_perf.loadgen.load_generator import StageRuntimeInfo
 from pydantic import BaseModel
 
 
 class PerfRuntimeParameters:
-    def __init__(self, start_time: float, duration: float, model_server_client: ModelServerClient) -> None:
+    def __init__(
+        self, start_time: float, duration: float, model_server_client: ModelServerClient, stages: dict[int, StageRuntimeInfo]
+    ) -> None:
         self.start_time = start_time
         self.duration = duration
+        self.stages = stages
         self.model_server_client = model_server_client
 
 
@@ -56,7 +60,11 @@ class MetricsClient(ABC):
         pass
 
     @abstractmethod
-    def collect_model_server_metrics(self, runtime_parameters: PerfRuntimeParameters) -> ModelServerMetrics | None:
+    def collect_metrics_summary(self, runtime_parameters: PerfRuntimeParameters) -> ModelServerMetrics | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def collect_metrics_for_stage(self, runtime_parameters: PerfRuntimeParameters, stage_id: int) -> ModelServerMetrics | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/inference_perf/client/metricsclient/mock_client.py
+++ b/inference_perf/client/metricsclient/mock_client.py
@@ -18,7 +18,10 @@ class MockMetricsClient(MetricsClient):
     def __init__(self) -> None:
         pass
 
-    def collect_model_server_metrics(self, runtime_parameters: PerfRuntimeParameters) -> ModelServerMetrics | None:
+    def collect_metrics_summary(self, runtime_parameters: PerfRuntimeParameters) -> ModelServerMetrics | None:
+        return None
+
+    def collect_metrics_for_stage(self, runtime_parameters: PerfRuntimeParameters, stage_id: int) -> ModelServerMetrics | None:
         return None
 
     def wait(self) -> None:

--- a/inference_perf/client/metricsclient/prometheus_client.py
+++ b/inference_perf/client/metricsclient/prometheus_client.py
@@ -267,7 +267,7 @@ class PrometheusMetricsClient(MetricsClient):
                 # and return it
                 # Convert the value to float
                 try:
-                    query_result = float(result[0]["value"][1])
+                    query_result = round(float(result[0]["value"][1]), 6)
                 except ValueError:
                     print("Error converting value to float: %s" % (result[0]["value"][1]))
                     return query_result

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -90,8 +90,14 @@ class RequestLifecycleMetricsReportConfig(BaseModel):
     per_request: Optional[bool] = False
 
 
+class PrometheusMetricsReportConfig(BaseModel):
+    summary: Optional[bool] = True
+    per_stage: Optional[bool] = False
+
+
 class ReportConfig(BaseModel):
     request_lifecycle: RequestLifecycleMetricsReportConfig = RequestLifecycleMetricsReportConfig()
+    prometheus: PrometheusMetricsReportConfig = PrometheusMetricsReportConfig()
 
 
 class PrometheusClientConfig(BaseModel):

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -19,6 +19,7 @@ from .base import DataGenerator, IODistribution
 from typing import Generator, List
 from inference_perf.config import APIType
 
+
 # Random data generator generates random tokens from the model's
 # vocabulary for the desired input and output distribution.
 class RandomDataGenerator(DataGenerator):

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -22,8 +22,8 @@ import time
 
 class StageRuntimeInfo(BaseModel):
     stage_id: int
+    end_time: float
     start_time: float
-    duration: float
 
 
 class LoadGenerator:
@@ -58,8 +58,8 @@ class LoadGenerator:
                     else:
                         break
             self.stage_runtime_info[stage_id] = StageRuntimeInfo(
-                stage_id=stage_id, start_time=start_time, duration=time.time() - start_time
+                stage_id=stage_id, start_time=start_time,  end_time=time.time()
             )
             print(f"Stage {stage_id} - run completed")
-            if self.stageInterval:
+            if self.stageInterval and stage_id < len(self.stages) - 1:
                 await sleep(self.stageInterval)

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pydantic import BaseModel
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer
 from inference_perf.datagen import DataGenerator
 from inference_perf.client.modelserver import ModelServerClient
@@ -19,12 +20,19 @@ from asyncio import TaskGroup, sleep
 import time
 
 
+class StageRuntimeInfo(BaseModel):
+    stage_id: int
+    start_time: float
+    duration: float
+
+
 class LoadGenerator:
     def __init__(self, datagen: DataGenerator, load_config: LoadConfig) -> None:
         self.datagen = datagen
         self.stageInterval = load_config.interval
         self.load_type = load_config.type
         self.stages = load_config.stages
+        self.stage_runtime_info = dict[int, StageRuntimeInfo]()
 
     def get_timer(self, rate: float) -> LoadTimer:
         if self.load_type == LoadType.POISSON:
@@ -49,6 +57,9 @@ class LoadGenerator:
                         continue
                     else:
                         break
+            self.stage_runtime_info[stage_id] = StageRuntimeInfo(
+                stage_id=stage_id, start_time=start_time, duration=time.time() - start_time
+            )
             print(f"Stage {stage_id} - run completed")
             if self.stageInterval:
                 await sleep(self.stageInterval)

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -58,7 +58,7 @@ class LoadGenerator:
                     else:
                         break
             self.stage_runtime_info[stage_id] = StageRuntimeInfo(
-                stage_id=stage_id, start_time=start_time,  end_time=time.time()
+                stage_id=stage_id, start_time=start_time, end_time=time.time()
             )
             print(f"Stage {stage_id} - run completed")
             if self.stageInterval and stage_id < len(self.stages) - 1:

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -18,7 +18,7 @@ from inference_perf.config import (
     DataGenType,
     MetricsClientType,
     ModelServerType,
-    RequestLifecycleMetricsReportConfig,
+    ReportConfig,
     read_config,
 )
 from inference_perf.datagen import DataGenerator, MockDataGenerator, HFShareGPTDataGenerator, SyntheticDataGenerator
@@ -47,9 +47,7 @@ class InferencePerfRunner:
     def run(self) -> None:
         asyncio.run(self.loadgen.run(self.client))
 
-    def generate_reports(
-        self, report_config: RequestLifecycleMetricsReportConfig, runtime_parameters: PerfRuntimeParameters
-    ) -> List[ReportFile]:
+    def generate_reports(self, report_config: ReportConfig, runtime_parameters: PerfRuntimeParameters) -> List[ReportFile]:
         return asyncio.run(self.reportgen.generate_reports(report_config=report_config, runtime_parameters=runtime_parameters))
 
     def save_reports(self, reports: List[ReportFile]) -> None:
@@ -133,6 +131,8 @@ def main_cli() -> None:
 
     # Define LoadGenerator
     if config.load:
+        if isinstance(metrics_client, PrometheusMetricsClient) and config.report.prometheus.per_stage:
+            config.load.interval = max(config.load.interval, metrics_client.scrape_interval)
         loadgen = LoadGenerator(datagen, config.load)
     else:
         raise Exception("load config missing")
@@ -150,8 +150,13 @@ def main_cli() -> None:
 
     # Generate Reports after the tests
     reports = perfrunner.generate_reports(
-        report_config=config.report.request_lifecycle,
-        runtime_parameters=PerfRuntimeParameters(start_time, duration, model_server_client),
+        report_config=config.report,
+        runtime_parameters=PerfRuntimeParameters(
+            start_time=start_time,
+            duration=duration,
+            model_server_client=model_server_client,
+            stages=loadgen.stage_runtime_info,
+        ),
     )
 
     # Save Reports

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -55,14 +55,11 @@ class ResponsesSummary(BaseModel):
 
 def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummary:
     return ResponsesSummary(
-        load_summary={
-            "count": metrics.total_requests,
-        },
+        load_summary={},  # model server doesn't report failed requests
+        failures={},
         successes={
-            "request": {
-                "count": metrics.total_requests,
-                "rate": metrics.requests_per_second,
-            },
+            "count": metrics.total_requests,
+            "rate": metrics.requests_per_second,
             "prompt_len": {
                 "mean": metrics.avg_prompt_tokens,
                 "rate": metrics.prompt_tokens_per_second,
@@ -93,7 +90,6 @@ def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummar
                 "p99": metrics.p99_time_per_output_token,
             },
         },
-        failures={},
     )
 
 
@@ -216,8 +212,6 @@ class ReportGenerator:
                 if report_file is not None:
                     print(f"Successfully saved summary report of prometheus metrics to {report_file.path}")
                 prometheus_metrics_reports.append(report_file)
-                for field_name, value in collected_metrics:
-                    print(f"{field_name}: {value}")
             else:
                 print("Report generation failed - no metrics collected by metrics client")
 
@@ -232,9 +226,6 @@ class ReportGenerator:
                     if report_file is not None:
                         print(f"Successfully saved stage {stage_id} report of prometheus metrics to {report_file.path}")
                     prometheus_metrics_reports.append(report_file)
-                    print(f"Metrics for Stage {stage_id}:")
-                    for field_name, value in collected_metrics:
-                        print(f"{field_name}: {value}")
                 else:
                     print(f"No metrics collected for Stage {stage_id}")
 


### PR DESCRIPTION
Solves https://github.com/kubernetes-sigs/inference-perf/pull/95  
# Multi-Stage Report Generation for Prometheus Metrics

This PR implements multi-stage report generation for Prometheus metrics with the following enhancements:
1. Sets stage intervals to match or exceed Prometheus scrape duration, ensuring complete metric collection before the next stage begins
2. Records stage-specific metrics from each stage's start time until the subsequent stage begins

## Known Issue
Prometheus metrics lack stage_id label, which can cause boundary inaccuracies between stages. Some metrics may be incorrectly attributed to adjacent stages.

### Sample reports

Given `config.yaml`:
```
load:
  type: constant
  stages:
  - rate: 1
    duration: 30
  - rate: 2
    duration: 30
...
report:
  request_lifecycle:
    summary: true
    per_stage: true
    per_request: false
  prometheus:
    summary: true
    per_stage: true
```

Saved in `stage_0_prometheus_metrics.json`
```
{
  "load_summary": {},
  "successes": {
    "count": 29,
    "rate": 0.6333333333333333,
    "prompt_len": {
      "mean": 0,
      "rate": 1068.3
    },
    "output_len": {
      "mean": 0,
      "rate": 18.733333333333334
    },
    "queue_len": {
      "mean": 0
    },
    "request_latency": {
      "mean": 0.1391881265138325,
      "p50": 0.15,
      "p90": 0.26999999999999996,
      "p99": 0.29700000000000004
    },
    "time_to_first_token": {
      "mean": 0.007634202639261881,
      "p50": 0.007647058823529411,
      "p90": 0.009764705882352943,
      "p99": 0.0182
    },
    "time_per_output_token": {
      "mean": 0.0045284770723596655,
      "p50": 0.005,
      "p90": 0.009000000000000001,
      "p99": 0.009899999999999999
    }
  },
  "failures": {}
}
```

Saved in `summary_prometheus_metrics.json`
```
{
  "load_summary": {},
  "successes": {
    "count": 94,
    "rate": 1.0533333333333332,
    "prompt_len": {
      "mean": 1557,
      "rate": 1501.2533333333333
    },
    "output_len": {
      "mean": 31,
      "rate": 31.599999999999998
    },
    "queue_len": {
      "mean": 0
    },
    "request_latency": {
      "mean": 0.13867275926131237,
      "p50": 0.15,
      "p90": 0.27,
      "p99": 0.297
    },
    "time_to_first_token": {
      "mean": 0.006867040561724313,
      "p50": 0.007386363636363636,
      "p90": 0.009780303030303032,
      "p99": 0.018420000000000006
    },
    "time_per_output_token": {
      "mean": 0.00454587086430287,
      "p50": 0.005,
      "p90": 0.009000000000000001,
      "p99": 0.0099
    }
  },
  "failures": {}
}
```