### PR TITLE
[WIP] Add raw time series metric output.

### DIFF
--- a/inference_perf/client/filestorage/local.py
+++ b/inference_perf/client/filestorage/local.py
@@ -37,6 +37,8 @@ class LocalStorageClient(StorageClient):
             with open(report_path, "w", encoding="utf-8") as f:
                 if report.file_type == "yaml":
                     yaml.dump(report.get_contents(), f, sort_keys=False, default_flow_style=False)
+                elif report.file_type == "prom":
+                    f.write(report.get_contents())
                 else:
                     f.write(json.dumps(report.get_contents(), indent=2))
             logger.info(f"Report saved to: {report_path}")

--- a/inference_perf/client/metricsclient/base.py
+++ b/inference_perf/client/metricsclient/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from abc import ABC, abstractmethod
 from enum import Enum, auto
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, List
 from pydantic import BaseModel
 
 
@@ -181,6 +181,17 @@ class MetricsClient(ABC):
     def collect_metrics_for_stage(
         self, runtime_parameters: PerfRuntimeParameters, stage_id: int
     ) -> Optional[ModelServerMetrics]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def collect_raw_metrics(
+        self,
+        filters: List[str],
+        metrics_metadata: Optional[MetricsMetadata] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        interval: int = 5,
+    ) -> dict[str, str] | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/inference_perf/client/metricsclient/mock_client.py
+++ b/inference_perf/client/metricsclient/mock_client.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .base import MetricsClient, PerfRuntimeParameters, ModelServerMetrics
-from typing import Optional
+from typing import List, Optional
+from .base import MetricsClient, PerfRuntimeParameters, ModelServerMetrics, MetricsMetadata
 
 
 class MockMetricsClient(MetricsClient):
@@ -25,6 +25,16 @@ class MockMetricsClient(MetricsClient):
     def collect_metrics_for_stage(
         self, runtime_parameters: PerfRuntimeParameters, stage_id: int
     ) -> Optional[ModelServerMetrics]:
+        return None
+
+    def collect_raw_metrics(
+        self,
+        filters: List[str],
+        metrics_metadata: Optional[MetricsMetadata] = None,
+        start_time: Optional[float] = None,
+        end_time: Optional[float] = None,
+        interval: int = 5,
+    ) -> dict[str, str] | None:
         return None
 
     def wait(self) -> None:

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -260,6 +260,8 @@ class RequestLifecycleMetricsReportConfig(BaseModel):
 class PrometheusMetricsReportConfig(BaseModel):
     summary: Optional[bool] = True
     per_stage: Optional[bool] = False
+    raw_time_series: bool = False
+    raw_time_series_interval: int = 5
 
 
 class ReportConfig(BaseModel):

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -594,6 +594,20 @@ class ReportGenerator:
             else:
                 logger.warning("Report generation failed - no metrics collected by metrics client")
 
+            if report_config.raw_time_series and self.config.metrics and self.config.metrics.prometheus:
+                raw_metrics = self.metrics_client.collect_raw_metrics(
+                    self.config.metrics.prometheus.filters,
+                    runtime_parameters.model_server_metrics,
+                    start_time=runtime_parameters.start_time,
+                    end_time=runtime_parameters.start_time + runtime_parameters.duration,
+                    interval=report_config.raw_time_series_interval,
+                )
+                if raw_metrics:
+                    for metric_name, metric_data in raw_metrics.items():
+                        prometheus_metrics_reports.append(
+                            ReportFile(name=f"raw_metrics/{metric_name}", contents=metric_data, file_type="prom")
+                        )
+
         if report_config.per_stage:
             for stage_id in runtime_parameters.stages:
                 collected_metrics = self.metrics_client.collect_metrics_for_stage(runtime_parameters, stage_id)

