### PR TITLE
feat: add percentiles configuration for request lifecycle metrics reporting

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -156,6 +156,7 @@ report:
     summary: true       # Generate high-level summary
     per_stage: true     # Include breakdown by load stage
     per_request: false  # Enable detailed per-request logs (verbose)
+    percentiles: [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9] # List of percentiles to calculate
   prometheus:
     summary: true       # Include Prometheus metrics summary
     per_stage: false    # Disable Prometheus stage breakdown

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -11,14 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from datetime import datetime
-from pydantic import BaseModel, HttpUrl, model_validator, Field
-from inference_perf.circuit_breaker import CircuitBreakerConfig
-from typing import Any, Optional, List, Union
 from enum import Enum
 from os import cpu_count
+from typing import Any, List, Optional, Union
+
 import yaml
-import logging
+from pydantic import BaseModel, Field, HttpUrl, model_validator
+
+from inference_perf.circuit_breaker import CircuitBreakerConfig
 
 
 class APIType(Enum):
@@ -219,6 +221,7 @@ class RequestLifecycleMetricsReportConfig(BaseModel):
     summary: Optional[bool] = True
     per_stage: Optional[bool] = True
     per_request: Optional[bool] = False
+    percentiles: List[float] = [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9]
 
 
 class PrometheusMetricsReportConfig(BaseModel):


### PR DESCRIPTION
When benchmarking high-throughput inference servers with complex architectures involving multiple network hops (e.g., llm-d), we observed that ITL often converge to near-zero values at lower percentiles.

To analyze these scenarios effectively, we need the ability to define granular percentile breakpoints rather than relying on a fixed set of standard percentiles.

The functionality was verified by building the image and running benchmarks with custom percentile configurations.