### PR TITLE
Write config.yaml to report directory

### DIFF
--- a/inference_perf/client/filestorage/local.py
+++ b/inference_perf/client/filestorage/local.py
@@ -19,6 +19,7 @@ from inference_perf.config import StorageConfigBase
 from inference_perf.utils import ReportFile
 import json
 import os
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -34,5 +35,8 @@ class LocalStorageClient(StorageClient):
             report_path = f"{self.config.path if self.config.path else ''}/{self.config.report_file_prefix if self.config.report_file_prefix else ''}{filename}"
             os.makedirs(os.path.dirname(report_path), exist_ok=True)
             with open(report_path, "w", encoding="utf-8") as f:
-                f.write(json.dumps(report.get_contents(), indent=2))
+                if report.file_type == "yaml":
+                    yaml.dump(report.get_contents(), f, sort_keys=False, default_flow_style=False)
+                else:
+                    f.write(json.dumps(report.get_contents(), indent=2))
             logger.info(f"Report saved to: {report_path}")

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -133,7 +133,7 @@ def main_cli() -> None:
         collector = MultiprocessRequestDataCollector()
     else:
         collector = LocalRequestDataCollector()
-    reportgen = ReportGenerator(metrics_client, collector)
+    reportgen = ReportGenerator(metrics_client, collector, config=config)
 
     # Create tokenizer based on tokenizer config
     tokenizer: Optional[CustomTokenizer] = None

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel
 from collections import defaultdict
 from inference_perf.client.metricsclient.base import ModelServerMetrics
 from inference_perf.client.metricsclient.prometheus_client import PrometheusMetricsClient
-from inference_perf.config import ReportConfig, PrometheusMetricsReportConfig
+from inference_perf.config import ReportConfig, PrometheusMetricsReportConfig, Config
 from inference_perf.client.metricsclient import MetricsClient, PerfRuntimeParameters
 from inference_perf.utils import ReportFile
 from inference_perf.client.requestdatacollector import RequestDataCollector
@@ -186,15 +186,27 @@ class ReportGenerator:
         self,
         metrics_client: Optional[MetricsClient],
         metrics_collector: RequestDataCollector,
+        config: "Config",
     ) -> None:
         self.metrics_collector = metrics_collector
         self.metrics_client = metrics_client
+        self.config = config
 
     def get_metrics_collector(self) -> RequestDataCollector:
         """
         Returns the metrics collector.
         """
         return self.metrics_collector
+
+    def generate_config_report(self) -> ReportFile:
+        """
+        Generates a report file containing the config.
+        """
+        return ReportFile(
+            name="config",
+            file_type="yaml",
+            contents=self.config.model_dump(mode="json"),
+        )
 
     async def generate_reports(
         self, report_config: ReportConfig, runtime_parameters: PerfRuntimeParameters
@@ -242,6 +254,8 @@ class ReportGenerator:
 
         if report_config.prometheus:
             lifecycle_reports.extend(self.generate_prometheus_metrics_report(runtime_parameters, report_config.prometheus))
+
+        lifecycle_reports.append(self.generate_config_report())
         return lifecycle_reports
 
     def generate_prometheus_metrics_report(

--- a/inference_perf/utils/report_file.py
+++ b/inference_perf/utils/report_file.py
@@ -19,12 +19,13 @@ class ReportFile:
     name: str
     contents: Any
 
-    def __init__(self, name: str, contents: Any):
+    def __init__(self, name: str, contents: Any, file_type: str = "json"):
         self.name = name
         self.contents = contents
+        self.file_type = file_type
 
     def get_filename(self) -> str:
-        return f"{self.name}.json"
+        return f"{self.name}.{self.file_type}"
 
     def get_contents(self) -> Any:
         return self.contents


### PR DESCRIPTION
This adds the config yaml to the report directory by default. The written config can be used directly to repeat the benchmark.

Fixes https://github.com/kubernetes-sigs/inference-perf/issues/165