### PR TITLE
Rename schedule_accuracy to schedule_delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ Multiple load generators are supported:
 Multiple load patterns can be specified:
 - Stages with configurable duration and QPS along with specific timeouts in between them allows you to simulate different load patterns like burst in traffic, constantly increasing load till hardware saturation, etc.
 
+Load generator reports metrics per stage on the delays between the request schedule time vs the actual send time. Ideally the schedule_delay should be near 0, if not
+the load generator is failing to meet the desired load.
+
+Example:
+```
+"load_summary": {
+"count": 480,
+"schedule_delay": {
+    "mean": 0.0033437913275217094,
+    "min": -0.0008108859183266759,
+    "p10": -2.9846763936802738e-05,
+    "p50": 0.0010809275845531374,
+    "p90": 0.007055185985518622,
+    "max": 0.06699507019948214
+},
+"send_duration": 59.98128472798271,
+"requested_rate": 8.0,
+"achieved_rate": 8.00249614820385
+}
+```
+
 ### API
 
 OpenAI completion and chat completion APIs are supported. It can be pointed to any endpoints which support these APIs - currently verified against vLLM deployments. Other APIs and model server support can be added easily.

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -114,13 +114,13 @@ def summarize_requests(metrics: List[RequestLifecycleMetric], stage_rate: Option
 
     load_summary: dict[Any, Any] = {
         "count": len(metrics),
-        "schedule_accuracy": summarize(schedule_deltas),
+        "schedule_delay": summarize(schedule_deltas),
     }
 
     if stage_rate is not None:
         load_summary = {
             "count": len(metrics),
-            "schedule_accuracy": summarize(schedule_deltas),
+            "schedule_delay": summarize(schedule_deltas),
             "send_duration": send_duration,
             "requested_rate": stage_rate,
             "achieved_rate": len(metrics) / send_duration,


### PR DESCRIPTION
New name more clearly indicates that 0 is better.
Added README example.