### PR TITLE
Defer InferenceAPIData gen to worker procs

### DIFF
--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -91,7 +91,7 @@ class LoadConfig(BaseModel):
     type: LoadType = LoadType.CONSTANT
     interval: float = 1.0
     stages: List[LoadStage] = []
-    num_workers: int = max(1, cpu_count() // 2)  # type: ignore
+    num_workers: int = max(1, cpu_count())  # type: ignore
     worker_max_concurrency: int = 10
     worker_max_tcp_connections: int = 2500
 

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -92,7 +92,7 @@ class LoadConfig(BaseModel):
     interval: float = 1.0
     stages: List[LoadStage] = []
     num_workers: int = max(1, cpu_count())  # type: ignore
-    worker_max_concurrency: int = 10
+    worker_max_concurrency: int = 100
     worker_max_tcp_connections: int = 2500
 
 

--- a/inference_perf/datagen/base.py
+++ b/inference_perf/datagen/base.py
@@ -58,6 +58,10 @@ class DataGenerator(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_request(self, n: int) -> InferenceAPIData:
+        raise NotImplementedError
+
+    @abstractmethod
     def is_io_distribution_supported(self) -> bool:
         raise NotImplementedError
 

--- a/inference_perf/datagen/base.py
+++ b/inference_perf/datagen/base.py
@@ -58,10 +58,6 @@ class DataGenerator(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_request(self, n: int) -> InferenceAPIData:
-        raise NotImplementedError
-
-    @abstractmethod
     def is_io_distribution_supported(self) -> bool:
         raise NotImplementedError
 

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -80,6 +80,17 @@ class RandomDataGenerator(DataGenerator):
     def is_shared_prefix_supported(self) -> bool:
         return False
 
+    def get_request(self, n: int) -> InferenceAPIData:
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for RandomDataGenerator")
+
+        if self.api_config.type == APIType.Completion:
+            tokens = np.random.randint(0, self.vocab_size, size=self.input_lengths[n], dtype=np.int64)
+            prompt_text = self.tokenizer.get_tokenizer().decode(tokens.tolist())
+            return CompletionAPIData(prompt=prompt_text, max_tokens=self.output_lengths[n])
+        else:
+            raise Exception("Unsupported API type")
+
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         i = 0
 

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -56,6 +56,10 @@ class SharedPrefixDataGenerator(DataGenerator):
     def is_shared_prefix_supported(self) -> bool:
         return True
 
+    def get_request(self, n: int) -> InferenceAPIData:
+        i = n % len(self.prompts)
+        return CompletionAPIData(prompt=self.prompts[i], max_tokens=self.output_len)
+
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         if not self.prompts:
             return

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -55,6 +55,18 @@ class SyntheticDataGenerator(DataGenerator):
     def is_shared_prefix_supported(self) -> bool:
         return False
 
+    def get_request(self, n: int) -> InferenceAPIData:
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for SyntheticDataGenerator")
+
+        if self.api_config.type == APIType.Completion:
+            return CompletionAPIData(
+                prompt=self.tokenizer.get_tokenizer().decode(self.token_ids[: self.input_lengths[n]]),
+                max_tokens=self.output_lengths[n]
+            )
+        else:
+            raise Exception("Unsupported API type")
+
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         i = 0
         while True:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 from pydantic import BaseModel
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer
-from inference_perf.datagen import DataGenerator, HFShareGPTDataGenerator
+from inference_perf.datagen import DataGenerator
 from inference_perf.apis import InferenceAPIData
 from inference_perf.client.modelserver import ModelServerClient
 from inference_perf.config import LoadType, LoadConfig
-from asyncio import Semaphore, TaskGroup, create_task, gather, run, sleep
+from asyncio import Semaphore, TaskGroup, create_task, gather, run, sleep, set_event_loop_policy
 from enum import Enum, auto
 from typing import List, Union, Tuple, TypeAlias
 import time
 import multiprocessing as mp
 import logging
-import random
+import uvloop
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,14 @@ class Status(Enum):
 
 
 class Worker(mp.Process):
-    def __init__(self, id: int, client: ModelServerClient, request_queue: mp.Queue, datagen: DataGenerator, max_concurrency: int):  # type: ignore[type-arg]
+    def __init__(
+        self,
+        id: int,
+        client: ModelServerClient,
+        request_queue: mp.Queue,  # type: ignore[type-arg]
+        datagen: DataGenerator,
+        max_concurrency: int,
+    ):
         super().__init__()
         self.id = id
         self.client = client
@@ -57,16 +64,17 @@ class Worker(mp.Process):
         semaphore = Semaphore(self.max_concurrency)
         tasks = []
 
-        # Force an early gather for the worker.
-        # This causes workers to send and offset their queue processing from eachother
-        first_jitter = True
-        jitter_at_request = random.randint(1, 4)
         while True:
             try:
                 await semaphore.acquire()
                 item = self.request_queue.get_nowait()
 
-                async def schedule_client(queue: mp.Queue, request_data: InferenceAPIData, request_time: float, stage_id: int) -> None:  # type: ignore[type-arg]
+                async def schedule_client(
+                    queue: mp.Queue,  # type: ignore[type-arg]
+                    request_data: InferenceAPIData,
+                    request_time: float,
+                    stage_id: int,
+                ) -> None:
                     current_time = time.perf_counter()
                     sleep_time = request_time - current_time
                     if sleep_time > 0:
@@ -81,14 +89,12 @@ class Worker(mp.Process):
                 request_data = self.datagen.get_request(request) if isinstance(request, int) else request
                 task = create_task(schedule_client(self.request_queue, request_data, request_time, stage_id))
                 tasks.append(task)
-
-                if first_jitter and len(tasks) >= jitter_at_request:
-                    first_jitter = False
-                    await gather(*tasks)
-                    tasks = []
+                await sleep(0)
             except mp.queues.Empty:
                 semaphore.release()
                 status = self.check_status()
+                if status is None:
+                    await sleep(0)
                 if status is not None:
                     logger.debug(f"[Worker {self.id}] received {status}, awaiting {len(tasks)} tasks")
                     await gather(*tasks)
@@ -100,6 +106,7 @@ class Worker(mp.Process):
                     break
 
     def run(self) -> None:
+        set_event_loop_policy(uvloop.EventLoopPolicy())
         run(self.loop())
 
 
@@ -121,10 +128,10 @@ class LoadGenerator:
         self.workers: List[Worker] = []
         self.worker_max_concurrency = load_config.worker_max_concurrency
 
-    def get_timer(self, rate: float) -> LoadTimer:
+    def get_timer(self, rate: float, duration: float) -> LoadTimer:
         if self.load_type == LoadType.POISSON:
-            return PoissonLoadTimer(rate=rate)
-        return ConstantLoadTimer(rate=rate)
+            return PoissonLoadTimer(rate=rate, duration=duration)
+        return ConstantLoadTimer(rate=rate, duration=duration)
 
     async def mp_run(self, client: ModelServerClient) -> None:
         request_queue: mp.Queue[RequestQueueData] = mp.JoinableQueue()
@@ -135,27 +142,26 @@ class LoadGenerator:
 
         for stage_id, stage in enumerate(self.stages):
             logger.info("Stage %d - run started", stage_id)
-            timer = self.get_timer(stage.rate)
+            timer = self.get_timer(stage.rate, stage.duration)
 
             # Allow generation a second to begin populating the queue so the workers
             # don't miss the initial scheuled request times
             start_time_epoch = time.time()
             start_time = time.perf_counter() + 1
             num_requests = int(stage.rate * stage.duration)
+            start_time_epoch = time.time()
 
-            if hasattr(self.datagen, 'get_request'):
+            time_generator = timer.start_timer(start_time)
+            if hasattr(self.datagen, "get_request"):
                 # Datagen supports deferring to workers, enqueue request number
                 for request_number in range(num_requests):
-                    request_time = next(timer.start_timer(start_time))
+                    request_time = next(time_generator)
                     request_queue.put((stage_id, request_number, request_time))
             else:
                 # Datagen requires queueing request_data
-                for request_number, (request_data, request_time) in enumerate(
-                    zip(self.datagen.get_data(), timer.start_timer(start_time), strict=True)
-                ):
-                    if request_number >= num_requests:
-                        break
-                    request_queue.put((stage_id, request_data, request_time))
+                data_generator = self.datagen.get_data()
+                for _ in range(num_requests):
+                    request_queue.put((stage_id, next(data_generator), next(time_generator)))
 
             await sleep(start_time + stage.duration - time.perf_counter())
 
@@ -192,15 +198,14 @@ class LoadGenerator:
             return await self.mp_run(client)
 
         for stage_id, stage in enumerate(self.stages):
-            timer = self.get_timer(stage.rate)
+            timer = self.get_timer(stage.rate, stage.duration)
             start_time_epoch = time.time()
             start_time = time.perf_counter()
             end_time = start_time + stage.duration
             logger.info("Stage %d - run started", stage_id)
             async with TaskGroup() as tg:
-                for _, (data, time_index) in enumerate(
-                    zip(self.datagen.get_data(), timer.start_timer(start_time), strict=True)
-                ):
+                time_generator = timer.start_timer(start_time)
+                for _, (data, time_index) in enumerate(zip(self.datagen.get_data(), time_generator, strict=True)):
                     now = time.perf_counter()
                     if time_index < end_time and now < end_time:
                         if time_index > now:

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "lint", "test", "types"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:913ff09fd0299f44d12f4af8a1a4eec4b2fa5f7e6cdd8119cbd1742b2342f8f4"
+content_hash = "sha256:79b41f19c10132fe42e1d316ef40498f79427e12bbdb8fe921b5a46b53d654e0"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -1869,6 +1869,28 @@ groups = ["default", "types"]
 files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
+]
+
+[[package]]
+name = "uvloop"
+version = "0.21.0"
+requires_python = ">=3.8.0"
+summary = "Fast implementation of asyncio event loop on top of libuv"
+groups = ["default"]
+files = [
+    {file = "uvloop-0.21.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:359ec2c888397b9e592a889c4d72ba3d6befba8b2bb01743f72fffbde663b59c"},
+    {file = "uvloop-0.21.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f7089d2dc73179ce5ac255bdf37c236a9f914b264825fdaacaded6990a7fb4c2"},
+    {file = "uvloop-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baa4dcdbd9ae0a372f2167a207cd98c9f9a1ea1188a8a526431eef2f8116cc8d"},
+    {file = "uvloop-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86975dca1c773a2c9864f4c52c5a55631038e387b47eaf56210f873887b6c8dc"},
+    {file = "uvloop-0.21.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:461d9ae6660fbbafedd07559c6a2e57cd553b34b0065b6550685f6653a98c1cb"},
+    {file = "uvloop-0.21.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:183aef7c8730e54c9a3ee3227464daed66e37ba13040bb3f350bc2ddc040f22f"},
+    {file = "uvloop-0.21.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bfd55dfcc2a512316e65f16e503e9e450cab148ef11df4e4e679b5e8253a5281"},
+    {file = "uvloop-0.21.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787ae31ad8a2856fc4e7c095341cccc7209bd657d0e71ad0dc2ea83c4a6fa8af"},
+    {file = "uvloop-0.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ee4d4ef48036ff6e5cfffb09dd192c7a5027153948d85b8da7ff705065bacc6"},
+    {file = "uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816"},
+    {file = "uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc"},
+    {file = "uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553"},
+    {file = "uvloop-0.21.0.tar.gz", hash = "sha256:3bf12b0fda68447806a7ad847bfa591613177275d35b6724b1ee573faa3704e3"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "google-cloud-storage>=3.1.0",
     "pyyaml>=6.0.2",
     "boto3>=1.39.0",
+    "uvloop>=0.21.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary ##

Loadgen architecture performance improvements (and qps accuracy improvements).
Achieves > 10k qps in some cases (large machine, random/synthetic/shared_prefix datasets, low request latency).
Improved schedule accuracy in low qps scenarios.

Fixes #188 

## Changes ##
- Updates default num_wokers == num_cpus
- Updates default worker_max_concurrency to 100
- Sharegpt remains using the old path, a later PR can support preprocessing the dataset (~100s latency vs 6s for current streaming method). Preprocessing is only really useful for > 1000qps.
- Use uvloop in worker processes for drop in event loop improvement.
- Adds sleep(0) in worker loop to yield event loop

## Future Recommendations ##

- Automated load testing #40 
- Configurable HF datagen preprocessing to support deferring get_request to workers #191 
- Enforce worker scheduling strategy like round robin to disperse requests across processes.

## Testing Done ##

Later comments show acceptable scheduling accuracy conformance for:
- High qps against low latency server
- low qps against real vllm llama3-8b deployment
- sharegpt low qps against llama3-8b deployment

Also profiling and vllm metric comparison in #188 
