### PR TITLE
Add shared prefix generator to benchmark prefix caching

### DIFF
--- a/examples/vllm/config-shared-prefix.yml
+++ b/examples/vllm/config-shared-prefix.yml
@@ -1,0 +1,34 @@
+load:
+  type: constant
+  interval: 15
+  stages:
+  - rate: 1
+    duration: 30
+  - rate: 2
+    duration: 30
+api: completion
+server:
+  type: vllm
+  model_name: HuggingFaceTB/SmolLM2-135M-Instruct
+  base_url: http://0.0.0.0:8000
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: HuggingFaceTB/SmolLM2-135M-Instruct
+data:
+  type: shared_prefix
+  shared_prefix:
+    num_groups: 10                # Number of distinct shared prefixes
+    num_prompts_per_group: 10     # Number of unique questions per shared prefix
+    system_prompt_len: 100        # Length of the shared prefix (in tokens)
+    question_len: 50              # Length of the unique question part (in tokens)
+    output_len: 50                # Target length for the model's generated output (in tokens)
+metrics:
+  type: prometheus
+  prometheus:
+    url: http://localhost:9090
+    scrape_interval: 15
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -29,6 +29,7 @@ class DataGenType(Enum):
     ShareGPT = "shareGPT"
     Synthetic = "synthetic"
     Random = "random"
+    SharedPrefix = "shared_prefix"
 
 
 # Represents the distribution for input prompts and output generations.
@@ -40,11 +41,21 @@ class Distribution(BaseModel):
     total_count: int = 1000
 
 
+# Configuration for shared prefix datagen which allows users to specify shared prefixes.
+class SharedPrefix(BaseModel):
+    num_groups: int = 10
+    num_prompts_per_group: int = 10
+    system_prompt_len: int = 100
+    question_len: int = 50
+    output_len: int = 50
+
+
 class DataConfig(BaseModel):
     type: DataGenType = DataGenType.Mock
     # Distributions are only supported for synthetic/random dataset at this moment
-    input_distribution: Optional[Distribution] = Distribution()
-    output_distribution: Optional[Distribution] = Distribution()
+    input_distribution: Optional[Distribution] = None
+    output_distribution: Optional[Distribution] = None
+    shared_prefix: Optional[SharedPrefix] = None
 
 
 class ModelServerType(Enum):
@@ -109,7 +120,7 @@ class ModelServerClientConfig(BaseModel):
     type: ModelServerType = ModelServerType.VLLM
     model_name: str
     base_url: str
-    ignore_eos: bool
+    ignore_eos: bool = True
 
 
 class CustomTokenizerConfig(BaseModel):

--- a/inference_perf/datagen/__init__.py
+++ b/inference_perf/datagen/__init__.py
@@ -16,6 +16,7 @@ from .mock_datagen import MockDataGenerator
 from .hf_sharegpt_datagen import HFShareGPTDataGenerator
 from .synthetic_datagen import SyntheticDataGenerator
 from .random_datagen import RandomDataGenerator
