### PR TITLE
Invalidate Responses with Zero Tokens

### DIFF
--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -57,7 +57,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                     chunk_str = chunk_bytes.decode('utf-8').removeprefix("data: ")
                     output_token_times.append(time.perf_counter())
                 except UnicodeDecodeError:
-                    continue
+                    raise Exception(f"failed to decode JSON chunk: '{line}'")
                 for line in chunk_str.splitlines():
                     if line == '[DONE]':
                         break
@@ -70,7 +70,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                             if content:
                                 output_text += content
                     except (json.JSONDecodeError, IndexError):
-                        continue
+                        raise Exception(f"failed to decode JSON line in chunk: '{line}'")
                 else:
                     continue
                 break
@@ -78,7 +78,7 @@ class ChatCompletionAPIData(InferenceAPIData):
             prompt_len = tokenizer.count_tokens(prompt_text)
             output_len = tokenizer.count_tokens(output_text)
             if output_len == 0:
-                raise Exception(f"response of length zero inferred from response: {output_text}")
+                raise Exception(f"response of length zero inferred from streamed response: '{output_text}'")
             return InferenceInfo(
                 input_tokens=prompt_len,
                 output_tokens=output_len,
@@ -93,7 +93,7 @@ class ChatCompletionAPIData(InferenceAPIData):
             output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
             output_len = tokenizer.count_tokens(output_text)
             if output_len == 0:
-                raise Exception(f"response of length zero inferred from response: {output_text}")
+                raise Exception(f"response of length zero inferred from response: '{output_text}'")
             return InferenceInfo(
                 input_tokens=prompt_len,
                 output_tokens=output_len,

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -57,7 +57,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                     chunk_str = chunk_bytes.decode('utf-8').removeprefix("data: ")
                     output_token_times.append(time.perf_counter())
                 except UnicodeDecodeError:
-                    raise Exception(f"failed to decode JSON chunk: '{line}'")
+                    continue
                 for line in chunk_str.splitlines():
                     if line == '[DONE]':
                         break
@@ -70,7 +70,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                             if content:
                                 output_text += content
                     except (json.JSONDecodeError, IndexError):
-                        raise Exception(f"failed to decode JSON line in chunk: '{line}'")
+                        continue
                 else:
                     continue
                 break

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -77,6 +77,8 @@ class ChatCompletionAPIData(InferenceAPIData):
             prompt_text = "".join([msg.content for msg in self.messages if msg.content])
             prompt_len = tokenizer.count_tokens(prompt_text)
             output_len = tokenizer.count_tokens(output_text)
+            if output_len == 0:
+                raise Exception(f"response of length zero inferred from response: {output_text}")
             return InferenceInfo(
                 input_tokens=prompt_len,
                 output_tokens=output_len,
@@ -90,6 +92,8 @@ class ChatCompletionAPIData(InferenceAPIData):
                 return InferenceInfo(input_tokens=prompt_len)
             output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
             output_len = tokenizer.count_tokens(output_text)
+            if output_len == 0:
+                raise Exception(f"response of length zero inferred from response: {output_text}")
             return InferenceInfo(
                 input_tokens=prompt_len,
                 output_tokens=output_len,

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -16,12 +16,14 @@
 import json
 import time
 from typing import Any, List
+import logging
 
 from aiohttp import ClientResponse
 from inference_perf.apis import InferenceAPIData, InferenceInfo
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.config import APIConfig, APIType
 
+logger = logging.getLogger(__name__)
 
 class CompletionAPIData(InferenceAPIData):
     prompt: str
@@ -66,7 +68,7 @@ class CompletionAPIData(InferenceAPIData):
             prompt_len = tokenizer.count_tokens(self.prompt)
             output_len = tokenizer.count_tokens(output_text)
             if output_len == 0:
-                raise Exception(f"response of length zero inferred from response: {output_text}")
+                raise Exception(f"response of length zero inferred from streamed response: '{output_text}'")
             return InferenceInfo(
                 input_tokens=prompt_len,
                 output_tokens=output_len,
@@ -81,5 +83,5 @@ class CompletionAPIData(InferenceAPIData):
             output_text = choices[0].get("text", "")
             output_len = tokenizer.count_tokens(output_text)
             if output_len == 0:
-                raise Exception(f"response of length zero inferred from response: {output_text}")
+                raise Exception(f"response of length zero inferred from response: '{output_text}'")
             return InferenceInfo(input_tokens=prompt_len, output_tokens=output_len)

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -16,14 +16,12 @@
 import json
 import time
 from typing import Any, List
-import logging
 
 from aiohttp import ClientResponse
 from inference_perf.apis import InferenceAPIData, InferenceInfo
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.config import APIConfig, APIType
 
-logger = logging.getLogger(__name__)
 
 class CompletionAPIData(InferenceAPIData):
     prompt: str

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -56,13 +56,10 @@ class CompletionAPIData(InferenceAPIData):
                 # After removing the "data: " prefix, each chunk decodes to a response json for a single token or "[DONE]" if end of stream
                 chunk = chunk_bytes.decode("utf-8").removeprefix("data: ")
                 if chunk != "[DONE]":
-                    try:
-                        data = json.loads(chunk)
-                        if choices := data.get("choices"):
-                            text = choices[0].get("text")
-                            output_text += text
-                    except (json.JSONDecodeError, IndexError):
-                        raise Exception(f"failed to decode JSON response: {chunk}")
+                    data = json.loads(chunk)
+                    if choices := data.get("choices"):
+                        text = choices[0].get("text")
+                        output_text += text
             prompt_len = tokenizer.count_tokens(self.prompt)
             output_len = tokenizer.count_tokens(output_text)
             if output_len == 0:


### PR DESCRIPTION
Responses must now have at least one token to be considered valid.
See: https://github.com/kubernetes-sigs/inference-perf/issues/189