### PR TITLE
Reduce CPU utilization of waiting workers

### DIFF
--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -17,24 +17,20 @@ from inference_perf.datagen import DataGenerator
 from inference_perf.apis import InferenceAPIData
 from inference_perf.client.modelserver import ModelServerClient
 from inference_perf.config import LoadType, LoadConfig
-from asyncio import Semaphore, TaskGroup, create_task, gather, run, sleep, set_event_loop_policy
-from enum import Enum, auto
-from typing import List, Union, Tuple, TypeAlias
+from asyncio import Semaphore, TaskGroup, create_task, gather, run, sleep, set_event_loop_policy, get_event_loop
+from typing import List, Tuple, TypeAlias
 import time
 import multiprocessing as mp
+from multiprocessing.synchronize import Event as SyncEvent
+from multiprocessing.sharedctypes import Synchronized
+from concurrent.futures import TimeoutError
+from functools import partial
 import logging
 import uvloop
 
 logger = logging.getLogger(__name__)
 
-
 RequestQueueData: TypeAlias = Tuple[int, InferenceAPIData | int, float]
-
-
-class Status(Enum):
-    UNKNOWN = auto()
-    STAGE_END = auto()
-    WORKER_STOP = auto()
 
 
 class Worker(mp.Process):
@@ -45,29 +41,47 @@ class Worker(mp.Process):
         request_queue: mp.Queue,  # type: ignore[type-arg]
         datagen: DataGenerator,
         max_concurrency: int,
+        stop_signal: SyncEvent,
+        request_phase: SyncEvent,
+        finished_requests_counter: "Synchronized[int]",
     ):
         super().__init__()
         self.id = id
         self.client = client
         self.request_queue = request_queue
-        self.status_queue: mp.JoinableQueue[Status] = mp.JoinableQueue()
         self.max_concurrency = max_concurrency
         self.datagen = datagen
-
-    def check_status(self) -> Union[Status, None]:
-        try:
-            return self.status_queue.get_nowait()
-        except mp.queues.Empty:
-            return None
+        self.stop_signal = stop_signal
+        self.request_phase = request_phase
+        self.finished_requests_counter = finished_requests_counter
 
     async def loop(self) -> None:
         semaphore = Semaphore(self.max_concurrency)
         tasks = []
+        event_loop = get_event_loop()
+        item = None
+        timeout = 0.5
 
-        while True:
-            try:
+        while not self.stop_signal.is_set():
+            while self.request_phase.is_set():
                 await semaphore.acquire()
