### PR TITLE
Use logging methods with levels instead of print

### DIFF
--- a/inference_perf/client/filestorage/base.py
+++ b/inference_perf/client/filestorage/base.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from abc import ABC, abstractmethod
 from typing import List
 from inference_perf.config import StorageConfigBase
 from inference_perf.utils import ReportFile
 
+logger = logging.getLogger(__name__)
+
 
 class StorageClient(ABC):
     def __init__(self, config: StorageConfigBase) -> None:
         self.config = config
-        print(f"Report files will be stored at: {self.config.path}")
+        logger.info(f"Report files will be stored at: {self.config.path}")
 
     @abstractmethod
     def save_report(self, reports: List[ReportFile]) -> None:

--- a/inference_perf/client/filestorage/gcs.py
+++ b/inference_perf/client/filestorage/gcs.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class GoogleCloudStorageClient(StorageClient):
     def __init__(self, config: GoogleCloudStorageConfig) -> None:
         super().__init__(config=config)
-        logger.info("Created new GCS client")
+        logger.debug("Created new GCS client")
         self.output_bucket = config.bucket_name
         self.client = storage.Client()
 

--- a/inference_perf/client/filestorage/gcs.py
+++ b/inference_perf/client/filestorage/gcs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import logging
 from typing import List
 from google.cloud import storage
 from google.cloud.exceptions import GoogleCloudError
@@ -19,11 +20,13 @@ from inference_perf.client.filestorage import StorageClient
 from inference_perf.config import GoogleCloudStorageConfig
 from inference_perf.utils import ReportFile
 
+logger = logging.getLogger(__name__)
+
 
 class GoogleCloudStorageClient(StorageClient):
     def __init__(self, config: GoogleCloudStorageConfig) -> None:
         super().__init__(config=config)
-        print("Created new GCS client")
+        logger.info("Created new GCS client")
         self.output_bucket = config.bucket_name
         self.client = storage.Client()
 
@@ -42,11 +45,11 @@ class GoogleCloudStorageClient(StorageClient):
             blob = self.bucket.blob(blob_path)
 
             if blob.exists():
-                print(f"Skipping upload: gs://{self.output_bucket}/{blob_path} already exists")
+                logger.info(f"Skipping upload: gs://{self.output_bucket}/{blob_path} already exists")
                 continue
 
             try:
                 blob.upload_from_string(json.dumps(report.get_contents()), content_type="application/json")
-                print(f"Uploaded gs://{self.output_bucket}/{blob_path}")
+                logger.info(f"Uploaded gs://{self.output_bucket}/{blob_path}")
             except GoogleCloudError as e:
-                print(f"Failed to upload {blob_path}: {e}")
+                logger.error(f"Failed to upload {blob_path}: {e}")

--- a/inference_perf/client/metricsclient/prometheus_client.py
+++ b/inference_perf/client/metricsclient/prometheus_client.py
@@ -147,7 +147,9 @@ class PrometheusMetricsClient(MetricsClient):
             return None
 
         if runtime_parameters.stages is None or stage_id not in runtime_parameters.stages:
-            logger.warning(f"Stage ID {stage_id} is not present in the runtime parameters, skipping metrics collection for this stage")
+            logger.warning(
+                f"Stage ID {stage_id} is not present in the runtime parameters, skipping metrics collection for this stage"
+            )
             return None
 
         # Get the query evaluation time and duration for the stage

--- a/inference_perf/client/metricsclient/prometheus_client.py
+++ b/inference_perf/client/metricsclient/prometheus_client.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import time
 from typing import cast
 import requests
@@ -19,6 +20,8 @@ from inference_perf.config import PrometheusClientConfig
 from .base import MetricsClient, PerfRuntimeParameters, ModelServerMetrics
 
 PROMETHEUS_SCRAPE_BUFFER_SEC = 2
+
+logger = logging.getLogger(__name__)
 
 
 class PrometheusQueryBuilder:
@@ -82,10 +85,10 @@ class PrometheusQueryBuilder:
 
         queries = self.get_queries()
         if metric_type not in queries:
-            print("Invalid metric type: %s" % (metric_type))
+            logger.warning("Invalid metric type: %s" % (metric_type))
             return ""
         if query_op not in queries[metric_type]:
