### PR TITLE
feat: Enhance Helm chart flexibility for job

### DIFF
--- a/deploy/inference-perf/templates/job.yaml
+++ b/deploy/inference-perf/templates/job.yaml
@@ -14,6 +14,10 @@ spec:
         app: inference-perf
     spec:
       restartPolicy: Never
+      {{- with .Values.job.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: inference-perf-container
           image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag | default .Chart.AppVersion }}"
@@ -24,20 +28,19 @@ spec:
             - "--log-level"
             - {{ .Values.logLevel }}
           env:
-{{- if .Values.hfToken }}
-          - name: HF_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "inference-perf.hfSecret" . }}
-                key: {{ include "inference-perf.hfKey" . }}
-{{- end }}
+            {{- if .Values.hfToken }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "inference-perf.hfSecret" . }}
+                  key: {{ include "inference-perf.hfKey" . }}
+            {{- end }}
           volumeMounts:
             - name: config-volume
               mountPath: {{ include "inference-perf.configMount" . }}
               readOnly: true
           resources:
-            requests:
-              memory: {{ .Values.job.memory }}
+            {{- toYaml .Values.job.resources | nindent 12 }}
       volumes:
         - name: config-volume
           configMap:

--- a/deploy/inference-perf/values.yaml
+++ b/deploy/inference-perf/values.yaml
@@ -2,8 +2,17 @@
 job:
   image:
     repository: quay.io/inference-perf/inference-perf
-    tag: ""
-  memory: "8G"
+    tag: "" # Defaults to .Chart.AppVersion
+  nodeSelector: {}
+  # Example resources:
+  # resources:
+  #   requests:
+  #     cpu: "1"
+  #     memory: "4Gi"
+  #   limits:
+  #     cpu: "2"
+  #     memory: "8Gi"
+  resources: {}
 
 logLevel: INFO
 


### PR DESCRIPTION
Adds support for nodeSelector and custom resources to the inference-perf Helm chart.

-   `job.nodeSelector`: Allows specifying node constraints for the job.
-   `job.resources`: Enables full definition of resource requests and
    limits (CPU, memory, etc.), replacing the previous `job.memory`.

These changes provide greater control over job scheduling and resource allocation when deploying with Helm. The values.yaml has been updated to reflect the new structure.