-                item = self.request_queue.get_nowait()
+                try:
+                    # Use partial to pass named arg
+                    get = partial(self.request_queue.get, timeout=timeout)
+                    item = await event_loop.run_in_executor(None, get)
+                    if item is None:
+                        semaphore.release()
+                        continue
+                except TimeoutError:
+                    semaphore.release()
+                    continue
+                except mp.queues.Empty:
+                    semaphore.release()
+                    continue
+                except Exception as e:
+                    logger.info(f"[Worker {self.id}] hit exception {e}")
+                    semaphore.release()
+                    continue
 
                 async def schedule_client(
                     queue: mp.Queue,  # type: ignore[type-arg]
@@ -82,6 +96,8 @@ class Worker(mp.Process):
                     else:
                         logger.debug(f"Worker {self.id} missed scheduled request time by {-1.0 * sleep_time:0.2f}")
                     await self.client.process_request(request_data, stage_id, request_time)
+                    with self.finished_requests_counter.get_lock():
+                        self.finished_requests_counter.value += 1
                     queue.task_done()
                     semaphore.release()
 
@@ -90,20 +106,12 @@ class Worker(mp.Process):
                 task = create_task(schedule_client(self.request_queue, request_data, request_time, stage_id))
                 tasks.append(task)
                 await sleep(0)
-            except mp.queues.Empty:
-                semaphore.release()
-                status = self.check_status()
-                if status is None:
-                    await sleep(0)
-                if status is not None:
-                    logger.debug(f"[Worker {self.id}] received {status}, awaiting {len(tasks)} tasks")
-                    await gather(*tasks)
-                    tasks = []
-                    self.status_queue.task_done()
-                if status == Status.STAGE_END:
-                    continue
-                if status == Status.WORKER_STOP:
-                    break
+
+            await gather(*tasks)
+            tasks = []
+            self.request_phase.wait()
+
+        logger.debug(f"[Worker {self.id}] stopped")
 
     def run(self) -> None:
         set_event_loop_policy(uvloop.EventLoopPolicy())
@@ -135,13 +143,32 @@ class LoadGenerator:
 
     async def mp_run(self, client: ModelServerClient) -> None:
         request_queue: mp.Queue[RequestQueueData] = mp.JoinableQueue()
+        finished_requests_counter: "Synchronized[int]" = mp.Value("i", 0)
+        request_phase: SyncEvent = mp.Event()
+        stop_signal: SyncEvent = mp.Event()
+        # start workers in the request phase
+        request_phase.set()
 
         for id in range(self.num_workers):
-            self.workers.append(Worker(id, client, request_queue, self.datagen, self.worker_max_concurrency))
+            self.workers.append(
+                Worker(
+                    id,
+                    client,
+                    request_queue,
+                    self.datagen,
+                    self.worker_max_concurrency,
+                    stop_signal,
+                    request_phase,
+                    finished_requests_counter,
+                )
+            )
             self.workers[-1].start()
 
         for stage_id, stage in enumerate(self.stages):
             logger.info("Stage %d - run started", stage_id)
+            request_phase.set()
+            with finished_requests_counter.get_lock():
+                finished_requests_counter.value = 0
             timer = self.get_timer(stage.rate, stage.duration)
 
             # Allow generation a second to begin populating the queue so the workers
@@ -149,7 +176,6 @@ class LoadGenerator:
             start_time_epoch = time.time()
             start_time = time.perf_counter() + 1
             num_requests = int(stage.rate * stage.duration)
-            start_time_epoch = time.time()
 
             time_generator = timer.start_timer(start_time)
             if hasattr(self.datagen, "get_request"):
@@ -163,35 +189,28 @@ class LoadGenerator:
                 for _ in range(num_requests):
                     request_queue.put((stage_id, next(data_generator), next(time_generator)))
 
+            logger.debug("Loadgen sleeping until end of stage")
             await sleep(start_time + stage.duration - time.perf_counter())
 
-            # Join on request queue to ensure that all workers have completed
-            # their requests for the stage
-            while request_queue.qsize() > 0:
-                logger.debug(f"Loadgen awaiting empty request queue, current size: {request_queue.qsize()}")
+            # Wait until all requests are finished processing
+            while finished_requests_counter.value < num_requests:
+                logger.debug(f"Loadgen waiting for all requests to finish: {finished_requests_counter.value}/{num_requests}")
                 await sleep(1)
 
-            logger.debug("Loadgen sending STAGE_END to workers")
-            for worker in self.workers:
-                worker.status_queue.put(Status.STAGE_END)
-
-            for worker in self.workers:
-                while worker.status_queue.qsize() > 0:
-                    logger.debug(f"Loadgen waiting for worker {worker.id} to process STAGE_END")
-                    await sleep(1)
-                worker.status_queue.join()
-
-            logger.debug("Loadgen joining request queue")
+            # Clear the request_phase event to force worker gather
+            request_phase.clear()
             request_queue.join()
+
             self.stage_runtime_info[stage_id] = StageRuntimeInfo(
                 stage_id=stage_id, rate=stage.rate, start_time=start_time_epoch, end_time=time.time()
             )
             logger.info("Stage %d - run completed", stage_id)
-            if self.stageInterval and stage_id < len(self.stages) - 1:
+            if self.stageInterval:
                 await sleep(self.stageInterval)
 
-        for worker in self.workers:
-            worker.status_queue.put(Status.WORKER_STOP)
+        # Reset the request phase to get workers out of their final wait()
+        request_phase.set()
+        stop_signal.set()
 
     async def run(self, client: ModelServerClient) -> None:
         if self.num_workers > 0:


### PR DESCRIPTION
1. Event switch workers based on stage state
2. Offload request queue polling to event loop executor

This PR has significant reduction in idle worker CPU utilization

Example running with config before / after apply these changes.

```
data:
  type: shareGPT
  path: null
  input_distribution:
    max: 1024
  output_distribution:
    max: 1024
  shared_prefix: null
load:
  type: constant
  interval: 1.0
  stages:
  - rate: 1
    duration: 30
  num_workers: 24
  worker_max_concurrency: 100
  worker_max_tcp_connections: 2500
```

before:
```
real    1m33.187s
user    17m57.995s
sys     2m45.289s
```

after
```
real    1m57.977s
user    0m14.210s
sys     0m8.397s
```