-            print("Invalid query operation: %s" % (query_op))
+            logger.warning("Invalid query operation: %s" % (query_op))
             return ""
         return queries[metric_type][query_op]
 
@@ -119,7 +122,7 @@ class PrometheusMetricsClient(MetricsClient):
         A ModelServerMetrics object containing the summary metrics.
         """
         if runtime_parameters is None:
-            print("Perf Runtime parameters are not set, skipping metrics collection")
+            logger.warning("Perf Runtime parameters are not set, skipping metrics collection")
             return None
 
         # Get the duration and model server client from the runtime parameters
@@ -140,11 +143,11 @@ class PrometheusMetricsClient(MetricsClient):
         A ModelServerMetrics object containing the summary metrics for the specified stage.
         """
         if runtime_parameters is None:
-            print("Perf Runtime parameters are not set, skipping metrics collection")
+            logger.warning("Perf Runtime parameters are not set, skipping metrics collection")
             return None
 
         if runtime_parameters.stages is None or stage_id not in runtime_parameters.stages:
-            print(f"Stage ID {stage_id} is not present in the runtime parameters, skipping metrics collection for this stage")
+            logger.warning(f"Stage ID {stage_id} is not present in the runtime parameters, skipping metrics collection for this stage")
             return None
 
         # Get the query evaluation time and duration for the stage
@@ -172,21 +175,21 @@ class PrometheusMetricsClient(MetricsClient):
 
         # Get the engine and model from the model server client
         if not model_server_client:
-            print("Model server client is not set")
+            logger.warning("Model server client is not set")
             return None
 
         metrics_metadata = model_server_client.get_prometheus_metric_metadata()
         if not metrics_metadata:
-            print("Metrics metadata is not present for the runtime")
+            logger.warning("Metrics metadata is not present for the runtime")
             return None
         for summary_metric_name in metrics_metadata:
             summary_metric_metadata = metrics_metadata.get(summary_metric_name)
             if summary_metric_metadata is None:
-                print("Metric metadata is not present for metric: %s. Skipping this metric." % (summary_metric_name))
+                logger.warning("Metric metadata is not present for metric: %s. Skipping this metric." % (summary_metric_name))
                 continue
             summary_metric_metadata = cast(ModelServerPrometheusMetric, summary_metric_metadata)
             if summary_metric_metadata is None:
-                print(
+                logger.warning(
                     "Metric metadata for %s is missing or has an incorrect format. Skipping this metric."
                     % (summary_metric_name)
                 )
@@ -195,13 +198,13 @@ class PrometheusMetricsClient(MetricsClient):
             query_builder = PrometheusQueryBuilder(summary_metric_metadata, query_duration)
             query = query_builder.build_query()
             if not query:
-                print("No query found for metric: %s. Skipping metric." % (summary_metric_name))
+                logger.warning("No query found for metric: %s. Skipping metric." % (summary_metric_name))
                 continue
 
             # Execute the query and get the result
             result = self.execute_query(query, str(query_eval_time))
             if result is None:
-                print("Error executing query: %s" % (query))
+                logger.error("Error executing query: %s" % (query))
                 continue
             # Set the result in metrics summary
             attr = getattr(model_server_metrics, summary_metric_name)
@@ -226,12 +229,12 @@ class PrometheusMetricsClient(MetricsClient):
         try:
             response = requests.get(f"{self.url}/api/v1/query", params={"query": query, "time": eval_time})
             if response is None:
-                print("Error executing query: %s" % (query))
+                logger.error("Error executing query: %s" % (query))
                 return query_result
 
             response.raise_for_status()
         except Exception as e:
-            print("Error executing query: %s" % (e))
+            logger.error("Error executing query: %s" % (e))
             return query_result
 
         # Check if the response is valid
@@ -253,7 +256,7 @@ class PrometheusMetricsClient(MetricsClient):
         # }
         response_obj = response.json()
         if response_obj.get("status") != "success":
-            print("Error executing query: %s" % (response_obj))
+            logger.error("Error executing query: %s" % (response_obj))
             return query_result
 
         data = response_obj.get("data", {})
@@ -269,6 +272,6 @@ class PrometheusMetricsClient(MetricsClient):
                 try:
                     query_result = round(float(result[0]["value"][1]), 6)
                 except ValueError:
-                    print("Error converting value to float: %s" % (result[0]["value"][1]))
+                    logger.error("Error converting value to float: %s" % (result[0]["value"][1]))
                     return query_result
         return query_result

--- a/inference_perf/client/modelserver/mock_client.py
+++ b/inference_perf/client/modelserver/mock_client.py
@@ -19,6 +19,9 @@ from inference_perf.apis import InferenceAPIData, InferenceInfo, RequestLifecycl
 from .base import ModelServerClient
 import asyncio
 import time
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MockModelServerClient(ModelServerClient):
@@ -28,7 +31,7 @@ class MockModelServerClient(ModelServerClient):
 
     async def process_request(self, data: InferenceAPIData, stage_id: int) -> None:
         start = time.monotonic()
-        print("Processing mock request for stage - " + str(stage_id))
+        logger.debug("Processing mock request for stage %d", stage_id)
         await asyncio.sleep(3)
         self.metrics_collector.record_metric(
             RequestLifecycleMetric(

--- a/inference_perf/client/requestdatacollector/multiprocess.py
+++ b/inference_perf/client/requestdatacollector/multiprocess.py
@@ -41,7 +41,7 @@ class MultiprocessRequestDataCollector(RequestDataCollector):
 
     def start(self) -> None:
         self.collection = create_task(self.collect_metrics())
-    
+
     async def stop(self) -> None:
         # Ensure that the collection queue is empty before joining
         while self.queue.qsize() > 0:

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -87,7 +87,7 @@ class LoadConfig(BaseModel):
     type: LoadType = LoadType.CONSTANT
     interval: float = 1.0
     stages: List[LoadStage] = []
-    num_workers: int = max(1, cpu_count() // 2) # type: ignore
+    num_workers: int = max(1, cpu_count() // 2)  # type: ignore
     worker_max_concurrency: int = 10
     worker_max_tcp_connections: int = 2500
 
@@ -175,7 +175,6 @@ def read_config(config_file: str) -> Config:
     merged_cfg = deep_merge(default_cfg, cfg)
 
     logger.info(
-        "Benchmarking with the following config:\n\n%s\n",
-        yaml.dump(merged_cfg, sort_keys=False, default_flow_style=False)
+        "Benchmarking with the following config:\n\n%s\n", yaml.dump(merged_cfg, sort_keys=False, default_flow_style=False)
     )
     return Config(**merged_cfg)

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -11,12 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
 from inference_perf.config import APIConfig, APIType, DataConfig
 from typing import Generator, List
 from datasets import load_dataset
+
+logger = logging.getLogger(__name__)
 
 
 class HFShareGPTDataGenerator(DataGenerator):
@@ -59,7 +62,7 @@ class HFShareGPTDataGenerator(DataGenerator):
                             continue
                         yield CompletionAPIData(prompt=prompt)
                     except (KeyError, TypeError) as e:
-                        print(f"Skipping invalid completion data: {e}")
+                        logger.warning(f"Skipping invalid completion data: {e}")
                         continue
                 elif self.api_config.type == APIType.Chat:
                     yield ChatCompletionAPIData(

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 RequestQueueData: TypeAlias = Tuple[int, InferenceAPIData, float]
 
+
 class Status(Enum):
     UNKNOWN = auto()
     STAGE_END = auto()
@@ -37,7 +38,7 @@ class Status(Enum):
 
 
 class Worker(mp.Process):
-    def __init__(self, id: int, client: ModelServerClient, request_queue: mp.Queue, max_concurrency: int): # type: ignore[type-arg]
+    def __init__(self, id: int, client: ModelServerClient, request_queue: mp.Queue, max_concurrency: int):  # type: ignore[type-arg]
         super().__init__()
         self.id = id
         self.client = client
@@ -59,7 +60,7 @@ class Worker(mp.Process):
                 await semaphore.acquire()
                 item = self.request_queue.get_nowait()
 
-                async def schedule_client(queue: mp.Queue, data: InferenceAPIData, request_time: float, stage_id: int) -> None: # type: ignore[type-arg]
+                async def schedule_client(queue: mp.Queue, data: InferenceAPIData, request_time: float, stage_id: int) -> None:  # type: ignore[type-arg]
                     current_time = time.time()
                     sleep_time = request_time - current_time
                     if sleep_time > 0:
@@ -150,7 +151,6 @@ class LoadGenerator:
 
         for worker in self.workers:
             worker.status_queue.put(Status.WORKER_STOP)
-
 
     async def run(self, client: ModelServerClient) -> None:
         if self.num_workers > 0:

--- a/inference_perf/logger.py
+++ b/inference_perf/logger.py
@@ -1,0 +1,37 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+
+def setup_logging(level) -> None:
+    """
+    Setup logging configuration for inference_perf.
+
+    Args:
+        level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    """
+    numeric_level = getattr(logging, level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f'Invalid log level: {level}')
+
+    logging.basicConfig(
+        level=numeric_level,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=[
+            logging.StreamHandler(sys.stdout)
+        ],
+        force=True,
+    )

--- a/inference_perf/logger.py
+++ b/inference_perf/logger.py
@@ -25,13 +25,11 @@ def setup_logging(level: str) -> None:
     """
     numeric_level = getattr(logging, level.upper(), None)
     if not isinstance(numeric_level, int):
-        raise ValueError(f'Invalid log level: {level}')
+        raise ValueError(f"Invalid log level: {level}")
 
     logging.basicConfig(
         level=numeric_level,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=[
-            logging.StreamHandler(sys.stdout)
-        ],
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
         force=True,
     )

--- a/inference_perf/logger.py
+++ b/inference_perf/logger.py
@@ -16,7 +16,7 @@ import logging
 import sys
 
 
-def setup_logging(level) -> None:
+def setup_logging(level: str) -> None:
     """
     Setup logging configuration for inference_perf.
 

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -32,7 +32,11 @@ from inference_perf.datagen import (
 from inference_perf.client.modelserver import ModelServerClient, vLLMModelServerClient
 from inference_perf.client.metricsclient import MetricsClient, PerfRuntimeParameters, PrometheusMetricsClient
 from inference_perf.client.filestorage import StorageClient, GoogleCloudStorageClient
-from inference_perf.client.requestdatacollector import RequestDataCollector, LocalRequestDataCollector, MultiprocessRequestDataCollector
+from inference_perf.client.requestdatacollector import (
+    RequestDataCollector,
+    LocalRequestDataCollector,
+    MultiprocessRequestDataCollector,
+)
 from inference_perf.reportgen import ReportGenerator
 from inference_perf.utils import CustomTokenizer, ReportFile
 from inference_perf.logger import setup_logging
@@ -61,6 +65,7 @@ class InferencePerfRunner:
             await self.loadgen.run(self.client)
             if isinstance(collector, MultiprocessRequestDataCollector):
                 await collector.stop()
+
         asyncio.run(_run())
 
     def generate_reports(self, report_config: ReportConfig, runtime_parameters: PerfRuntimeParameters) -> List[ReportFile]:
@@ -78,8 +83,9 @@ def main_cli() -> None:
     # Parse command line arguments
     parser = ArgumentParser()
     parser.add_argument("-c", "--config_file", help="Config File", required=True)
-    parser.add_argument("--log-level", help="Logging level", default="INFO",
-                       choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+    parser.add_argument(
+        "--log-level", help="Logging level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    )
     args = parser.parse_args()
 
     setup_logging(args.log_level)
@@ -130,7 +136,7 @@ def main_cli() -> None:
                 model_name=config.server.model_name,
                 tokenizer=tokenizer,
                 ignore_eos=config.server.ignore_eos,
-                max_tcp_connections=config.load.worker_max_tcp_connections
+                max_tcp_connections=config.load.worker_max_tcp_connections,
             )
     else:
         raise Exception("model server client config missing")

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from argparse import ArgumentParser
 from typing import List, Optional
 from inference_perf.loadgen import LoadGenerator
 from inference_perf.config import (
@@ -34,6 +35,7 @@ from inference_perf.client.filestorage import StorageClient, GoogleCloudStorageC
 from inference_perf.client.requestdatacollector import RequestDataCollector, LocalRequestDataCollector, MultiprocessRequestDataCollector
 from inference_perf.reportgen import ReportGenerator
 from inference_perf.utils import CustomTokenizer, ReportFile
+from inference_perf.logger import setup_logging
 import asyncio
 import time
 
@@ -67,13 +69,21 @@ class InferencePerfRunner:
     def save_reports(self, reports: List[ReportFile]) -> None:
         for storage_client in self.storage_clients:
             storage_client.save_report(reports)
-    
+
     def stop(self) -> None:
         asyncio.run(self.loadgen.stop())
 
 
 def main_cli() -> None:
-    config = read_config()
+    # Parse command line arguments
+    parser = ArgumentParser()
+    parser.add_argument("-c", "--config_file", help="Config File", required=True)
+    parser.add_argument("--log-level", help="Logging level", default="INFO",
+                       choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+    args = parser.parse_args()
+
+    setup_logging(args.log_level)
+    config = read_config(args.config_file)
 
     # Define Metrics Client
     metrics_client: Optional[MetricsClient] = None

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -193,7 +193,9 @@ class ReportGenerator:
                 )
                 lifecycle_reports.append(report_file)
                 if report_file is not None:
-                    logger.info("Successfully saved stage %d report of request lifecycle metrics to %s", stage_id, report_file.path)
+                    logger.info(
+                        "Successfully saved stage %d report of request lifecycle metrics to %s", stage_id, report_file.path
+                    )
 
         if report_config.request_lifecycle.per_request:
             report_file = ReportFile(
@@ -255,7 +257,9 @@ class ReportGenerator:
                         contents=summarize_prometheus_metrics(collected_metrics).model_dump(),
                     )
                     if report_file is not None:
-                        logger.info("Successfully saved stage %d report of prometheus metrics to %s", stage_id, report_file.path)
+                        logger.info(
+                            "Successfully saved stage %d report of prometheus metrics to %s", stage_id, report_file.path
+                        )
                     prometheus_metrics_reports.append(report_file)
                 else:
                     logger.warning("No metrics collected for Stage %d", stage_id)

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -22,6 +22,9 @@ from inference_perf.utils import ReportFile
 from inference_perf.client.requestdatacollector import RequestDataCollector
 from inference_perf.apis import RequestLifecycleMetric
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def safe_float(value: Any) -> float:
@@ -165,7 +168,7 @@ class ReportGenerator:
     async def generate_reports(
         self, report_config: ReportConfig, runtime_parameters: PerfRuntimeParameters
     ) -> List[ReportFile]:
-        print("\n\nGenerating Reports ..")
+        logger.info("Generating Reports...")
         lifecycle_reports = []
         request_metrics = self.metrics_collector.get_metrics()
         if report_config.request_lifecycle.summary:
@@ -176,7 +179,7 @@ class ReportGenerator:
                 )
                 lifecycle_reports.append(report_file)
                 if report_file.path is not None:
-                    print(f"Successfully saved summary report of request lifecycle metrics to {report_file.path}")
+                    logger.info("Successfully saved summary report of request lifecycle metrics to %s", report_file.path)
 
         if report_config.request_lifecycle.per_stage:
             stage_buckets: dict[int, List[RequestLifecycleMetric]] = defaultdict(list)
@@ -190,7 +193,7 @@ class ReportGenerator:
                 )
                 lifecycle_reports.append(report_file)
                 if report_file is not None:
-                    print(f"Successfully saved stage {stage_id} report of request lifecycle metrics to {report_file.path}")
+                    logger.info("Successfully saved stage %d report of request lifecycle metrics to %s", stage_id, report_file.path)
 
         if report_config.request_lifecycle.per_request:
             report_file = ReportFile(
@@ -208,7 +211,7 @@ class ReportGenerator:
             )
             lifecycle_reports.append(report_file)
             if report_file is not None:
-                print(f"Successfully saved per request report of request lifecycle metrics to {report_file.path}")
+                logger.info("Successfully saved per request report of request lifecycle metrics to %s", report_file.path)
 
         lifecycle_reports.extend(self.generate_prometheus_metrics_report(runtime_parameters, report_config.prometheus))
         return lifecycle_reports
@@ -224,7 +227,7 @@ class ReportGenerator:
         prometheus_metrics_reports: List[ReportFile] = []
 
         if self.metrics_client is None or not isinstance(self.metrics_client, PrometheusMetricsClient):
-            print("Prometheus Metrics Client is not configured or not of type PrometheusMetricsClient")
+            logger.warning("Prometheus Metrics Client is not configured or not of type PrometheusMetricsClient")
             return prometheus_metrics_reports
 
         # Wait for Prometheus to collect metrics for the last stage
@@ -238,10 +241,10 @@ class ReportGenerator:
                     contents=summarize_prometheus_metrics(collected_metrics).model_dump(),
                 )
                 if report_file is not None:
-                    print(f"Successfully saved summary report of prometheus metrics to {report_file.path}")
+                    logger.info("Successfully saved summary report of prometheus metrics to %s", report_file.path)
                 prometheus_metrics_reports.append(report_file)
             else:
-                print("Report generation failed - no metrics collected by metrics client")
+                logger.warning("Report generation failed - no metrics collected by metrics client")
 
         if report_config.per_stage:
             for stage_id, _stage_info in runtime_parameters.stages.items():
@@ -252,9 +255,9 @@ class ReportGenerator:
                         contents=summarize_prometheus_metrics(collected_metrics).model_dump(),
                     )
                     if report_file is not None:
-                        print(f"Successfully saved stage {stage_id} report of prometheus metrics to {report_file.path}")
+                        logger.info("Successfully saved stage %d report of prometheus metrics to %s", stage_id, report_file.path)
                     prometheus_metrics_reports.append(report_file)
                 else:
-                    print(f"No metrics collected for Stage {stage_id}")
+                    logger.warning("No metrics collected for Stage %d", stage_id)
 
         return prometheus_metrics_reports

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import os
 
 def test_read_config() -> None:
     config_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "config.yml"))
-    config = read_config(["-c", config_path])
+    config = read_config(config_path)
 
     assert isinstance(config, Config)
     assert config.api.type == APIType.Chat

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -13,14 +13,14 @@ from inference_perf.logger import setup_logging
         ("CRITICAL", logging.CRITICAL),
     ],
 )
-def test_setup_logging_valid_levels(level, expected_level):
+def test_setup_logging_valid_levels(level: str, expected_level: int) -> None:
     """Test setup_logging with valid logging levels."""
     setup_logging(level)
     root_logger = logging.getLogger()
     assert root_logger.level == expected_level
 
 
-def test_setup_logging_invalid_level():
+def test_setup_logging_invalid_level() -> None:
     """Test setup_logging with an invalid logging level."""
     with pytest.raises(ValueError, match="Invalid log level: INVALID"):
         setup_logging("INVALID")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,26 @@
+import logging
+import pytest
+from inference_perf.logger import setup_logging
+
+
+@pytest.mark.parametrize(
+    "level,expected_level",
+    [
+        ("DEBUG", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("CRITICAL", logging.CRITICAL),
+    ],
+)
+def test_setup_logging_valid_levels(level, expected_level):
+    """Test setup_logging with valid logging levels."""
+    setup_logging(level)
+    root_logger = logging.getLogger()
+    assert root_logger.level == expected_level
+
+
+def test_setup_logging_invalid_level():
+    """Test setup_logging with an invalid logging level."""
+    with pytest.raises(ValueError, match="Invalid log level: INVALID"):
+        setup_logging("INVALID")


### PR DESCRIPTION
Resolves https://github.com/kubernetes-sigs/inference-perf/issues/48

Use logging methods with levels instead of print. Confirmed the make lint and make test passed locally.

<details><summary>Details</summary>

```console
$ git show HEAD | head -n 5
commit 5c98255215ce47e08a83a9079dd8671f2f0931e6
Author: Shotaro Kohama <khmshtr28@gmail.com>
Date:   Tue Jun 3 21:29:56 2025 -0700

    Replace print with logging with levels

$ make lint
Linting Python files with ruff check...
.venv/bin/ruff check
All checks passed!

$ make test | tail
configfile: pyproject.toml
testpaths: .
collected 10 items

tests/apis/test_chat.py .                                                [ 10%]
tests/apis/test_completion.py .                                          [ 20%]
tests/test_config.py ..                                                  [ 40%]
tests/test_logger.py ......                                              [100%]

============================== 10 passed in 1.26s ==============================
```

</details> 