+from .shared_prefix_datagen import SharedPrefixDataGenerator
 
 __all__ = [
     "DataGenerator",
@@ -23,4 +24,5 @@ __all__ = [
     "HFShareGPTDataGenerator",
     "SyntheticDataGenerator",
     "RandomDataGenerator",
+    "SharedPrefixDataGenerator",
 ]

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from .base import DataGenerator, IODistribution, Optional
-from inference_perf.config import APIType
+from .base import DataGenerator
+from inference_perf.config import APIType, DataConfig
 from typing import Generator, List
 from datasets import load_dataset
 
 
 class HFShareGPTDataGenerator(DataGenerator):
-    def __init__(self, apiType: APIType, ioDistribution: Optional[IODistribution], tokenizer: CustomTokenizer) -> None:
-        super().__init__(apiType, ioDistribution, tokenizer)
+    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: CustomTokenizer) -> None:
+        super().__init__(apiType, config, tokenizer)
         self.sharegpt_dataset = iter(
             load_dataset(
                 "anon8231489123/ShareGPT_Vicuna_unfiltered",
@@ -72,4 +72,7 @@ class HFShareGPTDataGenerator(DataGenerator):
                     raise Exception("Unsupported API type")
 
     def is_io_distribution_supported(self) -> bool:
+        return False
+
+    def is_shared_prefix_supported(self) -> bool:
         return False

--- a/inference_perf/datagen/mock_datagen.py
+++ b/inference_perf/datagen/mock_datagen.py
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Generator, List
-from inference_perf.config import APIType
+from typing import Generator, List, Optional
+from inference_perf.config import APIType, DataConfig
 from inference_perf.datagen.base import DataGenerator
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
 class MockDataGenerator(DataGenerator):
-    def __init__(self, apiType: APIType) -> None:
-        super().__init__(apiType, ioDistribution=None, tokenizer=None)
+    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
+        super().__init__(apiType, config, tokenizer)
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion, APIType.Chat]
@@ -36,4 +37,7 @@ class MockDataGenerator(DataGenerator):
                 raise Exception("Unsupported API type")
 
     def is_io_distribution_supported(self) -> bool:
+        return False
+
+    def is_shared_prefix_supported(self) -> bool:
         return False

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -15,9 +15,10 @@ import numpy as np
 from inference_perf.apis import InferenceAPIData, CompletionAPIData
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import generate_distribution
-from .base import DataGenerator, IODistribution
+from .base import DataGenerator
 from typing import Generator, List
-from inference_perf.config import APIType
+from inference_perf.config import APIType, DataConfig
+
 
 # Random data generator generates random tokens from the model's
 # vocabulary for the desired input and output distribution.
@@ -25,27 +26,27 @@ class RandomDataGenerator(DataGenerator):
     def __init__(
         self,
         apiType: APIType,
-        ioDistribution: IODistribution,
+        config: DataConfig,
         tokenizer: CustomTokenizer,
     ) -> None:
-        super().__init__(apiType, ioDistribution, tokenizer)
+        super().__init__(apiType, config, tokenizer)
 
-        if self.ioDistribution is None:
-            raise ValueError("IODistribution is required for RandomDataGenerator")
+        if self.input_distribution is None or self.output_distribution is None:
+            raise ValueError("Input and Output Distribution are required for RandomDataGenerator")
 
         self.input_lengths = generate_distribution(
-            self.ioDistribution.input.min,
-            self.ioDistribution.input.max,
-            self.ioDistribution.input.mean,
-            self.ioDistribution.input.std_dev,
-            self.ioDistribution.input.total_count,
+            self.input_distribution.min,
+            self.input_distribution.max,
+            self.input_distribution.mean,
+            self.input_distribution.std_dev,
+            self.input_distribution.total_count,
         )
         self.output_lengths = generate_distribution(
-            self.ioDistribution.output.min,
-            self.ioDistribution.output.max,
-            self.ioDistribution.output.mean,
-            self.ioDistribution.output.std_dev,
-            self.ioDistribution.output.total_count,
+            self.output_distribution.min,
+            self.output_distribution.max,
+            self.output_distribution.mean,
+            self.output_distribution.std_dev,
+            self.output_distribution.total_count,
         )
 
         if self.tokenizer is None:
@@ -72,6 +73,9 @@ class RandomDataGenerator(DataGenerator):
 
     def is_io_distribution_supported(self) -> bool:
         return True
+
+    def is_shared_prefix_supported(self) -> bool:
+        return False
 
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         i = 0

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -1,0 +1,99 @@
+import random
+from typing import Generator, List
+import numpy as np
+
+from inference_perf.apis.base import InferenceAPIData
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.config import APIType, DataConfig
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from .base import DataGenerator
+
+
+# Shared Prefix Generator generates shared prefix in the prompts that are sent.
+# This can be used to benchmark prefix caching cases.
+class SharedPrefixDataGenerator(DataGenerator):
+    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: CustomTokenizer) -> None:
+        super().__init__(apiType, config, tokenizer)
+
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for SharedPrefixDataGenerator but was not initialized.")
+
+        # Initialize vocab_size
+        hf_tokenizer = self.tokenizer.get_tokenizer()
+        if hasattr(hf_tokenizer, "vocab_size") and hf_tokenizer.vocab_size is not None:
+            self.vocab_size: int = hf_tokenizer.vocab_size
+        elif hasattr(hf_tokenizer, "get_vocab") and callable(hf_tokenizer.get_vocab):
+            self.vocab_size = len(hf_tokenizer.get_vocab())
+        else:
+            try:
+                self.vocab_size = len(hf_tokenizer)
+            except TypeError as e:
+                raise ValueError(
+                    "Tokenizer does not have a 'vocab_size' attribute, 'get_vocab()' method, "
+                    "or support len() for vocabulary size. Cannot use random token generation."
+                ) from e
+        if self.vocab_size <= 0:
+            raise ValueError(f"Tokenizer vocabulary size must be positive, got {self.vocab_size}.")
+
+        if self.shared_prefix is None:
+            raise ValueError("Shared Prefix config is required for SharedPrefixDataGenerator")
+
+        self.num_groups: int = self.shared_prefix.num_groups
+        self.num_prompts_per_group: int = self.shared_prefix.num_prompts_per_group
+        self.system_prompt_len: int = self.shared_prefix.system_prompt_len
+        self.question_len: int = self.shared_prefix.question_len
+        self.output_len: int = self.shared_prefix.output_len
+
+        self.prompts: List[str] = []
+        self._generate_prompts()
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Completion]
+
+    def is_io_distribution_supported(self) -> bool:
+        return True
+
+    def is_shared_prefix_supported(self) -> bool:
+        return True
+
+    def get_data(self) -> Generator[InferenceAPIData, None, None]:
+        if not self.prompts:
+            return
+
+        i = 0
+        while True:
+            yield CompletionAPIData(prompt=self.prompts[i], max_tokens=self.output_len)
+            i = (i + 1) % len(self.prompts)
+
+    def _generate_random_token_ids(self, length: int) -> List[int]:
+        """Generates a list of random token IDs of a specified length."""
+        if length == 0:
+            return []
+        # np.random.randint's high parameter is exclusive
+        return np.random.randint(0, self.vocab_size, size=length, dtype=np.int64).tolist()  # type: ignore[no-any-return]
+
+    def _generate_prompts(self) -> None:
+        """Pre-generates all prompts based on the configuration."""
+        if self.tokenizer is None:
+            # This check is defensive; __init__ should have already validated this.
+            raise ValueError("Tokenizer is not available for generating prompts.")
+
+        hf_tokenizer = self.tokenizer.get_tokenizer()
+
+        for _ in range(self.num_groups):
+            # Generate a shared prefix (system prompt)
+            shared_prefix_token_ids = self._generate_random_token_ids(self.system_prompt_len)
+            shared_prefix_text = hf_tokenizer.decode(shared_prefix_token_ids, skip_special_tokens=True)
+
+            for _ in range(self.num_prompts_per_group):
+                # Generate a unique question
+                question_token_ids = self._generate_random_token_ids(self.question_len)
+                question_text = hf_tokenizer.decode(question_token_ids, skip_special_tokens=True)
+
+                # Combine shared prefix and question
+                full_prompt_text = shared_prefix_text + " " + question_text
+
+                self.prompts.append(full_prompt_text)
+
+        # Shuffle the generated prompts to ensure randomness if served sequentially by different workers
+        random.shuffle(self.prompts)

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -14,31 +14,31 @@
 from inference_perf.apis import InferenceAPIData, CompletionAPIData
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import generate_distribution
-from .base import DataGenerator, IODistribution
+from .base import DataGenerator
 from typing import Generator, List
