### PR TITLE
Update helm chart to pass in gcs bucket to download datasets.

### DIFF
--- a/deploy/inference-perf/README.md
+++ b/deploy/inference-perf/README.md
@@ -1,14 +1,82 @@
-## Run `inference-perf` via Helm Chart
+## 🚀 Deploying `inference-perf` via Helm Chart
 
 This guide explains how to deploy `inference-perf` to a Kubernetes cluster with Helm.
 
-### Setup
+---
 
-Within the deploy/infernce-perf directory, edit values.yaml to configure the Helm Chart and infernce-perf options.
+### 1. Prerequisites
 
-### Run
+Make sure you have the following tools installed and configured:
 
-Deploy locally via `helm install test .` optionally including the hfToken via `helm install test . --set hfToken=<token>`.
+* **Kubernetes Cluster:** Access to a functional cluster (e.g., GKE).
+* **Helm:** The Helm CLI installed locally.
 
-The chart can also be deployed locally with a custom yaml file specifying overrides.
-`helm install test . -f test.yaml`
+---
+
+### 2. Configuration (`values.yaml`)
+
+Before deployment, navigate to the **`deploy/inference-perf`** directory and edit the **`values.yaml`** file to customize your deployment and the benchmark parameters.
+
+#### Optional Parameters
+
+| Key | Description | Default |
+| :--- | :--- | :--- |
+| `hfToken` | Hugging Face API token. If provided, a Kubernetes `Secret` named `hf-token-secret` will be created for authentication. | `""` |
+| `nodeSelector` |  Standard Kubernetes `nodeSelector` map to constrain pod placement to nodes with matching labels. | `{}` |
+| `resources` | Standard Kubernetes resource requests and limits for the main `inference-perf` container. | `{}` |
+---
+
+> **Example Resource Block:**
+> ```yaml
+> # resources:
+> #   requests:
+> #     cpu: "1"
+> #     memory: "4Gi"
+> #   limits:
+> #     cpu: "2"
+> #     memory: "8Gi"
+> ```
+
+#### GKE Specific Parameters
+
+This section details the necessary configuration and permissions for using a Google Cloud Storage (GCS) path to manage your dataset, typical for deployments on GKE.
+
+##### Required IAM Permissions
+
+The identity executing the workload (e.g., the associated Kubernetes Service Account, often configured via **Workload Identity**) must possess the following IAM roles on the target GCS bucket for data transfer:
+
+* **`roles/storage.objectViewer`** (Required to read/download the input dataset from GCS).
+* **`roles/storage.objectCreator`** (Required to write/push benchmark results back to GCS).
+
+
+| Key | Description | Default |
+| :--- | :--- | :--- |
+| `gcsPath` | A GCS URI pointing to the dataset file (e.g., `gs://my-bucket/dataset.json`). The file will be automatically copied to the running pod during initialization. | `""` |
+
+---
+
+### 3. Run Deployment
+
+Use the **`helm install`** command from the **`deploy/inference-perf`** directory to deploy the chart.
+
+* **Standard Install:** Deploy using the default `values.yaml`.
+    ```bash
+    helm install test .
+    ```
+
+* **Set `hfToken` Override:** Pass the Hugging Face token directly.
+    ```bash
+    helm install test . --set hfToken="<TOKEN>"
+    ```
+
+* **Custom Config Override:** Make changes to the values file for custom settings.
+    ```bash
+    helm install test . -f values.yaml
+    ```
+
+### 4. Cleanup
+
+To remove the benchmark deployment.
+    ```bash
+    helm uninstall test
+    ```

--- a/deploy/inference-perf/templates/job.yaml
+++ b/deploy/inference-perf/templates/job.yaml
@@ -18,6 +18,15 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- if .Values.gcsPath}}
+      initContainers:
+        - name: fetch-dataset
+          image: google/cloud-sdk:latest
+          command: ["sh", "-c", "gsutil cp {{ .Values.gcsPath }} /dataset/dataset.json"]
+          volumeMounts:
+            - name: dataset-volume
+              mountPath: /dataset
+{{- end }}
       containers:
         - name: inference-perf-container
           image: "{{ .Values.job.image.repository }}:{{ .Values.job.image.tag | default .Chart.AppVersion }}"

--- a/deploy/inference-perf/values.yaml
+++ b/deploy/inference-perf/values.yaml
@@ -16,6 +16,12 @@ job:
 
 logLevel: INFO
 
+# A GCS bucket path that points to the dataset file.
+# The file will be copied from this path to the local file system
+# at /dataset/dataset.json for use during the run.
+# NOTE: For this dataset to be used, config.data.path must also be explicitly set to /dataset/dataset.json.
+gcsPath: ""
+
 # hfToken optionally creates a secret with the specified token.
 # Can be set using helm install --set hftoken=<token>
 hfToken: ""


### PR DESCRIPTION
This is useful for the  billsum and infinity instruct datasets.