### PR TITLE
Fix for Zeroed KV-Cache Usage metrics

### DIFF
--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -50,7 +50,7 @@ class CompletionAPIData(InferenceAPIData):
             output_token_times: List[float] = []
             async for chunk_bytes in response.content:
                 chunk_bytes = chunk_bytes.strip()
-                output_token_times.append(time.perf_counter())
+                output_token_times.append(time.time())
                 if not chunk_bytes:
                     continue
                 # After removing the "data: " prefix, each chunk decodes to a response json for a single token or "[DONE]" if end of stream

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -50,7 +50,7 @@ class CompletionAPIData(InferenceAPIData):
             output_token_times: List[float] = []
             async for chunk_bytes in response.content:
                 chunk_bytes = chunk_bytes.strip()
-                output_token_times.append(time.time())
+                output_token_times.append(time.perf_counter())
                 if not chunk_bytes:
                     continue
                 # After removing the "data: " prefix, each chunk decodes to a response json for a single token or "[DONE]" if end of stream

--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -53,6 +53,12 @@ class ModelServerMetrics(BaseModel):
     avg_output_tokens: int = 0
     avg_queue_length: int = 0
 
+    # Usage
+    avg_kv_cache_usage: float = 0
+    median_kv_cache_usage: float = 0
+    p90_kv_cache_usage: float = 0
+    p99_kv_cache_usage: float = 0
+
 
 class MetricsClient(ABC):
     @abstractmethod

--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -54,10 +54,10 @@ class ModelServerMetrics(BaseModel):
     avg_queue_length: int = 0
 
     # Usage
-    avg_kv_cache_usage: float = 0
-    median_kv_cache_usage: float = 0
-    p90_kv_cache_usage: float = 0
-    p99_kv_cache_usage: float = 0
+    avg_kv_cache_usage: float = 0.0
+    median_kv_cache_usage: float = 0.0
+    p90_kv_cache_usage: float = 0.0
+    p99_kv_cache_usage: float = 0.0
 
 
 class MetricsClient(ABC):

--- a/inference_perf/client/metricsclient/prometheus_client/base.py
+++ b/inference_perf/client/metricsclient/prometheus_client/base.py
@@ -156,7 +156,6 @@ class PrometheusMetricsClient(MetricsClient):
         # Get the query evaluation time and duration for the stage
         # The query evaluation time is the end time of the stage plus the scrape interval and a buffer to ensure metrics are collected
         # Duration is calculated as the difference between the eval time and start time of the stage
-        logger.debug(f"runtime parameters for stage {stage_id}: {runtime_parameters}")
         query_eval_time = runtime_parameters.stages[stage_id].end_time + self.scrape_interval + PROMETHEUS_SCRAPE_BUFFER_SEC
         query_duration = query_eval_time - runtime_parameters.stages[stage_id].start_time
         return self.get_model_server_metrics(runtime_parameters.model_server_client, query_duration, query_eval_time)