-from inference_perf.config import APIType
+from inference_perf.config import APIType, DataConfig
 
 
 class SyntheticDataGenerator(DataGenerator):
-    def __init__(self, apiType: APIType, ioDistribution: IODistribution, tokenizer: CustomTokenizer) -> None:
-        super().__init__(apiType, ioDistribution, tokenizer)
+    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: CustomTokenizer) -> None:
+        super().__init__(apiType, config, tokenizer)
 
-        if self.ioDistribution is None or self.tokenizer is None:
+        if self.input_distribution is None or self.output_distribution is None or self.tokenizer is None:
             raise ValueError("IODistribution and tokenizer are required for SyntheticDataGenerator")
 
         self.input_lengths = generate_distribution(
-            self.ioDistribution.input.min,
-            self.ioDistribution.input.max,
-            self.ioDistribution.input.mean,
-            self.ioDistribution.input.std_dev,
-            self.ioDistribution.input.total_count,
+            self.input_distribution.min,
+            self.input_distribution.max,
+            self.input_distribution.mean,
+            self.input_distribution.std_dev,
+            self.input_distribution.total_count,
         )
         self.output_lengths = generate_distribution(
-            self.ioDistribution.output.min,
-            self.ioDistribution.output.max,
-            self.ioDistribution.output.mean,
-            self.ioDistribution.output.std_dev,
-            self.ioDistribution.output.total_count,
+            self.output_distribution.min,
+            self.output_distribution.max,
+            self.output_distribution.mean,
+            self.output_distribution.std_dev,
+            self.output_distribution.total_count,
         )
         base_prompt = "Pick as many lines as you can from these poem lines:\n"
         self.token_ids = self.tokenizer.get_tokenizer().encode(base_prompt + self.get_sonnet_data())
