### PR TITLE
Add Support for Streaming Requests to Completions API

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,8 @@ load:
   stages:
   - rate: 1
     duration: 30
-api: chat
+api: 
+  type: chat
 server:
   type: vllm
   model_name: HuggingFaceTB/SmolLM2-135M-Instruct

--- a/examples/vllm/config-random.yml
+++ b/examples/vllm/config-random.yml
@@ -3,7 +3,8 @@ load:
   stages:
   - rate: 1
     duration: 30
-api: completion
+api: 
+  type: completion
 server:
   type: vllm
   model_name: HuggingFaceTB/SmolLM2-135M-Instruct

--- a/examples/vllm/config.yml
+++ b/examples/vllm/config.yml
@@ -5,7 +5,8 @@ load:
   stages:
   - rate: 1
     duration: 30
-api: chat
+api: 
+  type: chat
 server:
   type: vllm
   model_name: HuggingFaceTB/SmolLM2-135M-Instruct

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, List, Optional
+from aiohttp import ClientResponse
 from pydantic import BaseModel
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from inference_perf.config import APIType
+from inference_perf.config import APIConfig, APIType
 
 
 class InferenceInfo(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
+    output_token_times: List[float] = []
 
 
 class ErrorResponseInfo(BaseModel):
@@ -49,9 +51,9 @@ class InferenceAPIData(BaseModel):
         raise NotImplementedError
 
     @abstractmethod
-    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool) -> dict[str, Any]:
+    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool) -> dict[str, Any]:
         raise NotImplementedError
 
     @abstractmethod
-    def process_response(self, data: dict[str, Any], tokenizer: CustomTokenizer) -> InferenceInfo:
+    async def process_response(self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer) -> InferenceInfo:
         raise NotImplementedError

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -36,6 +36,8 @@ class ChatCompletionAPIData(InferenceAPIData):
         return "/v1/chat/completions"
 
     def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool) -> dict[str, Any]:
+        if streaming:
+            raise Exception("Generating streaming request payloads for the Chat API is not currently supported.")
         if self.max_tokens == 0:
             self.max_tokens = max_tokens
         return {
@@ -47,11 +49,7 @@ class ChatCompletionAPIData(InferenceAPIData):
 
     async def process_response(self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer) -> InferenceInfo:
         if config.streaming:
-            print("Decoding streaming responses currently not supported for Chat API")
-            return InferenceInfo(
-                input_tokens=0,
-                output_tokens=0,
-            )
+            raise Exception("Decoding responses from the Chat API is not currently supported")
         else:
             data = await response.json()
             choices = data.get("choices", [])

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -49,7 +49,7 @@ class ChatCompletionAPIData(InferenceAPIData):
 
     async def process_response(self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer) -> InferenceInfo:
         if config.streaming:
-            raise Exception("Decoding responses from the Chat API is not currently supported")
+            raise Exception("Decoding streamed responses from the Chat API is not currently supported")
         else:
             data = await response.json()
             choices = data.get("choices", [])

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from typing import Any, List
+from aiohttp import ClientResponse
 from pydantic import BaseModel
 from inference_perf.apis import InferenceAPIData, InferenceInfo
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from inference_perf.config import APIType
+from inference_perf.config import APIConfig, APIType
 
 
 class ChatMessage(BaseModel):
@@ -34,7 +35,7 @@ class ChatCompletionAPIData(InferenceAPIData):
     def get_route(self) -> str:
         return "/v1/chat/completions"
 
-    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool) -> dict[str, Any]:
+    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool) -> dict[str, Any]:
         if self.max_tokens == 0:
             self.max_tokens = max_tokens
         return {
@@ -44,11 +45,19 @@ class ChatCompletionAPIData(InferenceAPIData):
             "ignore_eos": ignore_eos,
         }
 
-    def process_response(self, data: dict[str, Any], tokenizer: CustomTokenizer) -> InferenceInfo:
-        choices = data.get("choices", [])
-        output_text = choices[0].get("message", {}).get("content", "")
-        output_len = tokenizer.count_tokens(output_text)
-        return InferenceInfo(
-            input_tokens=0,
-            output_tokens=output_len,
-        )
+    async def process_response(self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer) -> InferenceInfo:
+        if config.streaming:
+            print("Decoding streaming responses currently not supported for Chat API")
+            return InferenceInfo(
+                input_tokens=0,
+                output_tokens=0,
+            )
+        else:
+            data = await response.json()
+            choices = data.get("choices", [])
+            output_text = choices[0].get("message", {}).get("content", "")
+            output_len = tokenizer.count_tokens(output_text)
+            return InferenceInfo(
+                input_tokens=0,
+                output_tokens=output_len,
+            )

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -53,7 +53,7 @@ class CompletionAPIData(InferenceAPIData):
                 output_token_times.append(time.perf_counter())
                 if not chunk_bytes_stripped:
                     continue
