### PR TITLE
fix: handle ShareGPT dataset exhaustion by reinitializing iterator

### DIFF
--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import itertools
 import logging
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
 from inference_perf.config import APIConfig, APIType, DataConfig
-from typing import Generator, List, Optional
+from typing import Generator, Iterator, List, Optional, Any
 from datasets import load_dataset
 import os
 
@@ -32,25 +31,35 @@ class HFShareGPTDataGenerator(DataGenerator):
     def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
         super().__init__(api_config, config, tokenizer)
 
-        if config.path is not None:
+        # Store config for reinitializing the dataset when exhausted
+        self._config_path = config.path
+        self._sharegpt_iterator: Optional[Iterator[Any]] = None
+        self._init_sharegpt_dataset()
+
+        self.min_num_turns = 2
+        self.data_key = "conversations"
+        self.role_key = "from"
+        self.content_key = "value"
+
+    def _init_sharegpt_dataset(self) -> None:
+        """Initialize or reinitialize the ShareGPT dataset iterator."""
+        if self._config_path is not None:
             # check if the path is valid
-            if not os.path.exists(config.path):
-                raise ValueError(f"Invalid dataset path: {config.path}. Path does not exist.")
+            if not os.path.exists(self._config_path):
+                raise ValueError(f"Invalid dataset path: {self._config_path}. Path does not exist.")
             # depending on whether the dataset is a single file or a directory, we need to load it differently
             # TODO: add support for other file types
