### PR TITLE
Share aiohttp.ClientSessions per worker

### DIFF
--- a/inference_perf/client/modelserver/__init__.py
+++ b/inference_perf/client/modelserver/__init__.py
@@ -11,10 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .base import ModelServerClient
+from .base import ModelServerClient, ModelServerClientSession
 from .mock_client import MockModelServerClient
 from .vllm_client import vLLMModelServerClient
 from .sglang_client import SGlangModelServerClient
 
 
-__all__ = ["ModelServerClient", "MockModelServerClient", "vLLMModelServerClient", "SGlangModelServerClient"]
+__all__ = [
+    "ModelServerClient",
+    "ModelServerClientSession",
+    "MockModelServerClient",
+    "vLLMModelServerClient",
+    "SGlangModelServerClient",
+]

--- a/inference_perf/client/modelserver/base.py
+++ b/inference_perf/client/modelserver/base.py
@@ -15,7 +15,6 @@ from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 from inference_perf.client.metricsclient.base import MetricsMetadata
 from inference_perf.config import APIConfig, APIType
-
 from inference_perf.apis import InferenceAPIData
 
 
@@ -82,6 +81,9 @@ class ModelServerClient(ABC):
         self.api_config = api_config
         self.timeout = timeout
 
+    def new_session(self) -> "ModelServerClientSession":
+        return ModelServerClientSession(self)
+
     @abstractmethod
     def get_supported_apis(self) -> List[APIType]:
         raise NotImplementedError
@@ -94,3 +96,14 @@ class ModelServerClient(ABC):
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         # assumption: all metrics clients have metrics exported in Prometheus format
         raise NotImplementedError
+
+
+class ModelServerClientSession:
+    def __init__(self, client: ModelServerClient):
+        self.client = client
+
+    async def process_request(self, data: InferenceAPIData, stage_id: int, scheduled_time: float) -> None:
+        await self.client.process_request(data, stage_id, scheduled_time)
+
+    async def close(self) -> None:  # noqa - subclasses optionally override this
+        pass


### PR DESCRIPTION
Slightly refactor `openAIModelServerClient` to add a new method,
`process_request_with_session`, that accepts a custom
`ReusableHTTPClientSession` per request, which allows the caller to
reuse an HTTP client session per worker.

The previous method, `process_request`, is made to create a fresh HTTP
client session then call `process_request_with_session`, preserving the
previous behavior.

Prior to this commit, a new `aiohttp.ClientSession` is created for each
request. Not only is this inefficient and lowers throughput, on certain
environments, it also leads to inotify watch issues:

    aiodns - WARNING - Failed to create DNS resolver channel with
    automatic monitoring of resolver configuration changes. This usually
    means the system ran out of inotify watches. Falling back to socket
    state callback. Consider increasing the system inotify watch limit:
    Failed to initialize c-ares channel

Indeed, because each DNS resolver is created for a new `ClientSession`,
creating tons of new `ClientSession`s causes eventual inotify watch
exhaustion. Sharing `ClientSession`s solves this issue.

Relevant links:

- https://docs.aiohttp.org/en/stable/http_request_lifecycle.html
- https://stackoverflow.com/questions/62707369/one-aiohttp-clientsession-per-thread
- https://github.com/home-assistant/core/issues/144457#issuecomment-2869008923

Relevant PR: https://github.com/kubernetes-sigs/inference-perf/pull/247
(doesn't address the issue of worker sharing).