### PR TITLE
Add mTLS support in vllm client

### DIFF
--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -35,6 +35,8 @@ class vLLMModelServerClient(openAIModelServerClient):
         ignore_eos: bool = True,
         api_key: Optional[str] = None,
         timeout: Optional[float] = None,
+        cert_path: Optional[str] = None,
+        key_path: Optional[str] = None,
     ) -> None:
         super().__init__(
             metrics_collector,
@@ -47,6 +49,8 @@ class vLLMModelServerClient(openAIModelServerClient):
             ignore_eos,
             api_key,
             timeout,
+            cert_path,
+            key_path,
         )
         self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
 

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -255,6 +255,8 @@ class ModelServerClientConfig(BaseModel):
     base_url: str
     ignore_eos: bool = True
     api_key: Optional[str] = None
+    cert_path: Optional[str] = None
+    key_path: Optional[str] = None
 
 
 class CustomTokenizerConfig(BaseModel):

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -185,6 +185,8 @@ def main_cli() -> None:
                 additional_filters=config.metrics.prometheus.filters if config.metrics and config.metrics.prometheus else [],
                 api_key=config.server.api_key,
                 timeout=config.load.request_timeout,
+                cert_path=config.server.cert_path,
+                key_path=config.server.key_path,
             )
             # vllm_client supports inferring the tokenizer
             tokenizer = model_server_client.tokenizer


### PR DESCRIPTION
Add mTLS support in vllm client

This change adds two new optional `cert_path` and `key_path` config item to support mTLS auth with vllm client.