### PR TITLE
Fix loadgen hang

### DIFF
--- a/inference_perf/client/requestdatacollector/multiprocess.py
+++ b/inference_perf/client/requestdatacollector/multiprocess.py
@@ -16,8 +16,11 @@ import multiprocessing as mp
 
 from asyncio import create_task, sleep
 from typing import List
+import logging
 from inference_perf.client.requestdatacollector import RequestDataCollector
 from inference_perf.apis import RequestLifecycleMetric
+
+logger = logging.getLogger(__name__)
 
 
 class MultiprocessRequestDataCollector(RequestDataCollector):
@@ -45,6 +48,7 @@ class MultiprocessRequestDataCollector(RequestDataCollector):
     async def stop(self) -> None:
         # Ensure that the collection queue is empty before joining
         while self.queue.qsize() > 0:
+            logger.debug(f"Collector waiting for empty request data queue, current size {self.queue.qsize()}")
             await sleep(1)
         self.queue.join()
 

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -34,7 +34,6 @@ class Status(Enum):
     UNKNOWN = auto()
     STAGE_END = auto()
     WORKER_STOP = auto()
-    ACK = auto()
 
 
 class Worker(mp.Process):
@@ -78,6 +77,7 @@ class Worker(mp.Process):
                 semaphore.release()
                 status = self.check_status()
                 if status is not None:
+                    logger.debug(f"[Worker {self.id}] received {status}, awaiting {len(tasks)} tasks")
                     await gather(*tasks)
                     tasks = []
                     self.status_queue.task_done()
@@ -139,16 +139,20 @@ class LoadGenerator:
             # Join on request queue to ensure that all workers have completed
             # their requests for the stage
             while request_queue.qsize() > 0:
+                logger.debug(f"Loadgen awaiting empty request queue, current size: {request_queue.qsize()}")
                 await sleep(1)
 
+            logger.debug("Loadgen sending STAGE_END to workers")
             for worker in self.workers:
                 worker.status_queue.put(Status.STAGE_END)
 
             for worker in self.workers:
                 while worker.status_queue.qsize() > 0:
+                    logger.debug(f"Loadgen waiting for worker {worker.id} to process STAGE_END")
                     await sleep(1)
                 worker.status_queue.join()
 
+            logger.debug("Loadgen joining request queue")
             request_queue.join()
             self.stage_runtime_info[stage_id] = StageRuntimeInfo(
                 stage_id=stage_id, start_time=start_time, end_time=time.time()

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -143,8 +143,8 @@ class LoadGenerator:
 
             for worker in self.workers:
                 worker.status_queue.put(Status.STAGE_END)
-            
-            for i, worker in enumerate(self.workers):
+
+            for worker in self.workers:
                 while worker.status_queue.qsize() > 0:
                     await sleep(1)
                 worker.status_queue.join()


### PR DESCRIPTION
Slower machines may cause starvation on request_queue join, causing loadgen to hang. This change reorders the STAGE_END signal and joins.

This ensures that workers gather tasks only after the full request queue is emptied for the stage.

The loadgen now joins the workers' status queues before joining the request_queue.