-                # After removing the "data: " prefix, each chunk decodes to a response json or "[DONE]" if end of stream
+                # After removing the "data: " prefix, each chunk decodes to a response json for a single token or "[DONE]" if end of stream
                 if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]":
                     output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]
             prompt_len = tokenizer.count_tokens(self.prompt)

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -53,6 +53,7 @@ class CompletionAPIData(InferenceAPIData):
                 output_token_times.append(time.perf_counter())
                 if not chunk_bytes_stripped:
                     continue
+                print(chunk_bytes_stripped.decode("utf-8"))
                 if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]":
                     output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]
             prompt_len = tokenizer.count_tokens(self.prompt)

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 
-from typing import Any
+import json
+import time
+from typing import Any, List
+
+from aiohttp import ClientResponse
 from inference_perf.apis import InferenceAPIData, InferenceInfo
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from inference_perf.config import APIType
+from inference_perf.config import APIConfig, APIType
 
 
 class CompletionAPIData(InferenceAPIData):
@@ -29,7 +33,7 @@ class CompletionAPIData(InferenceAPIData):
     def get_route(self) -> str:
         return "/v1/completions"
 
-    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool) -> dict[str, Any]:
+    def to_payload(self, model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool) -> dict[str, Any]:
         if self.max_tokens == 0:
             self.max_tokens = max_tokens
         return {
@@ -37,11 +41,31 @@ class CompletionAPIData(InferenceAPIData):
             "prompt": self.prompt,
             "max_tokens": self.max_tokens,
             "ignore_eos": ignore_eos,
+            "stream": streaming,
         }
 
-    def process_response(self, data: dict[str, Any], tokenizer: CustomTokenizer) -> InferenceInfo:
-        choices = data.get("choices", [])
-        prompt_len = tokenizer.count_tokens(self.prompt)
-        output_text = choices[0].get("text", "")
-        output_len = tokenizer.count_tokens(output_text)
-        return InferenceInfo(input_tokens=prompt_len, output_tokens=output_len)
+    async def process_response(self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer) -> InferenceInfo:
+        if config.streaming:
+            output_text = ""
+            output_token_times: List[float] = []
+            async for chunk_bytes in response.content.iter_chunks():
+                chunk_bytes_stripped = chunk_bytes[0].strip()
+                output_token_times.append(time.perf_counter())
+                if not chunk_bytes_stripped:
+                    continue
+                if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]":
+                    output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]
+            prompt_len = tokenizer.count_tokens(self.prompt)
+            output_len = tokenizer.count_tokens(output_text)
+            return InferenceInfo(
+                input_tokens=prompt_len,
+                output_tokens=output_len,
+                output_token_times=output_token_times,
+            )
+        else:
+            data = await response.json()
+            choices = data.get("choices", [])
+            prompt_len = tokenizer.count_tokens(self.prompt)
+            output_text = choices[0].get("text", "")
+            output_len = tokenizer.count_tokens(output_text)
+            return InferenceInfo(input_tokens=prompt_len, output_tokens=output_len)

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -53,8 +53,8 @@ class CompletionAPIData(InferenceAPIData):
                 output_token_times.append(time.perf_counter())
                 if not chunk_bytes_stripped:
                     continue
-                print(chunk_bytes_stripped.decode("utf-8"))
-                if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]":
+                # Each chunk decodes to "data: <token>" or "[DONE]" if end of stream
+                if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]": #  Remove "data:" prefix
                     output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]
             prompt_len = tokenizer.count_tokens(self.prompt)
             output_len = tokenizer.count_tokens(output_text)

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -53,7 +53,7 @@ class CompletionAPIData(InferenceAPIData):
                 output_token_times.append(time.perf_counter())
                 if not chunk_bytes_stripped:
                     continue
-                # Each chunk decodes to a response json prefixed with "data: " or "[DONE]" if end of stream
+                # Each chunk decodes to a response json or "[DONE]" if end of stream
                 if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]":
                     output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]  # Remove "data: " prefix
             prompt_len = tokenizer.count_tokens(self.prompt)

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -53,9 +53,9 @@ class CompletionAPIData(InferenceAPIData):
                 output_token_times.append(time.perf_counter())
                 if not chunk_bytes_stripped:
                     continue
-                # Each chunk decodes to a response json or "[DONE]" if end of stream
+                # After removing the "data: " prefix, each chunk decodes to a response json or "[DONE]" if end of stream
                 if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]":
