### PR TITLE
chore: improve openai client error handling by including status code and reason

### DIFF
--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -103,7 +103,10 @@ class openAIModelServerClient(ModelServerClient):
                     end_time = time.perf_counter()
                     error = None
                     if response.status != 200:
-                        error = ErrorResponseInfo(error_msg=response_content, error_type="Error response")
+                        error = ErrorResponseInfo(
+                            error_msg=response_content,
+                            error_type=f"{response.status} {response.reason}",
+                        )
 
                     self.metrics_collector.record_metric(
                         RequestLifecycleMetric(


### PR DESCRIPTION
I can't detect an error if the error message is empty, so I set the error type to the response status.