### PR TITLE
Implement DatasetTrace data generation feature

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -39,7 +39,7 @@ Configures the test data generation methodology:
 
 ```yaml
 data:
-  type: mock|shareGPT|synthetic|random|shared_prefix|cnn_dailymail|billsum_conversations|infinity_instruct # Data generation type
+  type: mock|shareGPT|synthetic|random|shared_prefix|cnn_dailymail|billsum_conversations|infinity_instruct|dataset_trace # Data generation type
   path: ./data/shareGPT/ShareGPT_V3_unfiltered_cleaned_split.json # For shareGPT type, path where dataset to be used is present. Path needs to be set for cnn_dailymail, billsum_conversations and infinity_instruct as well
   input_distribution:                                 # For synthetic/random types
     min: 10                                           # Minimum prompt length (tokens)
@@ -58,8 +58,36 @@ data:
     num_prompts_per_group: 10 # Unique questions per group
     system_prompt_len: 100    # Shared prefix length (tokens)
     question_len: 50          # Question length (tokens)
-    output_len: 50            # Target output length (tokens)  
+    output_len: 50            # Target output length (tokens)
+  trace:                      # For random/dataset_trace types
+    file: ./traces/trace.jsonl # Path to trace file
+    format: DatasetTrace       # Trace format: AzurePublicDataset or DatasetTrace
 ```
+
+#### DatasetTrace Data Generation
+
+The `dataset_trace` type allows you to provide custom prompts via a JSONL file. Each line in the file should be a JSON object with:
+
+- `text_input` (required): The actual prompt text to send to the model
+- `output_length` (optional): If provided, sets `max_tokens` for the request; if omitted, uses server default
+
+**Example trace file (`trace.jsonl`):**
+```jsonl
+{"text_input": "What is the capital of France?", "output_length": 20}
+{"text_input": "Explain quantum computing in simple terms."}
+{"text_input": "Write a Python function for fibonacci.", "output_length": 150}
+```
+
+**Example configuration:**
+```yaml
+data:
+  type: dataset_trace
+  trace:
+    file: ./traces/my_prompts.jsonl
+    format: DatasetTrace
+```
+
+The `dataset_trace` generator supports both `completion` and `chat` API types. For chat API, prompts are automatically wrapped in a user message.
 
 ### Load Configuration
 

--- a/docs/loadgen.md
+++ b/docs/loadgen.md
@@ -149,7 +149,9 @@ load:
 
 Trace replay allows you to reproduce real-world production traffic patterns in your benchmarks. This is valuable for testing how your inference server performs under realistic load patterns, including request bursts, idle periods, and varying token distributions.
 
