### PR TITLE
fix: preserve configured tokenizer when using MockModelServerClient

### DIFF
--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -229,7 +229,9 @@ def main_cli() -> None:
                 api_config=config.api,
                 timeout=config.load.request_timeout,
             )
-            tokenizer = model_server_client.tokenizer
+            # Don't overwrite tokenizer if mock client doesn't provide one
+            if model_server_client.tokenizer is not None:
+                tokenizer = model_server_client.tokenizer
     else:
         raise Exception("model server client config missing")
 


### PR DESCRIPTION
# PR Template
**What type of PR is this?**

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR fix the ability to use the `MockModelServerClient` with the `SharedPrefixDataGenerator`

Add null check to prevent overwriting a previously configured tokenizer when using MockModelServerClient, which currently always returns None for its tokenizer. This ensures that if a tokenizer was set up from the config, it won't be lost. The null check also future-proofs the code in case MockModelServerClient is updated to return a tokenizer.

This change enables using SharedPrefixDataGenerator with the mock server, which requires a tokenizer to be configured. Without this fix, the following error occurs:
AttributeError: 'SharedPrefixDataGenerator' object has no attribute 'tokenizer'
**Which issue(s) this PR fixes**:

Fixes #352 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No

# Testing
Testing was done the default config.yml.


<details>
<summary>Click to expand functional test output</summary>
```
pdm run inference-perf -c examples/vllm/config.yml
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
2026-02-24 11:52:21,649 - inference_perf.config - INFO - Using configuration from: examples/vllm/config.yml
2026-02-24 11:52:21,651 - inference_perf.config - INFO - Benchmarking with the following config:

api:
  type: chat
  streaming: false
  headers: null
  slo_unit: null
  slo_tpot_header: null
  slo_ttft_header: null
data:
  type: shareGPT
  path: null
  input_distribution: null
  output_distribution: null
  shared_prefix: null
  trace: null
load:
  type: constant
  interval: 1.0
  stages:
  - !!python/object:inference_perf.config.StandardLoadStage
    __dict__:
      rate: 1.0
      duration: 30
      num_requests: null
      concurrency_level: null
    __pydantic_extra__: null
    __pydantic_fields_set__: !!set
      duration: null
      rate: null
    __pydantic_private__: null
  sweep: null
  num_workers: 16
  worker_max_concurrency: 100
  worker_max_tcp_connections: 2500
  trace: null
  circuit_breakers: []
  request_timeout: null
  lora_traffic_split: null
metrics: null
report:
  request_lifecycle:
    summary: true
    per_stage: true
    per_request: false
    per_adapter: true
    per_adapter_stage: false
    percentiles:
    - 0.1
    - 1.0
    - 5.0
    - 10.0
    - 25.0
    - 50.0
    - 75.0
    - 90.0
    - 95.0
    - 99.0
    - 99.9
  prometheus:
    summary: true
    per_stage: false
storage:
  local_storage:
    path: reports-20260224-115220
    report_file_prefix: null
  google_cloud_storage: null
  simple_storage_service: null
server:
  type: vllm
  model_name: HuggingFaceTB/SmolLM2-135M-Instruct
  base_url: ***
tokenizer: null
circuit_breakers: null


2026-02-24 11:52:21,651 - inference_perf.client.filestorage.local - INFO - Report files will be stored at: reports-20260224-115220

2026-02-24 11:53:08,227 - inference_perf.loadgen.load_generator - INFO - Stage 0 - run started
Stage 0 progress: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.0/1.0 [00:32<00:00, 32.03s/it]
2026-02-24 11:53:40,265 - inference_perf.loadgen.load_generator - INFO - Stage 0 - run completed
2026-02-24 11:53:41,269 - inference_perf.reportgen.base - INFO - Generating Reports...
2026-02-24 11:53:41,272 - inference_perf.reportgen.base - WARNING - Prometheus Metrics Client is not configured or not of type PrometheusMetricsClient
2026-02-24 11:53:41,273 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20260224-115220/summary_lifecycle_metrics.json
2026-02-24 11:53:41,273 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20260224-115220/stage_0_lifecycle_metrics.json
2026-02-24 11:53:41,274 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20260224-115220/config.yaml
```