### PR TITLE
fix: improve Docker build workflow with better secret handling and debugging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
           echo "TAG_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Show environment variables
+        if: ${{ env.DEBUG_MODE == 'true' }}
         run: |
           echo "=== Environment Variables ==="
           echo "GITHUB_REF: $GITHUB_REF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,28 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: quay.io/${{ secrets.QUAY_USERNAME }}/inference-perf
-          tags: |
-            type=raw,value=${{ github.ref_name }},enable=true
-            type=raw,value=latest,enable=true
+      - name: Set image name and tags
+        run: |
+          echo "IMAGE_NAME=quay.io/${{ secrets.QUAY_USERNAME }}/inference-perf" >> $GITHUB_ENV
+          echo "TAG_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+
+      - name: Show environment variables
+        run: |
+          echo "=== Environment Variables ==="
+          echo "GITHUB_REF: $GITHUB_REF"
+          echo "GITHUB_REF_NAME: $GITHUB_REF_NAME"
+          echo "IMAGE_NAME: $IMAGE_NAME"
+          echo "TAG_VERSION: $TAG_VERSION"
+          echo "GITHUB_SHA: $GITHUB_SHA"
+          echo "GITHUB_REPOSITORY: $GITHUB_REPOSITORY"
+          echo "GITHUB_SERVER_URL: $GITHUB_SERVER_URL"
+          echo "============================="
+
+      - name: Debug image configuration
+        run: |
+          echo "Image name: ${{ env.IMAGE_NAME }}"
+          echo "Tag version: ${{ env.TAG_VERSION }}"
+          echo "Full tags: ${{ env.IMAGE_NAME }}:${{ env.TAG_VERSION }}, ${{ env.IMAGE_NAME }}:latest"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -69,7 +83,16 @@ jobs:
           context: .
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.TAG_VERSION }}
+            ${{ env.IMAGE_NAME }}:latest
+          labels: |
+            org.opencontainers.image.title=inference-perf
+            org.opencontainers.image.description=GenAI inference performance benchmarking tool
+            org.opencontainers.image.version=${{ env.TAG_VERSION }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.licenses=Apache-2.0
           cache-from: type=gha
           cache-to: type=gha,mode=max 


### PR DESCRIPTION
## Changes

This PR fixes the Docker build workflow issue where the image tag was showing as 'quay.io/***/inference-perf' instead of the proper username.

### Key Changes:
- Remove `docker/metadata-action@v5` to avoid secret substitution issues
- Set image name and tags as environment variables first, then use them directly
- Add comprehensive debugging output for environment variables
- Directly specify Docker tags and labels in build action
- Add validation and debug steps for better troubleshooting

### Testing:
- The workflow now shows all environment variables for debugging
- Docker tags are constructed directly from environment variables
- This should resolve the 'invalid reference format' error

### Related Issue:
Fixes the Docker build error: 'invalid tag \"quay.io/***/inference-perf:v0.1.0\": invalid reference format'"
Fix #119 