-                    output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]  # Remove "data: " prefix
+                    output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]
             prompt_len = tokenizer.count_tokens(self.prompt)
             output_len = tokenizer.count_tokens(output_text)
             return InferenceInfo(

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -53,9 +53,9 @@ class CompletionAPIData(InferenceAPIData):
                 output_token_times.append(time.perf_counter())
                 if not chunk_bytes_stripped:
                     continue
-                # Each chunk decodes to "data: <token>" or "[DONE]" if end of stream
-                if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]": #  Remove "data:" prefix
-                    output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]
+                # Each chunk decodes to a response json prefixed with "data: " or "[DONE]" if end of stream
+                if chunk_bytes_stripped.decode("utf-8")[6:] != "[DONE]":
+                    output_text += json.loads(chunk_bytes_stripped.decode("utf-8")[6:])["choices"][0]["text"]  # Remove "data: " prefix
             prompt_len = tokenizer.count_tokens(self.prompt)
             output_len = tokenizer.count_tokens(output_text)
             return InferenceInfo(

--- a/inference_perf/client/modelserver/base.py
+++ b/inference_perf/client/modelserver/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from abc import ABC, abstractmethod
 from typing import List, Tuple, TypedDict
-from inference_perf.config import APIType
+from inference_perf.config import APIConfig, APIType
 
 from inference_perf.apis import InferenceAPIData
 
@@ -58,11 +58,11 @@ class PrometheusMetricMetadata(TypedDict):
 
 class ModelServerClient(ABC):
     @abstractmethod
-    def __init__(self, api_type: APIType, *args: Tuple[int, ...]) -> None:
-        if api_type not in self.get_supported_apis():
-            raise Exception(f"Unsupported API type {api_type}")
+    def __init__(self, api_config: APIConfig, *args: Tuple[int, ...]) -> None:
+        if api_config.type not in self.get_supported_apis():
+            raise Exception(f"Unsupported API type {api_config}")
 
-        self.apiType = api_type
+        self.api_config = api_config
 
     @abstractmethod
     def get_supported_apis(self) -> List[APIType]:

--- a/inference_perf/client/modelserver/mock_client.py
+++ b/inference_perf/client/modelserver/mock_client.py
@@ -14,7 +14,7 @@
 
 from inference_perf.client.requestdatacollector import RequestDataCollector
 from typing import List
-from inference_perf.config import APIType
+from inference_perf.config import APIConfig, APIType
 from inference_perf.apis import InferenceAPIData, InferenceInfo, RequestLifecycleMetric
 from .base import ModelServerClient
 import asyncio
@@ -22,8 +22,8 @@ import time
 
 
 class MockModelServerClient(ModelServerClient):
-    def __init__(self, metrics_collector: RequestDataCollector, api_type: APIType) -> None:
-        super().__init__(api_type)
+    def __init__(self, metrics_collector: RequestDataCollector, api_config: APIConfig) -> None:
+        super().__init__(api_config)
         self.metrics_collector = metrics_collector
 
     async def process_request(self, data: InferenceAPIData, stage_id: int) -> None:
@@ -33,7 +33,7 @@ class MockModelServerClient(ModelServerClient):
         self.metrics_collector.record_metric(
             RequestLifecycleMetric(
                 stage_id=stage_id,
-                request_data=str(data.to_payload("mock_model", 3, False)),
+                request_data=str(data.to_payload("mock_model", 3, False, False)),
                 info=InferenceInfo(
                     input_tokens=0,
                     output_tokens=0,

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from inference_perf.client.requestdatacollector import RequestDataCollector
-from inference_perf.config import APIType
+from inference_perf.config import APIConfig, APIType
 from inference_perf.apis import InferenceAPIData, InferenceInfo, RequestLifecycleMetric, ErrorResponseInfo
 from inference_perf.utils import CustomTokenizer
 from .base import ModelServerClient, PrometheusMetricMetadata, ModelServerPrometheusMetric
@@ -27,13 +27,13 @@ class vLLMModelServerClient(ModelServerClient):
     def __init__(
         self,
         metrics_collector: RequestDataCollector,
-        api_type: APIType,
+        api_config: APIConfig,
         uri: str,
         model_name: str,
         tokenizer: CustomTokenizer,
         ignore_eos: bool = True,
     ) -> None:
-        super().__init__(api_type)
+        super().__init__(api_config)
         self.model_name = model_name
         self.uri = uri
         self.max_completion_tokens = 30  # default to use when not set at the request level
@@ -103,7 +103,10 @@ class vLLMModelServerClient(ModelServerClient):
 
     async def process_request(self, data: InferenceAPIData, stage_id: int) -> None:
         payload = data.to_payload(
-            model_name=self.model_name, max_tokens=self.max_completion_tokens, ignore_eos=self.ignore_eos
+            model_name=self.model_name,
+            max_tokens=self.max_completion_tokens,
+            ignore_eos=self.ignore_eos,
+            streaming=self.api_config.streaming,
         )
         headers = {"Content-Type": "application/json"}
         async with aiohttp.ClientSession() as session:
@@ -111,13 +114,14 @@ class vLLMModelServerClient(ModelServerClient):
             try:
                 async with session.post(self.uri + data.get_route(), headers=headers, data=json.dumps(payload)) as response:
                     if response.status == 200:
-                        content = await response.json()
-                        response_info = data.process_response(data=content, tokenizer=self.tokenizer)
+                        response_info = await data.process_response(
+                            response=response, config=self.api_config, tokenizer=self.tokenizer
+                        )
                         self.metrics_collector.record_metric(
                             RequestLifecycleMetric(
                                 stage_id=stage_id,
                                 request_data=json.dumps(payload),
-                                response_data=json.dumps(content),
+                                response_data=json.dumps(await response.text()),
                                 info=response_info,
                                 error=None,
                                 start_time=start,
@@ -138,6 +142,7 @@ class vLLMModelServerClient(ModelServerClient):
                             )
                         )
             except Exception as e:
+                print(f"exception: {e}")
                 self.metrics_collector.record_metric(
                     RequestLifecycleMetric(
                         stage_id=stage_id,

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -142,7 +142,6 @@ class vLLMModelServerClient(ModelServerClient):
                             )
                         )
             except Exception as e:
-                print(f"exception: {e}")
                 self.metrics_collector.record_metric(
                     RequestLifecycleMetric(
                         stage_id=stage_id,

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -24,6 +24,11 @@ class APIType(Enum):
     Chat = "chat"
 
 
+class APIConfig(BaseModel):
+    type: APIType = APIType.Completion
+    streaming: bool = False
+
+
 class DataGenType(Enum):
     Mock = "mock"
     ShareGPT = "shareGPT"
@@ -136,7 +141,7 @@ class CustomTokenizerConfig(BaseModel):
 
 
 class Config(BaseModel):
-    api: APIType = APIType.Completion
+    api: APIConfig = APIConfig()
     data: DataConfig = DataConfig()
     load: LoadConfig = LoadConfig()
     metrics: Optional[MetricsClientConfig] = None

--- a/inference_perf/datagen/base.py
+++ b/inference_perf/datagen/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from inference_perf.apis import InferenceAPIData
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from inference_perf.config import APIConfig, APIConfig, APIType, DataConfig, Distribution, SharedPrefix
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, SharedPrefix
 from abc import ABC, abstractmethod
 from typing import Generator, Optional, List
 

--- a/inference_perf/datagen/base.py
+++ b/inference_perf/datagen/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from inference_perf.apis import InferenceAPIData
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from inference_perf.config import APIType, DataConfig, Distribution, SharedPrefix
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, SharedPrefix
 from abc import ABC, abstractmethod
 from typing import Generator, Optional, List
 
@@ -21,7 +21,7 @@ from typing import Generator, Optional, List
 class DataGenerator(ABC):
     """Abstract base class for data generators."""
 
-    apiType: APIType
+    api_config: APIConfig
     input_distribution: Optional[Distribution]
     output_distribution: Optional[Distribution]
     shared_prefix: Optional[SharedPrefix]
@@ -29,9 +29,9 @@ class DataGenerator(ABC):
 
     """Abstract base class for data generators."""
 
-    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
-        if apiType not in self.get_supported_apis():
-            raise Exception(f"Unsupported API type {apiType}")
+    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
+        if api_config.type not in self.get_supported_apis():
+            raise Exception(f"Unsupported API type {api_config}")
 
         if (
             config.input_distribution is not None or config.output_distribution is not None
@@ -44,7 +44,7 @@ class DataGenerator(ABC):
         if tokenizer is not None:
             self.tokenizer = tokenizer
 
-        self.apiType = apiType
+        self.api_config = api_config
         self.input_distribution = config.input_distribution
         self.output_distribution = config.output_distribution
         self.shared_prefix = config.shared_prefix

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -14,14 +14,14 @@
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
-from inference_perf.config import APIType, DataConfig
+from inference_perf.config import APIConfig, APIType, DataConfig
 from typing import Generator, List
 from datasets import load_dataset
 
 
 class HFShareGPTDataGenerator(DataGenerator):
-    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: CustomTokenizer) -> None:
-        super().__init__(apiType, config, tokenizer)
+    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: CustomTokenizer) -> None:
+        super().__init__(api_config, config, tokenizer)
         self.sharegpt_dataset = iter(
             load_dataset(
                 "anon8231489123/ShareGPT_Vicuna_unfiltered",
@@ -52,7 +52,7 @@ class HFShareGPTDataGenerator(DataGenerator):
                 ):
                     continue
 
-                if self.apiType == APIType.Completion:
+                if self.api_config.type == APIType.Completion:
                     try:
                         prompt = data[self.data_key][0].get(self.content_key)
                         if not prompt:
@@ -61,7 +61,7 @@ class HFShareGPTDataGenerator(DataGenerator):
                     except (KeyError, TypeError) as e:
                         print(f"Skipping invalid completion data: {e}")
                         continue
-                elif self.apiType == APIType.Chat:
+                elif self.api_config.type == APIType.Chat:
                     yield ChatCompletionAPIData(
                         messages=[
                             ChatMessage(role=conversation[self.role_key], content=conversation[self.content_key])

--- a/inference_perf/datagen/mock_datagen.py
+++ b/inference_perf/datagen/mock_datagen.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Generator, List, Optional
-from inference_perf.config import APIConfig, APIConfig, APIType, DataConfig
+from inference_perf.config import APIConfig, APIType, DataConfig
 from inference_perf.datagen.base import DataGenerator
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer

--- a/inference_perf/datagen/mock_datagen.py
+++ b/inference_perf/datagen/mock_datagen.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import Generator, List, Optional
-from inference_perf.config import APIType, DataConfig
+from inference_perf.config import APIConfig, APIType, DataConfig
 from inference_perf.datagen.base import DataGenerator
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
 class MockDataGenerator(DataGenerator):
-    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
-        super().__init__(apiType, config, tokenizer)
+    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
+        super().__init__(api_config, config, tokenizer)
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion, APIType.Chat]
@@ -29,9 +29,9 @@ class MockDataGenerator(DataGenerator):
         i = 0
         while True:
             i += 1
-            if self.apiType == APIType.Completion:
+            if self.api_config.type == APIType.Completion:
                 yield CompletionAPIData(prompt="text" + str(i))
-            elif self.apiType == APIType.Chat:
+            elif self.api_config.type == APIType.Chat:
                 yield ChatCompletionAPIData(messages=[ChatMessage(role="user", content="text" + str(i))])
             else:
                 raise Exception("Unsupported API type")

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -17,7 +17,7 @@ from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import generate_distribution
 from .base import DataGenerator
 from typing import Generator, List
-from inference_perf.config import APIType, DataConfig
+from inference_perf.config import APIType, APIConfig, DataConfig
 
 
 
@@ -27,11 +27,11 @@ from inference_perf.config import APIType, DataConfig
 class RandomDataGenerator(DataGenerator):
     def __init__(
         self,
-        apiType: APIType,
+        api_config: APIConfig,
         config: DataConfig,
         tokenizer: CustomTokenizer,
     ) -> None:
-        super().__init__(apiType, config, tokenizer)
+        super().__init__(api_config, config, tokenizer)
 
         if self.input_distribution is None or self.output_distribution is None:
             raise ValueError("Input and Output Distribution are required for RandomDataGenerator")
@@ -86,7 +86,7 @@ class RandomDataGenerator(DataGenerator):
             if self.tokenizer is None:
                 raise ValueError("Tokenizer is required for RandomDataGenerator")
 
-            if self.apiType == APIType.Completion:
+            if self.api_config.type == APIType.Completion:
                 prompt_text: str
                 if self.input_lengths[i] <= 0:
                     random_token_ids_list = []
@@ -101,4 +101,4 @@ class RandomDataGenerator(DataGenerator):
                 )
                 i += 1
             else:
-                raise Exception(f"Unsupported API type: {self.apiType}. RandomDataGenerator only supports Completion.")
+                raise Exception(f"Unsupported API type: {self.api_config}. RandomDataGenerator only supports Completion.")

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -20,8 +20,6 @@ from typing import Generator, List
 from inference_perf.config import APIType, APIConfig, DataConfig
 
 
-
-
 # Random data generator generates random tokens from the model's
 # vocabulary for the desired input and output distribution.
 class RandomDataGenerator(DataGenerator):

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from inference_perf.apis.base import InferenceAPIData
 from inference_perf.apis.completion import CompletionAPIData
-from inference_perf.config import APIType, DataConfig
+from inference_perf.config import APIConfig, APIType, DataConfig
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
 
@@ -12,8 +12,8 @@ from .base import DataGenerator
 # Shared Prefix Generator generates shared prefix in the prompts that are sent.
 # This can be used to benchmark prefix caching cases.
 class SharedPrefixDataGenerator(DataGenerator):
-    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: CustomTokenizer) -> None:
-        super().__init__(apiType, config, tokenizer)
+    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: CustomTokenizer) -> None:
+        super().__init__(api_config, config, tokenizer)
 
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for SharedPrefixDataGenerator but was not initialized.")

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -16,7 +16,7 @@ from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import generate_distribution
 from .base import DataGenerator
 from typing import Generator, List
-from inference_perf.config import APIConfig, APIConfig, APIType, DataConfig
+from inference_perf.config import APIConfig, APIType, DataConfig
 
 
 class SyntheticDataGenerator(DataGenerator):

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -16,12 +16,12 @@ from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import generate_distribution
 from .base import DataGenerator
 from typing import Generator, List
-from inference_perf.config import APIType, DataConfig
+from inference_perf.config import APIConfig, APIType, DataConfig
 
 
 class SyntheticDataGenerator(DataGenerator):
-    def __init__(self, apiType: APIType, config: DataConfig, tokenizer: CustomTokenizer) -> None:
-        super().__init__(apiType, config, tokenizer)
+    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: CustomTokenizer) -> None:
+        super().__init__(api_config, config, tokenizer)
 
         if self.input_distribution is None or self.output_distribution is None or self.tokenizer is None:
             raise ValueError("IODistribution and tokenizer are required for SyntheticDataGenerator")
@@ -57,7 +57,7 @@ class SyntheticDataGenerator(DataGenerator):
         while True:
             if self.tokenizer is None:
                 raise ValueError("Tokenizer is required for SyntheticDataGenerator")
-            if self.apiType == APIType.Completion:
+            if self.api_config.type == APIType.Completion:
                 yield CompletionAPIData(
                     prompt=self.tokenizer.get_tokenizer().decode(self.token_ids[: self.input_lengths[i]]),
                     max_tokens=self.output_lengths[i],

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -99,7 +99,7 @@ def main_cli() -> None:
                 )
             model_server_client = vLLMModelServerClient(
                 reportgen.get_metrics_collector(),
-                api_type=config.api,
+                api_config=config.api,
                 uri=config.server.base_url,
                 model_name=config.server.model_name,
                 tokenizer=tokenizer,

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -119,7 +119,7 @@ def summarize_requests(metrics: List[RequestLifecycleMetric]) -> ResponsesSummar
                     [
                         (x.info.output_token_times[-1] - x.info.output_token_times[0]) / (len(x.info.output_token_times) - 1)
                         for x in streamable
-                        if len(x.info.output_token_times) > 2
+                        if len(x.info.output_token_times) > 1
                     ]
                 ),
                 "time_to_first_token": summarize([x.info.output_token_times[0] - x.start_time for x in streamable]),

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -119,7 +119,7 @@ def summarize_requests(metrics: List[RequestLifecycleMetric]) -> ResponsesSummar
                     [
                         (x.info.output_token_times[-1] - x.info.output_token_times[0]) / (len(x.info.output_token_times) - 1)
                         for x in streamable
-                        if len(x.info.output_token_times) > 1
+                        if len(x.info.output_token_times) > 2
                     ]
                 ),
                 "time_to_first_token": summarize([x.info.output_token_times[0] - x.start_time for x in streamable]),

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -98,52 +98,53 @@ def summarize_requests(metrics: List[RequestLifecycleMetric]) -> ResponsesSummar
     all_failed: List[RequestLifecycleMetric] = [x for x in metrics if x.error is not None]
 
     total_time = max(x.end_time for x in metrics) - min(x.start_time for x in metrics)
-
-    load_summary: dict[str, Any] = {
-        "count": len(metrics),
-    }
-    successes: dict[str, Any] = {
-        "count": len(all_successful),
-        "request_latency": summarize([(successful.end_time - successful.start_time) for successful in all_successful]),
-        "prompt_len": summarize([safe_float(success.info.input_tokens) for success in all_successful]),
-        "output_len": summarize([float(v) for success in all_successful if (v := success.info.output_tokens) is not None]),
-        "normalized_time_per_output_token": summarize(
-            [
-                ((metric.end_time - metric.start_time) / output_len) if output_len and output_len != 0 else 0
-                for metric in all_successful
-                for output_len in [safe_float(metric.info.output_tokens)]
-            ]
-        ),
-    }
-
     streamable = [x for x in all_successful if x.info.output_token_times and len(x.info.output_token_times) > 1]
-    if streamable:
-        stream_metrics: dict[str, Any] = {
-            "count": len(streamable),
-            "time_per_output_token": summarize(
-                [
-                    (x.info.output_token_times[-1] - x.info.output_token_times[0]) / (len(x.info.output_token_times) - 1)
-                    for x in streamable
-                    if len(x.info.output_token_times) > 1
-                ]
-            ),
-            "time_to_first_token": summarize([x.info.output_token_times[0] - x.start_time for x in streamable]),
-            "inter_token_latency": summarize(
-                [
-                    t2 - t1
-                    for x in streamable
-                    for t1, t2 in zip(x.info.output_token_times, x.info.output_token_times[1:], strict=False)
-                ]
-            ),
-        }
-        successes["stream_metrics"] = stream_metrics
 
-    failures: dict[str, Any] = {
-        "count": len(all_failed),
-        "request_latency": summarize([(failed.end_time - failed.start_time) for failed in all_failed]),
-    }
-
-    return ResponsesSummary(load_summary=load_summary, successes=successes, failures=failures)
+    return ResponsesSummary(
+        load_summary={
+            "count": len(metrics),
+        },
+        successes={
+            "count": len(all_successful),
+            "latency": {
+                "request_latency": summarize([(successful.end_time - successful.start_time) for successful in all_successful]),
+                "normalized_time_per_output_token": summarize(
+                    [
+                        ((metric.end_time - metric.start_time) / output_len) if output_len and output_len != 0 else 0
+                        for metric in all_successful
+                        for output_len in [safe_float(metric.info.output_tokens)]
+                    ]
+                ),
+                "time_per_output_token": summarize(
+                    [
+                        (x.info.output_token_times[-1] - x.info.output_token_times[0]) / (len(x.info.output_token_times) - 1)
+                        for x in streamable
+                        if len(x.info.output_token_times) > 1
+                    ]
+                ),
+                "time_to_first_token": summarize([x.info.output_token_times[0] - x.start_time for x in streamable]),
+                "inter_token_latency": summarize(
+                    [
+                        t2 - t1
+                        for x in streamable
+                        for t1, t2 in zip(x.info.output_token_times, x.info.output_token_times[1:], strict=False)
+                    ]
+                ),
+            },
+            "throughput": {
+                "input_tokens_per_sec": sum(x.info.input_tokens for x in all_successful) / total_time,
+                "output_tokens_per_sec": sum(x.info.output_tokens for x in all_successful) / total_time,
+                "total_tokens_per_sec": sum((x.info.input_tokens + x.info.output_tokens) for x in all_successful) / total_time,
+                "requests_per_sec": len(all_successful) / total_time,
+            },
+            "prompt_len": summarize([safe_float(success.info.input_tokens) for success in all_successful]),
+            "output_len": summarize([float(v) for success in all_successful if (v := success.info.output_tokens) is not None]),
+        },
+        failures={
+            "count": len(all_failed),
+            "request_latency": summarize([(failed.end_time - failed.start_time) for failed in all_failed]),
+        },
+    )
 
 
 class ReportGenerator:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -99,34 +99,51 @@ def summarize_requests(metrics: List[RequestLifecycleMetric]) -> ResponsesSummar
 
     total_time = max(x.end_time for x in metrics) - min(x.start_time for x in metrics)
 
-    return ResponsesSummary(
-        load_summary={
-            "count": len(metrics),
-        },
-        successes={
-            "count": len(all_successful),
-            "throughput": {
-                "input_tokens_per_sec": sum(x.info.input_tokens for x in all_successful) / total_time,
-                "output_tokens_per_sec": sum(x.info.output_tokens for x in all_successful) / total_time,
-                "total_tokens_per_sec": sum((x.info.input_tokens + x.info.output_tokens) for x in all_successful) / total_time,
-                "requests_per_sec": len(all_successful) / total_time,
-            },
-            "request_latency": summarize([(successful.end_time - successful.start_time) for successful in all_successful]),
-            "prompt_len": summarize([safe_float(success.info.input_tokens) for success in all_successful]),
-            "output_len": summarize([float(v) for success in all_successful if (v := success.info.output_tokens) is not None]),
-            "normalized_time_per_output_token": summarize(
+    load_summary: dict[str, Any] = {
+        "count": len(metrics),
+    }
+    successes: dict[str, Any] = {
+        "count": len(all_successful),
+        "request_latency": summarize([(successful.end_time - successful.start_time) for successful in all_successful]),
+        "prompt_len": summarize([safe_float(success.info.input_tokens) for success in all_successful]),
+        "output_len": summarize([float(v) for success in all_successful if (v := success.info.output_tokens) is not None]),
+        "normalized_time_per_output_token": summarize(
+            [
+                ((metric.end_time - metric.start_time) / output_len) if output_len and output_len != 0 else 0
+                for metric in all_successful
+                for output_len in [safe_float(metric.info.output_tokens)]
+            ]
+        ),
+    }
+
+    streamable = [x for x in all_successful if x.info.output_token_times and len(x.info.output_token_times) > 1]
+    if streamable:
+        stream_metrics: dict[str, Any] = {
+            "count": len(streamable),
+            "time_per_output_token": summarize(
                 [
-                    ((metric.end_time - metric.start_time) / output_len) if output_len and output_len != 0 else 0
-                    for metric in all_successful
-                    for output_len in [safe_float(metric.info.output_tokens)]
+                    (x.info.output_token_times[-1] - x.info.output_token_times[0]) / (len(x.info.output_token_times) - 1)
+                    for x in streamable
+                    if len(x.info.output_token_times) > 1
                 ]
             ),
-        },
-        failures={
-            "count": len(all_failed),
-            "request_latency": summarize([(failed.end_time - failed.start_time) for failed in all_failed]),
-        },
-    )
+            "time_to_first_token": summarize([x.info.output_token_times[0] - x.start_time for x in streamable]),
+            "inter_token_latency": summarize(
+                [
+                    t2 - t1
+                    for x in streamable
+                    for t1, t2 in zip(x.info.output_token_times, x.info.output_token_times[1:], strict=False)
+                ]
+            ),
+        }
+        successes["stream_metrics"] = stream_metrics
+
+    failures: dict[str, Any] = {
+        "count": len(all_failed),
+        "request_latency": summarize([(failed.end_time - failed.start_time) for failed in all_failed]),
+    }
+
+    return ResponsesSummary(load_summary=load_summary, successes=successes, failures=failures)
 
 
 class ReportGenerator:

--- a/tests/apis/test_chat.py
+++ b/tests/apis/test_chat.py
@@ -6,7 +6,7 @@ def test_chat_completion_api_data() -> None:
     data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="Hello, world!")])
     assert data.get_api_type() == APIType.Chat
     assert len(data.messages) == 1
