### PR TITLE
Improve loadgen coverage

### DIFF
--- a/scripts/check_coverage_regression.py
+++ b/scripts/check_coverage_regression.py
@@ -65,12 +65,12 @@ def generate_baseline(output_path: Path):
 
         # 2. Setup a fresh virtual environment to avoid contamination
         print("Setting up fresh virtualenv for baseline...")
-        run_command("python -m venv .venv", cwd=temp_dir)
+        run_command("python3 -m venv .venv", cwd=temp_dir)
 
         print("Installing dependencies in baseline environment...")
         # We must make sure we don't accidentally use the parent's __pypackages__ if configured that way,
         # but standard behavior with .venv presence is to use it.
-        run_command("pdm install -dG test -G analysis", cwd=temp_dir)
+        run_command("pdm install --group test --group analysis", cwd=temp_dir)
 
         # 3. Run tests
         print("Running tests on main branch...")
@@ -95,9 +95,7 @@ def generate_baseline(output_path: Path):
 def generate_current(output_path: Path):
     """Generates coverage for the current branch/environment."""
     print("--- Generating current coverage ---")
-    # Use the current python executable to run pytest directly
-    # This avoids issues with nested 'pdm run' calls and ensures we use the same environment
-    cmd = f"{sys.executable} -m pytest --cov=inference_perf --cov-report=json:{output_path.absolute()} tests/"
+    cmd = f"pdm run pytest --cov=inference_perf --cov-report=json:{output_path.absolute()} tests/"
     run_command(cmd)
     print(f"✅ Current report generated: {output_path.name}")
 

--- a/tests/datagen/test_shared_prefix_datagen.py
+++ b/tests/datagen/test_shared_prefix_datagen.py
@@ -30,6 +30,7 @@ from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 # --- Tests from HEAD (Mock based) ---
 
+
 def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
     """Create a mock tokenizer that returns predictable text."""
     mock_tokenizer = MagicMock()
@@ -164,8 +165,9 @@ class TestMultiTurnChat:
 
 # --- Tests from d168373 (Tokenizer based) ---
 
+
 @pytest.fixture
