### PR TITLE
Update Quay.io Organization Name in Docker Build Workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    env:
-      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,7 +26,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: quay.io/${{ env.QUAY_USERNAME }}/inference-perf
+          images: quay.io/inference-perf/inference-perf
           tags: |
             type=ref,event=branch
             type=sha,format=short


### PR DESCRIPTION
This PR updates the GitHub Actions workflow for Docker image builds to use a hardcoded Quay.io organization `inference-perf` and repository name (`quay.io/inference-perf/inference-perf`) when tagging and pushing images.

The `secrets.QUAY_USERNAME` actually differs from the org name.