-    assert data.to_payload("test-model", 100, False) == {
+    assert data.to_payload("test-model", 100, False, False) == {
         "model": "test-model",
         "messages": [{"role": "user", "content": "Hello, world!"}],
         "max_tokens": 100,

--- a/tests/apis/test_completion.py
+++ b/tests/apis/test_completion.py
@@ -6,9 +6,10 @@ def test_completion_api_data() -> None:
     data = CompletionAPIData(prompt="Hello, world!")
     assert data.get_api_type() == APIType.Completion
     assert data.prompt == "Hello, world!"
-    assert data.to_payload("test-model", 100, False) == {
+    assert data.to_payload("test-model", 100, False, True) == {
         "model": "test-model",
         "prompt": "Hello, world!",
         "max_tokens": 100,
         "ignore_eos": False,
+        "stream": True,
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ def test_read_config() -> None:
     config = read_config(["-c", config_path])
 
     assert isinstance(config, Config)
-    assert config.api == APIType.Chat
+    assert config.api.type == APIType.Chat
     assert config.data.type == DataGenType.ShareGPT
     assert config.load.type == LoadType.CONSTANT
     if config.metrics:


### PR DESCRIPTION
Addresses https://github.com/kubernetes-sigs/inference-perf/issues/15

Changes:
* Setting `.api.streaming` to true will make all responses streamed (default: False)
* API type config moved from `.api` to `.api.type`
* Report now includes `stream_metrics` section when streaming responses since TPOT, TTFT, and ITL depend on per token latency measurements.

Report snippet from local testing:

```
  "successes": {
    "count": 33,
    "latency": {
      "request_latency": {
        "mean": 3.31325431142327,
        "min": 1.62129471905064,
        "p10": 1.67609986825846,
        "p50": 2.11507539497688,
        "p90": 5.94717199734878,
        "max": 6.30658466403838
      },
      "normalized_time_per_output_token": {
        "mean": 0.104340420636009,
        "min": 0.0506654599703325,
        "p10": 0.0523781208830769,
        "p50": 0.0670631669655753,
        "p90": 0.189047570470012,
        "max": 0.20343821496898
      },
      "time_per_output_token": {
        "mean": 0.0836929455635872,
        "min": 0.0517028436646797,
        "p10": 0.0530815053513894,
        "p50": 0.0611870964678625,
        "p90": 0.152292036800645,
        "max": 0.17837208439984
      },
      "time_to_first_token": {
        "mean": 0.800974442732916,
        "min": 0.0625283779809251,
        "p10": 0.072068731742911,
        "p50": 0.203539535985328,
        "p90": 2.26959549135063,
        "max": 4.46773961000145
      },
      "inter_token_latency": {
        "mean": 0.0836929455635872,
        "min": 0.000007129972800612,
        "p10": 0.0534287681337446,
        "p50": 0.0591336835059337,
        "p90": 0.084046097996179,
        "max": 0.614475268055685
      }
    },
    "throughput": {
      "input_tokens_per_sec": 643.576644186323,
      "output_tokens_per_sec": 32.544923821416,
      "total_tokens_per_sec": 676.121568007739,
      "requests_per_sec": 1.0238155253639
    },
    "prompt_len": {
      "mean": 628.606060606061,
      "min": 4,
      "p10": 11.4,
      "p50": 364,
      "p90": 2427.6,
      "max": 3836
    },
    "output_len": {
      "mean": 31.7878787878788,
      "min": 30,
      "p10": 31,
      "p50": 32,
      "p90": 32,
      "max": 32
    }
  },
```