-We currently support the [AzurePublicDataset](https://github.com/Azure/AzurePublicDataset/blob/master/data/AzureLLMInferenceTrace_conv.csv) trace format, which contains timestamped request logs with input and output token counts.
+We currently support two trace formats:
+1. **[AzurePublicDataset](https://github.com/Azure/AzurePublicDataset/blob/master/data/AzureLLMInferenceTrace_conv.csv)**: Contains timestamped request logs with input and output token counts
+2. **DatasetTrace**: JSONL format with actual prompt text and optional output length specifications
 
 #### How Trace Replay Works
 
@@ -171,7 +173,7 @@ load:
     format: AzurePublicDataset
 ```
 
-**Data Configuration** - Trace replay feature is only supported for random data generator. Matches the token counts from the trace:
+**Data Configuration** - For AzurePublicDataset format, use the random data generator to match token counts:
 ```yaml
 data:
   type: random
@@ -180,7 +182,18 @@ data:
     format: AzurePublicDataset
 ```
 
-#### Trace Format
+For DatasetTrace format, use the dataset_trace data generator to use actual prompts:
+```yaml
+data:
+  type: dataset_trace
+  trace:
+    file: ./traces/trace.jsonl
+    format: DatasetTrace
+```
+
+#### Trace Formats
+
+**AzurePublicDataset Format**
 
 The AzurePublicDataset format is a CSV file with the following columns:
 ```
@@ -194,6 +207,21 @@ For example:
 ```
 
 The trace reader normalizes timestamps to start from 0, so only the relative timing between requests matters.
+
+**DatasetTrace Format**
+
+The DatasetTrace format is a JSONL file where each line is a JSON object with:
+- `text_input` (required): The actual prompt text to send
+- `output_length` (optional): If provided, sets `max_tokens`; if omitted, uses server default
+
+For example:
+```jsonl
+{"text_input": "What is the capital of France?", "output_length": 20}
+{"text_input": "Explain quantum computing in simple terms."}
+{"text_input": "Write a Python function for fibonacci.", "output_length": 150}
+```
+
+This format allows you to use your own custom prompts instead of generating random tokens, making it useful for testing with specific workloads or reproducing exact user queries.
 
 ## Troubleshooting
 

--- a/examples/trace-replay/trace.jsonl
+++ b/examples/trace-replay/trace.jsonl
@@ -1,0 +1,11 @@
+{"text_input": "What is the capital of France?", "output_length": 20}
+{"text_input": "Explain quantum computing in simple terms.", "output_length": 100}
+{"text_input": "Write a Python function to calculate the factorial of a number.", "output_length": 150}
+{"text_input": "Describe the process of photosynthesis."}
+{"text_input": "What are the main differences between machine learning and deep learning?", "output_length": 200}
+{"text_input": "How does a neural network learn?", "output_length": 120}
+{"text_input": "Explain the concept of recursion in programming."}
+{"text_input": "What is the difference between supervised and unsupervised learning?", "output_length": 180}
+{"text_input": "Describe the water cycle.", "output_length": 80}
+{"text_input": "What is the purpose of the transformer architecture in NLP?", "output_length": 250}
+

--- a/examples/vllm/config-dataset-trace.yml
+++ b/examples/vllm/config-dataset-trace.yml
@@ -1,0 +1,34 @@
+load:
+  type: constant
+  stages:
+  - rate: 1
+    duration: 30
+api: 
+  type: completion
+  streaming: true
+server:
+  type: vllm
+  model_name: HuggingFaceTB/SmolLM2-135M-Instruct
+  base_url: http://0.0.0.0:8000
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: HuggingFaceTB/SmolLM2-135M-Instruct
+data:
+  type: dataset_trace
+  trace:
+    file: ../trace-replay/trace.jsonl
+    format: DatasetTrace
+metrics:
+  type: prometheus
+  prometheus:
+    url: http://localhost:9090
+    scrape_interval: 15
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: true
+    per_request: true
+  prometheus:
+    summary: true
+    per_stage: false
+

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -36,6 +36,7 @@ class APIConfig(BaseModel):
 
 class TraceFormat(Enum):
     AZURE_PUBLIC_DATASET = "AzurePublicDataset"
+    DATASET_TRACE = "DatasetTrace"
 
 
 class TraceConfig(BaseModel):
@@ -52,6 +53,7 @@ class DataGenType(Enum):
     CNNDailyMail = "cnn_dailymail"
     InfinityInstruct = "infinity_instruct"
     BillsumConversations = "billsum_conversations"
+    DatasetTrace = "dataset_trace"
 
 
 # Represents the distribution for input prompts and output generations.

--- a/inference_perf/datagen/__init__.py
+++ b/inference_perf/datagen/__init__.py
@@ -20,6 +20,7 @@ from .shared_prefix_datagen import SharedPrefixDataGenerator
 from .cnn_dailymail_datagen import CNNDailyMailDataGenerator
 from .infinity_instruct_datagen import InfinityInstructDataGenerator
 from .hf_billsum_datagen import BillsumConversationsDataGenerator
+from .dataset_trace_datagen import DatasetTraceDataGenerator
 
 __all__ = [
     "DataGenerator",
@@ -32,4 +33,5 @@ __all__ = [
     "CNNDailyMailDataGenerator",
     "InfinityInstructDataGenerator",
     "BillsumConversationsDataGenerator",
+    "DatasetTraceDataGenerator",
 ]

--- a/inference_perf/datagen/dataset_trace_datagen.py
+++ b/inference_perf/datagen/dataset_trace_datagen.py
@@ -1,0 +1,94 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage, LazyLoadInferenceAPIData
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from .base import DataGenerator, LazyLoadDataMixin
+from typing import Generator, List, Optional
+from inference_perf.config import APIType, APIConfig, DataConfig, TraceFormat
+from inference_perf.utils.trace_reader import DatasetTraceReader, DatasetTraceEntry
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class DatasetTraceDataGenerator(DataGenerator, LazyLoadDataMixin):
+    """
+    Data generator that reads prompts from a JSONL file (DatasetTrace format).
+    
+    Each line in the JSONL file should contain:
+    - text_input (required): The actual prompt text to send
+    - output_length (optional): If provided, sets max_tokens; if omitted, uses server default
+    
+    Supports both Completion and Chat API types.
+    """
+
+    def __init__(
+        self,
+        api_config: APIConfig,
+        config: DataConfig,
+        tokenizer: Optional[CustomTokenizer] = None,
+    ) -> None:
+        super().__init__(api_config, config, tokenizer)
+
+        if self.trace is None:
+            raise ValueError("DatasetTraceDataGenerator requires a trace config to be provided")
+
+        if self.trace.format != TraceFormat.DATASET_TRACE:
+            raise ValueError(f"DatasetTraceDataGenerator requires trace format to be DatasetTrace, got {self.trace.format}")
+
+        self.trace_reader = DatasetTraceReader()
+        self.entries: List[DatasetTraceEntry] = self.trace_reader.load_entries(Path(self.trace.file))
+
+        if len(self.entries) == 0:
+            raise ValueError(f"No valid entries found in trace file: {self.trace.file}")
+
+        logger.info(f"Loaded {len(self.entries)} prompts from {self.trace.file}")
+
+    def get_request_count(self) -> int:
+        return len(self.entries)
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Completion, APIType.Chat]
+
+    def is_io_distribution_supported(self) -> bool:
+        return False
+
+    def is_shared_prefix_supported(self) -> bool:
+        return False
+
+    def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> InferenceAPIData:
+        n = data.data_index % len(self.entries)
+        entry = self.entries[n]
+
+        if self.api_config.type == APIType.Completion:
+            # max_tokens=0 means server default will be used (handled in to_payload)
+            max_tokens = entry.output_length if entry.output_length is not None else 0
+            return CompletionAPIData(prompt=entry.text_input, max_tokens=max_tokens)
+        elif self.api_config.type == APIType.Chat:
+            max_tokens = entry.output_length if entry.output_length is not None else 0
+            return ChatCompletionAPIData(
+                messages=[ChatMessage(role="user", content=entry.text_input)],
+                max_tokens=max_tokens,
+            )
+        else:
+            raise Exception(f"Unsupported API type: {self.api_config.type}")
+
+    def get_data(self) -> Generator[InferenceAPIData, None, None]:
+        i = 0
+        while True:
+            yield LazyLoadInferenceAPIData(data_index=i)
+            i += 1
+
+

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -36,6 +36,7 @@ from inference_perf.datagen import (
     CNNDailyMailDataGenerator,
     InfinityInstructDataGenerator,
     BillsumConversationsDataGenerator,
+    DatasetTraceDataGenerator,
 )
 from inference_perf.client.modelserver import (
     ModelServerClient,
@@ -299,6 +300,10 @@ def main_cli() -> None:
             datagen = InfinityInstructDataGenerator(config.api, config.data, tokenizer)
         elif config.data.type == DataGenType.BillsumConversations:
             datagen = BillsumConversationsDataGenerator(config.api, config.data, tokenizer)
+        elif config.data.type == DataGenType.DatasetTrace:
+            if config.data.trace is None:
+                raise Exception("DatasetTrace data generator requires 'trace' to be configured")
+            datagen = DatasetTraceDataGenerator(config.api, config.data, tokenizer)
         else:
             datagen = MockDataGenerator(config.api, config.data, tokenizer)
     else:

--- a/tests/test_dataset_trace.py
+++ b/tests/test_dataset_trace.py
@@ -1,0 +1,402 @@
+import tempfile
+import traceback
+from pathlib import Path
+from inference_perf.apis import LazyLoadInferenceAPIData, CompletionAPIData, ChatCompletionAPIData
+from inference_perf.datagen.base import LazyLoadDataMixin
+from inference_perf.datagen.dataset_trace_datagen import DatasetTraceDataGenerator
+from inference_perf.utils.trace_reader import DatasetTraceReader, DatasetTraceEntry
+from inference_perf.config import APIConfig, DataConfig, APIType, TraceFormat, TraceConfig, DataGenType
+
+
+def test_dataset_trace_reader_basic():
+    """Test basic JSONL parsing with text_input and output_length."""
+    content = """{"text_input": "What is the capital of France?", "output_length": 20}
+{"text_input": "Explain quantum computing in simple terms.", "output_length": 100}
+{"text_input": "Write a Python function for fibonacci.", "output_length": 150}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        reader = DatasetTraceReader()
+        entries = reader.load_entries(temp_path)
+
+        assert len(entries) == 3, f"Expected 3 entries, got {len(entries)}"
+        assert entries[0].text_input == "What is the capital of France?"
+        assert entries[0].output_length == 20
+        assert entries[1].text_input == "Explain quantum computing in simple terms."
+        assert entries[1].output_length == 100
+        assert entries[2].text_input == "Write a Python function for fibonacci."
+        assert entries[2].output_length == 150
+        print("PASSED: test_dataset_trace_reader_basic")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_reader_without_output_length():
+    """Test JSONL parsing when output_length is omitted."""
+    content = """{"text_input": "What is the capital of France?"}
+{"text_input": "Another prompt without output length"}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        reader = DatasetTraceReader()
+        entries = reader.load_entries(temp_path)
+
+        assert len(entries) == 2, f"Expected 2 entries, got {len(entries)}"
+        assert entries[0].text_input == "What is the capital of France?"
+        assert entries[0].output_length is None
+        assert entries[1].text_input == "Another prompt without output length"
+        assert entries[1].output_length is None
+        print("PASSED: test_dataset_trace_reader_without_output_length")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_reader_mixed():
+    """Test JSONL parsing with mixed entries (some with output_length, some without)."""
+    content = """{"text_input": "Prompt with length", "output_length": 50}
+{"text_input": "Prompt without length"}
+{"text_input": "Another with length", "output_length": 200}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        reader = DatasetTraceReader()
+        entries = reader.load_entries(temp_path)
+
+        assert len(entries) == 3, f"Expected 3 entries, got {len(entries)}"
+        assert entries[0].output_length == 50
+        assert entries[1].output_length is None
+        assert entries[2].output_length == 200
+        print("PASSED: test_dataset_trace_reader_mixed")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_reader_stream_entries():
+    """Test streaming entries from JSONL file."""
+    content = """{"text_input": "First prompt", "output_length": 10}
+{"text_input": "Second prompt", "output_length": 20}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        reader = DatasetTraceReader()
+        entries = list(reader.stream_entries(temp_path))
+
+        assert len(entries) == 2, f"Expected 2 entries, got {len(entries)}"
+        assert entries[0].text_input == "First prompt"
+        assert entries[0].output_length == 10
+        assert entries[1].text_input == "Second prompt"
+        assert entries[1].output_length == 20
+        print("PASSED: test_dataset_trace_reader_stream_entries")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_reader_skips_empty_lines():
+    """Test that empty lines are skipped."""
+    content = """{"text_input": "First prompt"}
+
+{"text_input": "Second prompt"}
+
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        reader = DatasetTraceReader()
+        entries = reader.load_entries(temp_path)
+
+        assert len(entries) == 2, f"Expected 2 entries, got {len(entries)}"
+        print("PASSED: test_dataset_trace_reader_skips_empty_lines")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_reader_handles_invalid_json():
+    """Test that invalid JSON lines are skipped with a warning."""
+    content = """{"text_input": "Valid prompt"}
+{invalid json here}
+{"text_input": "Another valid prompt"}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        reader = DatasetTraceReader()
+        entries = reader.load_entries(temp_path)
+
+        # Should skip the invalid line and parse 2 valid entries
+        assert len(entries) == 2, f"Expected 2 entries, got {len(entries)}"
+        assert entries[0].text_input == "Valid prompt"
+        assert entries[1].text_input == "Another valid prompt"
+        print("PASSED: test_dataset_trace_reader_handles_invalid_json")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_reader_handles_missing_text_input():
+    """Test that entries missing text_input field are skipped."""
+    content = """{"text_input": "Valid prompt"}
+{"output_length": 50}
+{"text_input": "Another valid prompt"}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        reader = DatasetTraceReader()
+        entries = reader.load_entries(temp_path)
+
+        # Should skip the entry without text_input
+        assert len(entries) == 2, f"Expected 2 entries, got {len(entries)}"
+        print("PASSED: test_dataset_trace_reader_handles_missing_text_input")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_datagen_completion_api():
+    """Test DatasetTraceDataGenerator with Completion API."""
+    content = """{"text_input": "What is the capital of France?", "output_length": 20}
+{"text_input": "Explain quantum computing.", "output_length": 100}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        api_config = APIConfig(type=APIType.Completion)
+        trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.DATASET_TRACE)
+        data_config = DataConfig(type=DataGenType.DatasetTrace, trace=trace_config)
+
+        datagen = DatasetTraceDataGenerator(api_config=api_config, config=data_config)
+
+        data_generator = datagen.get_data()
+        lazy_data_list = [next(data_generator) for _ in range(2)]
+        assert all(isinstance(data, LazyLoadInferenceAPIData) for data in lazy_data_list)
+
+        data_list = [LazyLoadDataMixin.get_request(datagen, data) for data in lazy_data_list]
+
+        assert len(data_list) == 2
+        assert isinstance(data_list[0], CompletionAPIData)
+        assert data_list[0].prompt == "What is the capital of France?"
+        assert data_list[0].max_tokens == 20
+        assert isinstance(data_list[1], CompletionAPIData)
+        assert data_list[1].prompt == "Explain quantum computing."
+        assert data_list[1].max_tokens == 100
+        print("PASSED: test_dataset_trace_datagen_completion_api")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_datagen_chat_api():
+    """Test DatasetTraceDataGenerator with Chat API."""
+    content = """{"text_input": "What is the capital of France?", "output_length": 20}
+{"text_input": "Explain quantum computing.", "output_length": 100}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        api_config = APIConfig(type=APIType.Chat)
+        trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.DATASET_TRACE)
+        data_config = DataConfig(type=DataGenType.DatasetTrace, trace=trace_config)
+
+        datagen = DatasetTraceDataGenerator(api_config=api_config, config=data_config)
+
+        data_generator = datagen.get_data()
+        lazy_data_list = [next(data_generator) for _ in range(2)]
+
+        data_list = [LazyLoadDataMixin.get_request(datagen, data) for data in lazy_data_list]
+
+        assert len(data_list) == 2
+        assert isinstance(data_list[0], ChatCompletionAPIData)
+        assert len(data_list[0].messages) == 1
+        assert data_list[0].messages[0].role == "user"
+        assert data_list[0].messages[0].content == "What is the capital of France?"
+        assert data_list[0].max_tokens == 20
+        assert isinstance(data_list[1], ChatCompletionAPIData)
+        assert data_list[1].messages[0].content == "Explain quantum computing."
+        assert data_list[1].max_tokens == 100
+        print("PASSED: test_dataset_trace_datagen_chat_api")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_datagen_without_output_length():
+    """Test DatasetTraceDataGenerator when output_length is not specified."""
+    content = """{"text_input": "What is the capital of France?"}
+{"text_input": "Explain quantum computing."}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        api_config = APIConfig(type=APIType.Completion)
+        trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.DATASET_TRACE)
+        data_config = DataConfig(type=DataGenType.DatasetTrace, trace=trace_config)
+
+        datagen = DatasetTraceDataGenerator(api_config=api_config, config=data_config)
+
+        data_generator = datagen.get_data()
+        lazy_data_list = [next(data_generator) for _ in range(2)]
+        data_list = [LazyLoadDataMixin.get_request(datagen, data) for data in lazy_data_list]
+
+        # When output_length is not specified, max_tokens should be 0 (server default)
+        assert data_list[0].max_tokens == 0
+        assert data_list[1].max_tokens == 0
+        print("PASSED: test_dataset_trace_datagen_without_output_length")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_datagen_cycles_entries():
+    """Test that DatasetTraceDataGenerator cycles through entries."""
+    content = """{"text_input": "First prompt", "output_length": 10}
+{"text_input": "Second prompt", "output_length": 20}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        api_config = APIConfig(type=APIType.Completion)
+        trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.DATASET_TRACE)
+        data_config = DataConfig(type=DataGenType.DatasetTrace, trace=trace_config)
+
+        datagen = DatasetTraceDataGenerator(api_config=api_config, config=data_config)
+
+        data_generator = datagen.get_data()
+        # Get more entries than in the file to test cycling
+        lazy_data_list = [next(data_generator) for _ in range(5)]
+        data_list = [LazyLoadDataMixin.get_request(datagen, data) for data in lazy_data_list]
+
+        # Should cycle: first, second, first, second, first
+        assert data_list[0].prompt == "First prompt"
+        assert data_list[1].prompt == "Second prompt"
+        assert data_list[2].prompt == "First prompt"
+        assert data_list[3].prompt == "Second prompt"
+        assert data_list[4].prompt == "First prompt"
+        print("PASSED: test_dataset_trace_datagen_cycles_entries")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_datagen_requires_trace_config():
+    """Test that DatasetTraceDataGenerator raises error when trace config is missing."""
+    api_config = APIConfig(type=APIType.Completion)
+    data_config = DataConfig(type=DataGenType.DatasetTrace, trace=None)
+
+    try:
+        DatasetTraceDataGenerator(api_config=api_config, config=data_config)
+        assert False, "Expected ValueError to be raised"
+    except ValueError as e:
+        assert "requires a trace config" in str(e)
+        print("PASSED: test_dataset_trace_datagen_requires_trace_config")
+
+
+def test_dataset_trace_datagen_requires_correct_format():
+    """Test that DatasetTraceDataGenerator raises error for wrong trace format."""
+    content = """{"text_input": "Test prompt"}
+"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        api_config = APIConfig(type=APIType.Completion)
+        # Use wrong format
+        trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.AZURE_PUBLIC_DATASET)
+        data_config = DataConfig(type=DataGenType.DatasetTrace, trace=trace_config)
+
+        DatasetTraceDataGenerator(api_config=api_config, config=data_config)
+        assert False, "Expected ValueError to be raised"
+    except ValueError as e:
+        assert "DatasetTrace" in str(e)
+        print("PASSED: test_dataset_trace_datagen_requires_correct_format")
+    finally:
+        temp_path.unlink()
+
+
+def test_dataset_trace_datagen_empty_file():
+    """Test that DatasetTraceDataGenerator raises error for empty file."""
+    content = ""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".jsonl") as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+
+    try:
+        api_config = APIConfig(type=APIType.Completion)
+        trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.DATASET_TRACE)
+        data_config = DataConfig(type=DataGenType.DatasetTrace, trace=trace_config)
+
+        DatasetTraceDataGenerator(api_config=api_config, config=data_config)
+        assert False, "Expected ValueError to be raised"
+    except ValueError as e:
+        assert "No valid entries" in str(e)
+        print("PASSED: test_dataset_trace_datagen_empty_file")
+    finally:
+        temp_path.unlink()
+
+
+if __name__ == "__main__":
+    tests = [
+        test_dataset_trace_reader_basic,
+        test_dataset_trace_reader_without_output_length,
+        test_dataset_trace_reader_mixed,
+        test_dataset_trace_reader_stream_entries,
+        test_dataset_trace_reader_skips_empty_lines,
+        test_dataset_trace_reader_handles_invalid_json,
+        test_dataset_trace_reader_handles_missing_text_input,
+        test_dataset_trace_datagen_completion_api,
+        test_dataset_trace_datagen_chat_api,
+        test_dataset_trace_datagen_without_output_length,
+        test_dataset_trace_datagen_cycles_entries,
+        test_dataset_trace_datagen_requires_trace_config,
+        test_dataset_trace_datagen_requires_correct_format,
+        test_dataset_trace_datagen_empty_file,
+    ]
+
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except Exception as e:
+            print(f"FAILED: {test.__name__}")
+            traceback.print_exc()
+            failed += 1
+
+    print(f"\n{'='*50}")
+    print(f"Tests passed: {passed}/{len(tests)}")
+    print(f"Tests failed: {failed}/{len(tests)}")
+


### PR DESCRIPTION
This commit introduces a new data generation type, `dataset_trace`, which allows users to provide custom prompts via a JSONL file. Each entry in the file can specify a `text_input` and an optional `output_length`. The feature is integrated into the existing framework, enabling both Completion and Chat API types.

Additionally, the documentation has been updated to reflect this new functionality, including examples of configuration and usage. A new trace reader class has been added to handle the DatasetTrace format, and comprehensive tests have been implemented to ensure its reliability.

Key changes include:
- New `DatasetTraceDataGenerator` class for handling dataset trace inputs.
- Updates to configuration files and documentation to support the new data type.
- Added tests for various scenarios involving dataset trace entries.