### PR TITLE
Include KV-Cache Usage Percentage Metrics in Prometheus Reports

### DIFF
--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -53,6 +53,12 @@ class ModelServerMetrics(BaseModel):
     avg_output_tokens: int = 0
     avg_queue_length: int = 0
 
+    # Usage
+    avg_kv_cache_usage: float = 0
+    median_kv_cache_usage: float = 0
+    p90_kv_cache_usage: float = 0
+    p99_kv_cache_usage: float = 0
+
 
 class MetricsClient(ABC):
     @abstractmethod

--- a/inference_perf/client/modelserver/base.py
+++ b/inference_perf/client/modelserver/base.py
@@ -55,6 +55,11 @@ class PrometheusMetricMetadata(TypedDict):
     avg_output_tokens: ModelServerPrometheusMetric
     avg_queue_length: ModelServerPrometheusMetric
 
+    # Usage
+    avg_kv_cache_usage: ModelServerPrometheusMetric
+    median_kv_cache_usage: ModelServerPrometheusMetric
+    p90_kv_cache_usage: ModelServerPrometheusMetric
+    p99_kv_cache_usage: ModelServerPrometheusMetric
 
 class ModelServerClient(ABC):
     @abstractmethod

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -158,6 +158,10 @@ class vLLMModelServerClient(ModelServerClient):
                 "histogram",
                 filters,
             ),
+            avg_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "mean", "gauge"),
+            median_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "median", "gauge"),
+            p90_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p90", "gauge"),
+            p99_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p99", "gauge"),
         )
 
     async def process_request(self, data: InferenceAPIData, stage_id: int, scheduled_time: float) -> None:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -92,6 +92,12 @@ def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummar
                 "p90": metrics.p90_time_per_output_token,
                 "p99": metrics.p99_time_per_output_token,
             },
+            "kv_cache_usage_percentage": {
+                "mean": metrics.avg_kv_cache_usage,
+                "p50": metrics.median_kv_cache_usage,
+                "p90": metrics.p90_kv_cache_usage,
+                "p99": metrics.p99_kv_cache_usage,
+            },
         },
     )
 


### PR DESCRIPTION
Prometheus client now also queries vllm:gpu_cache_usage_perc for kv-cache usage, current description of metric as per [docs](https://docs.vllm.ai/en/v0.4.1/serving/metrics.html#production-metrics):

```
       self.gauge_gpu_cache_usage = Gauge(
            name="vllm:gpu_cache_usage_perc",
            documentation="GPU KV-cache usage. 1 means 100 percent usage.",
            labelnames=labelnames)
```