### PR TITLE
bugfix: `self.additional_metrics_filters` -> `self.metrics_filters`

### DIFF
--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -205,12 +205,12 @@ class vLLMModelServerClient(openAIModelServerClient):
                 "vllm:gpu_prefix_cache_hits_total",
                 "increase",
                 "counter",
-                self.additional_metric_filters,
+                self.metric_filters,
             ),
             prefix_cache_queries=ModelServerPrometheusMetric(
                 "vllm:gpu_prefix_cache_queries_total",
                 "increase",
                 "counter",
-                self.additional_metric_filters,
+                self.metric_filters,
             ),
         )


### PR DESCRIPTION
Fixes the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/inference-perf", line 7, in <module>
    sys.exit(main_cli())
             ^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/inference_perf/main.py", line 269, in main_cli
    model_server_metrics=model_server_client.get_prometheus_metric_metadata(),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/inference_perf/client/modelserver/vllm_client.py", line 208, in get_prometheus_metric_metadata
    self.additional_metric_filters,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'vLLMModelServerClient' object has no attribute 'additional_metric_filters'. Did you mean: 'additional_filters'?
```