-def api_config():
+def api_config() -> APIConfig:
     return APIConfig(
         api_type=APIType.Completion,
         model_name="gpt2",
@@ -174,7 +176,7 @@ def api_config():
 
 
 @pytest.fixture
-def shared_prefix_config():
+def shared_prefix_config() -> SharedPrefix:
     return SharedPrefix(
         num_groups=2,
         num_prompts_per_group=3,
@@ -185,17 +187,19 @@ def shared_prefix_config():
 
 
 @pytest.fixture
-def data_config(shared_prefix_config):
+def data_config(shared_prefix_config: SharedPrefix) -> DataConfig:
     return DataConfig(shared_prefix=shared_prefix_config)
 
 
 @pytest.fixture
-def tokenizer():
+def tokenizer() -> CustomTokenizer:
     tokenizer_config = CustomTokenizerConfig(pretrained_model_name_or_path="gpt2")
     return CustomTokenizer(tokenizer_config)
 
 
-def test_shared_prefix_datagen_token_counts(api_config, data_config, tokenizer, shared_prefix_config):
+def test_shared_prefix_datagen_token_counts(
+    api_config: APIConfig, data_config: DataConfig, tokenizer: CustomTokenizer, shared_prefix_config: SharedPrefix
+) -> None:
     generator = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
 
     # The generator shuffles prompts, so we test all of them
@@ -206,6 +210,8 @@ def test_shared_prefix_datagen_token_counts(api_config, data_config, tokenizer, 
 
         # The expected total length is system_prompt_len + question_len.
         # There's also a space added between them, which is usually 1 token.
+        assert isinstance(shared_prefix_config.system_prompt_len, int)
+        assert isinstance(shared_prefix_config.question_len, int)
         expected_min_len = shared_prefix_config.system_prompt_len + shared_prefix_config.question_len
 
         token_ids = tokenizer.get_tokenizer().encode(prompt)

--- a/tests/datagen/test_shared_prefix_datagen.py
+++ b/tests/datagen/test_shared_prefix_datagen.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import pytest
 from unittest.mock import MagicMock
 
 from inference_perf.config import (
@@ -21,9 +23,12 @@ from inference_perf.config import (
     Distribution,
     DistributionType,
     SharedPrefix,
+    CustomTokenizerConfig,
 )
 from inference_perf.datagen.shared_prefix_datagen import SharedPrefixDataGenerator
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
+# --- Tests from HEAD (Mock based) ---
 
 def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
     """Create a mock tokenizer that returns predictable text."""
@@ -155,3 +160,56 @@ class TestMultiTurnChat:
         items = [next(data_iter) for _ in range(10)]
         assert len(items) == 10
         assert all(hasattr(item, "data_index") for item in items)
+
+
+# --- Tests from d168373 (Tokenizer based) ---
+
+@pytest.fixture
+def api_config():
+    return APIConfig(
+        api_type=APIType.Completion,
+        model_name="gpt2",
+        tokenizer_name="gpt2",
+    )
+
+
+@pytest.fixture
+def shared_prefix_config():
+    return SharedPrefix(
+        num_groups=2,
+        num_prompts_per_group=3,
+        system_prompt_len=10,
+        question_len=5,
+        output_len=15,
+    )
+
+
+@pytest.fixture
+def data_config(shared_prefix_config):
+    return DataConfig(shared_prefix=shared_prefix_config)
+
+
+@pytest.fixture
+def tokenizer():
+    tokenizer_config = CustomTokenizerConfig(pretrained_model_name_or_path="gpt2")
+    return CustomTokenizer(tokenizer_config)
+
+
+def test_shared_prefix_datagen_token_counts(api_config, data_config, tokenizer, shared_prefix_config):
+    generator = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
+
+    # The generator shuffles prompts, so we test all of them
+    for prompt in generator.prompts:
+        # It's tricky to perfectly split the prompt back into system and question
+        # because of how tokenization and decoding works (e.g., spaces).
+        # Instead, we'll check the total token count.
+
+        # The expected total length is system_prompt_len + question_len.
+        # There's also a space added between them, which is usually 1 token.
+        expected_min_len = shared_prefix_config.system_prompt_len + shared_prefix_config.question_len
+
+        token_ids = tokenizer.get_tokenizer().encode(prompt)
+
+        # The actual token count might be slightly different due to the space
+        # and how tokens are combined. We'll check if it's very close.
+        assert abs(len(token_ids) - expected_min_len) <= 5, f"Prompt: '{prompt}', Tokens: {len(token_ids)}"

--- a/tests/loadgen/test_load_generator.py
+++ b/tests/loadgen/test_load_generator.py
@@ -45,8 +45,6 @@ if sys.version_info < (3, 11):
 if sys.version_info < (3, 10):
     typing.TypeAlias = typing.Any
 
-from inference_perf.loadgen.load_generator import LoadGenerator
-from inference_perf.config import LoadConfig, LoadType
 from inference_perf.datagen import DataGenerator
 
 

--- a/tests/loadgen/test_load_generator.py
+++ b/tests/loadgen/test_load_generator.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock, patch
 import multiprocessing as mp
 import asyncio
 import typing
 import sys
+import numpy as np
 from typing import Any
+
+from inference_perf.loadgen.load_generator import LoadGenerator, RequestQueueData
+from inference_perf.config import LoadConfig, LoadType, TraceConfig, TraceFormat, StandardLoadStage
+from inference_perf.client.modelserver import ModelServerClient
+from inference_perf.apis import InferenceAPIData
+from inference_perf.utils.request_queue import RequestQueue
 
 # Patch asyncio.TaskGroup for Python < 3.11
 if sys.version_info < (3, 11):
@@ -103,6 +110,152 @@ class TestLoadGeneratorConcurrency(unittest.TestCase):
         self.assertEqual(self.load_generator.workers[1].shared_max_concurrency.value, 1)  # type: ignore
         self.assertEqual(self.load_generator.workers[2].shared_max_concurrency.value, 1)  # type: ignore
         self.assertEqual(self.load_generator.workers[3].shared_max_concurrency.value, 0)  # type: ignore
+
+
+class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.mock_datagen = MagicMock(spec=DataGenerator)
+        self.mock_datagen.get_data.return_value = iter([MagicMock(preferred_worker_id=-1) for _ in range(100)])
+        self.mock_datagen.trace = None
+
+        self.mock_client = AsyncMock(spec=ModelServerClient)
+
+        self.load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            num_workers=2,
+            worker_max_concurrency=10,
+            interval=1,
+            stages=[StandardLoadStage(rate=10, duration=1)],
+            circuit_breakers=[],
+            base_seed=42,
+        )
+
+        with patch("inference_perf.loadgen.load_generator.get_circuit_breaker"):
+            self.load_generator = LoadGenerator(self.mock_datagen, self.load_config)
+
+    def test_get_lora_adapter(self) -> None:
+        # No config
+        self.assertIsNone(self.load_generator._get_lora_adapter())
+
+        # With config
+        self.load_generator.lora_adapters = ["adapter1", "adapter2"]
+        self.load_generator.lora_weights = [1.0, 0.0]
+
+        np.random.seed(42)  # For reproducibility
+        self.assertEqual(self.load_generator._get_lora_adapter(), "adapter1")
+
+        self.load_generator.lora_weights = [0.0, 1.0]
+        self.assertEqual(self.load_generator._get_lora_adapter(), "adapter2")
+
+    def test_get_timer(self) -> None:
+        from inference_perf.loadgen.load_timer import ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
+
+        # Constant
+        self.load_generator.load_type = LoadType.CONSTANT
+        timer = self.load_generator.get_timer(10, 5)
+        self.assertIsInstance(timer, ConstantLoadTimer)
+
+        # Poisson
+        self.load_generator.load_type = LoadType.POISSON
+        timer = self.load_generator.get_timer(10, 5)
+        self.assertIsInstance(timer, PoissonLoadTimer)
+
+        # Trace (Needs trace config setup)
+        self.load_generator.load_type = LoadType.TRACE_REPLAY
+        self.load_generator.trace = TraceConfig(format=TraceFormat.AZURE_PUBLIC_DATASET, file="dummy.csv")
+        self.load_generator.trace_reader = MagicMock()
+        timer = self.load_generator.get_timer(10, 5)
+        self.assertIsInstance(timer, TraceReplayLoadTimer)
+
+    @patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock)
+    @patch("inference_perf.loadgen.load_generator.time")
+    async def test_run_stage_timeout(self, mock_time: MagicMock, mock_sleep: AsyncMock) -> None:
+        mock_time.time.return_value = 1000
+        mock_time.perf_counter.side_effect = [0, 10, 20]  # simulate time passing
+
+        request_queue = MagicMock(spec=RequestQueue)
+        request_queue.drain = MagicMock()
+        active_counter = MagicMock()
+        active_counter.value = 0
+        finished_counter = MagicMock()
+        finished_counter.value = 0
+        request_phase = MagicMock()
+        cancel_signal = MagicMock()
+
+        # Force a timeout
+        mock_sleep.return_value = None
+
+        # We need a timer that generates times in the future so the queue loop doesn't instantly finish
+        mock_timer = MagicMock()
+        mock_timer.start_timer.return_value = iter([10.0] * 10)
+        with patch.object(self.load_generator, "get_timer", return_value=mock_timer):
+            await self.load_generator.run_stage(
+                stage_id=0,
+                rate=10,
+                duration=1,
+                request_queue=request_queue,
+                active_requests_counter=active_counter,
+                finished_requests_counter=finished_counter,
+                request_phase=request_phase,
+                cancel_signal=cancel_signal,
+                timeout=5.0,
+            )
+
+        # The timeout logic sets the cancel signal
+        cancel_signal.set.assert_called_once()
+        self.assertEqual(self.load_generator.stage_runtime_info[0].status.name, "FAILED")
+
+    @patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock)
+    async def test_run_single_worker_mode(self, mock_sleep: AsyncMock) -> None:
+        # Setup for num_workers = 0 (single worker loop)
+        self.load_generator.num_workers = 0
+        self.load_config.num_workers = 0
+        self.load_generator.stages = [StandardLoadStage(rate=2, duration=1)]
+
+        mock_data = MagicMock(spec=InferenceAPIData)
+        mock_data.preferred_worker_id = -1
+        self.mock_datagen.get_data.return_value = iter([mock_data, mock_data])
+
+        # Patch LazyLoadDataMixin to just return the object
+        with (
+            patch("inference_perf.loadgen.load_generator.LazyLoadDataMixin.get_request", return_value=mock_data),
+            patch("inference_perf.loadgen.load_generator.TaskGroup") as MockTaskGroup,
+            patch("inference_perf.loadgen.load_generator.time.perf_counter", return_value=0.0),
+        ):
+            mock_tg = MagicMock()
+            MockTaskGroup.return_value.__aenter__.return_value = mock_tg
+
+            async def dummy_process_request(*args: Any, **kwargs: Any) -> None:
+                pass
+
+            self.mock_client.process_request = AsyncMock(side_effect=dummy_process_request)
+
+            mock_timer = MagicMock()
+            mock_timer.start_timer.return_value = iter([0.1, 0.2])
+            with patch.object(self.load_generator, "get_timer", return_value=mock_timer):
+                await self.load_generator.run(self.mock_client)
+
+            self.assertEqual(mock_tg.create_task.call_count, 2)
+            self.assertEqual(self.load_generator.stage_runtime_info[0].status.name, "COMPLETED")
+
+    async def test_drain(self) -> None:
+        q: RequestQueue[RequestQueueData] = RequestQueue(1)
+        q.put(RequestQueueData(0, 1, 0.0, None), 0)
+        q.put(RequestQueueData(0, 2, 0.0, None), 0)
+
+        # Small sleep to let queue populate
+        await asyncio.sleep(0.1)
+
+        # Add tasks to queue so task_done doesn't fail
+        await self.load_generator.drain(q.get_channel(0))
+        self.assertTrue(q.get_channel(0).empty())
+
+    def test_sigint_handler(self) -> None:
+        import signal
+
+        self.assertFalse(self.load_generator.interrupt_sig)
+        self.load_generator._sigint_handler(signal.SIGINT, None)
+        self.assertTrue(self.load_generator.interrupt_sig)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds detailed coverage report options for coverage script (per file coverage).
html coverage reports can be generated with `pdm run pytest --cov=inference_perf --cov-report=html:cov_html tests/`

Added loadgen unit tests that increase coverage to ~42%.
Dealing with multiprocess issue preventing coverage numbers for Worker process.