### PR TITLE
Add support for api_key #116

### DIFF
--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -17,7 +17,7 @@ from inference_perf.config import APIConfig, APIType
 from inference_perf.apis import InferenceAPIData, InferenceInfo, RequestLifecycleMetric, ErrorResponseInfo
 from inference_perf.utils import CustomTokenizer
 from .base import ModelServerClient, PrometheusMetricMetadata, ModelServerPrometheusMetric
-from typing import List
+from typing import List, Optional
 import aiohttp
 import json
 import time
@@ -33,6 +33,7 @@ class vLLMModelServerClient(ModelServerClient):
         tokenizer: CustomTokenizer,
         max_tcp_connections: int,
         ignore_eos: bool = True,
+        api_key: Optional[str] = None,
     ) -> None:
         super().__init__(api_config)
         self.model_name = model_name
@@ -42,6 +43,7 @@ class vLLMModelServerClient(ModelServerClient):
         self.tokenizer = tokenizer
         self.metrics_collector = metrics_collector
         self.max_tcp_connections = max_tcp_connections
+        self.api_key = api_key
 
         self.prometheus_metric_metadata: PrometheusMetricMetadata = {
             "avg_queue_length": ModelServerPrometheusMetric(
@@ -111,6 +113,9 @@ class vLLMModelServerClient(ModelServerClient):
             streaming=self.api_config.streaming,
         )
         headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
         async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=self.max_tcp_connections)) as session:
             start = time.monotonic()
             try:
@@ -163,3 +168,4 @@ class vLLMModelServerClient(ModelServerClient):
 
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         return self.prometheus_metric_metadata
+        

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -136,6 +136,7 @@ class ModelServerClientConfig(BaseModel):
     model_name: str
     base_url: str
     ignore_eos: bool = True
+    api_key: Optional[str] = None
 
 
 class CustomTokenizerConfig(BaseModel):

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -137,6 +137,7 @@ def main_cli() -> None:
                 tokenizer=tokenizer,
                 ignore_eos=config.server.ignore_eos,
                 max_tcp_connections=config.load.worker_max_tcp_connections,
+                api_key=config.server.api_key,
             )
     else:
         raise Exception("model server client config missing")


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Description

This pull request introduces API key authentication for the `vLLMClient`. This allows `inference-perf` to connect to vLLM server instances that are protected and [require an `Authorization` header](https://docs.vllm.ai/en/stable/getting_started/quickstart.html?h=vllm_api_key#openai-compatible-server) for requests.

## Changes Implemented

* **`inference_perf/client/modelserver/vllm_client.py`**:
    * The `__init__` method of `VLLMClient` has been updated to accept an optional `api_key` argument.
    * In the `process_request` method, an `Authorization` header with a Bearer token is now added to the request if an `api_key` was provided during client initialization.

* **`inference_perf/main.py`**:
    * The `VLLMClient` is now instantiated with the `api_key` from the server configuration (`config.server.api_key`), enabling the feature to be configured directly from the main config file.

This change is backward-compatible and will not affect connections to vLLM servers that do not require authentication.