--- a/tests/test_prometheus_client.py
+++ b/tests/test_prometheus_client.py
@@ -1,0 +1,185 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock, patch
+from inference_perf.client.metricsclient.prometheus_client.base import PrometheusMetricsClient
+from inference_perf.config import PrometheusClientConfig
+from inference_perf.client.modelserver.base import ModelServerPrometheusMetric
+from pydantic import HttpUrl
+
+def test_collect_raw_metrics() -> None:
+    config = PrometheusClientConfig(
+        url=HttpUrl("http://localhost:9090"),
+        scrape_interval=15,
+        filters=["job='vllm'", "namespace='default'"]
+    )
+    client = PrometheusMetricsClient(config)
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "metric_name{job=\"vllm\",namespace=\"default\"} 1.0\nmetric_name2{job=\"vllm\"} 2.0"
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        raw_metrics = client.collect_raw_metrics(config.filters)
+
+        assert raw_metrics == {"metric_name": "metric_name{job=\"vllm\",namespace=\"default\"} 1.0\n", "metric_name2": "metric_name2{job=\"vllm\"} 2.0\n"}
+        mock_get.assert_called_once_with(
+            "http://localhost:9090/federate",
+            headers={},
+            params={"match[]": "{job='vllm',namespace='default'}"}
+        )
+
+def test_collect_raw_metrics_error() -> None:
+    config = PrometheusClientConfig(
+        url=HttpUrl("http://localhost:9090"),
+        scrape_interval=15
+    )
+    client = PrometheusMetricsClient(config)
+    
+    with patch("requests.get") as mock_get:
+        mock_get.side_effect = Exception("Connection error")
+        
+        raw_metrics = client.collect_raw_metrics([])
+        
+        assert raw_metrics is None
+
+def test_collect_raw_metrics_range_query() -> None:
+    config = PrometheusClientConfig(
+        url=HttpUrl("http://localhost:9090"),
+        scrape_interval=15,
+        filters=["job='vllm'"]
+    )
+    client = PrometheusMetricsClient(config)
+    
+    start_time = 1000.0
+    end_time = 1100.0
+    interval = 10
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        # Mocking JSON response for range query
+        mock_response.json.return_value = {
+            "status": "success",
+            "data": {
+                "resultType": "matrix",
+                "result": [
+                    {
+                        "metric": {"__name__": "vllm_gpu_cache_usage", "instance": "pod1"},
+                        "values": [
+                            [1000.0, "0.1"],
+                            [1010.0, "0.2"]
+                        ]
+                    }
+                ]
+            }
+        }
+        mock_get.return_value = mock_response
+
+        raw_metrics = client.collect_raw_metrics(
+            config.filters, 
+            start_time=start_time, 
+            end_time=end_time, 
+            interval=interval
+        )
+
+        assert raw_metrics is not None
+        assert "vllm_gpu_cache_usage" in raw_metrics
+        # Expected Prometheus text format for range query results (including timestamps in ms)
+        expected_line1 = 'vllm_gpu_cache_usage{instance="pod1"} 0.1 1000000'
+        expected_line2 = 'vllm_gpu_cache_usage{instance="pod1"} 0.2 1010000'
+        assert expected_line1 in raw_metrics["vllm_gpu_cache_usage"]
+        assert expected_line2 in raw_metrics["vllm_gpu_cache_usage"]
+        
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        assert args[0] == "http://localhost:9090/api/v1/query_range"
+        assert kwargs["params"]["start"] == "1000.0"
+        assert kwargs["params"]["end"] == "1100.0"
+        assert kwargs["params"]["step"] == "10s"
+        assert kwargs["params"]["query"] == "{job='vllm'}"
+
+def test_collect_raw_metrics_google_managed_fallback() -> None:
+    # URL containing monitoring.googleapis.com triggers is_google_managed
+    config = PrometheusClientConfig(
+        url=HttpUrl("https://monitoring.googleapis.com/v1/projects/my-project/locations/global/prometheus"),
+        scrape_interval=15,
+        filters=["job='vllm'"]
+    )
+    client = PrometheusMetricsClient(config)
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {
+                        "metric": {"__name__": "vllm_throughput", "instance": "pod1"},
+                        "value": [1600000000.0, "15.5"]
+                    }
+                ]
+            }
+        }
+        mock_get.return_value = mock_response
+
+        raw_metrics = client.collect_raw_metrics(config.filters)
+
+        assert raw_metrics is not None
+        assert "vllm_throughput" in raw_metrics
+        assert 'vllm_throughput{instance="pod1"} 15.5' in raw_metrics["vllm_throughput"]
+        
+        # Should NOT call /federate
+        mock_get.assert_called_once()
+        args, kwargs = mock_get.call_args
+        assert "/api/v1/query" in args[0]
+        assert "/federate" not in args[0]
+
+def test_collect_raw_metrics_gmp_with_metadata() -> None:
+    config = PrometheusClientConfig(
+        url=HttpUrl("https://monitoring.googleapis.com/v1/projects/my-project/locations/global/prometheus"),
+        scrape_interval=15,
+        filters=["namespace='default'"]
+    )
+    client = PrometheusMetricsClient(config)
+    
+    metrics_metadata = {
+        "throughput": ModelServerPrometheusMetric(name="vllm_throughput", op="rate", type="counter", filters=["namespace='default'"]),
+        "latency": ModelServerPrometheusMetric(name="vllm_latency", op="mean", type="gauge", filters=["namespace='default'"])
+    }
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "success",
+            "data": {"resultType": "vector", "result": []}
+        }
+        mock_get.return_value = mock_response
+
+        client.collect_raw_metrics(config.filters, metrics_metadata=metrics_metadata)
+
+        # GMP with metadata should try individual queries for each metric name
+        # 1. general {namespace='default'}
+        # 2. vllm_throughput{namespace='default'}
+        # 3. vllm_latency{namespace='default'}
+        assert mock_get.call_count == 3
+        
+        queries_sent = [call.kwargs["params"]["query"] for call in mock_get.call_args_list]
+        assert "{namespace='default'}" in queries_sent
+        assert "vllm_throughput{namespace='default'}" in queries_sent
+        assert "vllm_latency{namespace='default'}" in queries_sent


