### PR TITLE
Add vllm prefix metrics

### DIFF
--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -61,6 +61,10 @@ class ModelServerMetrics(BaseModel):
     p90_kv_cache_usage: float = 0.0
     p99_kv_cache_usage: float = 0.0
 
+    # Prefix Cache
+    prefix_cache_hits: float = 0.0
+    prefix_cache_queries: float = 0.0
+
 
 class MetricsClient(ABC):
     @abstractmethod

--- a/inference_perf/client/modelserver/base.py
+++ b/inference_perf/client/modelserver/base.py
@@ -67,6 +67,10 @@ class PrometheusMetricMetadata(TypedDict):
     num_preemptions_total: Optional[ModelServerPrometheusMetric]
     num_requests_swapped: Optional[ModelServerPrometheusMetric]
 
+    # Prefix Cache
+    prefix_cache_hits: Optional[ModelServerPrometheusMetric]
+    prefix_cache_queries: Optional[ModelServerPrometheusMetric]
+
 
 class ModelServerClient(ABC):
     @abstractmethod

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -95,12 +95,12 @@ class openAIModelServerClient(ModelServerClient):
                         response=response, config=self.api_config, tokenizer=self.tokenizer
                     )
                     response_content = await response.text()
-                    
+
                     end_time = time.perf_counter()
                     error = None
                     if response.status != 200:
                         error = ErrorResponseInfo(error_msg=response_content, error_type="Error response")
-                    
+
                     self.metrics_collector.record_metric(
                         RequestLifecycleMetric(
                             stage_id=stage_id,

--- a/inference_perf/client/modelserver/sglang_client.py
+++ b/inference_perf/client/modelserver/sglang_client.py
@@ -169,4 +169,6 @@ class SGlangModelServerClient(openAIModelServerClient):
             p99_time_per_output_token=None,
             num_preemptions_total=None,
             num_requests_swapped=None,
+            prefix_cache_hits=None,
+            prefix_cache_queries=None,
         )

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -173,4 +173,16 @@ class vLLMModelServerClient(openAIModelServerClient):
             median_inter_token_latency=None,
             p90_inter_token_latency=None,
             p99_inter_token_latency=None,
+            prefix_cache_hits=ModelServerPrometheusMetric(
+                "vllm:gpu_prefix_cache_hits_total",
+                "increase",
+                "counter",
+                self.additional_metric_filters,
+            ),
+            prefix_cache_queries=ModelServerPrometheusMetric(
+                "vllm:gpu_prefix_cache_queries_total",
+                "increase",
+                "counter",
+                self.additional_metric_filters,
+            ),
         )

--- a/inference_perf/datagen/cnn_dailymail_datagen.py
+++ b/inference_perf/datagen/cnn_dailymail_datagen.py
@@ -35,10 +35,14 @@ class CNNDailyMailDataGenerator(DataGenerator):
             # depending on whether the dataset is a single file or a directory, we need to load it differently
             # TODO: add support for other file types
             if os.path.isfile(config.path) and config.path.endswith(".json"):
-                self.cnn_dailymail_dataset = itertools.cycle(load_dataset("json", data_files=config.path, streaming=True, split="train"))
+                self.cnn_dailymail_dataset = itertools.cycle(
+                    load_dataset("json", data_files=config.path, streaming=True, split="train")
+                )
             elif os.path.isdir(config.path):
                 json_files = [f for f in os.listdir(config.path) if f.endswith(".json")]
-                self.cnn_dailymail_dataset = itertools.cycle(load_dataset("json", data_files=json_files, streaming=True, split="train"))
+                self.cnn_dailymail_dataset = itertools.cycle(
+                    load_dataset("json", data_files=json_files, streaming=True, split="train")
+                )
             else:
                 raise ValueError(f"Invalid dataset path: {config.path}")
         else:

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -39,10 +39,14 @@ class HFShareGPTDataGenerator(DataGenerator):
             # depending on whether the dataset is a single file or a directory, we need to load it differently
             # TODO: add support for other file types
             if os.path.isfile(config.path) and config.path.endswith(".json"):
-                self.sharegpt_dataset = itertools.cycle(load_dataset("json", data_files=config.path, streaming=True, split="train"))
+                self.sharegpt_dataset = itertools.cycle(
+                    load_dataset("json", data_files=config.path, streaming=True, split="train")
+                )
             elif os.path.isdir(config.path):
                 json_files = [f for f in os.listdir(config.path) if f.endswith(".json")]
-                self.sharegpt_dataset = itertools.cycle(load_dataset("json", data_files=json_files, streaming=True, split="train"))
+                self.sharegpt_dataset = itertools.cycle(
+                    load_dataset("json", data_files=json_files, streaming=True, split="train")
+                )
             else:
                 raise ValueError(f"Invalid dataset path: {config.path}")
         else:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -102,6 +102,11 @@ def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummar
                 "mean": metrics.num_requests_swapped,
             },
             "num_preemptions_total": {"mean": metrics.num_preemptions_total},
