### PR TITLE
feat: revise Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.12.9-slim-bookworm AS dev
 
-RUN apt-get update -y \
-    && apt-get install -y python3-pip
-
 # Upgrade pip
 RUN pip3 install --upgrade pip
 
@@ -10,7 +7,8 @@ RUN pip3 install --upgrade pip
 WORKDIR /workspace
 
 # Copy project files
-COPY . /workspace
+COPY inference_perf/ /workspace/inference_perf/
+COPY pyproject.toml /workspace/
 
 # Install dependencies
 RUN pip install -e .


### PR DESCRIPTION
This commit reduces image size from 1.22GB to 753MB and I have tested the newly built one. 

If there are other methods that can reduce the image size that I haven't done, please don't hesitate to tell me.

https://github.com/kubernetes-sigs/inference-perf/issues/161