### PR TITLE
Add basic Helm Chart

### DIFF
--- a/deploy/inference-perf/.helmignore
+++ b/deploy/inference-perf/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/inference-perf/Chart.yaml
+++ b/deploy/inference-perf/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: inference-perf
+description: A Helm chart for running inference-perf benchmarking tool
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/inference-perf/README.md
+++ b/deploy/inference-perf/README.md
@@ -1,0 +1,11 @@
+## Run `inference-perf` via Helm Chart
+
+This guide explains how to deploy `inference-perf` to a Kubernetes cluster with Helm.
+
+### Setup
+
+Within the deploy/infernce-perf directory, edit the config.yaml and values.yaml to configure the Helm Chart and infernce-perf options.
+
+### Run
+
+Deploy locally via `helm install test .` optionally including the hfToken via `helm install test . --set hfToken=<token>`.

--- a/deploy/inference-perf/config.yaml
+++ b/deploy/inference-perf/config.yaml
@@ -1,0 +1,29 @@
+load:
+  type: constant
+  stages:
+  - rate: 1
+    duration: 30
+api: 
+  type: chat
+server:
+  type: vllm
+  model_name: HuggingFaceTB/SmolLM2-135M-Instruct
+  base_url: http://0.0.0.0:8000
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: HuggingFaceTB/SmolLM2-135M-Instruct
+data:
+  type: shareGPT
+metrics:
+  type: prometheus
+  prometheus:
+    url: http://localhost:9090
+    scrape_interval: 15
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: false
+  prometheus:
+    summary: true
+    per_stage: false

--- a/deploy/inference-perf/templates/_helpers.tpl
+++ b/deploy/inference-perf/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "inference-perf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "inference-perf.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "inference-perf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "inference-perf.labels" -}}
+helm.sh/chart: {{ include "inference-perf.chart" . }}
+{{ include "inference-perf.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "inference-perf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "inference-perf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common Secret Name for HuggingFace credentials
+*/}}
+{{- define "inference-perf.hfSecret" -}}
+{{ include "inference-perf.fullname" . }}-hf-secret
+{{- end -}}
+
+{{/*
+Common Secret Key for HuggingFace credentials
+*/}}
+{{- define "inference-perf.hfKey" -}}
+{{ include "inference-perf.fullname" . }}-hf-key
+{{- end -}}

--- a/deploy/inference-perf/templates/configmap.yaml
+++ b/deploy/inference-perf/templates/configmap.yaml
@@ -1,0 +1,10 @@
+# inference-perf/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "inference-perf.fullname" . }}-config
+  labels:
+    {{- include "inference-perf.labels" . | nindent 4 }}
+data:
+  {{ .Values.configMap.fileName }}: |
+    {{ .Files.Get .Values.configMap.fileName | nindent 4 }}

--- a/deploy/inference-perf/templates/job.yaml
+++ b/deploy/inference-perf/templates/job.yaml
@@ -1,0 +1,44 @@
+# inference-perf/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "inference-perf.fullname" . }}-job
+  labels:
+    {{- include "inference-perf.labels" . | nindent 4 }}
+    app: inference-perf
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "inference-perf.selectorLabels" . | nindent 8 }}
+        app: inference-perf
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: inference-perf-container
+          image: {{ .Values.job.image }}
+          command: ["inference-perf"]
+          args: 
+            - "--config_file"
+            - "{{ .Values.configMap.mountPath }}/{{ .Values.configMap.fileName }}"
+            - "--log-level"
+            - {{ .Values.logLevel }}
+          env:
+{{- if .Values.hfToken }}
+          - name: HF_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "inference-perf.hfSecret" . }}
+                key: {{ include "inference-perf.hfKey" . }}
+{{- end }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: {{ .Values.configMap.mountPath }}
+              readOnly: true
+          resources:
+            requests:
+              memory: {{ .Values.job.memory }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ include "inference-perf.fullname" . }}-config

--- a/deploy/inference-perf/templates/secret.yaml
+++ b/deploy/inference-perf/templates/secret.yaml
@@ -1,0 +1,12 @@
+# inference-perf/templates/secret.yaml
+{{- if .Values.hfToken }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "inference-perf.hfSecret" . }}
+  labels:
+    {{- include "inference-perf.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ include "inference-perf.hfKey" . }}: {{ .Values.hfToken | quote }}
+{{- end }}

--- a/deploy/inference-perf/values.yaml
+++ b/deploy/inference-perf/values.yaml
@@ -1,0 +1,15 @@
+# inference-perf/values.yaml
+job:
+  image: us-central1-docker.pkg.dev/gke-gkit-dev/ai-benchmark/inference-perf:latest
+  memory: "8G"
+
+configMap:
+  name: inference-perf-config
+  fileName: config.yaml
+  mountPath: /etc/config
+
+logLevel: INFO
+
+# hfToken optionally creates a secret with the specified token.
+# Can be set using helm install --set hftoken=<token>
+hfToken: ""


### PR DESCRIPTION
Creates a Helm Chart to deploy inference-perf as a job. #113 

```
$ helm install test .
NAME: test
LAST DEPLOYED: Thu Jun  5 22:55:01 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
$ helm list
NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
test    default         1               2025-06-05 22:55:01.956306722 +0000 UTC deployed        inference-perf-0.1.0    0.1.0      
$ k get jobs
NAME                      STATUS    COMPLETIONS   DURATION   AGE
test-inference-perf-job   Running   0/1           9s         9s
```