+            "prefix_cache_hit_percent": {
+                "mean": (metrics.prefix_cache_hits / metrics.prefix_cache_queries) * 100.0
+                if metrics.prefix_cache_queries > 0
+                else 0.0
+            },
         },
     )
 


### PR DESCRIPTION
Adds prefix cache hits and queries, reports as hit percentage. Also adds pdm fixes.

Testing:

```
# inference-perf -c metrics.yml 
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
2025-09-09 16:41:21,906 - inference_perf.config - INFO - Using configuration from: metrics.yml
2025-09-09 16:41:21,909 - inference_perf.config - INFO - Benchmarking with the following config:

api:
  type: completion
  streaming: true
  headers: null
data:
  type: shareGPT
  path: null
  input_distribution: null
  output_distribution: null
  shared_prefix: null
load:
  type: constant
  interval: 1.0
  stages:
  - rate: 1
    duration: 30
  num_workers: 88
  worker_max_concurrency: 100
  worker_max_tcp_connections: 2500
metrics:
  type: prometheus
  prometheus:
    google_managed: true
    scrape_interval: 15
report:
  request_lifecycle:
    summary: true
    per_stage: true
    per_request: false
  prometheus:
    summary: true
    per_stage: true
storage:
  local_storage:
    path: reports-20250909-164121
    report_file_prefix: null
  google_cloud_storage: null
  simple_storage_service: null
server:
  type: vllm
  base_url: http://gemma-3-4b-it-vllm-service:8000
  ignore_eos: true


2025-09-09 16:41:21,936 - inference_perf.client.filestorage.local - INFO - Report files will be stored at: reports-20250909-164121
2025-09-09 16:41:21,941 - inference_perf.client.modelserver.openai_client - INFO - Inferred model google/gemma-3-4b-it
2025-09-09 16:41:30,530 - inference_perf.loadgen.load_generator - INFO - Stage 0 - run started
2025-09-09 16:42:41,581 - inference_perf.loadgen.load_generator - INFO - Stage 0 - run completed
2025-09-09 16:42:56,584 - inference_perf.reportgen.base - INFO - Generating Reports...
2025-09-09 16:43:20,108 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: avg_inter_token_latency. Skipping this metric.
2025-09-09 16:43:20,108 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: median_inter_token_latency. Skipping this metric.
2025-09-09 16:43:20,108 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: p90_inter_token_latency. Skipping this metric.
2025-09-09 16:43:20,108 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: p99_inter_token_latency. Skipping this metric.
2025-09-09 16:43:27,050 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: avg_inter_token_latency. Skipping this metric.
2025-09-09 16:43:27,050 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: median_inter_token_latency. Skipping this metric.
2025-09-09 16:43:27,050 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: p90_inter_token_latency. Skipping this metric.
2025-09-09 16:43:27,050 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: p99_inter_token_latency. Skipping this metric.
2025-09-09 16:43:27,543 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20250909-164121/summary_lifecycle_metrics.json
2025-09-09 16:43:27,544 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20250909-164121/stage_0_lifecycle_metrics.json
2025-09-09 16:43:27,544 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20250909-164121/summary_prometheus_metrics.json
2025-09-09 16:43:27,544 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20250909-164121/stage_0_prometheus_metrics.json
root@inference-perf-forever:/workspace# cat reports-20250909-164121/stage_0_prometheus_metrics.json
{
  "load_summary": {},
  "successes": {
    "count": 26,
    "rate": 0.303121,
    "prompt_len": {
      "mean": 58,
      "rate": 67.640386
    },
    "output_len": {
      "mean": 36,
      "rate": 57.653152
    },
    "queue_len": {
      "mean": 0
    },
    "request_latency": {
      "mean": 7.699654,
      "median": 3.4375,
      "p90": 21.5,
      "p99": 47.3
    },
    "time_to_first_token": {
      "mean": 0.059828,
      "median": 0.055294,
      "p90": 0.078286,
      "p99": 0.0974
    },
    "time_per_output_token": {
      "mean": 0.039448,
      "median": 0.0375,
      "p90": 0.0475,
      "p99": 0.04975
    },
    "kv_cache_usage_percentage": {
      "mean": 0.011414,
      "median": 0.013025,
      "p90": 0.016084,
      "p99": 0.016529
    },
    "num_requests_swapped": {
      "mean": 0
    },
    "num_preemptions_total": {
      "mean": 0
    },
    "prefix_cache_hit_percent": {
      "mean": 97.09207483291485
    }
  },
  "failures": {}
```