### PR TITLE
Added throughput metrics to output report

### DIFF
--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -19,6 +19,7 @@ from .base import DataGenerator, IODistribution
 from typing import Generator, List
 from inference_perf.config import APIType
 
+
 # Random data generator generates random tokens from the model's
 # vocabulary for the desired input and output distribution.
 class RandomDataGenerator(DataGenerator):

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -19,7 +19,6 @@ from .base import DataGenerator, IODistribution
 from typing import Generator, List
 from inference_perf.config import APIType
 
-
 # Random data generator generates random tokens from the model's
 # vocabulary for the desired input and output distribution.
 class RandomDataGenerator(DataGenerator):

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -52,7 +52,7 @@ class ResponsesSummary(BaseModel):
 
 
 def summarize_requests(metrics: List[RequestLifecycleMetric]) -> ResponsesSummary:
-    all_successful: List[RequestLifecycleMetric] = [x.get for x in metrics if x.error is None]
+    all_successful: List[RequestLifecycleMetric] = [x for x in metrics if x.error is None]
     all_failed: List[RequestLifecycleMetric] = [x for x in metrics if x.error is not None]
 
     total_time = max(x.end_time for x in metrics) - min(x.start_time for x in metrics)

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -67,7 +67,7 @@ def summarize_requests(metrics: List[RequestLifecycleMetric]) -> ResponsesSummar
                 "input_tokens_per_sec": sum(x.info.input_tokens for x in all_successful) / total_time,
                 "output_tokens_per_sec": sum(x.info.output_tokens for x in all_successful) / total_time,
                 "total_tokens_per_sec": sum((x.info.input_tokens + x.info.output_tokens) for x in all_successful) / total_time,
-                "requests_per_sec": len(metrics) / total_time,
+                "requests_per_sec": len(all_successful) / total_time,
             },
             "request_latency": summarize([(successful.end_time - successful.start_time) for successful in all_successful]),
             "prompt_len": summarize([safe_float(success.info.input_tokens) for success in all_successful]),


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/inference-perf/issues/56

Tested with the following load:
```
load:
  type: constant
  interval: 1.0
  stages:
  - rate: 1
    duration: 10
  - rate: 2
    duration: 15
 ```

Snippet from summary report:
```
  "successes": {
    "count": 57,
    "throughput": {
      "input_tokens_per_sec": 991.276762334537,
      "output_tokens_per_sec": 61.6511605483135,
      "total_tokens_per_sec": 1052.92792288285,
      "requests_per_sec": 1.95011995075132
    },
    ...
```

Snippet from stage 1 report:
```
  "successes": {
    "count": 15,
    "throughput": {
      "input_tokens_per_sec": 348.772345751132,
      "output_tokens_per_sec": 42.5222957473787,
      "total_tokens_per_sec": 391.29464149851,
      "requests_per_sec": 1.34280933939091
    },
    ...
```

Snippet from stage 2 report:
```
  "successes": {
    "count": 42,
    "throughput": {
      "input_tokens_per_sec": 1512.35074099061,
      "output_tokens_per_sec": 80.0258965345935,
      "total_tokens_per_sec": 1592.3766375252,
      "requests_per_sec": 2.53284676296377
    },
    ...
```