### PR TITLE
Support for running inference-perf offline

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -38,7 +38,7 @@ Configures the test data generation methodology:
 data:
   type: mock|shareGPT|synthetic|random|shared_prefix  # Data generation type
   mode: offline|online                                # For shareGPT type, whether Dataset is offline or online, default mode is online
-  dataset_path: ./data/sharegpt/ShareGPT_V3_unfiltered_cleaned_split.json # For shareGPT type in offline mode, path where dataset to be used is present
+  path: ./data/shareGPT/ShareGPT_V3_unfiltered_cleaned_split.json # For shareGPT type in offline mode, path where dataset to be used is present
   input_distribution:                                 # For synthetic/random types
     min: 10                                           # Minimum prompt length (tokens)
     max: 100                                          # Maximum prompt length
@@ -233,7 +233,7 @@ tokenizer:
 data:
   type: shareGPT
   mode: offline # mode is used to specify if the shareGPT dataset is online or offline
-  dataset_path: ./data/shareGPT # dataset_path is used to specify the path to the shareGPT dataset if mode is offline
+  path: ./data/shareGPT/ShareGPT_V3_unfiltered_cleaned_split.json # path to the downloaded shareGPT dataset if mode is offline
 metrics:
   type: prometheus
   prometheus:

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -37,6 +37,8 @@ Configures the test data generation methodology:
 ```yaml
 data:
   type: mock|shareGPT|synthetic|random|shared_prefix  # Data generation type
+  mode: offline|online                                # For shareGPT type, whether Dataset is offline or online, default mode is online
+  dataset_path: ./data/sharegpt/ShareGPT_V3_unfiltered_cleaned_split.json # For shareGPT type in offline mode, path where dataset to be used is present
   input_distribution:                                 # For synthetic/random types
     min: 10                                           # Minimum prompt length (tokens)
     max: 100                                          # Maximum prompt length

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -37,8 +37,7 @@ Configures the test data generation methodology:
 ```yaml
 data:
   type: mock|shareGPT|synthetic|random|shared_prefix  # Data generation type
-  mode: offline|online                                # For shareGPT type, whether Dataset is offline or online, default mode is online
-  path: ./data/shareGPT/ShareGPT_V3_unfiltered_cleaned_split.json # For shareGPT type in offline mode, path where dataset to be used is present
+  path: ./data/shareGPT/ShareGPT_V3_unfiltered_cleaned_split.json # For shareGPT type, path where dataset to be used is present
   input_distribution:                                 # For synthetic/random types
     min: 10                                           # Minimum prompt length (tokens)
     max: 100                                          # Maximum prompt length
@@ -232,8 +231,7 @@ tokenizer:
   pretrained_model_name_or_path: ./models/SmolLM2-135M-Instruct
 data:
   type: shareGPT
-  mode: offline # mode is used to specify if the shareGPT dataset is online or offline
-  path: ./data/shareGPT/ShareGPT_V3_unfiltered_cleaned_split.json # path to the downloaded shareGPT dataset if mode is offline
+  path: ./data/shareGPT/ShareGPT_V3_unfiltered_cleaned_split.json # path to the downloaded shareGPT dataset
 metrics:
   type: prometheus
   prometheus:

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -208,4 +208,43 @@ report:
     summary: true
     per_stage: true
     per_request: true