@@ -48,6 +48,9 @@ class SyntheticDataGenerator(DataGenerator):
 
     def is_io_distribution_supported(self) -> bool:
         return True
+
+    def is_shared_prefix_supported(self) -> bool:
+        return False
 
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         i = 0

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import List, Optional
-from inference_perf.datagen.base import IODistribution
 from inference_perf.loadgen import LoadGenerator
 from inference_perf.config import (
     DataGenType,
@@ -27,6 +26,7 @@ from inference_perf.datagen import (
     HFShareGPTDataGenerator,
     SyntheticDataGenerator,
     RandomDataGenerator,
+    SharedPrefixDataGenerator,
 )
 from inference_perf.client.modelserver import ModelServerClient, vLLMModelServerClient
 from inference_perf.client.metricsclient import MetricsClient, PerfRuntimeParameters, PrometheusMetricsClient
@@ -125,17 +125,19 @@ def main_cli() -> None:
                 raise Exception(f"{config.data.type.value} data generator requires 'input_distribution' to be configured")
             if config.data.output_distribution is None:
                 raise Exception(f"{config.data.type.value} data generator requires 'output_distribution' to be configured")
+        if config.data.type == DataGenType.SharedPrefix and config.data.shared_prefix is None:
+            raise Exception(f"{config.data.type.value} data generator requires 'shared_prefix' to be configured")
 
         if config.data.type == DataGenType.ShareGPT:
-            datagen = HFShareGPTDataGenerator(config.api, None, tokenizer)
+            datagen = HFShareGPTDataGenerator(config.api, config.data, tokenizer)
         elif config.data.type == DataGenType.Synthetic:
-            io_distribution = IODistribution(input=config.data.input_distribution, output=config.data.output_distribution)  # type: ignore
-            datagen = SyntheticDataGenerator(config.api, ioDistribution=io_distribution, tokenizer=tokenizer)
+            datagen = SyntheticDataGenerator(config.api, config.data, tokenizer)
         elif config.data.type == DataGenType.Random:
-            io_distribution = IODistribution(input=config.data.input_distribution, output=config.data.output_distribution)  # type: ignore
-            datagen = RandomDataGenerator(config.api, ioDistribution=io_distribution, tokenizer=tokenizer)
+            datagen = RandomDataGenerator(config.api, config.data, tokenizer)
+        elif config.data.type == DataGenType.SharedPrefix:
+            datagen = SharedPrefixDataGenerator(config.api, config.data, tokenizer)
         else:
-            datagen = MockDataGenerator(config.api)
+            datagen = MockDataGenerator(config.api, config.data, tokenizer)
     else:
         raise Exception("data config missing")
 


### PR DESCRIPTION
This change adds random shared prefixes that are common within a prompt group. This allows us to benchmark prefix caching enabled systems where shared prefix can make a difference. 

Fixes https://github.com/kubernetes-sigs/inference-perf/issues/93