### PR TITLE
Update title and URL for wg-serving reference

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -8,11 +8,11 @@
 
 @misc{wg-serving,
   author = {{The Kubernetes Authors}},
-  title = {Kubernetes wg-serving},
+  title = {Kubernetes Serving Working Group},
   year = {2024},
   publisher = {GitHub},
   journal = {GitHub repository},
-  url = {https://github.com/kubernetes-sigs/wg-serving}
+  url = {https://github.com/kubernetes/community/tree/master/archive/wg-serving}
 }
 
 @inproceedings{vllm,


### PR DESCRIPTION
This will be the new location once WG has been archived by https://github.com/kubernetes/community/pull/8848.