### PR TITLE
Shared Prefix Trace Replay & Tree-of-Thought Generation

### DIFF
--- a/docs/loadgen.md
+++ b/docs/loadgen.md
@@ -271,10 +271,12 @@ load:
   type: trace_replay
   trace:
     file: ./traces/traces.csv
-    format: AzurePublicDataset
+    format: AzurePublicDataset # Or SharedPrefix
 ```
 
-**Data Configuration** - Trace replay feature is only supported for random data generator. Matches the token counts from the trace:
+**Data Configuration** - Defines how the token counts are matched to the requests.
+
+*For AzurePublicDataset (using random tokens)*:
 ```yaml
 data:
   type: random
@@ -283,7 +285,18 @@ data:
     format: AzurePublicDataset
 ```
 
-#### Trace Format
+*For SharedPrefix (using dynamically generated prefix text)*:
+```yaml
+data:
+  type: shared_prefix
+  trace:
+    file: ./traces/trace_tot.jsonl
+    format: SharedPrefix
+```
+
+#### Trace Formats
+
+**AzurePublicDataset Format**
 
 The AzurePublicDataset format is a CSV file with the following columns:
 ```
@@ -297,6 +310,25 @@ For example:
 ```
 
 The trace reader normalizes timestamps to start from 0, so only the relative timing between requests matters.
+
+**SharedPrefix Format**
+
+The SharedPrefix format is a JSONL file specifically designed to simulate workloads like Tree of Thought, where multiple requests share the same prompt prefix, allowing inference servers to utilize prefix caching.
+
+Fields:
+- `timestamp`: Float. The time the request should be sent. Normalizes to start from 0.
+- `shared_prefix_length`: Integer. The length of the shared prompt prefix.
+- `tail_input_length`: Integer. The length of the unique input tokens appended to the prefix.
+- `output_length`: Integer. The number of tokens expected to be generated.
+- `shared_prefix_id`: Integer (Optional). Requests with the same ID and `shared_prefix_length` will generate the exact same random token sequence for their prefix, simulating a cache hit.
+
+For example:
+```json
+{"timestamp": 10.0, "shared_prefix_length": 100, "tail_input_length": 50, "output_length": 20, "shared_prefix_id": 1}
+{"timestamp": 12.5, "shared_prefix_length": 100, "tail_input_length": 30, "output_length": 20, "shared_prefix_id": 1}
+{"timestamp": 15.0, "shared_prefix_length": 50, "tail_input_length": 10, "output_length": 10}
+```
+*Note: For `SharedPrefix` trace format to work, you must define a valid `tokenizer` configuration in your configuration file so that `inference-perf` can accurately simulate token distributions.*
 
 ## Troubleshooting
 

--- a/docs/tracegen.md
+++ b/docs/tracegen.md
@@ -1,0 +1,114 @@
+# Trace Generation
+
+`inference-perf` includes built-in trace generation modules capable of generating complex workload patterns synthetically. Currently, it supports generating advanced shared prefix traces for Tree-of-Thought (ToT) patterns.
+
+## General Usage
+
+You can run trace generation as a standalone step before running a full benchmark by utilizing the `--tracegen` CLI flag.
+
+```bash
+inference-perf --tracegen <module>:<path/to/tracegen_config.yaml>
+```
+
+Presently, the supported module is:
+- `tot`: Tree of Thought (ToT) synthetic trace generation.
+
+---
+
+## Tree of Thought (ToT) Trace Generation
+
+The `tot` trace generation module simulates a Tree-of-Thought workload, where a language model explores multiple reasoning paths simultaneously (branches), creating a tree-like structure. The system maintains a set of active thoughts (beams or "expand top" nodes) and expands them layer by layer.
+
+This trace generation produces a `SharedPrefix` formatted JSONL file. Each entry corresponds to an individual completion request in the tree. Because requests within the same branch share their entire generation history up to that point, they will carry identical `shared_prefix_id`s, instructing the benchmark runner to simulate prefix caching.
+
+### Configuration Parameters
+
+A typical ToT trace generation configuration file looks like this:
+
+```yaml
+# Example: configs/tracegen_tot.yaml
+num_layers: 3
+branching_factor: 3
+expand_top: 2
+system_prompt_len: 200
+thought_prompt_len: 50
+thought_len: 150
+start_timestamp: 0.0
+output_file: "data/trace_tot_cli.jsonl"
+```
+
+| Parameter            | Type    | Description |
+|----------------------|---------|-------------|
+| `num_layers`         | `int`   | The total number of thought layers (depth) to simulate in the tree. |
+| `branching_factor`   | `int`   | The number of new thoughts (requests) to branch out from each active node. |
+| `expand_top`         | `int`   | The number of nodes (thoughts) selected to advance to the next layer (akin to beam width). |
+| `system_prompt_len`  | `int`   | The length of the initial system prompt (root node) in tokens. |
+| `thought_prompt_len` | `int`   | The length of the new user prompt asking the model to expand the thought in tokens. |
+| `thought_len`        | `int`   | The length of the model's generated thought response in tokens. |
+| `start_timestamp`    | `float` | The initial starting timestamp in seconds. |
+| `output_file`        | `str`   | The path where the generated JSONL trace file will be saved. |
+| `graph_output`       | `str`   | (Optional) The path where a Graphviz `.dot` file of the generated tree will be saved. |
+
+### Running the Trace Generator
+
+To generate the trace, run the `inference-perf` CLI with the `--tracegen` flag:
+
+```bash
+inference-perf --tracegen tot:configs/tracegen_tot.yaml
+```
+
+The output will be written to `data/trace_tot_cli.jsonl` (as defined in the `output_file` parameter).
+
+### Replaying the Trace
+
+Once generated, the trace will follow the `SharedPrefix` trace format, which can be natively replayed by `inference-perf`. You can refer to this trace inside an `inference-perf` benchmark configuration.
+
+```yaml
+# Example: configs/trace-tot.yaml
+load:
+  type: trace_replay
+  trace:
+    file: data/trace_tot_cli.jsonl
+    format: SharedPrefix
+  worker_max_concurrency: 100
+
+api:
+  type: completion
+  streaming: true
+
+server:
+  type: vllm
+  model_name: google/gemma-3-1b-it
+  base_url: http://0.0.0.0:8000
+  ignore_eos: true
+
+tokenizer:
+  # The tokenizer is necessary to randomly generate token IDs
+  pretrained_model_name_or_path: gpt2
+
+data:
+  type: shared_prefix
+  trace:
+    file: data/trace_tot_cli.jsonl
+    format: SharedPrefix
+```
+
+You can then run the benchmark using the generated trace with the standard command:
+
+```bash
+inference-perf -c configs/trace-tot.yaml
+```
+
+### Trace Details
+
+The generated trace follows the `SharedPrefix` JSONL format. Below is an example snippet of what the output looks like:
+
+```json
+{"timestamp":0.0,"shared_prefix_length":200,"tail_input_length":50,"output_length":150,"shared_prefix_id":1}
+{"timestamp":0.01,"shared_prefix_length":200,"tail_input_length":50,"output_length":150,"shared_prefix_id":1}
+{"timestamp":1.51,"shared_prefix_length":400,"tail_input_length":50,"output_length":150,"shared_prefix_id":2}
+{"timestamp":1.52,"shared_prefix_length":400,"tail_input_length":50,"output_length":150,"shared_prefix_id":3}
+```
+
+- **Shared Contexts (`shared_prefix_id`)**: Requests with the same `shared_prefix_id` and `shared_prefix_length` will be given identical random prefix token distributions. In an LLM server, the first hit will compute the prefix representation and subsequent requests will enjoy a KV-cache hit.
+- **Divergent Prompts (`tail_input_length`)**: The `tail_input_length` provides new token IDs appended uniquely to every individual request to represent the new portion of the reasoning sequence.

--- a/flake.nix
+++ b/flake.nix
@@ -77,37 +77,71 @@
                 in
                 python.pkgs.buildPythonPackage (buildAttrs // { });
 
-              llm-d-inference-sim = pkgs.buildGoModule rec {
-                pname = "llm-d-inference-sim";
-                version = "0.6.1";
+              llm-d-inference-sim =
+                let
+                  # create necessary python for kv-cache-manager-wrapper.
+                  neededPython = pkgs.python312.withPackages (
+                    ps: with ps; [
+                      packaging
+                      pillow
+                      torch
+                      transformers
+                      jinja2
+                    ]
+                  );
+                in
+                pkgs.buildGoModule rec {
+                  pname = "llm-d-inference-sim";
+                  version = "0.7.1";
 
-                src = pkgs.fetchFromGitHub {
-                  owner = "llm-d";
-                  repo = "llm-d-inference-sim";
-                  tag = "v${version}";
-                  hash = "sha256-KdA7dgdy1jGjRhrqXfkg4Z9V3SXPcKp1FnTtm+e5DSA=";
+                  src = pkgs.fetchFromGitHub {
+                    owner = "llm-d";
+                    repo = "llm-d-inference-sim";
+                    tag = "v${version}";
+                    hash = "sha256-PFXqhA1Dz8xg2a7RtRcWE11RIzovaEduZT1G7oAUTS0=";
+                  };
+                  vendorHash = "sha256-8+W3FloObny7ZWq5h02yWF4skOE2gRbceCtWBzmZslE=";
+
+                  nativeBuildInputs = with pkgs; [
+                    pkg-config
+                    makeWrapper
+                    neededPython
+                  ];
+
+                  buildInputs = with pkgs; [
+                    zeromq
+                    libtokenizers
+                    neededPython
+                  ];
+
+                  preBuild = ''
+                    # https://github.com/llm-d/llm-d-inference-sim/blob/cf682b5a7b160e27754e9b186b7e2dfeb24678bb/Dockerfile#L52-L53
+                    export CGO_CFLAGS="''${CGO_CFLAGS:-} $(${neededPython.executable}-config --cflags)"
+                    export CGO_LDFLAGS="''${CGO_LDFLAGS:-} $(${neededPython.executable}-config --ldflags --embed)"
+                  '';
+
+                  postInstall = ''
+                    mkdir -p $out/lib/python3.12/site-packages
+
+                    cp \
+                      vendor/github.com/llm-d/llm-d-kv-cache-manager/pkg/preprocessing/chat_completions/*.py \
+                      $out/lib/python3.12/site-packages/
+
+                    wrapProgram $out/bin/llm-d-inference-sim \
+                      --prefix PYTHONPATH : $out/lib/python3.12/site-packages \
+                      --set    PYTHON ${neededPython}
+                  '';
+
+                  # several tests require networking.
+                  doCheck = false;
+
+                  meta = {
+                    description = "A light weight vLLM simulator, for mocking out replicas";
+                    homepage = "https://github.com/llm-d/llm-d-inference-sim";
+                    license = with nixpkgs.lib.licenses; asl20;
+                    mainProgram = "llm-d-inference-sim";
+                  };
                 };
-                vendorHash = "sha256-MINH7J2ozTORFK/KgZvXBlwThYRISL1wlHebdZxvuvw=";
-
-                nativeBuildInputs = with pkgs; [
-                  pkg-config
-                ];
-
-                buildInputs = with pkgs; [
-                  zeromq
-                  libtokenizers
-                ];
-
-                # several tests require networking.
-                doCheck = false;
-
-                meta = {
-                  description = "A light weight vLLM simulator, for mocking out replicas";
-                  homepage = "https://github.com/llm-d/llm-d-inference-sim";
-                  license = with nixpkgs.lib.licenses; asl20;
-                  mainProgram = "llm-d-inference-sim";
-                };
-              };
 
               libtokenizers = pkgs.rustPlatform.buildRustPackage rec {
                 pname = "libtokenizers";

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -40,6 +40,7 @@ class APIConfig(BaseModel):
 
 class TraceFormat(Enum):
     AZURE_PUBLIC_DATASET = "AzurePublicDataset"
+    SHARED_PREFIX = "SharedPrefix"
 
 
 class TraceConfig(BaseModel):

--- a/inference_perf/datagen/base.py
+++ b/inference_perf/datagen/base.py
@@ -70,6 +70,9 @@ class DataGenerator(ABC):
     def is_prefered_worker_requested(self) -> bool:
         return False
 
+    def get_request_count(self) -> int:
+        return -1
+
 
 class LazyLoadDataMixin(ABC):
     """

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -1,12 +1,14 @@
 import random
-from typing import Generator, List, Optional
+from typing import Generator, List, Optional, Dict, Tuple
+from pathlib import Path
 from inference_perf.utils.distribution import generate_distribution
+from inference_perf.utils.shared_prefix_trace_reader import SharedPrefixTraceReader
 import numpy as np
 
 from inference_perf.apis.base import InferenceAPIData, LazyLoadInferenceAPIData
 from inference_perf.apis.completion import CompletionAPIData
 from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
-from inference_perf.config import APIConfig, APIType, DataConfig, Distribution
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, TraceFormat
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator, LazyLoadDataMixin
 
@@ -23,7 +25,7 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         # Initialize vocab_size
         hf_tokenizer = self.tokenizer.get_tokenizer()
         if hasattr(hf_tokenizer, "vocab_size") and hf_tokenizer.vocab_size is not None:
-            self.vocab_size: int = hf_tokenizer.vocab_size
+            self.vocab_size: int = int(hf_tokenizer.vocab_size)
         elif hasattr(hf_tokenizer, "get_vocab") and callable(hf_tokenizer.get_vocab):
             self.vocab_size = len(hf_tokenizer.get_vocab())
         else:
@@ -37,47 +39,102 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.vocab_size <= 0:
             raise ValueError(f"Tokenizer vocabulary size must be positive, got {self.vocab_size}.")
 
-        if self.shared_prefix is None:
-            raise ValueError("Shared Prefix config is required for SharedPrefixDataGenerator")
-
-        self.num_groups: int = self.shared_prefix.num_groups
-        self.num_prompts_per_group: int = self.shared_prefix.num_prompts_per_group
-        self.system_prompt_len: int = self.shared_prefix.system_prompt_len
-        self.enable_multi_turn_chat: bool = self.shared_prefix.enable_multi_turn_chat
-
-        # Use distribution configs, or fall back to question_len/output_len with std_dev=0
-        q_len = self.shared_prefix.question_len
-        o_len = self.shared_prefix.output_len
-        question_dist = self.shared_prefix.question_distribution or Distribution(min=q_len, max=q_len, mean=q_len, std_dev=0)
-        output_dist = self.shared_prefix.output_distribution or Distribution(min=o_len, max=o_len, mean=o_len, std_dev=0)
-
-        # Generate separate distributions for each group
-        self.question_len_list_per_group: List[List[int]] = []
-        self.output_len_list_per_group: List[List[int]] = []
-
-        for _ in range(self.num_groups):
-            question_lens = generate_distribution(
-                question_dist.min,
-                question_dist.max,
-                question_dist.mean,
-                question_dist.std_dev,
-                self.shared_prefix.num_prompts_per_group,
-            )
-            self.question_len_list_per_group.append(question_lens.tolist())
-
-            output_lens = generate_distribution(
-                output_dist.min,
-                output_dist.max,
-                output_dist.mean,
-                output_dist.std_dev,
-                self.shared_prefix.num_prompts_per_group,
-            )
-            self.output_len_list_per_group.append(output_lens.tolist())
-
         self.prompts: List[str] = []
         self.user_sessions: List[LocalUserSession] = []
         self.flat_output_lens: List[int] = []
-        self._generate_prompts()
+
+        if self.trace is not None:
+            if self.trace.format != TraceFormat.SHARED_PREFIX:
+                raise ValueError(f"Unsupported trace format for SharedPrefixDataGenerator: {self.trace.format}")
+
+            reader = SharedPrefixTraceReader()
+            traces = reader.load_entries(Path(self.trace.file))
+
+            hf_tokenizer = self.tokenizer.get_tokenizer()
+
+            # Cache for shared prefixes: (shared_prefix_id, length) -> prefix_text
+            # Using both shared_prefix_id and length in key to avoid collisions if id is reused for different lengths
+            prefix_cache: Dict[Tuple[int, int], str] = {}
+
+            for t in traces:
+                # Generate or retrieve shared prefix
+                shared_prefix_text = ""
+
+                # Check for cached prefix if shared_prefix_id is provided
+                if t.shared_prefix_id is not None:
+                    cache_key = (t.shared_prefix_id, t.shared_prefix_length)
+                    if cache_key in prefix_cache:
+                        shared_prefix_text = prefix_cache[cache_key]
+                    else:
+                        token_ids = self._generate_random_token_ids(t.shared_prefix_length)
+                        shared_prefix_text = hf_tokenizer.decode(token_ids, skip_special_tokens=True)
+                        prefix_cache[cache_key] = shared_prefix_text
+                else:
+                    # No group ID, generate unique prefix
+                    token_ids = self._generate_random_token_ids(t.shared_prefix_length)
+                    shared_prefix_text = hf_tokenizer.decode(token_ids, skip_special_tokens=True)
+
+                # Generate tail input
+                tail_token_ids = self._generate_random_token_ids(t.tail_input_length)
+                tail_text = hf_tokenizer.decode(tail_token_ids, skip_special_tokens=True)
+
+                # For single turn, concat prefix and tail
+                # TODO: make sure space is needed? usually yes between prefix and input
+                prompt = shared_prefix_text + " " + tail_text
+                self.prompts.append(prompt)
+
+                # Use output length directly from trace
+                self.flat_output_lens.append(t.output_length)
+
+            # Trace replay mode: we don't shuffle, we follow the trace order
+            # We also assume single-turn for now as per plan
+            self.enable_multi_turn_chat = False
+            self.num_groups = 1  # Default
+
+        else:
+            if self.shared_prefix is None:
+                raise ValueError("Shared Prefix config is required for SharedPrefixDataGenerator when no trace is provided")
+
+            self.num_groups = self.shared_prefix.num_groups
+            self.num_prompts_per_group = self.shared_prefix.num_prompts_per_group
+            self.system_prompt_len = self.shared_prefix.system_prompt_len
+            self.enable_multi_turn_chat = self.shared_prefix.enable_multi_turn_chat
+
+            # Use distribution configs, or fall back to question_len/output_len with std_dev=0
+            q_len = self.shared_prefix.question_len
+            o_len = self.shared_prefix.output_len
+            question_dist = self.shared_prefix.question_distribution or Distribution(
+                min=q_len, max=q_len, mean=q_len, std_dev=0
+            )
+            output_dist = self.shared_prefix.output_distribution or Distribution(min=o_len, max=o_len, mean=o_len, std_dev=0)
+
+            # Generate separate distributions for each group
+            self.question_len_list_per_group = []
+            self.output_len_list_per_group = []
+
+            for _ in range(self.num_groups):
+                question_lens = generate_distribution(
+                    question_dist.min,
+                    question_dist.max,
+                    question_dist.mean,
+                    question_dist.std_dev,
+                    self.shared_prefix.num_prompts_per_group,
+                )
+                self.question_len_list_per_group.append(question_lens.tolist())
+
+                output_lens = generate_distribution(
+                    output_dist.min,
+                    output_dist.max,
+                    output_dist.mean,
+                    output_dist.std_dev,
+                    self.shared_prefix.num_prompts_per_group,
+                )
+                self.output_len_list_per_group.append(output_lens.tolist())
+
+            self._generate_prompts()
+
+    def get_request_count(self) -> int:
+        return len(self.prompts)
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion]

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -14,6 +14,7 @@
 from pathlib import Path
 from inference_perf.client.metricsclient.base import StageRuntimeInfo, StageStatus
 from inference_perf.utils.trace_reader import AzurePublicDatasetReader
+from inference_perf.utils.shared_prefix_trace_reader import SharedPrefixTraceReader
 from inference_perf.utils.request_queue import RequestQueue
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
 from inference_perf.datagen import DataGenerator, LazyLoadDataMixin
@@ -48,7 +49,7 @@ else:
     # Runtime usage will still require Python 3.11+.
     TaskGroup = object
 
-from typing import List, Tuple, Optional, NamedTuple, Union
+from typing import Any, List, Tuple, Optional, NamedTuple, Union
 from types import FrameType
 import time
 import multiprocessing as mp
@@ -243,7 +244,9 @@ class LoadGenerator:
                 raise ValueError("Trace file is required for trace replay load generator")
 
             if self.trace.format == TraceFormat.AZURE_PUBLIC_DATASET:
-                self.trace_reader = AzurePublicDatasetReader()
+                self.trace_reader: Any = AzurePublicDatasetReader()
+            elif self.trace.format == TraceFormat.SHARED_PREFIX:
+                self.trace_reader = SharedPrefixTraceReader()
             else:
                 raise ValueError(f"Unsupported trace format: {self.trace.format}")
         self.lora_adapters: Optional[List[str]] = None

--- a/inference_perf/loadgen/load_timer.py
+++ b/inference_perf/loadgen/load_timer.py
@@ -15,8 +15,8 @@ import time
 from abc import ABC, abstractmethod
 from typing import Generator, Optional, Tuple
 import numpy as np
-from inference_perf.utils.trace_reader import TraceReader
 from pathlib import Path
+from inference_perf.utils.trace_reader import NewTraceReader, LegacyTraceReader, NewTraceEntry
 
 
 class LoadTimer(ABC):
@@ -98,11 +98,15 @@ class PoissonLoadTimer(LoadTimer):
 
 
 class TraceReplayLoadTimer(LoadTimer):
-    def __init__(self, trace_reader: TraceReader, trace_file: Path) -> None:
+    def __init__(self, trace_reader: NewTraceReader[NewTraceEntry] | LegacyTraceReader, trace_file: Path) -> None:
         self._trace_reader = trace_reader
         self._trace_file = trace_file
 
     def start_timer(self, initial: Optional[float] = None) -> Generator[float, None, None]:
         start_time = time.monotonic() if initial is None else initial
-        for timestamp, _, _ in self._trace_reader.load_traces(self._trace_file):
-            yield start_time + timestamp
+        if isinstance(self._trace_reader, NewTraceReader):
+            for entry in self._trace_reader.load_entries(self._trace_file):
+                yield start_time + entry.timestamp
+        else:
+            for timestamp, _, _ in self._trace_reader.load_traces(self._trace_file):
+                yield start_time + timestamp

--- a/inference_perf/loadgen/load_timer.py
+++ b/inference_perf/loadgen/load_timer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import time
 from abc import ABC, abstractmethod
-from typing import Generator, Optional, Tuple
+from typing import Generator, Optional, Tuple, Any
 import numpy as np
 from pathlib import Path
 from inference_perf.utils.trace_reader import NewTraceReader, LegacyTraceReader, NewTraceEntry
@@ -104,9 +104,15 @@ class TraceReplayLoadTimer(LoadTimer):
 
     def start_timer(self, initial: Optional[float] = None) -> Generator[float, None, None]:
         start_time = time.monotonic() if initial is None else initial
-        if isinstance(self._trace_reader, NewTraceReader):
-            for entry in self._trace_reader.load_entries(self._trace_file):
+        if hasattr(self._trace_reader, "load_entries"):
+            # SharedPrefixTraceReader logic
+            # Cast to Any to avoid "Item "LegacyTraceReader" of "NewTraceReader[Any] | LegacyTraceReader" has no attribute "load_entries""
+            reader: Any = self._trace_reader
+            for entry in reader.load_entries(self._trace_file):
                 yield start_time + entry.timestamp
         else:
-            for timestamp, _, _ in self._trace_reader.load_traces(self._trace_file):
-                yield start_time + timestamp
+            # AzurePublicDatasetReader logic
+            if isinstance(self._trace_reader, LegacyTraceReader):
+                reader_legacy = self._trace_reader
+                for timestamp, _, _ in reader_legacy.load_traces(self._trace_file):
+                    yield start_time + timestamp

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -288,7 +288,7 @@ def main_cli() -> None:
                 if config.data.output_distribution.total_count is None:
                     config.data.output_distribution.total_count = total_count
 
-        if config.data.type == DataGenType.SharedPrefix and config.data.shared_prefix is None:
+        if config.data.type == DataGenType.SharedPrefix and config.data.shared_prefix is None and config.data.trace is None:
             raise Exception(f"{config.data.type.value} data generator requires 'shared_prefix' to be configured")
 
         if config.data.type == DataGenType.ShareGPT:

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -104,18 +104,37 @@ def main_cli() -> None:
     parser.add_argument("-a", "--analyze", nargs="*", help="Path to a report directories to analyze", required=False)
     parser.add_argument("-u", "--unified_analysis_dir", help="Unified analysis directory path", required=False)
     parser.add_argument(
+        "--tracegen",
+        help="Run trace generation module. Format: <module>:<config_file>. Supported modules: tot",
+        required=False,
+    )
+    parser.add_argument(
         "--log-level", help="Logging level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     )
     args = parser.parse_args()
 
     setup_logging(args.log_level)
 
+    if args.tracegen:
+        try:
+            module, config_file = args.tracegen.split(":", 1)
+        except ValueError:
+            parser.error("--tracegen format must be <module>:<config_file>")
+
+        if module == "tot":
+            from inference_perf.tracegen.tot import main as tot_main
+
+            tot_main(config_file)
+            return
+        else:
+            parser.error(f"Unknown tracegen module: {module}")
+
     if args.analyze and len(args.analyze) > 0:
         analyze_reports(args.analyze, args.unified_analysis_dir)
         return
 
     if not args.config_file:
-        parser.error("argument -c/--config_file is required when not using --analyze")
+        parser.error("argument -c/--config_file is required when not using --analyze or --tracegen")
 
     config = read_config(args.config_file)
 
@@ -241,8 +260,12 @@ def main_cli() -> None:
     if config.load is None:
         raise Exception("load config missing")
 
-    if len(config.load.stages) == 0 and config.load.sweep is None:
+    if len(config.load.stages) == 0 and config.load.sweep is None and config.load.type != LoadType.TRACE_REPLAY:
         raise Exception("Load stages must be configured, or sweep must be configured")
+
+    if config.load.type == LoadType.TRACE_REPLAY and len(config.load.stages) == 0:
+        # Trace replay ignores rate and duration but requires at least one stage to execute
+        config.load.stages = [StandardLoadStage(rate=1.0, duration=1)]
 
     # Define DataGenerator
     datagen: DataGenerator

--- a/inference_perf/tracegen/__init__.py
+++ b/inference_perf/tracegen/__init__.py
@@ -1,0 +1,1 @@
+# Trace generation modules

--- a/inference_perf/tracegen/tot.py
+++ b/inference_perf/tracegen/tot.py
@@ -1,0 +1,183 @@
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+import random
+from typing import List
+from pydantic import BaseModel
+import yaml
+from inference_perf.utils.shared_prefix_trace_reader import SharedPrefixTraceEntry
+
+
+class ToTConfig(BaseModel):
+    num_layers: int = 3
+    branching_factor: int = 3
+    expand_top: int = 2
+    system_prompt_len: int = 100
+    thought_prompt_len: int = 20
+    thought_len: int = 100
+    start_timestamp: float = 0.0
+    graph_output: str | None = None
+
+
+@dataclass
+class ToTNode:
+    id: int
+    len: int
+    timestamp: float
+    level: int
+    parent_id: int | None = None
+    selected: bool = False
+    is_final: bool = False
+
+
+class ToTTraceGenerator:
+    def __init__(self, config: ToTConfig):
+        self.cfg = config
+        self.next_prefix_id = 1
+        self.nodes: List[ToTNode] = []
+
+    def generate(self) -> List[SharedPrefixTraceEntry]:
+        # Start with the root context
+        root_node = ToTNode(
+            id=self.next_prefix_id,
+            len=self.cfg.system_prompt_len,
+            timestamp=self.cfg.start_timestamp,
+            level=0,
+            selected=True,
+        )
+        current_layer_nodes = [root_node]
+        self.nodes.append(root_node)
+        self.next_prefix_id += 1
+
+        traces = []
+
+        for layer in range(self.cfg.num_layers):
+            next_layer_nodes = []
+
+            # For each node in the current layer (beam), generate branches
+            for node in current_layer_nodes:
+                # Make 'branching_factor' requests
+                for i in range(self.cfg.branching_factor):
+                    # Stagger requests slightly
+                    req_timestamp = node.timestamp + (i * 0.01)
+
+                    # Trace entry
+                    # shared_prefix_id = node.id refers to the parent context
+                    entry = SharedPrefixTraceEntry(
+                        timestamp=req_timestamp,
+                        shared_prefix_length=int(node.len),
+                        tail_input_length=self.cfg.thought_prompt_len,
+                        output_length=self.cfg.thought_len,
+                        shared_prefix_id=int(node.id),
+                    )
+                    traces.append(entry)
+
+                    # Calculate new length for the next node
+                    new_node_len = node.len + self.cfg.thought_prompt_len + self.cfg.thought_len
+
+                    # Estimate completion time (e.g. 100 tokens/sec) for next timestamp
+                    # This determines when the NEXT layer can start from this node
+                    completion_time = req_timestamp + (self.cfg.thought_len / 100.0)
+
+                    new_node = ToTNode(
+                        id=self.next_prefix_id,
+                        len=new_node_len,
+                        timestamp=completion_time,
+                        level=layer + 1,
+                        parent_id=node.id,
+                    )
+                    self.nodes.append(new_node)
+                    self.next_prefix_id += 1
+                    next_layer_nodes.append(new_node)
+
+            # Prune / Beam Search for next layer
+            if not next_layer_nodes:
+                break
+
+            if self.cfg.expand_top < len(next_layer_nodes):
+                # Pick 'expand_top' random nodes to continue
+                current_layer_nodes = random.sample(next_layer_nodes, self.cfg.expand_top)
+            else:
+                current_layer_nodes = next_layer_nodes
+
+            for n in current_layer_nodes:
+                n.selected = True
+
+        if current_layer_nodes:
+            current_layer_nodes[0].is_final = True
+
+        # Sort by timestamp to ensure chronological order
+        traces.sort(key=lambda x: x.timestamp)
+        return traces
+
+    def write_graph(self, filename: str) -> None:
+        """Generates a Graphviz DOT file for the Tree of Thoughts."""
+        logger = logging.getLogger(__name__)
+        try:
+            with open(filename, "w") as f:
+                f.write("digraph TreeOfThought {\n")
+                f.write('    rankdir="TB";\n')
+                f.write('    node [shape=box, style="filled,rounded"];\n')
+
+                for node in self.nodes:
+                    # Style based on selection
+                    fillcolor = "lightblue" if node.selected else "white"
+                    style = "filled,rounded"
+                    if node.selected:
+                        style += ",bold"
+
+                    # Label with small text for tokens
+                    label_text = f"<{node.id}<br/>"
+                    if node.is_final:
+                        label_text += "&#9733; "  # Star symbol
+                    label_text += f'<font point-size="10">shared_prefix_id={node.parent_id if node.parent_id is not None else "N/A"}</font>>'
+
+                    f.write(f'    {node.id} [label={label_text}, fillcolor="{fillcolor}", style="{style}"];\n')
+
+                    if node.parent_id is not None:
+                        f.write(f"    {node.parent_id} -> {node.id};\n")
+
+                f.write("}\n")
+            logger.info(f"Graphviz file written to {filename}")
+        except Exception as e:
+            logger.error(f"Failed to write graph file: {e}")
+
+
+def main(config_file: str) -> None:
+    logger = logging.getLogger(__name__)
+
+    with open(config_file, "r") as f:
+        config_data = yaml.safe_load(f)
+
+    # Extract tracegen config if nested under a 'tracegen' key, otherwise assume root
+    tot_config_data = config_data.get("tracegen", config_data)
+
+    # Filter for relevant keys to avoid pydantic errors with full benchmark configs
+    # Or just use the keys that match the model
+    # For now, let's assume the config file provided IS the ToT config or contains it
+    try:
+        config = ToTConfig(**tot_config_data)
+    except Exception:
+        # Fallback: maybe it's a full benchmark config with a 'data.shared_prefix' section?
+        # But the requirement says "devutils/configs/tracegen_tot.yaml", implying a specific config.
+        # Let's keep it simple for now.
+        config = ToTConfig(**tot_config_data)
+
+    output_path = Path(config_file).parent / "trace_tot.jsonl"
+    if "output_file" in tot_config_data:
+        output_path = Path(tot_config_data["output_file"])
+
+    generator = ToTTraceGenerator(config)
+    traces = generator.generate()
+
+    if config.graph_output:
+        # Assuming the graph_output is an absolute or relative path from current working directory
+        generator.write_graph(config.graph_output)
+
+    logger.info(f"Generated {len(traces)} trace entries.")
+
+    with open(output_path, "w") as f:
+        for t in traces:
+            f.write(t.model_dump_json() + "\n")
+
+    logger.info(f"Saved traces to {output_path}")

--- a/inference_perf/utils/shared_prefix_trace_reader.py
+++ b/inference_perf/utils/shared_prefix_trace_reader.py
@@ -1,0 +1,73 @@
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+from .trace_reader import NewTraceReader, NewTraceEntry
+
+logger = logging.getLogger(__name__)
+
+
+class SharedPrefixTraceEntry(NewTraceEntry):
+    shared_prefix_length: int
+    tail_input_length: int
+    output_length: int
+    shared_prefix_id: Optional[int] = None
+
+
+class SharedPrefixTraceReader(NewTraceReader[SharedPrefixTraceEntry]):
+    """Trace reader for Shared Prefix trace format (JSONL)."""
+
+    def __init__(self) -> None:
+        self.traces: List[SharedPrefixTraceEntry] = []
+
+    def load_entries(self, file_path: Path) -> List[SharedPrefixTraceEntry]:
+        """
+        Load traces from file into memory.
+        Returns a list of SharedPrefixTraceEntry.
+        """
+        if not self.traces:
+            self._load_data(file_path)
+
+        return self.traces
+
+    def _load_data(self, file_path: Path) -> None:
+        logger.info(f"Loading shared prefix traces from {file_path}")
+        self.traces = []
+        initial_timestamp: float = -1.0
+
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                for line_num, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        entry_dict = json.loads(line)
+
+                        # Validate required fields
+                        if "timestamp" not in entry_dict:
+                            logger.warning(f"Line {line_num} missing 'timestamp'. Skipping.")
+                            continue
+
+                        ts = float(entry_dict["timestamp"])
+                        if initial_timestamp < 0:
+                            initial_timestamp = ts
+
+                        # Normalize timestamp to start from 0
+                        entry_dict["timestamp"] = ts - initial_timestamp
+
+                        entry = SharedPrefixTraceEntry(**entry_dict)
+
+                        self.traces.append(entry)
+
+                    except json.JSONDecodeError as e:
+                        logger.warning(f"Error decoding JSON on line {line_num}: {e}")
+                    except ValueError as e:
+                        logger.warning(f"Error parsing value on line {line_num}: {e}")
+
+        except FileNotFoundError:
+            logger.error(f"Trace file not found: {file_path}")
+            raise
+
+        logger.info(f"Loaded {len(self.traces)} trace entries.")

--- a/inference_perf/utils/trace_reader.py
+++ b/inference_perf/utils/trace_reader.py
@@ -1,33 +1,33 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import Iterator, Optional, List, Tuple
+from typing import Iterator, List, Tuple, TypeVar, Generic
 from pathlib import Path
 import csv
 import logging
 import time
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class TraceEntry:
-    """Represents a single trace entry with timing and token information."""
+class NewTraceEntry(BaseModel):
+    """Base class for all trace entries."""
 
-    def __init__(
-        self,
-        timestamp: float,
-        input_tokens: int,
-        output_tokens: int,
-        prompt: Optional[str] = None,
-        completion: Optional[str] = None,
-    ):
-        self.timestamp = timestamp
-        self.input_tokens = input_tokens
-        self.output_tokens = output_tokens
-        self.prompt = prompt
-        self.completion = completion
+    timestamp: float
 
 
-class TraceReader(ABC):
+T = TypeVar("T", bound=NewTraceEntry)
+
+
+class NewTraceReader(ABC, Generic[T]):
+    """Abstract base class for new trace readers."""
+
+    @abstractmethod
+    def load_entries(self, file_path: Path) -> List[T]:
+        raise NotImplementedError
+
+
+class LegacyTraceReader(ABC):
     """Abstract base class for streaming trace readers."""
 
     @abstractmethod
@@ -41,7 +41,7 @@ class TraceReader(ABC):
         raise NotImplementedError
 
 
-class AzurePublicDatasetReader(TraceReader):
+class AzurePublicDatasetReader(LegacyTraceReader):
     """Trace reader for Azure Public Dataset format."""
 
     def __init__(self) -> None:

--- a/tests/test_shared_prefix_trace_lengths.py
+++ b/tests/test_shared_prefix_trace_lengths.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+from inference_perf.utils.shared_prefix_trace_reader import SharedPrefixTraceReader
+
+
+def test_shared_prefix_trace_reader_lengths(tmp_path: Path) -> None:
+    trace_file = tmp_path / "trace_lengths.jsonl"
+    entries = [
+        {
+            "timestamp": 10.0,
+            "shared_prefix_length": 50,
+            "tail_input_length": 25,
+            "output_length": 100,
+            "shared_prefix_id": 1,
+        },
+        {
+            "timestamp": 12.5,
+            "shared_prefix_length": 50,
+            "tail_input_length": 30,
+            "output_length": 100,
+            "shared_prefix_id": 1,
+        },
+        {
+            "timestamp": 15.0,
+            "shared_prefix_length": 40,
+            "tail_input_length": 20,
+            "output_length": 50,
+            "shared_prefix_id": 2,
+        },
+    ]
+
+    with open(trace_file, "w") as f:
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
+
+    reader = SharedPrefixTraceReader()
+    traces = reader.load_entries(trace_file)
+
+    assert len(traces) == 3
+    # First timestamp should be normalized to 0.0
+    assert traces[0].timestamp == 0.0
+    # Second timestamp: 12.5 - 10.0 = 2.5
+    assert traces[1].timestamp == 2.5
+    # Third timestamp: 15.0 - 10.0 = 5.0
+    assert traces[2].timestamp == 5.0
+
+    # Token counts
+    assert traces[0].shared_prefix_length == 50
+    assert traces[0].tail_input_length == 25
+    assert traces[1].shared_prefix_length == 50
+    assert traces[1].tail_input_length == 30
+    assert traces[2].shared_prefix_length == 40
+    assert traces[2].tail_input_length == 20
+
+    # Output lengths
+    assert traces[0].output_length == 100
+    assert traces[1].output_length == 100
+    assert traces[2].output_length == 50
+
+    assert traces[1].shared_prefix_id == 1
+    assert traces[2].shared_prefix_id == 2


### PR DESCRIPTION
This PR introduces the ability to replay advanced "Shared Prefix" traces, specifically targeting Tree-of-Thought (ToT) workloads where multiple requests share common system prompts or thought chains. This brings `inference-perf` closer to the [llm-d Agentic Runtime Northstar][northstar] proposal.

[northstar]: https://docs.google.com/document/d/1C3wRYLSZ9GPT2454MvDC6-8T_gvMPsPL_-ISVTZj4FU/edit?usp=sharing

<div align="center">
<img
  width="550"
  alt="rough roadmap for the PR, in increasing complexity and 'realism': Current Trace Generation, Proposed Shared Prefix Trace, Mooncake Trace and Alibaba Trace, Production Trace Capturing."
  src="https://github.com/user-attachments/assets/1d9fc4c5-863e-41fb-a62c-a09c90b6cc6d"
/>

("Realism" here defined as how close we are to representing the actual characteristics of natural agentic use cases.)

</div>

## Background

### Synthetic vs. Production Trace Generation

Trace generation generally falls into two categories: **synthetic** and **production**.

Production traces are collected from real-world, live workloads, capturing the exact complexities and distributions of actual user traffic. Synthetic traces, on the other hand, are programmatically generated to simulate specific workload patterns, edge cases, or theoretical models (like Tree of Thought).

This PR focuses on synthetic trace generation. This approach serves 2 purposes: it allows us to explore this new frontier of advanced tracing, and it ensures that `inference-perf` is eventually capable of accurately replaying complicated traces with complex shared prefix patterns.

Concurrently, there is an ongoing effort to explore production trace generation that `inference-perf` might be able to play back in the future (see [issue #361](https://github.com/kubernetes-sigs/inference-perf/issues/361)).

### About Tree of Thought (ToT)

Tree of Thought is a prompting framework that generalizes "Chain of Thought" prompting. Instead of generating a single sequence of thoughts, it explores multiple reasoning paths simultaneously (branches), creating a tree structure. The system maintains a set of active thoughts (beams) and expands them layer by layer.

From a benchmarking perspective, ToT generates a unique workload pattern:

- **Shared Prefixes:** Multiple requests expand from the same parent node, sharing the entire history up to that point. This tests the server's ability to reuse KV-caches for the common prefix.
- **Concurrent Branches:** Multiple distinct branches are expanded simultaneously, testing the server's ability to handle parallel requests with different prefixes.

## Key Changes

- **`SharedPrefixTraceReader`**: A new reader for JSONL traces that supports the `{timestamp, shared_prefix_length, tail_input_length, output_length, shared_prefix_id}` `SharedPrefixTrace` format.
- **`SharedPrefixDataGenerator`**: Updated to support trace replay. It dynamically generates random tokens for the shared prefix and tail input based on the lengths provided in the trace, ensuring that requests with the same `shared_prefix_id` and length share the exact same prefix content.
- **`tracegen/tot.py`**: A new module to simulate a Tree of Thought process via the new `--tracegen` flag.
  - Configurable parameters: `num_layers`, `branching_factor`, `expand_top` (beam width), and prompt lengths.
  - Simulates the expansion of the tree, generating trace entries with appropriate timestamps and shared prefix IDs.

### Tree of Thought Trace Generation

You can easily generate traces using the new `--tracegen` CLI flag. First, create a configuration file defining your desired Tree of Thought parameters:

```yaml
# config_tot.yaml
num_layers: 3
branching_factor: 3
expand_top: 2
system_prompt_len: 200
thought_prompt_len: 50
thought_len: 150
start_timestamp: 0.0
output_file: "trace_tot.jsonl"
graph_output: "tot_graph.dot"
```

Then, run the trace generator:

```bash
inference-perf --tracegen tot:config_tot.yaml
```

Below is a snippet from a generated ToT trace file.

```json
{"timestamp":0.0,"shared_prefix_length":200,"tail_input_length":50,"output_length":150,"shared_prefix_id":1}
{"timestamp":0.01,"shared_prefix_length":200,"tail_input_length":50,"output_length":150,"shared_prefix_id":1}
{"timestamp":0.02,"shared_prefix_length":200,"tail_input_length":50,"output_length":150,"shared_prefix_id":1}
{"timestamp":1.51,"shared_prefix_length":400,"tail_input_length":50,"output_length":150,"shared_prefix_id":3}
{"timestamp":1.52,"shared_prefix_length":400,"tail_input_length":50,"output_length":150,"shared_prefix_id":4}
{"timestamp":1.52,"shared_prefix_length":400,"tail_input_length":50,"output_length":150,"shared_prefix_id":3}
{"timestamp":1.53,"shared_prefix_length":400,"tail_input_length":50,"output_length":150,"shared_prefix_id":4}
{"timestamp":1.53,"shared_prefix_length":400,"tail_input_length":50,"output_length":150,"shared_prefix_id":3}
...
```

Analysis of the trace:

- **Layer 1 (Timestamp ~0.0s):** The root node (`shared_prefix_id=1`) is expanded 3 times (branching factor of 3). All 3 requests share the same 200-token system prompt.
- **Layer 2 (Timestamp ~1.5s):** The tree has expanded. We see multiple requests for `shared_prefix_id=3` and `shared_prefix_id=4`.
  - **Shared Prefix Reuse:** The multiple requests for `id=3` share the same 400-token history (root + thought A). Similarly for `id=4` (root + thought B).
  - **Concurrent Branch Exploration:** Notice that requests for `id=3` and `id=4` occur around the same time (`1.52s`). This represents the parallel exploration of different branches in the tree. The benchmark will stress the server's ability to handle these concurrent, divergent contexts simultaneously.

### Tree of Thought Graphviz Visualization

To help understand the generated trace and verify the Tree of Thought structure, the generator can output a `.dot` file representing the graph if the `graph_output` parameter is specified in the configuration.

<img width="1000" alt="graphviz visualization of the above trace" src="https://github.com/user-attachments/assets/a3b106db-095e-409c-ad2e-ccb00060d29b" />

This visualization makes it easy to see the node IDs, the accumulated prompt length at each step, and the specific branches that the `expand_top` selection strategy chose to keep alive (highlighted, with the final chosen output starred).

## Alternatives and Future Work

### Mooncake and Alibaba Qwen Traces

There's currently ongoing work to add production tracing support into llm-d-benchmark via [PR #761](https://github.com/llm-d/llm-d-benchmark/pull/761). This PR introduces Alibaba's Qwen trace format for trace replay of real-world multi-turn chat workflows:

```json
{"timestamp": 0.0, "hash_ids": [123, 456, 789], "chat_id": 1, "parent_chat_id": -1, "turn": 1}
```

This trace format heavily resembles the [Mooncake trace format][mooncake], which similarly uses a list of chunk hashes:

```json
{"timestamp": 0.0, "input_length": 48, "output_length": 20, "hash_ids": [123, 456, 789]}
```

Both of these trace formats contain a field for hash or token "IDs", with each ID being a hash of a block of actual tokens. When the benchmark reads these traces, it deterministically maps each hash ID to a fixed-size block of random tokens (e.g., seeding a PRNG with the hash to generate 16 tokens). This means that:

- The traces contain no private conversation data and are highly compressed.
- Because the entire prompt is represented as a concatenation of blocks, any two requests can share an arbitrary length prefix simply by matching the leading elements in their `hash_ids` array. For example, if Request A uses `[123, 456]` and Request B uses `[123, 456, 789]`, Request B naturally shares the exact token prefix of A.

The proposed `SharedPrefixTrace` format in this PR works similarly but is much simpler. Rather than having a list of token chunk-length hash IDs, a single ID (`shared_prefix_id`) paired with a length (`shared_prefix_length`) is used to represent the entirety of the shared prefix block, and the generator caches the underlying token sequence based on this pair.

While this makes the `SharedPrefixTrace` format much less expressive, it vastly simplifies the initial implementation for validating synthetic tree workloads.

A logical next follow-up for this PR would be to implement the full functionality of the chunked hash list approach used by the Qwen and Mooncake formats. This would allow us to seamlessly transition from simple synthetic generation to more complex generation of agentic workload traces and replaying real-world production traces.

[mooncake]: https://github.com/kvcache-ai/Mooncake/tree/main/FAST25-release

### Azure Traces

Currently, `inference-perf` supports trace replay using the `AzurePublicDataset` CSV format. This format is simple, consisting of `{timestamp, input_tokens, output_tokens}`, and serves well for basic load generation and testing variable request lengths. However, it lacks the structure necessary to capture more advanced conversational or reasoning patterns, such as multi-turn chat history or shared prefix opportunities across multiple concurrent requests.

This work extends `inference-perf`'s tracing capabilities to accommodate these more sophisticated scenarios, paving the way for more realistic and challenging benchmarks.