+  prometheus:
+    summary: true
+    per_stage: true
+```
+
+### To Run Inference Perf Offline
+
+```yaml
+load:
+  type: constant
+  stages:
+  - rate: 1
+    duration: 30
+api: 
+  type: chat
+server:
+  type: vllm
+  model_name: ./models/SmolLM2-135M-Instruct
+  base_url: http://0.0.0.0:8000
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: ./models/SmolLM2-135M-Instruct
+data:
+  type: shareGPT
+  mode: offline # mode is used to specify if the shareGPT dataset is online or offline
+  dataset_path: ./data/shareGPT # dataset_path is used to specify the path to the shareGPT dataset if mode is offline
+metrics:
+  type: prometheus
+  prometheus:
+    url: http://localhost:9090
+    scrape_interval: 15
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: false
+  prometheus:
+    summary: true
+    per_stage: true
 ```

--- a/inference_perf/client/filestorage/s3.py
+++ b/inference_perf/client/filestorage/s3.py
@@ -29,7 +29,6 @@ class SimpleStorageServiceClient(StorageClient):
         self.output_bucket = config.bucket_name
         self.client = boto3.client("s3")
 
-
     def save_report(self, reports: List[ReportFile]) -> None:
         filenames = [report.get_filename() for report in reports]
         if len(filenames) != len(set(filenames)):
@@ -37,22 +36,24 @@ class SimpleStorageServiceClient(StorageClient):
 
         for _, report in enumerate(reports):
             filename = report.get_filename()
-            blob_path = f"{self.config.path if self.config.path else ''}/{self.config.report_file_prefix if self.config.report_file_prefix else ''}{filename}".lstrip('/') # remove any leading slahes
+            blob_path = f"{self.config.path if self.config.path else ''}/{self.config.report_file_prefix if self.config.report_file_prefix else ''}{filename}".lstrip(
+                "/"
+            )  # remove any leading slahes
             try:
                 try:
                     self.client.head_object(Bucket=self.output_bucket, Key=blob_path)
                     logger.info(f"Skipping upload: s3://{self.output_bucket}/{blob_path} already exists")
                     continue
                 except self.client.exceptions.ClientError as e:
-                    if e.response['Error']['Code'] == '404':
+                    if e.response["Error"]["Code"] == "404":
                         pass
-                
+
                 # Upload the files
                 self.client.put_object(
-                    Bucket = self.output_bucket,
-                    Key = blob_path,
-                    Body = json.dumps(report.get_contents()),
-                    ContentType = "application/json"
+                    Bucket=self.output_bucket,
+                    Key=blob_path,
+                    Body=json.dumps(report.get_contents()),
+                    ContentType="application/json",
                 )
                 logger.info(f"Uploaded s3://{self.output_bucket}/{blob_path}")
             except Exception as e:

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -67,7 +67,7 @@ class DataConfig(BaseModel):
 
     # Valid only for shareGPT type at this moment
     mode: Optional[DataMode] = DataMode.Online  # mode is used to specify if the shareGPT dataset is online or offline
-    dataset_path: Optional[str] = None # dataset_path is used to specify the path to the shareGPT dataset if mode is offline
+    path: Optional[str] = None # path to the downloaded shareGPT dataset if mode is offline
     
     # Distributions are only supported for synthetic/random dataset at this moment
     input_distribution: Optional[Distribution] = None

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -38,12 +38,6 @@ class DataGenType(Enum):
     SharedPrefix = "shared_prefix"
 
 
-# DataMode is used to specify if the dataset is online or offline for shareGPT
-class DataMode(Enum):
-    Online = "online"
-    Offline = "offline"
-
-
 # Represents the distribution for input prompts and output generations.
 class Distribution(BaseModel):
     min: int = 10
@@ -66,8 +60,7 @@ class DataConfig(BaseModel):
     type: DataGenType = DataGenType.Mock
 
     # Valid only for shareGPT type at this moment
-    mode: Optional[DataMode] = DataMode.Online  # mode is used to specify if the shareGPT dataset is online or offline
-    path: Optional[str] = None # path to the downloaded shareGPT dataset if mode is offline
+    path: Optional[str] = None # path to the downloaded shareGPT dataset
     
     # Distributions are only supported for synthetic/random dataset at this moment
     input_distribution: Optional[Distribution] = None

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -38,6 +38,12 @@ class DataGenType(Enum):
     SharedPrefix = "shared_prefix"
 
 
+# DataMode is used to specify if the dataset is online or offline for shareGPT
+class DataMode(Enum):
+    Online = "online"
+    Offline = "offline"
+
+
 # Represents the distribution for input prompts and output generations.
 class Distribution(BaseModel):
     min: int = 10
@@ -58,6 +64,11 @@ class SharedPrefix(BaseModel):
 
 class DataConfig(BaseModel):
     type: DataGenType = DataGenType.Mock
+
+    # Valid only for shareGPT type at this moment
+    mode: Optional[DataMode] = DataMode.Online  # mode is used to specify if the shareGPT dataset is online or offline
+    dataset_path: Optional[str] = None # dataset_path is used to specify the path to the shareGPT dataset if mode is offline
+    
     # Distributions are only supported for synthetic/random dataset at this moment
     input_distribution: Optional[Distribution] = None
     output_distribution: Optional[Distribution] = None

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -60,8 +60,8 @@ class DataConfig(BaseModel):
     type: DataGenType = DataGenType.Mock
 
     # Valid only for shareGPT type at this moment
-    path: Optional[str] = None # path to the downloaded shareGPT dataset
-    
+    path: Optional[str] = None  # path to the downloaded shareGPT dataset
+
     # Distributions are only supported for synthetic/random dataset at this moment
     input_distribution: Optional[Distribution] = None
     output_distribution: Optional[Distribution] = None
@@ -104,8 +104,10 @@ class StorageConfigBase(BaseModel):
 class GoogleCloudStorageConfig(StorageConfigBase):
     bucket_name: str
 
+
 class SimpleStorageServiceConfig(StorageConfigBase):
     bucket_name: str
+
 
 class StorageConfig(BaseModel):
     local_storage: StorageConfigBase = StorageConfigBase()

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -15,9 +15,10 @@ import logging
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
-from inference_perf.config import APIConfig, APIType, DataConfig
+from inference_perf.config import APIConfig, APIType, DataConfig, DataMode
 from typing import Generator, List
 from datasets import load_dataset
+import os
 
 logger = logging.getLogger(__name__)
 

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -28,11 +28,11 @@ class HFShareGPTDataGenerator(DataGenerator):
         super().__init__(api_config, config, tokenizer)
 
         if config.mode == DataMode.Offline:
-            if config.dataset_path is None:
-                raise ValueError("dataset_path is required for offline mode")
+            if config.path is None:
+                raise ValueError("path is required for offline mode")
             self.sharegpt_dataset = iter(
                 self.load_offline_dataset(
-                    config.dataset_path, 
+                    config.path, 
                     streaming=True, 
                     split="train",
                 )
@@ -106,13 +106,13 @@ class HFShareGPTDataGenerator(DataGenerator):
     def is_shared_prefix_supported(self) -> bool:
         return False
 
-    def load_offline_dataset(self, dataset_path: str, streaming: bool, split: str) -> None:
+    def load_offline_dataset(self, path: str, streaming: bool, split: str) -> None:
         # depending on whether the dataset is a single file or a directory, we need to load it differently
         # TODO: add support for other file types
-        if os.path.isfile(dataset_path):
-            return load_dataset("json", data_files=dataset_path, streaming=streaming, split=split)
-        elif os.path.isdir(dataset_path):
-            json_files = [f for f in os.listdir(dataset_path) if f.endswith('.json')]
+        if os.path.isfile(path):
+            return load_dataset("json", data_files=path, streaming=streaming, split=split)
+        elif os.path.isdir(path):
+            json_files = [f for f in os.listdir(path) if f.endswith('.json')]
             return load_dataset("json", data_files=json_files, streaming=streaming, split=split)
         else:
-            raise ValueError(f"Invalid dataset path: {dataset_path}")
+            raise ValueError(f"Invalid dataset path: {path}")

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -15,7 +15,7 @@ import logging
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
-from inference_perf.config import APIConfig, APIType, DataConfig, DataMode
+from inference_perf.config import APIConfig, APIType, DataConfig
 from typing import Generator, List
 from datasets import load_dataset
 import os
@@ -27,9 +27,11 @@ class HFShareGPTDataGenerator(DataGenerator):
     def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: CustomTokenizer) -> None:
         super().__init__(api_config, config, tokenizer)
 
-        if config.mode == DataMode.Offline:
-            if config.path is None:
-                raise ValueError("path is required for offline mode")
+        if config.path is not None:
+            # check if the path is valid
+            if not os.path.exists(config.path):
+                raise ValueError(f"Invalid dataset path: {config.path}. Path does not exist.")
+
             self.sharegpt_dataset = iter(
                 self.load_offline_dataset(
                     config.path, 

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -33,7 +33,12 @@ from inference_perf.datagen import (
 from inference_perf.client.modelserver import ModelServerClient, vLLMModelServerClient
 from inference_perf.client.metricsclient.base import MetricsClient, PerfRuntimeParameters
 from inference_perf.client.metricsclient.prometheus_client import PrometheusMetricsClient, GoogleManagedPrometheusMetricsClient
-from inference_perf.client.filestorage import StorageClient, GoogleCloudStorageClient, LocalStorageClient, SimpleStorageServiceClient
+from inference_perf.client.filestorage import (
+    StorageClient,
+    GoogleCloudStorageClient,
+    LocalStorageClient,
+    SimpleStorageServiceClient,
+)
 from inference_perf.client.requestdatacollector import (
     RequestDataCollector,
     LocalRequestDataCollector,
@@ -119,7 +124,7 @@ def main_cli() -> None:
         if config.storage.google_cloud_storage:
             storage_clients.append(GoogleCloudStorageClient(config=config.storage.google_cloud_storage))
         if config.storage.simple_storage_service:
-            storage_clients.append(SimpleStorageServiceClient(config=config.storage.simple_storage_service))            
+            storage_clients.append(SimpleStorageServiceClient(config=config.storage.simple_storage_service))
 
     # Define Report Generator
     collector: RequestDataCollector


### PR DESCRIPTION
This PR adds support for running inference-perf offline. 
Fixes https://github.com/kubernetes-sigs/inference-perf/issues/138 & https://github.com/kubernetes-sigs/inference-perf/issues/127

### Changes:
Added the following config params for data.type=shareGPT:
```
data:
  type: shareGPT
  path: ./data/shareGPT # path to the downloaded shareGPT dataset
```

### To run inference-perf in offline mode:
1. Update server.model_name, tokenizer.pretrained_model_name_or_path with the location of your downloaded model.
2. Set data.path with the location of your downloaded dataset. If data.path is empty, download the dataset from huggingface.

This PR also fixes linting errors in `inference_perf/client/filestorage/s3.py`, `inference_perf/main.py`. There are a few other validation error that cause pre-commit hook to fail. Will raise a separate PR to fix them. 