### PR TITLE
Improve MultiprocessRequestDataCollector async

### DIFF
--- a/inference_perf/client/requestdatacollector/base.py
+++ b/inference_perf/client/requestdatacollector/base.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, AsyncIterator
+from contextlib import asynccontextmanager
 
 from inference_perf.apis import RequestLifecycleMetric
 
@@ -29,3 +30,7 @@ class RequestDataCollector(ABC):
     @abstractmethod
     def get_metrics(self) -> List[RequestLifecycleMetric]:
         raise NotImplementedError
+
+    @asynccontextmanager
+    async def start(self) -> AsyncIterator[None]:
+        yield

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -72,13 +72,9 @@ class InferencePerfRunner:
     def run(self) -> None:
         async def _run() -> None:
             # Start the collector, which will gather metrics from the model_server_client
-            collector = self.reportgen.get_metrics_collector()
-            if isinstance(collector, MultiprocessRequestDataCollector):
-                collector.start()
-            # Generate load that is sent to inference endpoint
-            await self.loadgen.run(self.client)
-            if isinstance(collector, MultiprocessRequestDataCollector):
-                await collector.stop()
+            async with self.reportgen.get_metrics_collector().start():
+                # Generate load that is sent to inference endpoint
+                await self.loadgen.run(self.client)
 
         asyncio.run(_run())
 


### PR DESCRIPTION
This commit refactors `MultiprocessRequestDataCollector` to better handle collecting metrics data asynchronously.

The most significant change is the switch from `queue.get_nowait` then `await sleep` to running the `queue.get` operation on an entirely separate thread. This ensures that metrics are immediately collected, speeding up overall runtime.

A new async-context-manager-based `start()` method now replaces the older `start()` and `stop()` methods, meaning that instead of using it like so:

    await start()
    do_operation()
    await stop()

We can now use it as:

    async with start():
        do_operation()

Draining and cleanup is automatically handled in the background.

Fixes https://github.com/kubernetes-sigs/inference-perf/issues/245.