### PR TITLE
refactor: Make base client concrete and usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Inference Perf is a GenAI inference performance benchmarking tool that allows yo
 * Highly scalable and can support benchmarking large inference production deployments.
 * Reports the key metrics needed to measure LLM performance.
 * Supports different real world and synthetic datasets.
-* Supports different APIs and supports multiple model servers with enhanced metrics like [vLLM](https://github.com/vllm-project/vllm), [SGLang](https://github.com/sgl-project/sglang) and [TGI](https://github.com/huggingface/text-generation-inference).
+* Supports different APIs and supports multiple model servers with enhanced metrics like [vLLM](https://github.com/vllm-project/vllm), [SGLang](https://github.com/sgl-project/sglang), [TGI](https://github.com/huggingface/text-generation-inference), and natively handles any standard OpenAI-compatible endpoints.
 * Supports benchmarking large deployments with frameworks like [llm-d](https://llm-d.ai/), [Dynamo](https://docs.nvidia.com/dynamo/latest/) and [Inference Gateway](https://gateway-api-inference-extension.sigs.k8s.io/).
 * Supports specifying an exact input and output distribution to simulate different scenarios - Gaussian distribution, fixed length, min-max cases are all supported.
 * Generates different load patterns and can benchmark specific cases like burst traffic, scaling to saturation and other autoscaling / routing scenarios.
@@ -46,7 +46,7 @@ Inference Perf is a GenAI inference performance benchmarking tool that allows yo
 - Hugging Face Authentication [**OPTIONAL**]
 
     > **Optional**: *the step is required for gated models only*
-    
+
     To download tokenizer from the Hugging Face Hub, you need to authenticate. You can do this in one of the following ways:
 
     1. Using `huggingface-cli login`:
@@ -144,7 +144,7 @@ Example:
 
 ### API
 
-OpenAI completion and chat completion APIs are supported. It can be pointed to any endpoints which support these APIs - currently verified against vLLM deployments. Other APIs and model server support can be added easily.
+OpenAI completion and chat completion APIs are supported. Benchmarks can be pointed to any endpoints which support these APIs—using the generic `openai` ModelServerType—but we additionally provide specialized clients with enhanced metric gathering capabilities for Native vLLM, SGLang, and TGI deployments. Other APIs and model server support can be added easily.
 
 ### Metrics
 
@@ -285,7 +285,7 @@ To debug any failure in testing, the end-to-end test workflow exposes output art
 
 ## Contributing
 
-Our community meeting is weekly on Thursdays alternating betweem 09:00 and 11:30 PDT ([Zoom Link](https://zoom.us/j/9955436256?pwd=Z2FQWU1jeDZkVC9RRTN4TlZyZTBHZz09), [Meeting Notes](https://docs.google.com/document/d/15XSF8q4DShcXIiExDfyiXxAYQslCmOmO2ARSJErVTak/edit?usp=sharing), [Meeting Recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP30qNanabU75ayPK7OPNAAS)). 
+Our community meeting is weekly on Thursdays alternating betweem 09:00 and 11:30 PDT ([Zoom Link](https://zoom.us/j/9955436256?pwd=Z2FQWU1jeDZkVC9RRTN4TlZyZTBHZz09), [Meeting Notes](https://docs.google.com/document/d/15XSF8q4DShcXIiExDfyiXxAYQslCmOmO2ARSJErVTak/edit?usp=sharing), [Meeting Recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP30qNanabU75ayPK7OPNAAS)).
 
 We currently utilize the [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf) channel in Kubernetes Slack workspace for communications.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,7 +36,7 @@ api:
   slo_unit: "ms"               # Optional SLO unit (e.g., ms, s), default is ms
   slo_tpot_header: "x-slo-tpot-ms"        # Optional header name for TPOT SLO Header, default is x-slo-tpot-ms
   slo_ttft_header: "x-slo-ttft-ms"        # Optional header name for TTFT SLO Header, default is x-slo-ttft-ms
-```  
+```
 
 ### Data Generation
 
@@ -123,12 +123,14 @@ Configures connection to the model serving backend:
 
 ```yaml
 server:
-  type: vllm                                          # Currently only vLLM supported
+  type: vllm                                          # Server type (vllm, sglang, tgi, openai, mock)
   model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"   # Required model identifier
   base_url: "http://0.0.0.0:8000"                     # Required server endpoint
   ignore_eos: true                                    # Whether to ignore End-of-Sequence tokens
   api_key: ""                                         # Optional API key for authenticated endpoints
 ```
+
+> **Note on `openai` Server Type**: The `openai` ModelServerType acts as a generic, vanilla client for testing *any* generic OpenAI-compatible endpoint. While it supports the same core OpenAI protocols (Chat and Completions), it does not export or gather the specialized Prometheus metrics (like KV cache statistics or Queue Depth) that the vendor-specific clients (`vllm`, `sglang`, `tgi`) natively support.
 
 ### Metrics Collection
 
@@ -227,10 +229,10 @@ load:
   stages:
   - rate: 1
     duration: 30
-api: 
+api:
   type: chat
 server:
-  type: vllm
+  type: openai
   model_name: HuggingFaceTB/SmolLM2-135M-Instruct
   base_url: http://0.0.0.0:8000
 ```
@@ -243,7 +245,7 @@ load:
   stages:
   - rate: 1
     duration: 30
-api: 
+api:
   type: completion
 server:
   type: vllm
@@ -289,10 +291,10 @@ load:
   stages:
   - rate: 1
     duration: 30
-api: 
+api:
   type: chat
 server:
-  type: vllm
+  type: openai
   model_name: ./models/SmolLM2-135M-Instruct
   base_url: http://0.0.0.0:8000
   ignore_eos: true

--- a/inference_perf/client/modelserver/__init__.py
+++ b/inference_perf/client/modelserver/__init__.py
@@ -15,7 +15,7 @@ from .base import ModelServerClient, ModelServerClientSession
 from .mock_client import MockModelServerClient
 from .vllm_client import vLLMModelServerClient
 from .sglang_client import SGlangModelServerClient
-
+from .openai_client import openAIModelServerClient
 
 __all__ = [
     "ModelServerClient",
@@ -23,4 +23,5 @@ __all__ = [
     "MockModelServerClient",
     "vLLMModelServerClient",
     "SGlangModelServerClient",
+    "openAIModelServerClient",
 ]

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -115,7 +115,7 @@ class openAIModelServerClient(ModelServerClient):
             self._session = None
 
     def get_supported_apis(self) -> List[APIType]:
-        return []
+        return [APIType.Completion, APIType.Chat]
 
     @abstractmethod
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import abstractmethod
+
 from inference_perf.client.requestdatacollector import RequestDataCollector
 from inference_perf.config import APIConfig, APIType, CustomTokenizerConfig, MultiLoRAConfig
 from inference_perf.apis import InferenceAPIData, InferenceInfo, RequestLifecycleMetric, ErrorResponseInfo
@@ -117,9 +117,8 @@ class openAIModelServerClient(ModelServerClient):
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion, APIType.Chat]
 
-    @abstractmethod
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
-        raise NotImplementedError
+        return PrometheusMetricMetadata()  # type: ignore[typeddict-item]
 
     def get_supported_models(self) -> List[dict[str, Any]]:
         try:

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -118,7 +118,7 @@ class openAIModelServerClient(ModelServerClient):
         return [APIType.Completion, APIType.Chat]
 
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
-        return PrometheusMetricMetadata()  # type: ignore[typeddict-item]
+        return PrometheusMetricMetadata()  # type: ignore[typeddict-item, no-any-return]
 
     def get_supported_models(self) -> List[dict[str, Any]]:
         try:

--- a/inference_perf/client/modelserver/sglang_client.py
+++ b/inference_perf/client/modelserver/sglang_client.py
@@ -52,8 +52,6 @@ class SGlangModelServerClient(openAIModelServerClient):
         )
         self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
 
-    def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Completion, APIType.Chat]
 
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         return PrometheusMetricMetadata(

--- a/inference_perf/client/modelserver/sglang_client.py
+++ b/inference_perf/client/modelserver/sglang_client.py
@@ -14,7 +14,7 @@
 
 from inference_perf.client.modelserver.openai_client import openAIModelServerClient
 from inference_perf.client.requestdatacollector import RequestDataCollector
-from inference_perf.config import APIConfig, APIType, CustomTokenizerConfig, MultiLoRAConfig
+from inference_perf.config import APIConfig, CustomTokenizerConfig, MultiLoRAConfig
 from .base import PrometheusMetricMetadata, ModelServerPrometheusMetric
 from typing import List, Optional
 import logging
@@ -51,7 +51,6 @@ class SGlangModelServerClient(openAIModelServerClient):
             lora_config=lora_config,
         )
         self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
-
 
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         return PrometheusMetricMetadata(

--- a/inference_perf/client/modelserver/tgi_client.py
+++ b/inference_perf/client/modelserver/tgi_client.py
@@ -52,9 +52,6 @@ class TGImodelServerClient(openAIModelServerClient):
         )
         self.metric_filters = additional_filters
 
-    def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Completion, APIType.Chat]
-
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         return PrometheusMetricMetadata(
             avg_queue_length=ModelServerPrometheusMetric(

--- a/inference_perf/client/modelserver/tgi_client.py
+++ b/inference_perf/client/modelserver/tgi_client.py
@@ -14,7 +14,7 @@
 
 from inference_perf.client.modelserver.openai_client import openAIModelServerClient
 from inference_perf.client.requestdatacollector import RequestDataCollector
-from inference_perf.config import APIConfig, APIType, CustomTokenizerConfig, MultiLoRAConfig
+from inference_perf.config import APIConfig, CustomTokenizerConfig, MultiLoRAConfig
 from .base import PrometheusMetricMetadata, ModelServerPrometheusMetric
 from typing import List, Optional
 import logging

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -56,9 +56,6 @@ class vLLMModelServerClient(openAIModelServerClient):
         )
         self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
 
-    def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Completion, APIType.Chat]
-
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         return PrometheusMetricMetadata(
             # Queue Length

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -14,7 +14,7 @@
 
 from inference_perf.client.modelserver.openai_client import openAIModelServerClient
 from inference_perf.client.requestdatacollector import RequestDataCollector
-from inference_perf.config import APIConfig, APIType, CustomTokenizerConfig, MultiLoRAConfig
+from inference_perf.config import APIConfig, CustomTokenizerConfig, MultiLoRAConfig
 from .base import PrometheusMetricMetadata, ModelServerPrometheusMetric
 from typing import List, Optional
 import logging

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -110,6 +110,7 @@ class ModelServerType(Enum):
     VLLM = "vllm"
     SGLANG = "sglang"
     TGI = "tgi"
+    OPENAI = "openai"
     MOCK = "mock"
 
 

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -41,6 +41,7 @@ from inference_perf.client.modelserver import (
     ModelServerClient,
     vLLMModelServerClient,
     SGlangModelServerClient,
+    openAIModelServerClient,
     MockModelServerClient,
 )
 from inference_perf.client.metricsclient.base import MetricsClient, PerfRuntimeParameters
@@ -222,6 +223,24 @@ def main_cli() -> None:
                 lora_config=config.load.lora_traffic_split,
             )
             # tgi_client supports inferring the tokenizer
+            tokenizer = model_server_client.tokenizer
+        if config.server.type == ModelServerType.OPENAI:
+            model_server_client = openAIModelServerClient(
+                reportgen.get_metrics_collector(),
+                api_config=config.api,
+                uri=config.server.base_url,
+                model_name=config.server.model_name,
+                tokenizer_config=config.tokenizer,
+                ignore_eos=config.server.ignore_eos,
+                max_tcp_connections=config.load.worker_max_tcp_connections,
+                additional_filters=config.metrics.prometheus.filters if config.metrics and config.metrics.prometheus else [],
+                api_key=config.server.api_key,
+                timeout=config.load.request_timeout,
+                cert_path=config.server.cert_path,
+                key_path=config.server.key_path,
+                lora_config=config.load.lora_traffic_split,
+            )
+            # OpenAI requires a tokenizer configured externally if not strictly string-based or inferred from the model_name
             tokenizer = model_server_client.tokenizer
         if config.server.type == ModelServerType.MOCK:
             model_server_client = MockModelServerClient(

--- a/tests/client/modelserver/test_openai_client.py
+++ b/tests/client/modelserver/test_openai_client.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock, patch
+from inference_perf.client.modelserver.openai_client import openAIModelServerClient
+from inference_perf.config import APIConfig, APIType
+
+
+@patch("inference_perf.client.modelserver.openai_client.CustomTokenizer")
+def test_openai_client_prometheus_metadata(mock_tokenizer):
+    # Setup standard mock configs
+    mock_collector = MagicMock()
+    mock_api_config = APIConfig(type=APIType.Chat, streaming=False)
+
+    # Initialize the client specifically to test the abstract method override
+    client = openAIModelServerClient(
+        metrics_collector=mock_collector,
+        api_config=mock_api_config,
+        uri="http://0.0.0.0:8000",
+        model_name="mock-model",
+        tokenizer_config=None,
+        max_tcp_connections=10,
+        additional_filters=[],
+    )
+
+    # Verify the empty MetricMetadata is safely returned
+    metadata = client.get_prometheus_metric_metadata()
+    assert isinstance(metadata, dict)
+    assert len(metadata) == 0
+
+
+@patch("inference_perf.client.modelserver.openai_client.CustomTokenizer")
+def test_openai_client_supported_apis(mock_tokenizer):
+    mock_collector = MagicMock()
+    mock_api_config = APIConfig(type=APIType.Chat, streaming=False)
+    client = openAIModelServerClient(
+        metrics_collector=mock_collector,
+        api_config=mock_api_config,
+        uri="http://0.0.0.0:8000",
+        model_name="mock-model",
+        tokenizer_config=None,
+        max_tcp_connections=10,
+        additional_filters=[],
+    )
+    apis = client.get_supported_apis()
+    assert APIType.Completion in apis
+    assert APIType.Chat in apis
+
+
+@patch("inference_perf.client.modelserver.openai_client.CustomTokenizer")
+@patch("inference_perf.client.modelserver.openai_client.requests.get")
+def test_openai_client_get_supported_models(mock_get, mock_tokenizer):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": [{"id": "model-1"}, {"id": "model-2"}]}
+    mock_get.return_value = mock_response
+
+    mock_collector = MagicMock()
+    mock_api_config = APIConfig(type=APIType.Chat, streaming=False)
+    client = openAIModelServerClient(
+        metrics_collector=mock_collector,
+        api_config=mock_api_config,
+        uri="http://0.0.0.0:8000",
+        model_name="mock-model",
+        tokenizer_config=None,
+        max_tcp_connections=10,
+        additional_filters=[],
+    )
+    models = client.get_supported_models()
+    assert len(models) == 2
+    assert models[0]["id"] == "model-1"
+    mock_get.assert_called_once_with("http://0.0.0.0:8000/v1/models")
+
+
+@patch("inference_perf.client.modelserver.openai_client.CustomTokenizer")
+@patch("inference_perf.client.modelserver.openai_client.requests.get")
+def test_openai_client_get_supported_models_error(mock_get, mock_tokenizer):
+    mock_get.side_effect = Exception("Connection Error")
+
+    mock_collector = MagicMock()
+    mock_api_config = APIConfig(type=APIType.Chat, streaming=False)
+    client = openAIModelServerClient(
+        metrics_collector=mock_collector,
+        api_config=mock_api_config,
+        uri="http://0.0.0.0:8000",
+        model_name="mock-model",
+        tokenizer_config=None,
+        max_tcp_connections=10,
+        additional_filters=[],
+    )
+    models = client.get_supported_models()
+    assert models == []


### PR DESCRIPTION
The openAIModelServerClient could not be instantiated directly as it declared no supported APIs. While this may have been intended to enforce it as a base class, making it concrete provides more flexibility.

This change allows the client to be used with any generic OpenAI-compatible endpoint. It also centralizes the API list so redundant overrides can be removed from the vLLM, TGI, and SGLang subclasses, improving maintainability.