### PR TITLE
[DRAFT] feat: Add Python package publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,48 @@ jobs:
           
           `${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}`
 
+          ## Python Package
+          
+          `pip install inference-perf==${{ env.RELEASE_VERSION }}`
+
           ## Contributors
           
           ${{ steps.github_release.outputs.contributors }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  python-package:
+    needs: build-and-publish  # Run after the release is created
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build twine
+
+      - name: Update version in pyproject.toml
+        run: |
+          # Extract version from tag (remove 'v' prefix)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Updating version to: $VERSION"
+          # Use sed to update the version in pyproject.toml
+          sed -i 's/version = ".*"/version = "'$VERSION'"/' pyproject.toml
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish package to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*
 
   docker:
     needs: build-and-publish  # Run after the release is created


### PR DESCRIPTION
## 🎯 Summary

This PR adds automatic Python package publishing to PyPI as part of our release workflow, following the official [Python Packaging tutorial](https://packaging.python.org/en/latest/tutorials/packaging-projects/).

## 🚧 **DRAFT STATUS**

This PR is currently in **DRAFT** status pending the setup of the required `PYPI_API_TOKEN` secret. 

**⚠️ DO NOT MERGE** until the PyPI API token has been configured in the repository secrets.

## 🔧 Required Setup Before Merging

Following the [official tutorial steps](https://packaging.python.org/en/latest/tutorials/packaging-projects/#uploading-the-distribution-archives):

1. **Register/Login to PyPI**: https://pypi.org/account/register/
2. **Create API Token**: 
   - Go to https://pypi.org/manage/account/#api-tokens
   - Create new token with "Entire account" scope
   - ⚠️ **Save the token immediately** (you won't see it again!)
3. **Add GitHub Secret**:
   - Repository Settings → Secrets and variables → Actions
   - Add new secret: `PYPI_API_TOKEN`
   - Value: Your PyPI API token (including the `pypi-` prefix)

## ✨ Changes Made

### 🆕 New Features
- **Python package publishing**: Automatically builds and publishes to PyPI on releases
- **Version synchronization**: Git tags (e.g., `v1.2.3`) automatically update `pyproject.toml` version to `1.2.3`
- **Parallel execution**: Python packaging runs alongside Docker image building
- **Enhanced release notes**: Now include pip install instructions

### 🔄 Workflow Updates
- Added new `python-package` job to `.github/workflows/release.yml`
- Uses official Python packaging tools: `build` and `twine`
- Follows PyPA best practices for CI/CD publishing

### 📦 Package Details
Our `pyproject.toml` was already properly configured with:
- ✅ Project metadata and dependencies
- ✅ Setuptools build backend
- ✅ CLI entry point (`inference-perf` command)
- ✅ Proper package structure

## 🚀 How It Works (After Setup)

1. **Create release tag**: `git tag v1.0.0 && git push origin v1.0.0`
2. **Automatic workflow**:
   - 📝 Creates GitHub release with changelog
   - 🐳 Builds and pushes Docker image to Quay.io
   - 🐍 **NEW**: Builds and publishes Python package to PyPI
3. **Users can install**: `pip install inference-perf==1.0.0`

## 🧪 Testing Plan

For testing before going live:
1. Set up TestPyPI account and token
2. Add `TEST_PYPI_API_TOKEN` secret
3. Create test workflow targeting TestPyPI
4. Verify package builds and uploads correctly

## 📚 References

- [Python Packaging Tutorial](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
- [PyPI API Tokens](https://packaging.python.org/en/latest/tutorials/packaging-projects/#uploading-the-distribution-archives)
- [GitHub Actions for Python Publishing](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)

## ✅ Ready to Merge When

- [ ] `PYPI_API_TOKEN` secret configured in repository
- [ ] Package name `inference-perf` verified as available on PyPI
- [ ] CI/CD permissions reviewed and approved
- [ ] Testing completed (optional: test with TestPyPI first)

---

**🎉 After merging**: Our releases will automatically publish both Docker images AND Python packages, making `inference-perf` installable via `pip install inference-perf`!