### PR DESCRIPTION
Adds new report.prometheus configuration that outputs a raw_metrics directory in the report direct. One prom file for each metric that is available. Example:

reports-20260225-165238/
├── config.yaml
├── raw_metrics
│   ├── vllm:e2e_request_latency_seconds_count.prom
│   ├── vllm:generation_tokens_total.prom
│   ├── vllm:kv_cache_usage_perc.prom
│   ├── vllm:num_preemptions_total.prom
│   ├── vllm:num_requests_waiting.prom
│   └── vllm:prompt_tokens_total.prom
├── stage_0_lifecycle_metrics.json
├── stage_0_prometheus_metrics.json
├── summary_lifecycle_metrics.json
└── summary_prometheus_metrics.json

The prom format is metric{attributes} value timestamp.


Example config.yaml

```
load:
  type: constant
  stages:
  - rate: 1
    duration: 120
api: 
  type: completion
  streaming: true
server:
  type: vllm
  base_url: "http://localhost:8000"
  ignore_eos: true
data:
  type: mock
metrics:
  type: prometheus
  prometheus:
    google_managed: true
    scrape_interval: 15
    filters:
      - 'pod="vllm-sim-67dfb6d4cb-g7gzt"'
report:
  request_lifecycle:
    summary: true
    per_stage: true
  prometheus:
    summary: true
    per_stage: true
    raw_time_series: true
    raw_time_series_interval: 10
```

Example .prom file output

```
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 240 1772038955953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 246 1772038965953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 246 1772038975953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 258 1772038985953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 271 1772038995953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 271 1772039005953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 286 1772039015953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 300 1772039025953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 300 1772039035953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 317 1772039045953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 333 1772039055953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 333 1772039065953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 350 1772039075953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 360 1772039085953
vllm:e2e_request_latency_seconds_count{cluster="prototype",instance="vllm-sim-67dfb6d4cb-g7gzt:8000",job="slo-exp-podmonitoring",location="us-west1",model_name="meta-llama/Llama-3.1-8B-Instruct",namespace="default",pod="vllm-sim-67dfb6d4cb-g7gzt",top_level_controller_name="vllm-sim",top_level_controller_type="Deployment"} 360 1772039095953
```