-            if os.path.isfile(config.path) and config.path.endswith(".json"):
-                self.sharegpt_dataset = itertools.cycle(
-                    load_dataset("json", data_files=config.path, streaming=True, split="train")
+            if os.path.isfile(self._config_path) and self._config_path.endswith(".json"):
+                self._sharegpt_iterator = iter(
+                    load_dataset("json", data_files=self._config_path, streaming=True, split="train")
                 )
-            elif os.path.isdir(config.path):
-                json_files = [f for f in os.listdir(config.path) if f.endswith(".json")]
-                self.sharegpt_dataset = itertools.cycle(
-                    load_dataset("json", data_files=json_files, streaming=True, split="train")
-                )
+            elif os.path.isdir(self._config_path):
+                json_files = [f for f in os.listdir(self._config_path) if f.endswith(".json")]
+                self._sharegpt_iterator = iter(load_dataset("json", data_files=json_files, streaming=True, split="train"))
             else:
-                raise ValueError(f"Invalid dataset path: {config.path}")
+                raise ValueError(f"Invalid dataset path: {self._config_path}")
         else:
-            self.sharegpt_dataset = itertools.cycle(
+            self._sharegpt_iterator = iter(
                 load_dataset(
                     SHAREGPT_HF_DATASET_URL,
                     data_files=SHAREGPT_HF_DATAFILES_PATH,
@@ -58,18 +67,29 @@ class HFShareGPTDataGenerator(DataGenerator):
                     split="train",
                 )
             )
-        self.min_num_turns = 2
-        self.data_key = "conversations"
-        self.role_key = "from"
-        self.content_key = "value"
-        # initialize data collection
-        next(self.sharegpt_dataset)
+        # Advance iterator once to initialize data collection
+        try:
+            next(self._sharegpt_iterator)
+        except StopIteration:
+            logger.warning("ShareGPT dataset appears to be empty")
+
+    def _next_data(self) -> Any:
+        """
+        Get the next item from the dataset iterator.
+        Reinitializes the iterator if exhausted to enable cycling through the dataset.
+        """
+        try:
+            return next(self._sharegpt_iterator)  # type: ignore[arg-type]
+        except StopIteration:
+            logger.info("ShareGPT dataset exhausted, reinitializing iterator to cycle data")
+            self._init_sharegpt_dataset()
+            return next(self._sharegpt_iterator)  # type: ignore[arg-type]
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Chat, APIType.Completion]
 
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
-        if self.sharegpt_dataset is None:
+        if self._sharegpt_iterator is None:
             return
         if self.api_config.type == APIType.Completion:
             yield from self.get_completion_data()
@@ -81,7 +101,7 @@ class HFShareGPTDataGenerator(DataGenerator):
         if self.tokenizer is None:
             raise Exception("Tokenizer is required for completion API of HFShareGPTDataGenerator")
         while True:
-            data = next(self.sharegpt_dataset)
+            data = self._next_data()
             if (
                 data is None
                 or data[self.data_key] is None
@@ -117,7 +137,7 @@ class HFShareGPTDataGenerator(DataGenerator):
 
     def get_chat_data(self) -> Generator[InferenceAPIData, None, None]:
         while True:
-            data = next(self.sharegpt_dataset)
+            data = self._next_data()
             if (
                 data is None
                 or data[self.data_key] is None

--- a/tests/datagen/__init__.py
+++ b/tests/datagen/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/datagen/test_hf_sharegpt_datagen.py
+++ b/tests/datagen/test_hf_sharegpt_datagen.py
@@ -1,0 +1,95 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestHFShareGPTDataGenerator(unittest.TestCase):
+    """Tests for HFShareGPTDataGenerator, specifically the StopIteration handling."""
+
+    @patch("inference_perf.datagen.hf_sharegpt_datagen.load_dataset")
+    def test_next_data_reloads_on_stopiteration(self, mock_load_dataset: MagicMock) -> None:
+        """Test that _next_data reinitializes the dataset when StopIteration is raised."""
+        from inference_perf.datagen.hf_sharegpt_datagen import HFShareGPTDataGenerator
+        from inference_perf.config import APIConfig, APIType, DataConfig
+
+        # Create mock data items
+        mock_data_item_1 = {"conversations": [{"from": "human", "value": "Hello"}, {"from": "gpt", "value": "Hi"}]}
+        mock_data_item_2 = {"conversations": [{"from": "human", "value": "Bye"}, {"from": "gpt", "value": "Goodbye"}]}
+
+        # First iterator: returns one item then raises StopIteration
+        first_iterator = iter([mock_data_item_1])
+        # Second iterator (after reload): returns another item
+        second_iterator = iter([mock_data_item_2])
+
+        # Mock load_dataset to return different iterators on each call
+        mock_dataset = MagicMock()
+        mock_load_dataset.return_value = mock_dataset
+        mock_dataset.__iter__ = MagicMock(side_effect=[first_iterator, second_iterator])
+
+        # Create the data generator
+        api_config = APIConfig(type=APIType.Chat)
+        data_config = DataConfig()
+        generator = HFShareGPTDataGenerator(api_config, data_config, tokenizer=None)
+
+        # First call should return the first item
+        result1 = generator._next_data()
+        self.assertEqual(result1["conversations"][0]["value"], "Hello")
+
+        # Second call should trigger StopIteration, reload, and return second item
+        result2 = generator._next_data()
+        self.assertEqual(result2["conversations"][0]["value"], "Bye")
+
+        # Verify load_dataset was called twice (initial load + reload)
+        self.assertEqual(mock_load_dataset.call_count, 2)
+
+    @patch("inference_perf.datagen.hf_sharegpt_datagen.load_dataset")
+    def test_next_data_normal_iteration(self, mock_load_dataset: MagicMock) -> None:
+        """Test that _next_data returns items normally when not exhausted."""
+        from inference_perf.datagen.hf_sharegpt_datagen import HFShareGPTDataGenerator
+        from inference_perf.config import APIConfig, APIType, DataConfig
+
+        # Create mock data items
+        mock_data_items = [
+            {"conversations": [{"from": "human", "value": "First"}, {"from": "gpt", "value": "Response 1"}]},
+            {"conversations": [{"from": "human", "value": "Second"}, {"from": "gpt", "value": "Response 2"}]},
+            {"conversations": [{"from": "human", "value": "Third"}, {"from": "gpt", "value": "Response 3"}]},
+        ]
+
+        # Mock load_dataset
+        mock_dataset = MagicMock()
+        mock_load_dataset.return_value = mock_dataset
+        mock_dataset.__iter__ = MagicMock(return_value=iter(mock_data_items))
+
+        # Create the data generator
+        api_config = APIConfig(type=APIType.Chat)
+        data_config = DataConfig()
+        generator = HFShareGPTDataGenerator(api_config, data_config, tokenizer=None)
+
+        # Iterate through items
+        result1 = generator._next_data()
+        result2 = generator._next_data()
+        result3 = generator._next_data()
+
+        self.assertEqual(result1["conversations"][0]["value"], "First")
+        self.assertEqual(result2["conversations"][0]["value"], "Second")
+        self.assertEqual(result3["conversations"][0]["value"], "Third")
+
+        # load_dataset should only be called once (initial load)
+        self.assertEqual(mock_load_dataset.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #100 by making `HFShareGPTDataGenerator` resilient when the streaming ShareGPT iterator is exhausted.

## Problem
When running high-volume benchmarks (e.g., rate=1000, duration=120s = 120,000 requests), the ShareGPT dataset may be exhausted before the benchmark completes, causing a `StopIteration` exception and crashing the benchmark run.

## Solution
- Replaced `itertools.cycle()` with explicit iterator management
- Added `_init_sharegpt_dataset()` helper method to (re)create the dataset iterator
- Added `_next_data()` helper that catches `StopIteration`, reinitializes the iterator, and continues
- Enables long/high-volume runs to cycle through data instead of crashing

## Changes
- Store the config path to enable reinitializing the dataset
- Use `_next_data()` in both `get_completion_data()` and `get_chat_data()` generators
- Keep existing filtering/distribution behavior unchanged

## Testing
This change enables the benchmark to continue running when the dataset is exhausted, automatically cycling back to the beginning of the dataset.