### PR TITLE
Make selected request rates accurate to two decimal places (formerly zero) when using linear sweep type

### DIFF
--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -334,7 +334,7 @@ class LoadGenerator:
             if gen_type == StageGenType.GEOM:
                 return [float(round(1 + target_request_rate - rr, 2)) for rr in np.geomspace(target_request_rate, 1, num=size)]
             elif gen_type == StageGenType.LINEAR:
-                return [float(round(r)) for r in np.linspace(1, target_request_rate, size)]
+                return [float(round(r, 2)) for r in np.linspace(1, target_request_rate, size)]
 
         rates = generateRates(saturation_point, self.sweep_config.num_stages, self.sweep_config.type)
         self.stages = [LoadStage(rate=r, duration=self.sweep_config.stage_duration) for r in rates]


### PR DESCRIPTION
Makes request rates chosen when using linear sweep of equal precision to the request rates chosen when using geometric sweep. Also reduces the likelihood of benchmarking duplicate request rates. Seeing the following request rates `[1.0, 7.09, 13.18]` when using config:
```
load:
  type: constant
  interval: 1.0
  sweep:
    type: linear
    timeout: 120
    num_stages: 3
    stage_duration: 60
  num_workers: 44
  worker_max_concurrency: 10
  worker_max_tcp_connections: 2500
  ```
  
 Partially addresses: https://github.com/kubernetes-sigs/inference-perf/issues/229