### PR TITLE
Add Docker build and push workflows for PRs and releases

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,7 +32,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=sha,format=short
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Docker Build and Push
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: quay.io/${{ secrets.QUAY_USERNAME }}/inference-perf
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,4 +36,40 @@ jobs:
           ## What's Changed
           ${{ steps.github_release.outputs.changelog }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    needs: build-and-publish  # Run after the release is created
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: quay.io/${{ secrets.QUAY_USERNAME }}/inference-perf
+          tags: |
+            type=raw,value=${{ github.ref_name }},enable=true
+            type=raw,value=latest,enable=true
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max 


### PR DESCRIPTION
This PR implements automated Docker image publishing (to quay.io/inference-perf) for both PR merges and releases. 

In detail, the changes include:

- A new workflow (in .github/workflows/docker‑build.yml) that triggers on PR merges (to main) and builds (and pushes) a Docker image (tagged with the PR number and “latest” for the main branch).
- An update to the release workflow (in .github/workflows/release.yml) so that (on a version tag) a Docker image is also built and pushed (tagged with the release version and “latest”).
- Both workflows use GitHub Actions’ caching (via “cache‑from” and “cache‑to”) for faster builds.

**Required Secrets:**
QUAY_USERNAME (your quay.io username)
QUAY_PASSWORD (your quay.io password or token)

**Testing:**
[x] Verified that the Docker image builds successfully (and is amd64).
[x] Tested locally (using Podman).
[x] (Note: The quay.io repository (quay.io/inference‑perf) must be created before the first push.)

Pull this container with the following Docker command:
```
docker pull quay.io/inference-perf/inference-perf:latest
```

Closes #85  