### PR TITLE
Fix Docker Tag Generation by Using env.QUAY_USERNAME in Workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    env:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -26,7 +28,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: quay.io/${{ secrets.QUAY_USERNAME }}/inference-perf
+          images: quay.io/${{ env.QUAY_USERNAME }}/inference-perf
           tags: |
             type=ref,event=branch
             type=sha,format=short


### PR DESCRIPTION
**The Problem**
The ${{ secrets.QUAY_USERNAME }} context is only available at the step level, not inside the with: block of another action (like docker/metadata-action). This can cause the tag to be rendered incorrectly (as quay.io//inference-perf:main or with ***).

**The Solution**
Use an environment variable for the username and reference that in your tags.

This PR updates the GitHub Actions workflow to use the environment variable `env.QUAY_USERNAME` (instead of `secrets.QUAY_USERNAME`) when generating Docker image tags.
This change ensures that Docker image tags are correctly formatted, preventing failures during the push step due to invalid tag references.
- No changes to workflow logic or triggers.
- Only the tag generation now references `env.QUAY_USERNAME` for compatibility.
