### PR TITLE
Enable Docker Build Workflow on Push to Main Branch

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,14 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   docker:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,10 @@
 name: Docker Build and Push
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    types: [closed]
     branches:
       - main
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to trigger Docker build and push jobs on every push to the main branch.
Previously, the workflow was only triggered by pull requests. And if the PR is merged from a forked repo, the secrets are not visible to the action job due to GitHub security settings.

With this change:
- The workflow will now run automatically on every push to main.
- This ensures Docker images are built and published to Quay.io for all direct updates to the main branch, improving release automation and consistency.
- 
No other workflow logic or steps were changed.