### PR TITLE
Add vllm metrics [preemptions and swapped requests] to prometheus metrics

### DIFF
--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -52,6 +52,9 @@ class ModelServerMetrics(BaseModel):
     avg_prompt_tokens: int = 0
     avg_output_tokens: int = 0
     avg_queue_length: int = 0
+    num_preemptions_total: int = 0
+    num_requests_swapped: int = 0
+    
 
     # Usage
     avg_kv_cache_usage: float = 0.0

--- a/inference_perf/client/modelserver/base.py
+++ b/inference_perf/client/modelserver/base.py
@@ -60,6 +60,8 @@ class PrometheusMetricMetadata(TypedDict):
     median_kv_cache_usage: ModelServerPrometheusMetric
     p90_kv_cache_usage: ModelServerPrometheusMetric
     p99_kv_cache_usage: ModelServerPrometheusMetric
+    num_preemptions_total: ModelServerPrometheusMetric
+    num_requests_swapped: ModelServerPrometheusMetric
 
 class ModelServerClient(ABC):
     @abstractmethod

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -162,6 +162,8 @@ class vLLMModelServerClient(ModelServerClient):
             median_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "median", "gauge", filters),
             p90_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p90", "gauge", filters),
             p99_kv_cache_usage=ModelServerPrometheusMetric("vllm:gpu_cache_usage_perc", "p99", "gauge", filters),
+            num_preemptions_total=ModelServerPrometheusMetric("vllm:num_preemptions_total", "mean", "gauge", filters),
+            num_requests_swapped=ModelServerPrometheusMetric("vllm:num_requests_swapped", "mean", "gauge", filters),
         )
 
     async def process_request(self, data: InferenceAPIData, stage_id: int, scheduled_time: float) -> None:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -98,6 +98,12 @@ def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummar
                 "p90": metrics.p90_kv_cache_usage,
                 "p99": metrics.p99_kv_cache_usage,
             },
+            "num_requests_swapped": {
+                "mean": metrics.num_requests_swapped,
+            },
+            "num_preemptions_total": {
+                "mean": metrics.num_preemptions_total
+            }
         },
     )
 


### PR DESCRIPTION
example output:
{"load_summary": {}, "successes": {"count": 0, "rate": 0.0, "prompt_len": {"mean": 0, "rate": 0.0}, "output_len": {"mean": 0, "rate": 0.0}, "queue_len": {"mean": 0}, "request_latency": {"mean": 0.0, "p50": 0.0, "p90": 0.0, "p99": 0.0}, "time_to_first_token": {"mean": 0.0, "p50": 0.0, "p90": 0.0, "p99": 0.0}, "time_per_output_token": {"mean": 0.0, "p50": 0.0, "p90": 0.0, "p99": 0.0}, "kv_cache_usage_percentage": {"mean": 0.0, "p50": 0.0, "p90": 0.0, "p99": 0.0}, "num_requests_swapped": {"mean": 0}, "num_preemptions_total": {"mean": 0}}, "failures": {}}

Metrics are zero since I ran this without the prometheus server, but metrics are outputted correctly.

