### PR TITLE
Feat: Add request timeouts and circuit breakers (#148)

### DIFF
--- a/examples/vllm/config-circuitbreaker.yml
+++ b/examples/vllm/config-circuitbreaker.yml
@@ -1,0 +1,27 @@
+circuit_breakers:
+  - name: request_timeout_breaker
+    metrics:
+      matches:
+        - error.error_type == 'TimeoutError'
+    triggers:
+      - type: consecutive # break when there are 10 consecutive errors
+        threshold: 10
+      - type: rate_over_window # break when there are more than 80% failed every 2.5 seconds (at least 2 samples)
+        window_sec: 2.5
+        threshold: 0.8
+        min_samples: 2
+data:
+  type: shareGPT
+load:
+  type: constant
+  stages:
+  - rate: 1
+    duration: 30
+  circuit_breakers:
+    - request_timeout_breaker # break running stage when request_timeout_breaker triggers
+api:
+  type: chat
+server:
+  type: vllm
+  model_name: HuggingFaceTB/SmolLM2-135M-Instruct
+  base_url: http://0.0.0.0:8000

--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
+from enum import Enum, auto
 from typing import TypedDict
 from pydantic import BaseModel
 
@@ -20,12 +21,18 @@ from pydantic import BaseModel
 class MetricsMetadata(TypedDict):
     pass
 
+class StageStatus(Enum):
+    COMPLETED=auto()
+    FAILED=auto()
+    RUNNING=auto()
+    SKIPPED=auto()
 
 class StageRuntimeInfo(BaseModel):
     stage_id: int
     rate: float
     end_time: float
     start_time: float
+    status: StageStatus
 
 
 class PerfRuntimeParameters:

--- a/inference_perf/client/modelserver/base.py
+++ b/inference_perf/client/modelserver/base.py
@@ -75,11 +75,12 @@ class PrometheusMetricMetadata(MetricsMetadata):
 
 class ModelServerClient(ABC):
     @abstractmethod
-    def __init__(self, api_config: APIConfig, *args: Tuple[int, ...]) -> None:
+    def __init__(self, api_config: APIConfig, timeout: Optional[float] = None, *args: Tuple[int, ...]) -> None:
         if api_config.type not in self.get_supported_apis():
             raise Exception(f"Unsupported API type {api_config}")
 
         self.api_config = api_config
+        self.timeout = timeout
 
     @abstractmethod
     def get_supported_apis(self) -> List[APIType]:

--- a/inference_perf/client/modelserver/mock_client.py
+++ b/inference_perf/client/modelserver/mock_client.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from inference_perf.client.requestdatacollector import RequestDataCollector
-from typing import List
+from typing import List, Optional
 from inference_perf.config import APIConfig, APIType
-from inference_perf.apis import InferenceAPIData, InferenceInfo, RequestLifecycleMetric
+from inference_perf.apis import InferenceAPIData, InferenceInfo, RequestLifecycleMetric, ErrorResponseInfo
 from .base import ModelServerClient
 import asyncio
 import time
@@ -25,28 +25,53 @@ logger = logging.getLogger(__name__)
 
 
 class MockModelServerClient(ModelServerClient):
-    def __init__(self, metrics_collector: RequestDataCollector, api_config: APIConfig) -> None:
-        super().__init__(api_config)
+    def __init__(self, metrics_collector: RequestDataCollector, api_config: APIConfig, timeout: Optional[int] = None, mock_latency: float = 3) -> None:
+        super().__init__(api_config, timeout)
         self.metrics_collector = metrics_collector
+        self.mock_latency = mock_latency
 
     async def process_request(self, data: InferenceAPIData, stage_id: int, scheduled_time: float) -> None:
         start = time.perf_counter()
         logger.debug("Processing mock request for stage %d", stage_id)
-        await asyncio.sleep(3)
-        self.metrics_collector.record_metric(
-            RequestLifecycleMetric(
-                stage_id=stage_id,
-                request_data=str(data.to_payload("mock_model", 3, False, False)),
-                info=InferenceInfo(
-                    input_tokens=0,
-                    output_tokens=0,
-                ),
-                error=None,
-                start_time=start,
-                end_time=time.perf_counter(),
-                scheduled_time=scheduled_time,
+        try:
+            if self.timeout and self.timeout < self.mock_latency:
+                await asyncio.sleep(self.timeout)
+                raise asyncio.exceptions.TimeoutError()
+            else:
+                await asyncio.sleep(self.mock_latency)
+                self.metrics_collector.record_metric(
+                    RequestLifecycleMetric(
+                        stage_id=stage_id,
+                        request_data=str(data.to_payload("mock_model", 3, False, False)),
+                        info=InferenceInfo(
+                            input_tokens=0,
+                            output_tokens=0,
+                        ),
+                        error=None,
+                        start_time=start,
+                        end_time=time.perf_counter(),
+                        scheduled_time=scheduled_time,
+                    )
+                )
+        except asyncio.exceptions.TimeoutError as e:
+            logger.debug("Request timedout after %f seconds", self.timeout)
+            self.metrics_collector.record_metric(
+                RequestLifecycleMetric(
+                    stage_id=stage_id,
+                    request_data=str(data.to_payload("mock_model", 3, False, False)),
+                    info=InferenceInfo(
+                        input_tokens=0,
+                        output_tokens=0,
+                    ),
+                    error=ErrorResponseInfo(
+                        error_msg=str(e),
+                        error_type=type(e).__name__,
+                    ),
+                    start_time=start,
+                    end_time=time.perf_counter(),
+                    scheduled_time=scheduled_time,
+                )
             )
-        )
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion, APIType.Chat]

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -20,6 +20,7 @@ from inference_perf.utils import CustomTokenizer
 from .base import ModelServerClient, PrometheusMetricMetadata
 from typing import List, Optional
 import aiohttp
+import asyncio
 import json
 import time
 import logging
@@ -40,8 +41,9 @@ class openAIModelServerClient(ModelServerClient):
         additional_filters: List[str],
         ignore_eos: bool = True,
         api_key: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
-        super().__init__(api_config)
+        super().__init__(api_config, timeout)
         self.uri = uri
         self.max_completion_tokens = 30  # default to use when not set at the request level
         self.ignore_eos = ignore_eos
@@ -85,7 +87,9 @@ class openAIModelServerClient(ModelServerClient):
 
         request_data = json.dumps(payload)
 
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=self.max_tcp_connections)) as session:
+        timeout = aiohttp.ClientTimeout(total=self.timeout) if self.timeout else aiohttp.helpers.sentinel
+
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit=self.max_tcp_connections), timeout=timeout) as session:
             start = time.perf_counter()
             try:
                 async with session.post(self.uri + data.get_route(), headers=headers, data=request_data) as response:
@@ -112,7 +116,10 @@ class openAIModelServerClient(ModelServerClient):
                         )
                     )
             except Exception as e:
-                logger.error("error occured during request processing:", exc_info=True)
+                if isinstance(e, asyncio.exceptions.TimeoutError):
+                    logger.error("request timed out:", exc_info=True)
+                else:
+                    logger.error("error occured during request processing:", exc_info=True)
                 self.metrics_collector.record_metric(
                     RequestLifecycleMetric(
                         stage_id=stage_id,

--- a/inference_perf/client/modelserver/sglang_client.py
+++ b/inference_perf/client/modelserver/sglang_client.py
@@ -34,6 +34,7 @@ class SGlangModelServerClient(openAIModelServerClient):
         additional_filters: List[str],
         ignore_eos: bool = True,
         api_key: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         super().__init__(
             metrics_collector,
@@ -45,6 +46,7 @@ class SGlangModelServerClient(openAIModelServerClient):
             additional_filters,
             ignore_eos,
             api_key,
+            timeout,
         )
         self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
 

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -34,6 +34,7 @@ class vLLMModelServerClient(openAIModelServerClient):
         additional_filters: List[str],
         ignore_eos: bool = True,
         api_key: Optional[str] = None,
+        timeout: Optional[float] = None,
     ) -> None:
         super().__init__(
             metrics_collector,
@@ -45,6 +46,7 @@ class vLLMModelServerClient(openAIModelServerClient):
             additional_filters,
             ignore_eos,
             api_key,
+            timeout,
         )
         self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
 

--- a/inference_perf/client/requestdatacollector/local.py
+++ b/inference_perf/client/requestdatacollector/local.py
@@ -15,6 +15,7 @@
 from typing import List
 from inference_perf.client.requestdatacollector import RequestDataCollector
 from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.utils.circuit_breaker import feed_breakers
 
 
 class LocalRequestDataCollector(RequestDataCollector):
@@ -25,6 +26,7 @@ class LocalRequestDataCollector(RequestDataCollector):
 
     def record_metric(self, metric: RequestLifecycleMetric) -> None:
         self.metrics.append(metric)
+        feed_breakers(metric)
 
     def get_metrics(self) -> List[RequestLifecycleMetric]:
         return self.metrics

--- a/inference_perf/client/requestdatacollector/multiprocess.py
+++ b/inference_perf/client/requestdatacollector/multiprocess.py
@@ -19,6 +19,7 @@ from typing import List
 import logging
 from inference_perf.client.requestdatacollector import RequestDataCollector
 from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.utils.circuit_breaker import feed_breakers
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ class MultiprocessRequestDataCollector(RequestDataCollector):
             try:
                 item = self.queue.get_nowait()
                 self.metrics.append(item)
+                feed_breakers(item)
                 self.queue.task_done()
             except mp.queues.Empty:
                 await sleep(1)

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from datetime import datetime
 from pydantic import BaseModel, HttpUrl, model_validator
+from inference_perf.utils.circuit_breaker import CircuitBreakerConfig
 from typing import Any, Optional, List
 from enum import Enum
 from os import cpu_count
@@ -114,6 +115,7 @@ class LoadConfig(BaseModel):
     num_workers: int = max(1, cpu_count())  # type: ignore
     worker_max_concurrency: int = 100
     worker_max_tcp_connections: int = 2500
+    circuit_breakers: List[str] = []
 
 
 class StorageConfigBase(BaseModel):
@@ -192,6 +194,7 @@ class Config(BaseModel):
     storage: Optional[StorageConfig] = StorageConfig()
     server: Optional[ModelServerClientConfig] = None
     tokenizer: Optional[CustomTokenizerConfig] = None
+    circuit_breakers: Optional[List[CircuitBreakerConfig]] = None
 
 
 def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from inference_perf.client.metricsclient.base import StageRuntimeInfo
+from inference_perf.client.metricsclient.base import StageRuntimeInfo, StageStatus
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer
 from inference_perf.datagen import DataGenerator
 from inference_perf.apis import InferenceAPIData
 from inference_perf.client.modelserver import ModelServerClient
 from inference_perf.config import LoadConfig, LoadStage, LoadType, StageGenType
+from inference_perf.utils import circuit_breaker
 from asyncio import (
     CancelledError,
     Semaphore,
@@ -163,6 +164,7 @@ class LoadGenerator:
         self.num_workers = load_config.num_workers
         self.workers: List[Worker] = []
         self.worker_max_concurrency = load_config.worker_max_concurrency
+        self.circuit_breakers = [circuit_breaker.get_circuit_breaker(breaker_name) for breaker_name in load_config.circuit_breakers]
         self.sweep_config = load_config.sweep
 
     def get_timer(self, rate: float, duration: float) -> LoadTimer:
@@ -207,6 +209,7 @@ class LoadGenerator:
         start_time_epoch = time.time()
         start_time = time.perf_counter() + 1
         num_requests = int(rate * duration)
+        stage_status = StageStatus.RUNNING
 
         time_generator = timer.start_timer(start_time)
         if hasattr(self.datagen, "get_request"):
@@ -232,6 +235,10 @@ class LoadGenerator:
                     logger.info(f"Loadgen timed out after {timeout:0.2f}s")
                     timed_out = True
                     break
+                if cb := next((cb for cb in self.circuit_breakers if cb.is_open()), None):
+                    logger.warning(f"Loadgen detects circuit breakers \"{cb.name}\" open, exit the stage.")
+                    timed_out = True
+                    break
                 await sleep(1)
                 timeout_progress = (time.perf_counter() - start_time) / timeout if timeout else 0
                 prog = min(1.0, max(timeout_progress, finished_requests_counter.value / num_requests))
@@ -247,14 +254,17 @@ class LoadGenerator:
                 await sleep(1)
             await self.drain(request_queue)
             cancel_signal.clear()
+            stage_status = StageStatus.FAILED     
+        else:
+            stage_status = StageStatus.COMPLETED    
         # Clear the request_phase event to force worker gather
         request_phase.clear()
         request_queue.join()
 
         self.stage_runtime_info[stage_id] = StageRuntimeInfo(
-            stage_id=stage_id, rate=rate, start_time=start_time_epoch, end_time=time.time()
+            stage_id=stage_id, rate=rate, start_time=start_time_epoch, end_time=time.time(), status=stage_status
         )
-        logger.info("Stage %d - run completed", stage_id)
+        logger.info("Stage %d - run completed" if stage_status == StageStatus.COMPLETED else "Stage %d - run failed", stage_id)
 
     async def preprocess(
         self,
@@ -398,22 +408,31 @@ class LoadGenerator:
             start_time_epoch = time.time()
             start_time = time.perf_counter()
             end_time = start_time + stage.duration
+            stage_status = StageStatus.RUNNING
             logger.info("Stage %d - run started", stage_id)
             async with TaskGroup() as tg:
                 time_generator = timer.start_timer(start_time)
                 for _, (data, time_index) in enumerate(zip(self.datagen.get_data(), time_generator, strict=True)):
                     now = time.perf_counter()
                     if time_index < end_time and now < end_time:
+                        if cb := next((cb for cb in self.circuit_breakers if cb.is_open()), None):
+                            logger.warning(f"Loadgen detects circuit breakers \"{cb.name}\" open, clean up stage and exit early.")
+                            stage_status = StageStatus.FAILED
+                            break
                         if time_index > now:
                             await sleep(time_index - time.perf_counter())
                         tg.create_task(client.process_request(data, stage_id, time_index))
                         continue
                     else:
                         break
+            if stage_status == StageStatus.RUNNING:
+                stage_status = StageStatus.COMPLETED
+                logger.info("Stage %d - run completed", stage_id)
+            else:
+                logger.info("Stage %d - run failed", stage_id)
             self.stage_runtime_info[stage_id] = StageRuntimeInfo(
-                stage_id=stage_id, rate=stage.rate, start_time=start_time_epoch, end_time=time.time()
+                stage_id=stage_id, rate=stage.rate, start_time=start_time_epoch, end_time=time.time(), status=stage_status
             )
-            logger.info("Stage %d - run completed", stage_id)
             if self.stageInterval and stage_id < len(self.stages) - 1:
                 await sleep(self.stageInterval)
 

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -48,7 +48,7 @@ from inference_perf.client.requestdatacollector import (
     MultiprocessRequestDataCollector,
 )
 from inference_perf.reportgen import ReportGenerator
-from inference_perf.utils import CustomTokenizer, ReportFile
+from inference_perf.utils import circuit_breaker, CustomTokenizer, ReportFile
 from inference_perf.logger import setup_logging
 import asyncio
 import time
@@ -109,6 +109,10 @@ def main_cli() -> None:
         parser.error("argument -c/--config_file is required when not using --analyze")
 
     config = read_config(args.config_file)
+
+    # Define Circuit Breakers
+    if config.circuit_breakers:
+        circuit_breaker.init_circuit_breakers(config.circuit_breakers)
 
     # Define Metrics Client
     metrics_client: Optional[MetricsClient] = None

--- a/inference_perf/utils/circuit_breaker/__init__.py
+++ b/inference_perf/utils/circuit_breaker/__init__.py
@@ -1,0 +1,45 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict, List
+
+from pydantic import BaseModel
+
+from .base import CircuitBreaker
+from .config import CircuitBreakerConfig
+from .simple_breaker import SimpleCircuitBreaker
+
+_initialized_circuit_breakers: Dict[str, CircuitBreaker] = {}
+
+def init_circuit_breakers(configs: List[CircuitBreakerConfig]) -> None:
+    if _initialized_circuit_breakers:
+        raise RuntimeError("Circuit breakers already initialized")
+    for config in configs:
+        _initialized_circuit_breakers[config.name] = SimpleCircuitBreaker(config)
+
+def feed_breakers(data: BaseModel):
+    for breaker in _initialized_circuit_breakers.values():
+        breaker.feed(data)
+
+def get_circuit_breaker(name: str) -> CircuitBreaker:
+    if name not in _initialized_circuit_breakers:
+        raise ValueError(f"Unknown circuit breaker: {name}")
+    return _initialized_circuit_breakers[name]
+
+__all__ = [
+    "feed_breakers",
+    "get_circuit_breaker",
+    "init_circuit_breakers",
+    "CircuitBreaker",
+    "CircuitBreakerConfig",
+]

--- a/inference_perf/utils/circuit_breaker/base.py
+++ b/inference_perf/utils/circuit_breaker/base.py
@@ -1,0 +1,42 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import ABC, abstractmethod
+from typing import List
+from pydantic import BaseModel
+from .config import CircuitBreakerConfig
+from .triggers.base import Trigger, build_trigger
+
+
+class CircuitBreaker(ABC):
+    """
+    Responsible for determine if the benchmark should short-circuit or not.
+    """
+    def __init__(self, config: CircuitBreakerConfig) -> None:
+        self.name = config.name
+        self._triggers: List[Trigger] = [build_trigger(t) for t in config.triggers]
+        self._open = False
+
+    @abstractmethod
+    def feed(self, metric: BaseModel) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_open(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def reset(self) -> None:
+        raise NotImplementedError
+
+

--- a/inference_perf/utils/circuit_breaker/config.py
+++ b/inference_perf/utils/circuit_breaker/config.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+from typing import List
+from .triggers.config import TriggerSpec
+
+class MetricsSpec(BaseModel):
+    """
+    Manage matches and rules to select target metrics. 
+    """
+    matches: List[str] = Field(..., description="Determine data is target metrics or not", min_length=1)
+    rules: List[str] = Field(default=[], description="Determine data is hit or not")
+
+class CircuitBreakerConfig(BaseModel):
+    """
+    Declarative breaker configuration.
+    """
+    name: str
+    metrics: MetricsSpec
+    triggers: List[TriggerSpec]

--- a/inference_perf/utils/circuit_breaker/simple_breaker.py
+++ b/inference_perf/utils/circuit_breaker/simple_breaker.py
@@ -1,0 +1,44 @@
+import jmespath
+
+from datetime import datetime
+from typing import Any, Dict, List
+from pydantic import BaseModel
+from .base import CircuitBreaker
+from .config import CircuitBreakerConfig
+from .triggers import HitSample
+
+class SimpleCircuitBreaker(CircuitBreaker):
+    """
+    Simple Expression-driven breaker.
+    - rules: JMESPath boolean expressions (OR semantics).
+    - triggers: OR semantics; any fired -> open.
+    """
+    def __init__(self, config: CircuitBreakerConfig) -> None:
+        super().__init__(config)
+        self._matches = [jmespath.compile(expr) for expr in config.metrics.matches]
+        self._rules = [jmespath.compile(expr) for expr in config.metrics.rules]
+
+    def _search(self, exprs: List[jmespath.parser.ParsedResult], data: Dict[str, Any]) -> bool:
+        for expr in exprs:
+            try:
+                if bool(expr.search(data)):
+                    return True
+            except Exception:
+                pass
+        return False
+
+    def feed(self, metric: BaseModel) -> None:
+        data = metric.model_dump(mode="json", exclude_unset=True, exclude_none=True)
+        if self._search(self._matches, data):
+            hit = 1 if not self._rules or self._search(self._rules, data) else 0
+            hit_sample = HitSample(datetime.now(), hit)
+            for t in self._triggers:
+                t.update(hit_sample)
+                if t.fired():
+                    self._open = True
+
+    def is_open(self) -> bool:
+        return self._open
+
+    def reset(self) -> None:
+        self._open = False

--- a/inference_perf/utils/circuit_breaker/triggers/__init__.py
+++ b/inference_perf/utils/circuit_breaker/triggers/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .base import build_trigger, Trigger, HitSample
+from .config import TriggerSpec
+
+from pkgutil import walk_packages
+from importlib import import_module
+
+for _, name, _ in walk_packages(__path__):
+    import_module(f"{__name__}.{name}")
+
+__all__ = [
+    "build_trigger",
+    "HitSample",
+    "Trigger",
+    "TriggerSpec",
+]

--- a/inference_perf/utils/circuit_breaker/triggers/base.py
+++ b/inference_perf/utils/circuit_breaker/triggers/base.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Type
+from datetime import datetime
+from .config import TriggerSpec
+
+trigger_implementations: dict[Type[TriggerSpec], Type[Trigger]] = {}
+
+class TriggerMeta(type):
+    def __new__(mcs, name, bases, dct, spec_cls: Type[TriggerSpec] = None):
+        cls = super().__new__(mcs, name, bases, dct)
+        if spec_cls:
+            if spec_cls in trigger_implementations:
+                raise ValueError(f'Trigger spec "{spec_cls}" already registered')
+            trigger_implementations[spec_cls] = cls
+        elif name != 'Trigger':
+            raise TypeError(f'Trigger class {name} must have a spec_cls to register')
+        return cls
+
+
+@dataclass
+class HitSample:
+    ts: datetime
+    hit: int
+
+
+class Trigger(metaclass=TriggerMeta):
+    def update(self, s: HitSample) -> None: ...
+    def fired(self) -> bool: ...
+    def reset(self) -> None: ...
+
+def _init_trigger(trigger_class: type[Trigger], type: str, **kargs) -> Trigger:
+    return trigger_class(**kargs)
+
+def build_trigger(spec: TriggerSpec) -> Trigger:
+    if type(spec) in trigger_implementations:
+        return _init_trigger(trigger_implementations[type(spec)], **spec.model_dump())
+    raise ValueError(f"Unknown trigger spec: {spec}")
+

--- a/inference_perf/utils/circuit_breaker/triggers/config.py
+++ b/inference_perf/utils/circuit_breaker/triggers/config.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+from typing import Literal, Union
+
+class TriggerConsecutive(BaseModel):
+    type: Literal["consecutive"]
+    threshold: int = Field(..., ge=1)
+
+class TriggerRateOverWindow(BaseModel):
+    type: Literal["rate_over_window"]
+    window_sec: float = Field(..., gt=0.0)
+    threshold: float = Field(..., ge=0.0, le=1.0)
+    min_samples: int = Field(0, ge=0)
+
+
+TriggerSpec = Union[
+    TriggerConsecutive,
+    TriggerRateOverWindow,
+]

--- a/inference_perf/utils/circuit_breaker/triggers/consecutive.py
+++ b/inference_perf/utils/circuit_breaker/triggers/consecutive.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+from .config import TriggerConsecutive
+from .base import Trigger, HitSample
+
+
+class Consecutive(Trigger, spec_cls=TriggerConsecutive):
+    """Open when N consecutive hits occur."""
+    def __init__(self, threshold: int):
+        self.n = threshold
+        self.c = 0
+        self._fired = False
+
+    def update(self, s: HitSample) -> None:
+        self.c = self.c + 1 if s.hit else 0
+        if self.c >= self.n:
+            self._fired = True
+
+    def fired(self) -> bool:
+        return self._fired
+    
+    def reset(self):
+        self.c = 0
+        self._fired = False

--- a/inference_perf/utils/circuit_breaker/triggers/rate_over_window.py
+++ b/inference_perf/utils/circuit_breaker/triggers/rate_over_window.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import datetime
+from typing import List
+from .base import Trigger, HitSample
+from .config import TriggerRateOverWindow
+
+class RateOverWindow(Trigger, spec_cls=TriggerRateOverWindow):
+    """Open when hit rate over a time window crosses threshold."""
+    def __init__(self, window_sec: float, threshold: float, min_samples: int = 0):
+        self.size = datetime.timedelta(seconds=window_sec)
+        self.th = threshold
+        self.min = min_samples
+        self.buf: List[HitSample] = []
+        self._fired = False
+
+    def update(self, s: HitSample) -> None:
+        now = s.ts
+        self.buf.append(s)
+        cutoff = now - self.size
+        self.buf = [x for x in self.buf if x.ts >= cutoff]
+        total = len(self.buf)
+        if total >= self.min:
+            hits = sum(x.hit for x in self.buf)
+            rate = hits / total if total else 0.0
+            if rate >= self.th:
+                self._fired = True
+
+    def fired(self) -> bool:
+        return self._fired
+    
+    def reset(self):
+        self.buf.clear()
+        self._fired = False


### PR DESCRIPTION
## Feat: Add request timeouts and circuit breakers

This change introduces robust error handling and resilience mechanisms into the benchmarking tool by adding support for request timeouts and a flexible circuit breaker system. These features allow for faster failure detection and more efficient use of resources by preventing the tool from continuing a test run that is clearly failing.

### Request Timeouts

A global request timeout can now be configured for the model server client. This prevents individual long-running requests from blocking the load generator and skewing results.

-   Timeouts are passed down to the underlying HTTP client (e.g., `aiohttp`).
-   When a request exceeds the specified timeout, it is marked as a `TimeoutError`, and this failure is recorded in the metrics.

### Circuit Breaker Design

A declarative, expression-driven circuit breaker system has been implemented to automatically halt a benchmark stage when failure conditions are met.

**Core Concepts:**

1.  **Circuit Breaker (`circuit_breakers`):** A top-level configuration object where you define one or more named circuit breakers.
2.  **Metrics Matching (`metrics`):** Each breaker targets specific metrics to monitor. It uses [JMESPath](https://jmespath.org/) expressions to filter the stream of request metrics. A metric is a candidate for triggering the breaker if it matches the `matches` expressions. and optional `rules` expressions help to detect a metrics "success" or "failure".
3.  **Triggers (`triggers`):** Define the conditions under which a circuit breaker will "open" (fire). Multiple triggers can be defined for a single breaker, and the breaker will open if any of them fire.

**Available Triggers:**

*   `consecutive`: Opens if a specified number of consecutive matching requests are considered failures.
*   `rate_over_window`: Opens if the failure rate within a sliding time window exceeds a certain threshold, given a minimum number of samples.

**How it Works:**

1.  Every request metric is fed to all defined circuit breakers.
2.  Each breaker uses its `metrics.matches` expressions to decide if the metric is relevant (e.g., selecting only errors of type `TimeoutError`).
3.  If relevant, the metric is evaluated by the breaker's triggers.
4.  The load generator checks the state of the circuit breakers associated with the current stage. If any breaker is open, the stage is immediately terminated and marked as failed.

### Configuration and Usage

Circuit breakers are defined in the main configuration file and then associated with a specific load configuration.

**Example Configuration:**

Here is an example that defines a circuit breaker to stop a run if there are 10 consecutive timeouts or if the timeout rate exceeds 80% in a 2.5-second window.

```yaml
# 1. Define the circuit breaker
circuit_breakers:
  - name: request_timeout_breaker
    metrics: 
      matches:
        - "error.error_type == 'TimeoutError'"
    triggers:
      - type: consecutive
        threshold: 10 
      - type: rate_over_window
        window_sec: 2.5
        threshold: 0.8
        min_samples: 2

# 2. Apply the breaker to the load configuration
load:
  type: constant
  stages:
  - rate: 1
    duration: 30
  circuit_breakers:
    - request_timeout_breaker
```

### Extension
The circuit breaker system can be reused by any components instead of only load generator. Any components can get/check breaker status and define their own logic.