### PR TITLE
fix: only assign tokenizer to model_name when not configured

### DIFF
--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -61,9 +61,9 @@ class vLLMModelServerClient(ModelServerClient):
         else:
             self.model_name = model_name
 
-        if tokenizer_config:
+        if tokenizer_config and not tokenizer_config.pretrained_model_name_or_path:
             tokenizer_config.pretrained_model_name_or_path = self.model_name
-        else:
+        elif not tokenizer_config:
             tokenizer_config = CustomTokenizerConfig(pretrained_model_name_or_path=self.model_name)
         self.tokenizer = CustomTokenizer(tokenizer_config)
 


### PR DESCRIPTION
The original code sets tokenizer model name to model_name in every situation which makes `pretrained_model_name_or_path` in `config.yml` useless. Therefore, I add some conditions to avoid that.

https://github.com/kubernetes-sigs/inference-perf/issues/159