### PR TITLE
Add multiprocess, multithreaded loadgen

### DIFF
--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -31,6 +31,7 @@ class vLLMModelServerClient(ModelServerClient):
         uri: str,
         model_name: str,
         tokenizer: CustomTokenizer,
+        max_tcp_connections: int,
         ignore_eos: bool = True,
     ) -> None:
         super().__init__(api_type)
@@ -40,6 +41,7 @@ class vLLMModelServerClient(ModelServerClient):
         self.ignore_eos = ignore_eos
         self.tokenizer = tokenizer
         self.metrics_collector = metrics_collector
+        self.max_tcp_connections = max_tcp_connections
 
         self.prometheus_metric_metadata: PrometheusMetricMetadata = {
             "avg_queue_length": ModelServerPrometheusMetric(
@@ -106,7 +108,7 @@ class vLLMModelServerClient(ModelServerClient):
             model_name=self.model_name, max_tokens=self.max_completion_tokens, ignore_eos=self.ignore_eos
         )
         headers = {"Content-Type": "application/json"}
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=self.max_tcp_connections)) as session:
             start = time.monotonic()
             try:
                 async with session.post(self.uri + data.get_route(), headers=headers, data=json.dumps(payload)) as response:

--- a/inference_perf/client/requestdatacollector/__init__.py
+++ b/inference_perf/client/requestdatacollector/__init__.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 from .base import RequestDataCollector
 from .local import LocalRequestDataCollector
+from .multiprocess import MultiprocessRequestDataCollector
 
 
 __all__ = [
     "RequestDataCollector",
     "LocalRequestDataCollector",
+    "MultiprocessRequestDataCollector",
 ]

--- a/inference_perf/client/requestdatacollector/multiprocess.py
+++ b/inference_perf/client/requestdatacollector/multiprocess.py
@@ -1,0 +1,52 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing as mp
+
+from asyncio import create_task, sleep
+from typing import List, Union
+from inference_perf.client.requestdatacollector import RequestDataCollector
+from inference_perf.apis import RequestLifecycleMetric
+
+
+class MultiprocessRequestDataCollector(RequestDataCollector):
+    """Responsible for accumulating client request metrics"""
+
+    def __init__(self) -> None:
+        self.queue = mp.JoinableQueue()
+        self.metrics: List[Union[RequestLifecycleMetric, str]] = []
+
+    def record_metric(self, metric: RequestLifecycleMetric) -> None:
+        self.queue.put(metric)
+
+    async def collect_metrics(self):
+        while True:
+            try:
+                item = self.queue.get_nowait()
+                self.metrics.append(item)
+                self.queue.task_done()
+            except mp.queues.Empty:
+                await sleep(1)
+
+    def start(self) -> None:
+        self.collection = create_task(self.collect_metrics())
+    
+    async def stop(self) -> None:
+        # Ensure that the collection queue is empty before joining
+        while self.queue.qsize() > 0:
+            await sleep(1)
+        self.queue.join()
+
+    def get_metrics(self) -> List[RequestLifecycleMetric]:
+        return self.metrics

--- a/inference_perf/client/requestdatacollector/multiprocess.py
+++ b/inference_perf/client/requestdatacollector/multiprocess.py
@@ -15,7 +15,7 @@
 import multiprocessing as mp
 
 from asyncio import create_task, sleep
-from typing import List, Union
+from typing import List
 from inference_perf.client.requestdatacollector import RequestDataCollector
 from inference_perf.apis import RequestLifecycleMetric
 
@@ -24,13 +24,13 @@ class MultiprocessRequestDataCollector(RequestDataCollector):
     """Responsible for accumulating client request metrics"""
 
     def __init__(self) -> None:
-        self.queue = mp.JoinableQueue()
-        self.metrics: List[Union[RequestLifecycleMetric, str]] = []
+        self.queue: mp.JoinableQueue[RequestLifecycleMetric] = mp.JoinableQueue()
+        self.metrics: List[RequestLifecycleMetric] = []
 
     def record_metric(self, metric: RequestLifecycleMetric) -> None:
         self.queue.put(metric)
 
