### PR TITLE
update streaming part in the documentation too to make it clear

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -27,7 +27,7 @@ Controls the API interaction behavior:
 ```yaml
 api:
   type: completion  # API type (completion|chat)
-  streaming: false  # Enable/disable streaming
+  streaming: false  # Enable/disable streaming (default: false), needs to be enabled for metrics like TTFT, ITL and TPOT to be measured
 ```  
 
 ### Data Generation


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/inference-perf/issues/150

why it is needed:

streaming: true needs to be set for some metrics to be reported. Default is non-streaming requests which would not give us these metrics. Might be good to update in the documentation too to make it clear.