@@ -231,15 +230,15 @@ class PrometheusMetricsClient(MetricsClient):
         """
         query_result = 0.0
         try:
-            logger.debug(f"making PromQL query: '{query}'")
+            logger.debug(f"Making PromQL query: '{query}'")
             response = requests.get(self.query_url, headers=self.get_headers(), params={"query": query, "time": eval_time})
             if response is None:
-                logger.error("error executing query: %s" % (query))
+                logger.error("Error executing query: %s" % (query))
                 return query_result
 
             response.raise_for_status()
         except Exception as e:
-            logger.error("error executing query: %s" % (e))
+            logger.error("Error executing query: %s" % (e))
             return query_result
 
         # Check if the response is valid
@@ -261,9 +260,8 @@ class PrometheusMetricsClient(MetricsClient):
         # }
         
         response_obj = response.json()
-        logger.debug(f"got result for query '{query}': {response_obj}")
         if response_obj.get("status") != "success":
-            logger.error("error executing query: %s" % (response_obj))
+            logger.error("Error executing query: %s" % (response_obj))
             return query_result
 
         data = response_obj.get("data", {})
@@ -279,9 +277,8 @@ class PrometheusMetricsClient(MetricsClient):
                 try:
                     query_result = round(float(result[0]["value"][1]), 6)
                 except ValueError:
-                    logger.error("error converting value to float: %s" % (result[0]["value"][1]))
+                    logger.error("Error converting value to float: %s" % (result[0]["value"][1]))
                     return query_result
-        logger.debug(f"inferred result from query '{query}': {query_result}")
         return query_result
 
     def get_headers(self) -> dict[str, Any]:

--- a/inference_perf/client/modelserver/base.py
+++ b/inference_perf/client/modelserver/base.py
@@ -55,6 +55,11 @@ class PrometheusMetricMetadata(TypedDict):
     avg_output_tokens: ModelServerPrometheusMetric
     avg_queue_length: ModelServerPrometheusMetric
 
+    # Usage
+    avg_kv_cache_usage: ModelServerPrometheusMetric
+    median_kv_cache_usage: ModelServerPrometheusMetric
+    p90_kv_cache_usage: ModelServerPrometheusMetric
+    p99_kv_cache_usage: ModelServerPrometheusMetric
 
 class ModelServerClient(ABC):
     @abstractmethod

--- a/inference_perf/client/modelserver/mock_client.py
+++ b/inference_perf/client/modelserver/mock_client.py
@@ -30,7 +30,7 @@ class MockModelServerClient(ModelServerClient):
         self.metrics_collector = metrics_collector
 
     async def process_request(self, data: InferenceAPIData, stage_id: int, scheduled_time: float) -> None:
-        start = time.monotonic()
+        start = time.perf_counter()
         logger.debug("Processing mock request for stage %d", stage_id)
         await asyncio.sleep(3)
         self.metrics_collector.record_metric(
@@ -43,7 +43,7 @@ class MockModelServerClient(ModelServerClient):
                 ),
                 error=None,
                 start_time=start,
-                end_time=time.monotonic(),
+                end_time=time.perf_counter(),
                 scheduled_time=scheduled_time,
             )
         )

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -179,7 +179,7 @@ class vLLMModelServerClient(ModelServerClient):
         request_data = json.dumps(payload)
 
         async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=self.max_tcp_connections)) as session:
-            start = time.time()
+            start = time.perf_counter()
             try:
                 async with session.post(self.uri + data.get_route(), headers=headers, data=request_data) as response:
                     response_info = await data.process_response(
@@ -195,7 +195,7 @@ class vLLMModelServerClient(ModelServerClient):
                                 info=response_info,
                                 error=None,
                                 start_time=start,
-                                end_time=time.time(),
+                                end_time=time.perf_counter(),
                                 scheduled_time=scheduled_time,
                             )
                         )
@@ -208,7 +208,7 @@ class vLLMModelServerClient(ModelServerClient):
                                 info=response_info,
                                 error=ErrorResponseInfo(error_msg=response_content, error_type="Error response"),
                                 start_time=start,
-                                end_time=time.time(),
+                                end_time=time.perf_counter(),
                                 scheduled_time=scheduled_time,
                             )
                         )
@@ -225,7 +225,7 @@ class vLLMModelServerClient(ModelServerClient):
                             error_type=type(e).__name__,
                         ),
                         start_time=start,
-                        end_time=time.time(),
+                        end_time=time.perf_counter(),
                         scheduled_time=scheduled_time,
                     )
                 )

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -179,7 +179,7 @@ class vLLMModelServerClient(ModelServerClient):
         request_data = json.dumps(payload)
 
         async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=self.max_tcp_connections)) as session:
-            start = time.perf_counter()
+            start = time.time()
             try:
                 async with session.post(self.uri + data.get_route(), headers=headers, data=request_data) as response:
                     response_info = await data.process_response(
@@ -195,7 +195,7 @@ class vLLMModelServerClient(ModelServerClient):
                                 info=response_info,
                                 error=None,
                                 start_time=start,
-                                end_time=time.perf_counter(),
+                                end_time=time.time(),
                                 scheduled_time=scheduled_time,
                             )
                         )
@@ -208,7 +208,7 @@ class vLLMModelServerClient(ModelServerClient):
                                 info=response_info,
                                 error=ErrorResponseInfo(error_msg=response_content, error_type="Error response"),
                                 start_time=start,
-                                end_time=time.perf_counter(),
+                                end_time=time.time(),
                                 scheduled_time=scheduled_time,
                             )
                         )
@@ -225,7 +225,7 @@ class vLLMModelServerClient(ModelServerClient):
                             error_type=type(e).__name__,
                         ),
                         start_time=start,
-                        end_time=time.perf_counter(),
+                        end_time=time.time(),
                         scheduled_time=scheduled_time,
                     )
                 )

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -158,6 +158,10 @@ class vLLMModelServerClient(ModelServerClient):
                 "histogram",
                 filters,
             ),
+            avg_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "mean", "gauge"),
+            median_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "median", "gauge"),
+            p90_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p90", "gauge"),
+            p99_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p99", "gauge"),
         )
 
     async def process_request(self, data: InferenceAPIData, stage_id: int, scheduled_time: float) -> None:

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -158,10 +158,10 @@ class vLLMModelServerClient(ModelServerClient):
                 "histogram",
                 filters,
             ),
-            avg_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "mean", "gauge"),
-            median_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "median", "gauge"),
-            p90_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p90", "gauge"),
-            p99_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p99", "gauge"),
+            avg_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "mean", "gauge", filters),
+            median_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "median", "gauge", filters),
+            p90_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p90", "gauge", filters),
+            p99_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p99", "gauge", filters),
         )
 
     async def process_request(self, data: InferenceAPIData, stage_id: int, scheduled_time: float) -> None:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -66,7 +66,7 @@ class Worker(mp.Process):
                 item = self.request_queue.get_nowait()
 
                 async def schedule_client(queue: mp.Queue, data: InferenceAPIData, request_time: float, stage_id: int) -> None:  # type: ignore[type-arg]
-                    current_time = time.time()
+                    current_time = time.perf_counter()
                     sleep_time = request_time - current_time
                     if sleep_time > 0:
                         await sleep(sleep_time)
@@ -137,7 +137,8 @@ class LoadGenerator:
 
             # Allow generation a second to begin populating the queue so the workers
             # don't miss the initial scheuled request times
-            start_time = time.time() + 1
+            start_time_epoch = time.time()
+            start_time = time.perf_counter() + 1
             num_requests = stage.rate * stage.duration
 
             for request_number, (request_data, request_time) in enumerate(
@@ -146,7 +147,7 @@ class LoadGenerator:
                 if request_number >= num_requests:
                     break
                 request_queue.put((stage_id, request_data, request_time))
-            await sleep(start_time + stage.duration - time.time())
+            await sleep(start_time + stage.duration - time.perf_counter())
 
             # Join on request queue to ensure that all workers have completed
             # their requests for the stage
@@ -167,7 +168,7 @@ class LoadGenerator:
             logger.debug("Loadgen joining request queue")
             request_queue.join()
             self.stage_runtime_info[stage_id] = StageRuntimeInfo(
-                stage_id=stage_id, rate=stage.rate, start_time=start_time, end_time=time.time()
+                stage_id=stage_id, rate=stage.rate, start_time=start_time_epoch, end_time=time.time()
             )
             logger.info("Stage %d - run completed", stage_id)
             if self.stageInterval and stage_id < len(self.stages) - 1:
@@ -182,23 +183,24 @@ class LoadGenerator:
 
         for stage_id, stage in enumerate(self.stages):
             timer = self.get_timer(stage.rate)
-            start_time = time.time()
+            start_time_epoch = time.time()
+            start_time = time.perf_counter()
             end_time = start_time + stage.duration
             logger.info("Stage %d - run started", stage_id)
             async with TaskGroup() as tg:
                 for _, (data, time_index) in enumerate(
                     zip(self.datagen.get_data(), timer.start_timer(start_time), strict=True)
                 ):
-                    now = time.time()
+                    now = time.perf_counter()
                     if time_index < end_time and now < end_time:
                         if time_index > now:
-                            await sleep(time_index - time.time())
+                            await sleep(time_index - time.perf_counter())
                         tg.create_task(client.process_request(data, stage_id, time_index))
                         continue
                     else:
                         break
             self.stage_runtime_info[stage_id] = StageRuntimeInfo(
-                stage_id=stage_id, rate=stage.rate, start_time=start_time, end_time=time.time()
+                stage_id=stage_id, rate=stage.rate, start_time=start_time_epoch, end_time=time.time()
             )
             logger.info("Stage %d - run completed", stage_id)
             if self.stageInterval and stage_id < len(self.stages) - 1:

--- a/inference_perf/loadgen/load_timer.py
+++ b/inference_perf/loadgen/load_timer.py
@@ -44,7 +44,7 @@ class ConstantLoadTimer(LoadTimer):
 
     def start_timer(self, initial: Optional[float] = None) -> Generator[float, None, None]:
         # Set start time
-        next_time = time.monotonic() if initial is None else initial
+        next_time = time.perf_counter() if initial is None else initial
 
         # Given a rate, yield a time to wait before the next request
         while True:
@@ -59,7 +59,7 @@ class PoissonLoadTimer(LoadTimer):
 
     def start_timer(self, initial: Optional[float] = None) -> Generator[float, None, None]:
         # Set start time
-        next_time = time.monotonic() if initial is None else initial
+        next_time = time.perf_counter() if initial is None else initial
 
         # Given a rate, yield a time to wait before the next request
         while True:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -92,6 +92,12 @@ def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummar
                 "p90": metrics.p90_time_per_output_token,
                 "p99": metrics.p99_time_per_output_token,
             },
+            "kv_cache_usage_percentage": {
+                "mean": metrics.avg_kv_cache_usage,
+                "p50": metrics.median_kv_cache_usage,
+                "p90": metrics.p90_kv_cache_usage,
+                "p99": metrics.p99_kv_cache_usage,
+            },
         },
     )
 


### PR DESCRIPTION
Metrics added as part of https://github.com/kubernetes-sigs/inference-perf/pull/184/files were mistakenly cast to `int`s by setting their default vlaues to 0, should be 0.0. 