-    async def collect_metrics(self):
+    async def collect_metrics(self) -> None:
         while True:
             try:
                 item = self.queue.get_nowait()

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -83,8 +83,8 @@ class LoadConfig(BaseModel):
     interval: float = 1.0
     stages: List[LoadStage] = []
     num_workers: int = max(1, cpu_count() // 2) # type: ignore
-    worker_max_concurrency: int = 100
-    worker_max_tcp_connections: int = 100
+    worker_max_concurrency: int = 1000
+    worker_max_tcp_connections: int = 1000
 
 
 class StorageConfigBase(BaseModel):

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -83,8 +83,8 @@ class LoadConfig(BaseModel):
     interval: float = 1.0
     stages: List[LoadStage] = []
     num_workers: int = max(1, cpu_count() // 2) # type: ignore
-    worker_max_concurrency: int = 1000
-    worker_max_tcp_connections: int = 1000
+    worker_max_concurrency: int = 10
+    worker_max_tcp_connections: int = 2500
 
 
 class StorageConfigBase(BaseModel):

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -82,7 +82,7 @@ class LoadConfig(BaseModel):
     type: LoadType = LoadType.CONSTANT
     interval: float = 1.0
     stages: List[LoadStage] = []
-    num_workers: int = max(1, cpu_count() // 2)
+    num_workers: int = max(1, cpu_count() // 2) # type: ignore
     worker_max_concurrency: int = 100
     worker_max_tcp_connections: int = 100
 

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, HttpUrl
 from typing import Any, Optional, List
 from argparse import ArgumentParser
 from enum import Enum
+from os import cpu_count
 import yaml
 
 
@@ -81,6 +82,9 @@ class LoadConfig(BaseModel):
     type: LoadType = LoadType.CONSTANT
     interval: float = 1.0
     stages: List[LoadStage] = []
+    num_workers: int = max(1, cpu_count() // 2)
+    worker_max_concurrency: int = 100
+    worker_max_tcp_connections: int = 100
 
 
 class StorageConfigBase(BaseModel):

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -75,7 +75,6 @@ class Worker(mp.Process):
             except mp.queues.Empty:
                 status = self.check_status()
                 if status is not None:
-                    print(f"Worker {self.id} awaiting {len(tasks)} tasks")
                     await gather(*tasks)
                     tasks = []
                     self.status_queue.task_done()
@@ -185,4 +184,4 @@ class LoadGenerator:
             worker.join(timeout=1.0)
             if worker.is_alive():
                 worker.terminate()
-                worker.join(timeout=1.0)
+                worker.join(timeout=0.0)

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -146,8 +146,13 @@ class LoadGenerator:
             # Join on request queue to ensure that all workers have completed
             # their requests for the stage
             request_queue.join()
-            await sleep(self.stageInterval)
+
+            self.stage_runtime_info[stage_id] = StageRuntimeInfo(
+                stage_id=stage_id, start_time=start_time, end_time=time.time()
+            )
             print(f"Stage {stage_id} - run completed")
+            if self.stageInterval and stage_id < len(self.stages) - 1:
+                await sleep(self.stageInterval)
 
         for worker in self.workers:
             worker.status_queue.put(Status.WORKER_STOP)

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -33,7 +33,7 @@ class Status(Enum):
 
 
 class Worker(mp.Process):
-    def __init__(self, id: int, client: ModelServerClient, request_queue: mp.Queue, max_concurrency: int):
+    def __init__(self, id: int, client: ModelServerClient, request_queue: mp.Queue, max_concurrency: int): # type: ignore[type-arg]
         super().__init__()
         self.id = id
         self.client = client
@@ -50,17 +50,15 @@ class Worker(mp.Process):
     async def loop(self) -> None:
         semaphore = Semaphore(self.max_concurrency)
         tasks = []
-
         # Allow the request_queue to begin populating
         while self.request_queue.qsize() == 0:
             await sleep(0.1)
-
         while True:
             try:
                 await semaphore.acquire()
                 item = self.request_queue.get_nowait()
 
-                async def schedule_client(queue: mp.Queue, data: InferenceAPIData, request_time: float, stage_id: int) -> None:
+                async def schedule_client(queue: mp.Queue, data: InferenceAPIData, request_time: float, stage_id: int) -> None: # type: ignore[type-arg]
                     current_time = time.time()
                     sleep_time = request_time - current_time
                     if sleep_time > 0:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -60,7 +60,8 @@ class Worker(mp.Process):
                     sleep_time = request_time - current_time
                     if sleep_time > 0:
                         await sleep(sleep_time)
-                    # TODO: Add observability into missed timing
+                    else:
+                        print(f"Worker {self.id} missed scheduled request time")
                     await self.client.process_request(data, stage_id)
                     semaphore.release()
                     queue.task_done()
@@ -116,7 +117,10 @@ class LoadGenerator:
         for stage_id, stage in enumerate(self.stages):
             print(f"Stage {stage_id} - run started")
             timer = self.get_timer(stage.rate)
-            start_time = time.time()
+
+            # Allow generation a second to begin populating the queue so the workers
+            # don't miss the initial scheuled request times
+            start_time = time.time() + 1
             num_requests = stage.rate * stage.duration
 
             for request_number, (request_data, request_time) in enumerate(

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -97,12 +97,6 @@ class StageRuntimeInfo(BaseModel):
     start_time: float
 
 
-class StageRuntimeInfo(BaseModel):
-    stage_id: int
-    end_time: float
-    start_time: float
-
-
 class LoadGenerator:
     def __init__(self, datagen: DataGenerator, load_config: LoadConfig) -> None:
         self.datagen = datagen

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -52,7 +52,7 @@ class InferencePerfRunner:
         self.storage_clients = storage_clients
 
     def run(self) -> None:
-        async def _run():
+        async def _run() -> None:
             collector = self.reportgen.get_metrics_collector()
             if isinstance(collector, MultiprocessRequestDataCollector):
                 collector.start()
@@ -68,7 +68,7 @@ class InferencePerfRunner:
         for storage_client in self.storage_clients:
             storage_client.save_report(reports)
     
-    def stop(self):
+    def stop(self) -> None:
         asyncio.run(self.loadgen.stop())
 
 

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -120,6 +120,7 @@ def main_cli() -> None:
                 model_name=config.server.model_name,
                 tokenizer=tokenizer,
                 ignore_eos=config.server.ignore_eos,
+                max_tcp_connections=config.load.worker_max_tcp_connections
             )
     else:
         raise Exception("model server client config missing")

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -19,7 +19,7 @@ from inference_perf.client.metricsclient.prometheus_client import PrometheusMetr
 from inference_perf.config import ReportConfig, PrometheusMetricsReportConfig
 from inference_perf.client.metricsclient import MetricsClient, PerfRuntimeParameters
 from inference_perf.utils import ReportFile
-from inference_perf.client.requestdatacollector import LocalRequestDataCollector, RequestDataCollector
+from inference_perf.client.requestdatacollector import RequestDataCollector
 from inference_perf.apis import RequestLifecycleMetric
 import numpy as np
 
@@ -125,8 +125,9 @@ class ReportGenerator:
     def __init__(
         self,
         metrics_client: Optional[MetricsClient],
+        metrics_collector: RequestDataCollector,
     ) -> None:
-        self.metrics_collector = LocalRequestDataCollector()
+        self.metrics_collector = metrics_collector
         self.metrics_client = metrics_client
 
     def get_metrics_collector(self) -> RequestDataCollector:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -175,6 +175,7 @@ class ReportGenerator:
                         "end_time": metric.end_time,
                         "request": metric.request_data,
                         "response": metric.response_data,
+                        "error": metric.error.model_dump() if metric.error else None,
                     }
                     for metric in request_metrics
                 ],


### PR DESCRIPTION
#86 

This adds configuration for multiple worker (processes) that handle request processing up to a configurable limit per worker. A new request data collector was added to receive results via multiprocessing queue.

The load generator pre-schedules request times and pushes onto a request queue that workers pull from until they see an empty request queue and receive a STAGE_END or WORKER_STOP sentinnel.