### PR TITLE
Fix `SharedPrefix` Datagen Prompt Length

### DIFF
--- a/e2e/tests/test_llm_d_inference_sim.py
+++ b/e2e/tests/test_llm_d_inference_sim.py
@@ -146,3 +146,68 @@ async def test_completion_successful_run(data: dict, load: dict):
     summary_report = result.reports["summary_lifecycle_metrics.json"]
     assert summary_report, "Missing summary report"
     assert summary_report["successes"]["count"] > 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+async def test_chat_successful_run():
+    """
+    Integration test for Chat API that verifies request and response lengths.
+    """
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+
+    load = {
+        "type": "constant",
+        "stages": [{"rate": 1, "duration": 5}],
+        "num_workers": 1,
+    }
+
+    async with LLMDInferenceSimRunner(model_name, port=18001) as sim:
+        result = await run_benchmark_minimal(
+            {
+                "data": {"type": "mock"},
+                "load": load,
+                "api": {
+                    "type": "chat",
+                    "streaming": True,
+                },
+                "server": {
+                    "type": "vllm",
+                    "model_name": model_name,
+                    "base_url": f"http://{sim.host}:{sim.port}",
+                    "ignore_eos": True,
+                },
+                "tokenizer": {
+                    "pretrained_model_name_or_path": str(model_path),
+                },
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                        "per_stage": True,
+                        "per_request": True,
+                    },
+                },
+            }
+        )
+
+    assert result.success, "Benchmark failed"
+    assert result.reports, "No reports generated from benchmark"
+
+    requests_report = result.reports["per_request_lifecycle_metrics.json"]
+    assert requests_report, "Missing per-request report"
+
+    for request in requests_report:
+        # Verify input tokens (from 'mock prompt i')
+        assert request["info"]["input_tokens"] > 0, "Input tokens should be greater than 0"
+        # Verify output tokens (default max_completion_tokens is 30). The
+        # client-side per-chunk re-tokenization in response_info.output_tokens
+        # is known to drift (HF tokenizer add_special_tokens=True default
+        # injects BOS/EOS per call), so assert against the server's
+        # authoritative count from stream_options.include_usage instead.
+        response_info = request["info"]["response_info"]
+        assert response_info is not None, "Missing response_info on successful streaming request"
+        server_usage = response_info["server_usage"]
+        assert server_usage is not None, "Missing server_usage; expected with stream_options.include_usage=true"
+        completion_tokens = server_usage["completion_tokens"]
+        assert completion_tokens == 30, f"Expected 30 output tokens, got {completion_tokens}"

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -59,8 +59,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
 
-            prompt_text = "".join([msg.content for msg in self.messages if msg.content])
-            prompt_len = tokenizer.count_tokens(prompt_text)
+            prompt_len = sum(tokenizer.count_tokens(msg.content) for msg in self.messages if msg.content)
             output_len = tokenizer.count_tokens(output_text)
             return InferenceInfo(
                 input_tokens=prompt_len,
@@ -76,7 +75,7 @@ class ChatCompletionAPIData(InferenceAPIData):
             )
         else:
             data = await response.json()
-            prompt_len = tokenizer.count_tokens("".join([m.content for m in self.messages]))
+            prompt_len = sum(tokenizer.count_tokens(msg.content) for msg in self.messages if msg.content)
             choices = data.get("choices", [])
             if len(choices) == 0:
                 return InferenceInfo(input_tokens=prompt_len, lora_adapter=lora_adapter)

--- a/inference_perf/apis/user_session.py
+++ b/inference_perf/apis/user_session.py
@@ -32,7 +32,7 @@ class LocalUserSession:
 
     def __init__(self, user_session_id: str, context: str = ""):
         self.user_session_id = user_session_id
-        self.contexts = context if context else ""
+        self.context = context if context else ""
         self._current_round = 0
         self._in_flight: Optional[asyncio.Lock] = None
         self._waiting_rounds: Optional[asyncio.Queue[asyncio.Future[bool]]] = None
@@ -65,10 +65,10 @@ class LocalUserSession:
             await future
         await self._in_flight.acquire()
         self._current_round += 1
-        return self.contexts
+        return self.context
 
     def update_context(self, response: str) -> None:
-        self.contexts = response
+        self.context = response
 
         self._ensure_initialized()
         assert self._waiting_rounds is not None

--- a/inference_perf/datagen/cnn_dailymail_datagen.py
+++ b/inference_perf/datagen/cnn_dailymail_datagen.py
@@ -85,7 +85,8 @@ class CNNDailyMailDataGenerator(DataGenerator):
 
                 completion = data[self.highlights_key]
                 completion_tokens = self.tokenizer.count_tokens(completion)
-                prompt_tokens = self.tokenizer.count_tokens(prompt)
+                prompt_ids = self.tokenizer.get_tokenizer().encode(prompt)
+                prompt_tokens = len(prompt_ids)
 
                 if self.input_distribution:
                     if prompt_tokens < self.input_distribution.min:

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -220,7 +220,7 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
                 context=bp.system_prompt,
             )
             logger.debug("Slot %d starting conversation %d", conv_idx, convo_num)
-        elif len(self.user_sessions[conv_idx].contexts) > 2_700_000:
+        elif len(self.user_sessions[conv_idx].context) > 2_700_000:
             # Safety reset: context is approaching max_model_len.
             # Random Qwen3 tokens decode to ~12 chars/token on average, so
             # 225K tokens ≈ 2.7M chars. Reset to fresh context rather than

--- a/inference_perf/datagen/datagen_utils.py
+++ b/inference_perf/datagen/datagen_utils.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, List, Set, Tuple
+
+import numpy as np
+
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+
+def init_vocab_sampling(tokenizer: CustomTokenizer) -> Tuple[int, Set[int], np.ndarray]:
+    """Resolve a tokenizer's vocab size and build the valid-token-id pool for random sampling.
+
+    Returns:
+        (vocab_size, special_token_ids, valid_token_ids) where valid_token_ids excludes
+        the tokenizer's special tokens.
+
+    Raises:
+        ValueError: If the tokenizer exposes no usable vocab-size signal, or if the
+          resolved vocab size is non-positive.
+    """
+    hf_tokenizer = tokenizer.get_tokenizer()
+    if hasattr(hf_tokenizer, "vocab_size") and hf_tokenizer.vocab_size is not None:
+        vocab_size: int = hf_tokenizer.vocab_size
+    elif hasattr(hf_tokenizer, "get_vocab") and callable(hf_tokenizer.get_vocab):
+        vocab_size = len(hf_tokenizer.get_vocab())
+    else:
+        try:
+            vocab_size = len(hf_tokenizer)
+        except TypeError as e:
+            raise ValueError(
+                "Tokenizer does not have a 'vocab_size' attribute, 'get_vocab()' method, "
+                "or support len() for vocabulary size. Cannot use random token generation."
+            ) from e
+    if vocab_size <= 0:
+        raise ValueError(f"Tokenizer vocabulary size must be positive, got {vocab_size}.")
+
+    special_token_ids: Set[int] = set(getattr(hf_tokenizer, "all_special_ids", None) or [])
+    valid_token_ids = np.array([i for i in range(vocab_size) if i not in special_token_ids], dtype=np.int64)
+    return vocab_size, special_token_ids, valid_token_ids
+
+
+def random_token_ids(rng: np.random.Generator, valid_token_ids: np.ndarray, length: int) -> List[int]:
+    """Sample `length` token IDs uniformly from `valid_token_ids` using `rng`.
+
+    Returns an empty list when length <= 0. The returned list is plain python
+    ints so callers can pass it straight to HF tokenizer decode().
+    """
+    if length <= 0:
+        return []
+    return rng.choice(valid_token_ids, size=length).tolist()  # type: ignore[no-any-return]
+
+
+def converge_to_exact_length_text(
+    tokenizer: CustomTokenizer,
+    target_len: int,
+    prefix_text: str,
+    initial_tokens: List[int],
+    adjust_tokens_fn: Callable[[List[int], int, int], List[int]],
+) -> str:
+    """Generates a string that tokenizes to exactly target_len, optionally prefixed.
+
+    Args:
+        tokenizer: The custom tokenizer.
+        target_len: The target token length.
+        prefix_text: Optional prefix to include in the length calculation.
+        initial_tokens: The initial list of token IDs to start with.
+        adjust_tokens_fn: A callback function to adjust the token list when the
+          length doesn't match. It takes (current_tokens, current_len,
+          target_len) and returns new_tokens.
+
+    Raises:
+        ValueError: If we cannot land on exactly `target_len` within the
+          iteration budget. Most often this happens when the tokenizer's BPE
+          merges around the prefix/suffix boundary keep flipping the count by
+          more than one token per adjustment, or when the requested length is
+          near the tokenizer's vocabulary edge cases (e.g. very small
+          target_len with a tokenizer that always prepends a BOS). Mitigation:
+          try a slightly different `target_len`, verify the tokenizer config
+          matches the model server's, or pre-tokenize the prefix once and
+          adjust around it instead of regenerating each iteration.
+    """
+    if target_len <= 0:
+        return ""
+
+    hf_tokenizer = tokenizer.get_tokenizer()
+
+    prefix_len = 0
+    if prefix_text:
+        prefix_len = tokenizer.count_tokens(prefix_text)
+        assert prefix_len < target_len, (
+            f"target_len ({target_len}) must be > prefix_len ({prefix_len}). "
+            f"This helper generates suffix tokens such that prefix_len + suffix_len == target_len; "
+            f"the caller is responsible for choosing target_len with room for a non-empty suffix."
+        )
+
+    current_tokens = initial_tokens
+
+    max_iterations = 20
+    last_len = -1
+    for _ in range(max_iterations):
+        text = hf_tokenizer.decode(current_tokens, skip_special_tokens=True)
+
+        full_text = prefix_text + " " + text if prefix_text else text
+
+        current_len = tokenizer.count_tokens(full_text)
+
+        if current_len == target_len:
+            return full_text if prefix_text else text
+
+        last_len = current_len
+        current_tokens = adjust_tokens_fn(current_tokens, current_len, target_len)
+
+    raise ValueError(
+        f"Could not generate a prompt of exactly {target_len} tokens after {max_iterations} "
+        f"attempts (got {last_len}). This is usually a configuration mismatch — try one of: "
+        f"(1) increase or decrease the requested length by a few tokens in your data config "
+        f"(e.g. data.input_distribution.mean / .std_dev, or data.shared_prefix.system_prompt_len "
+        f"/ .question_len); (2) ensure tokenizer.pretrained_model_name_or_path matches the model "
+        f"the server is running."
+    )
+
+
+def generate_random_exact_length_text(
+    rng: np.random.Generator,
+    valid_token_ids: np.ndarray,
+    tokenizer: CustomTokenizer,
+    target_len: int,
+    prefix_text: str = "",
+) -> str:
+    """Generate text that tokenizes to exactly target_len, optionally with a prefix.
+
+    Combines random token sampling with the convergence loop in
+    `generate_exact_length_text`. When prefix_text is provided the TOTAL length
+    including prefix will be target_len; the returned string is the full
+    combined text. Otherwise just the generated suffix is returned.
+    """
+    if target_len <= 0:
+        return ""
+
+    prefix_len = 0
+    if prefix_text:
+        prefix_len = tokenizer.count_tokens(prefix_text)
+        assert prefix_len < target_len, (
+            f"target_len ({target_len}) must be > prefix_len ({prefix_len}). "
+            f"This helper generates suffix tokens such that prefix_len + suffix_len == target_len; "
+            f"the caller is responsible for choosing target_len with room for a non-empty suffix."
+        )
+
+    initial_tokens = random_token_ids(rng, valid_token_ids, target_len - prefix_len)
+
+    def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
+        if current_len < target_len:
+            current_tokens.extend(random_token_ids(rng, valid_token_ids, target_len - current_len))
+        else:
+            diff = current_len - target_len
+            current_tokens = current_tokens[:-diff] if len(current_tokens) > diff else current_tokens[:1]
+        return current_tokens
+
+    return converge_to_exact_length_text(
+        tokenizer=tokenizer,
+        target_len=target_len,
+        prefix_text=prefix_text,
+        initial_tokens=initial_tokens,
+        adjust_tokens_fn=adjust_tokens,
+    )

--- a/inference_perf/datagen/hf_billsum_datagen.py
+++ b/inference_perf/datagen/hf_billsum_datagen.py
@@ -85,10 +85,10 @@ class BillsumConversationsDataGenerator(DataGenerator):
                         completion = data[self.data_key][1].get(self.content_key)
                         if not prompt:
                             continue
-                        # Ensured by main.py logic and __init__ type hint for this class
                         assert self.tokenizer is not None
+                        prompt_ids = self.tokenizer.get_tokenizer().encode(prompt)
+                        prompt_tokens = len(prompt_ids)
                         completion_tokens = self.tokenizer.count_tokens(completion)
-                        prompt_tokens = self.tokenizer.count_tokens(prompt)
 
                         if self.input_distribution:
                             if prompt_tokens < self.input_distribution.min or prompt_tokens > self.input_distribution.max:
@@ -105,15 +105,13 @@ class BillsumConversationsDataGenerator(DataGenerator):
                         logger.warning(f"Skipping invalid completion data: {e}")
                         continue
                 elif self.api_config.type == APIType.Chat:
-                    yield ChatCompletionAPIData(
-                        messages=[
-                            ChatMessage(
-                                role=conversation[self.role_key],
-                                content=conversation[self.content_key],
-                            )
-                            for conversation in data[self.data_key]
-                        ]
-                    )
+                    assert self.tokenizer is not None
+                    messages = []
+                    for conversation in data[self.data_key]:
+                        role = conversation[self.role_key]
+                        content = conversation[self.content_key]
+                        messages.append(ChatMessage(role=role, content=content))
+                    yield ChatCompletionAPIData(messages=messages)
                 else:
                     raise Exception("Unsupported API type")
 

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -95,8 +95,9 @@ class HFShareGPTDataGenerator(DataGenerator):
                 completion = data[self.data_key][1].get(self.content_key)
                 if not prompt:
                     continue
+                prompt_ids = self.tokenizer.get_tokenizer().encode(prompt)
+                prompt_tokens = len(prompt_ids)
                 completion_tokens = self.tokenizer.count_tokens(completion)
-                prompt_tokens = self.tokenizer.count_tokens(prompt)
 
                 if self.input_distribution:
                     if prompt_tokens < self.input_distribution.min:
@@ -116,6 +117,9 @@ class HFShareGPTDataGenerator(DataGenerator):
                 continue
 
     def get_chat_data(self) -> Generator[InferenceAPIData, None, None]:
+        if self.tokenizer is None:
+            raise Exception("Tokenizer is required for chat API of HFShareGPTDataGenerator")
+
         while True:
             data = next(self.sharegpt_dataset)
             if (
@@ -125,15 +129,14 @@ class HFShareGPTDataGenerator(DataGenerator):
                 or len(data[self.data_key]) == 0
             ):
                 continue
-            yield ChatCompletionAPIData(
-                messages=[
-                    ChatMessage(
-                        role=SHAREGPT_HF_CHAT_ROLE_MAP.get(conversation[self.role_key], "user"),
-                        content=conversation[self.content_key],
-                    )
-                    for conversation in data[self.data_key]
-                ]
-            )
+
+            messages = []
+            for conversation in data[self.data_key]:
+                role = SHAREGPT_HF_CHAT_ROLE_MAP.get(conversation[self.role_key], "user")
+                content = conversation[self.content_key]
+                messages.append(ChatMessage(role=role, content=content))
+
+            yield ChatCompletionAPIData(messages=messages)
 
     def is_io_distribution_supported(self) -> bool:
         return True

--- a/inference_perf/datagen/infinity_instruct_datagen.py
+++ b/inference_perf/datagen/infinity_instruct_datagen.py
@@ -81,8 +81,9 @@ class InfinityInstructDataGenerator(DataGenerator):
                             continue
 
                         assert self.tokenizer is not None
+                        prompt_ids = self.tokenizer.get_tokenizer().encode(prompt)
+                        prompt_tokens = len(prompt_ids)
                         completion_tokens = self.tokenizer.count_tokens(completion)
-                        prompt_tokens = self.tokenizer.count_tokens(prompt)
 
                         if self.input_distribution:
                             if prompt_tokens < self.input_distribution.min or prompt_tokens > self.input_distribution.max:
@@ -100,6 +101,7 @@ class InfinityInstructDataGenerator(DataGenerator):
                         continue
                 elif self.api_config.type == APIType.Chat:
                     try:
+                        assert self.tokenizer is not None
                         messages: List[ChatMessage] = []
                         for conv in conversations:
                             role = "user" if conv.get("from") == "human" else "assistant"

--- a/inference_perf/datagen/mock_datagen.py
+++ b/inference_perf/datagen/mock_datagen.py
@@ -30,11 +30,11 @@ class MockDataGenerator(DataGenerator):
         if self.api_config.type == APIType.Completion:
             while True:
                 i += 1
-                yield CompletionAPIData(prompt="text" + str(i))
+                yield CompletionAPIData(prompt=f"1 2 3 {i}")
         elif self.api_config.type == APIType.Chat:
             while True:
                 i += 1
-                yield ChatCompletionAPIData(messages=[ChatMessage(role="user", content="text" + str(i))])
+                yield ChatCompletionAPIData(messages=[ChatMessage(role="user", content=f"mock prompt {i}")])
         else:
             raise Exception("Unsupported API type")
 

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from pathlib import Path
+from typing import Generator, List, Optional
+
 import numpy as np
-from inference_perf.apis import InferenceAPIData, CompletionAPIData, LazyLoadInferenceAPIData
+
+from inference_perf.apis import CompletionAPIData, InferenceAPIData, LazyLoadInferenceAPIData
+from inference_perf.config import APIConfig, APIType, DataConfig, TraceFormat
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import generate_distribution
-from .base import DataGenerator, LazyLoadDataMixin
-from typing import Generator, List, Optional
-from inference_perf.config import APIType, APIConfig, DataConfig, TraceFormat
 from inference_perf.utils.trace_reader import AzurePublicDatasetReader
-import logging
+from .base import DataGenerator, LazyLoadDataMixin
+from .datagen_utils import generate_random_exact_length_text, init_vocab_sampling, random_token_ids
 
 logger = logging.getLogger(__name__)
 
@@ -79,21 +82,18 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for RandomDataGenerator")
 
-        hf_tokenizer = self.tokenizer.get_tokenizer()
-        if hasattr(hf_tokenizer, "vocab_size") and hf_tokenizer.vocab_size is not None:
-            self.vocab_size: int = hf_tokenizer.vocab_size
-        elif hasattr(hf_tokenizer, "get_vocab") and callable(hf_tokenizer.get_vocab):
-            self.vocab_size = len(hf_tokenizer.get_vocab())
-        else:
-            try:
-                self.vocab_size = len(hf_tokenizer)
-            except TypeError as e:
-                raise ValueError(
-                    "Tokenizer does not have a 'vocab_size' attribute, 'get_vocab()' method, "
-                    "or support len() for vocabulary size. Cannot use random token generation."
-                ) from e
-        if self.vocab_size <= 0:
-            raise ValueError(f"Tokenizer vocabulary size must be positive, got {self.vocab_size}.")
+        self.vocab_size, self.special_token_ids, self.valid_token_ids = init_vocab_sampling(self.tokenizer)
+        self.rng: np.random.Generator = np.random.default_rng()
+
+    def _generate_random_token_ids(self, length: int) -> List[int]:
+        """Generates a list of random token IDs of a specified length."""
+        return random_token_ids(self.rng, self.valid_token_ids, length)
+
+    def _generate_exact_length_text(self, target_len: int) -> str:
+        """Generates a string that tokenizes to exactly target_len."""
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for generating exact length prompts.")
+        return generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len)
 
     def get_request_count(self) -> int:
         return min(len(self.input_lengths), len(self.output_lengths))
@@ -114,9 +114,9 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
             raise ValueError("Tokenizer is required for RandomDataGenerator")
 
         if self.api_config.type == APIType.Completion:
-            tokens = np.random.randint(0, self.vocab_size, size=self.input_lengths[n], dtype=np.int64)
-            prompt_text = self.tokenizer.get_tokenizer().decode(tokens.tolist())
-            return CompletionAPIData(prompt=prompt_text, max_tokens=self.output_lengths[n])
+            length = self.input_lengths[n]
+            text = self._generate_exact_length_text(length)
+            return CompletionAPIData(prompt=text, max_tokens=self.output_lengths[n])
         else:
             raise Exception("Unsupported API type")
 

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from typing import Generator, List, Optional, Union
 
 import numpy as np
@@ -22,6 +23,9 @@ from inference_perf.config import APIConfig, APIType, DataConfig, Distribution
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import sample_from_distribution
 from .base import DataGenerator, LazyLoadDataMixin
+from .datagen_utils import generate_random_exact_length_text, init_vocab_sampling, random_token_ids
+
+logger = logging.getLogger(__name__)
 
 
 # Shared Prefix Generator generates shared prefix in the prompts that are sent.
@@ -47,22 +51,7 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for SharedPrefixDataGenerator but was not initialized.")
 
-        # Initialize vocab_size
-        hf_tokenizer = self.tokenizer.get_tokenizer()
-        if hasattr(hf_tokenizer, "vocab_size") and hf_tokenizer.vocab_size is not None:
-            self.vocab_size: int = hf_tokenizer.vocab_size
-        elif hasattr(hf_tokenizer, "get_vocab") and callable(hf_tokenizer.get_vocab):
-            self.vocab_size = len(hf_tokenizer.get_vocab())
-        else:
-            try:
-                self.vocab_size = len(hf_tokenizer)
-            except TypeError as e:
-                raise ValueError(
-                    "Tokenizer does not have a 'vocab_size' attribute, 'get_vocab()' method, "
-                    "or support len() for vocabulary size. Cannot use random token generation."
-                ) from e
-        if self.vocab_size <= 0:
-            raise ValueError(f"Tokenizer vocabulary size must be positive, got {self.vocab_size}.")
+        self.vocab_size, self.special_token_ids, self.valid_token_ids = init_vocab_sampling(self.tokenizer)
 
         if self.shared_prefix is None:
             raise ValueError("Shared Prefix config is required for SharedPrefixDataGenerator")
@@ -140,9 +129,17 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
 
     def _generate_random_token_ids(self, length: int) -> List[int]:
         """Generates a list of random token IDs of a specified length."""
-        if length == 0:
-            return []
-        return self.rng.integers(0, self.vocab_size, size=length, dtype=np.int64).tolist()  # type: ignore[no-any-return]
+        return random_token_ids(self.rng, self.valid_token_ids, length)
+
+    def _generate_exact_length_text(self, target_len: int, prefix_text: str = "") -> str:
+        """Generates a string that tokenizes to exactly target_len, optionally prefixed.
+
+        If prefix_text is provided, the TOTAL length including prefix will be target_len.
+        Returns the full combined text if prefix_text is provided, else just the generated text.
+        """
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for generating exact length prompts.")
+        return generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len, prefix_text)
 
     def _generate_prompts(self) -> None:
         """Pre-generates all prompts based on the configuration."""
@@ -152,39 +149,30 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.shared_prefix is None:
             raise ValueError("Shared prefix is not available for generating prompts.")
 
-        hf_tokenizer = self.tokenizer.get_tokenizer()
-
         for group_id in range(self.num_groups):
             # Generate a shared prefix (system prompt) with per-group length
             sys_prompt_len = self.system_prompt_lens_per_group[group_id]
-            shared_prefix_token_ids = self._generate_random_token_ids(sys_prompt_len)
-            shared_prefix_text = hf_tokenizer.decode(shared_prefix_token_ids, skip_special_tokens=True)
-
-            # Batch generate all question token IDs for this group
-            all_question_token_ids = [
-                self._generate_random_token_ids(self.question_len_list_per_group[group_id][prompt_id])
-                for prompt_id in range(self.num_prompts_per_group)
-            ]
-
-            # Batch decode all questions at once (much faster than individual decode calls)
-            all_question_texts = hf_tokenizer.batch_decode(all_question_token_ids, skip_special_tokens=True)
+            shared_prefix_text = self._generate_exact_length_text(sys_prompt_len)
 
             for prompt_id in range(self.num_prompts_per_group):
-                question_text = all_question_texts[prompt_id]
+                q_len = self.question_len_list_per_group[group_id][prompt_id]
+                target_total_len = sys_prompt_len + q_len
 
                 if self.enable_multi_turn_chat:
-                    # multi turn chat, create user to keep conversation
+                    full_text = self._generate_exact_length_text(target_total_len, prefix_text=shared_prefix_text)
+                    # Extract question part (skip prefix and space)
+                    question_text = full_text[len(shared_prefix_text) + 1 :]
+
                     self.user_sessions.append(
                         LocalUserSession(
                             user_session_id=f"user_session_{self.num_prompts_per_group * group_id + prompt_id}",
                             context=shared_prefix_text,
                         )
                     )
+                    self.prompts.append(question_text)
                 else:
-                    # Single turn chat, Combine shared prefix and question
-                    question_text = shared_prefix_text + " " + question_text
-
-                self.prompts.append(question_text)
+                    full_text = self._generate_exact_length_text(target_total_len, prefix_text=shared_prefix_text)
+                    self.prompts.append(full_text)
 
         # Flatten output lengths to match prompts ordering
         self.flat_output_lens = [

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -11,12 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from inference_perf.apis import InferenceAPIData, CompletionAPIData, LazyLoadInferenceAPIData
+import logging
+from typing import Generator, List, Optional
+
+from inference_perf.apis import CompletionAPIData, InferenceAPIData, LazyLoadInferenceAPIData
+from inference_perf.config import APIConfig, APIType, DataConfig
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import generate_distribution
 from .base import DataGenerator, LazyLoadDataMixin
-from typing import Generator, List, Optional
-from inference_perf.config import APIConfig, APIType, DataConfig
+from .datagen_utils import converge_to_exact_length_text
+
+logger = logging.getLogger(__name__)
 
 
 class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
@@ -44,7 +49,7 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
             self.output_distribution.total_count,
         )
         base_prompt = "Pick as many lines as you can from these poem lines:\n"
-        self.token_ids = self.tokenizer.get_tokenizer().encode(base_prompt + self.get_sonnet_data())
+        self.token_ids: list[int] = self.tokenizer.get_tokenizer().encode(base_prompt + self.get_sonnet_data())
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion]
@@ -55,6 +60,42 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
     def is_shared_prefix_supported(self) -> bool:
         return False
 
+    def _generate_exact_length_text(self, target_len: int) -> str:
+        """Generates a string from self.token_ids that tokenizes to exactly target_len."""
+        if target_len <= 0:
+            return ""
+
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for generating exact length prompts.")
+
+        # Start with a slice of target_len
+        current_slice_len = target_len
+
+        initial_slice_len = min(target_len, len(self.token_ids))
+        initial_tokens = self.token_ids[:initial_slice_len]
+
+        def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
+            nonlocal current_slice_len
+            if current_len < target_len:
+                diff = target_len - current_len
+                current_slice_len += diff
+            else:
+                diff = current_len - target_len
+                current_slice_len -= diff
+                if current_slice_len <= 0:
+                    current_slice_len = 1  # Keep at least one
+
+            slice_to_use = min(current_slice_len, len(self.token_ids))
+            return self.token_ids[:slice_to_use]
+
+        return converge_to_exact_length_text(
+            tokenizer=self.tokenizer,
+            target_len=target_len,
+            prefix_text="",
+            initial_tokens=initial_tokens,
+            adjust_tokens_fn=adjust_tokens,
+        )
+
     def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> InferenceAPIData:
         n = data.data_index
 
@@ -62,8 +103,10 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
             raise ValueError("Tokenizer is required for SyntheticDataGenerator")
 
         if self.api_config.type == APIType.Completion:
+            length = self.input_lengths[n]
+            prompt_text = self._generate_exact_length_text(length)
             return CompletionAPIData(
-                prompt=self.tokenizer.get_tokenizer().decode(self.token_ids[: self.input_lengths[n]]),
+                prompt=prompt_text,
                 max_tokens=self.output_lengths[n],
             )
         else:

--- a/tests/apis/test_user_session.py
+++ b/tests/apis/test_user_session.py
@@ -15,6 +15,7 @@
 """Tests for LocalUserSession lifecycle."""
 
 import multiprocessing as mp
+import re
 import pytest
 from collections import defaultdict
 from queue import Empty
@@ -45,6 +46,11 @@ def _mock_tokenizer() -> MagicMock:
     hf.decode = MagicMock(side_effect=lambda ids, **kw: f"tok_{len(ids)}")
     hf.batch_decode = MagicMock(side_effect=lambda batch, **kw: [f"tok_{len(ids)}" for ids in batch])
     tok.get_tokenizer.return_value = hf
+    # Match the decode mock's "tok_N" format so count_tokens returns a real int
+    # (the exact-length datagen path compares this against target_len).
+    tok.count_tokens = MagicMock(
+        side_effect=lambda text: sum(int(n) for n in re.findall(r"tok_(\d+)", text)) if isinstance(text, str) else 0
+    )
     return tok
 
 
@@ -112,11 +118,11 @@ class TestLocalUserSessionLifecycle:
 
     def test_clear_instances_resets_all_sessions(self) -> None:
         s1 = LocalUserSession.get_instance("sess_a")
-        s1.contexts = "accumulated context"
+        s1.context = "accumulated context"
         s1._current_round = 3
 
         s2 = LocalUserSession.get_instance("sess_b")
-        s2.contexts = "other context"
+        s2.context = "other context"
 
         LocalUserSession.clear_instances()
 
@@ -125,9 +131,9 @@ class TestLocalUserSessionLifecycle:
 
         assert new_s1 is not s1
         assert new_s2 is not s2
-        assert new_s1.contexts == ""
+        assert new_s1.context == ""
         assert new_s1._current_round == 0
-        assert new_s2.contexts == ""
+        assert new_s2.context == ""
 
     def test_context_does_not_leak_across_stage_boundary(self) -> None:
         """
@@ -137,13 +143,13 @@ class TestLocalUserSessionLifecycle:
 
         """
         session = LocalUserSession.get_instance("user_0")
-        session.contexts = "system prompt Q1 A1 Q2 A2"
+        session.context = "system prompt Q1 A1 Q2 A2"
         session._current_round = 2
 
         LocalUserSession.clear_instances()
 
         session_s1 = LocalUserSession.get_instance("user_0")
-        assert session_s1.contexts == ""
+        assert session_s1.context == ""
         assert session_s1._current_round == 0
 
     @pytest.mark.asyncio

--- a/tests/datagen/test_datagen_fuzz.py
+++ b/tests/datagen/test_datagen_fuzz.py
@@ -1,0 +1,102 @@
+import pytest
+from unittest.mock import MagicMock
+import numpy as np
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.apis import LazyLoadInferenceAPIData
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.datagen.random_datagen import RandomDataGenerator
+from inference_perf.datagen.synthetic_datagen import SyntheticDataGenerator
+from inference_perf.config import SharedPrefix
+from inference_perf.datagen.base import DataGenerator, LazyLoadDataMixin
+from inference_perf.datagen.shared_prefix_datagen import SharedPrefixDataGenerator
+
+
+def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
+    """Create a mock tokenizer that returns predictable text."""
+    mock_tokenizer = MagicMock()
+    hf_tok = MagicMock()
+    hf_tok.vocab_size = vocab_size
+    hf_tok.decode = MagicMock(side_effect=lambda ids, **kw: f"text_{len(ids)}")
+    hf_tok.batch_decode = MagicMock(side_effect=lambda batch, **kw: [f"text_{len(ids)}" for ids in batch])
+    hf_tok.encode = MagicMock(side_effect=lambda text, **kw: [1] * max(1000, len(text.split())))
+    mock_tokenizer.get_tokenizer.return_value = hf_tok
+
+    def count_tokens(text: str) -> int:
+        parts = text.split()
+        total = 0
+        for p in parts:
+            if p.startswith("text_"):
+                total += int(p[5:])
+            else:
+                total += 1
+        return total
+
+    mock_tokenizer.count_tokens.side_effect = count_tokens
+    return mock_tokenizer
+
+
+@pytest.mark.parametrize("gen_type", [DataGenType.Random, DataGenType.Synthetic, DataGenType.SharedPrefix])
+def test_datagen_length_fuzz(gen_type: DataGenType) -> None:
+    rng = np.random.default_rng(42)
+    mock_tokenizer = _make_mock_tokenizer()
+
+    # Run 10 random configurations
+    for _ in range(10):
+        target_len = int(rng.integers(10, 100))
+
+        api_config = APIConfig(type=APIType.Completion)
+
+        if gen_type == DataGenType.Random:
+            data_config = DataConfig(
+                type=DataGenType.Random,
+                input_distribution=Distribution(
+                    min=target_len, max=target_len, mean=float(target_len), std_dev=0.0, total_count=10
+                ),
+                output_distribution=Distribution(min=10, max=10, mean=10.0, std_dev=0.0, total_count=10),
+            )
+            gen: DataGenerator = RandomDataGenerator(api_config, data_config, mock_tokenizer)
+        elif gen_type == DataGenType.Synthetic:
+            data_config = DataConfig(
+                type=DataGenType.Synthetic,
+                input_distribution=Distribution(
+                    min=target_len, max=target_len, mean=float(target_len), std_dev=0.0, total_count=10
+                ),
+                output_distribution=Distribution(min=10, max=10, mean=10.0, std_dev=0.0, total_count=10),
+            )
+            gen = SyntheticDataGenerator(api_config, data_config, mock_tokenizer)
+        elif gen_type == DataGenType.SharedPrefix:
+            sp = SharedPrefix(
+                num_groups=2,
+                num_prompts_per_group=5,
+                question_len=target_len,
+                output_len=10,
+                system_prompt_len=10,
+            )
+            data_config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=sp)
+            gen = SharedPrefixDataGenerator(api_config, data_config, mock_tokenizer)
+
+        # Generate prompts and check length
+        assert isinstance(gen, LazyLoadDataMixin)
+        prompts = []
+        for i, p in enumerate(gen.get_data()):
+            if isinstance(p, LazyLoadInferenceAPIData):
+                p = gen.load_lazy_data(p)
+            prompts.append(p)
+            if i >= 9:
+                break
+
+        assert len(prompts) == 10
+
+        for p in prompts:
+            assert isinstance(p, CompletionAPIData)
+            actual_len = mock_tokenizer.count_tokens(p.prompt)
+
+            if gen_type == DataGenType.SharedPrefix:
+                # For SharedPrefix, the prompt is prefix + question.
+                # Expected length is system_prompt_len + question_len = 10 + target_len
+                expected_len = 10 + target_len
+            else:
+                expected_len = target_len
+
+            print(f"Type: {gen_type}, Expected: {expected_len}, Actual: {actual_len}")
+            assert actual_len == expected_len, f"Failed for {gen_type}, expected {expected_len}, got {actual_len}"

--- a/tests/datagen/test_datagen_utils.py
+++ b/tests/datagen/test_datagen_utils.py
@@ -1,0 +1,138 @@
+import numpy as np
+import pytest
+from typing import Any, List
+from inference_perf.datagen.datagen_utils import converge_to_exact_length_text, generate_random_exact_length_text
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+
+class DummyTokenizer:
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def encode(self, text: str) -> list[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return [4, 5, 6]
+
+    def decode(self, tokens: list[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+
+class DummyCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return DummyTokenizer()
+
+    def count_tokens(self, text: str) -> int:
+        return len(text.split())
+
+
+def test_generate_exact_length_text_success() -> None:
+    tokenizer = DummyCustomTokenizer()
+    target_len = 5
+    initial_tokens = [10, 20, 30]  # len 3
+
+    def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
+        if current_len < target_len:
+            current_tokens.append(40)
+        return current_tokens
+
+    result = converge_to_exact_length_text(
+        tokenizer=tokenizer,
+        target_len=target_len,
+        prefix_text="",
+        initial_tokens=initial_tokens,
+        adjust_tokens_fn=adjust_tokens,
+    )
+
+    assert tokenizer.count_tokens(result) == target_len
+    assert result == "10 20 30 40 40"  # initial 3 + 2 added
+
+
+def test_generate_exact_length_text_with_prefix() -> None:
+    tokenizer = DummyCustomTokenizer()
+    target_len = 6
+    prefix_text = "p1 p2"  # len 2
+    initial_tokens = [10, 20]  # len 2
+
+    def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
+        if current_len < target_len:
+            current_tokens.append(30)
+        return current_tokens
+
+    result = converge_to_exact_length_text(
+        tokenizer=tokenizer,
+        target_len=target_len,
+        prefix_text=prefix_text,
+        initial_tokens=initial_tokens,
+        adjust_tokens_fn=adjust_tokens,
+    )
+
+    assert tokenizer.count_tokens(result) == target_len
+    assert result == "p1 p2 10 20 30 30"  # prefix(2) + initial(2) + added(2) = 6
+
+
+def test_generate_exact_length_text_failure() -> None:
+    tokenizer = DummyCustomTokenizer()
+    target_len = 5
+    initial_tokens = [10, 20, 30]
+
+    # Callback does nothing, so it will never converge
+    def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
+        return current_tokens
+
+    with pytest.raises(ValueError, match="Could not generate a prompt of exactly 5 tokens after 20 attempts"):
+        converge_to_exact_length_text(
+            tokenizer=tokenizer,
+            target_len=target_len,
+            prefix_text="",
+            initial_tokens=initial_tokens,
+            adjust_tokens_fn=adjust_tokens,
+        )
+
+
+def test_generate_exact_length_text_zero_len() -> None:
+    tokenizer = DummyCustomTokenizer()
+    result = converge_to_exact_length_text(
+        tokenizer=tokenizer,
+        target_len=0,
+        prefix_text="",
+        initial_tokens=[10],
+        adjust_tokens_fn=lambda c, _, __: c,
+    )
+    assert result == ""
+
+
+def test_generate_exact_length_text_prefix_already_too_long() -> None:
+    tokenizer = DummyCustomTokenizer()
+    prefix_text = "p1 p2 p3"  # len 3
+    with pytest.raises(
+        AssertionError, match=r"target_len \(2\) must be > prefix_len \(3\)\. This helper generates suffix tokens"
+    ):
+        converge_to_exact_length_text(
+            tokenizer=tokenizer,
+            target_len=2,
+            prefix_text=prefix_text,
+            initial_tokens=[10],
+            adjust_tokens_fn=lambda c, _, __: c,
+        )
+
+
+def test_generate_random_exact_length_text_prefix_already_too_long() -> None:
+    tokenizer = DummyCustomTokenizer()
+    rng = np.random.default_rng(0)
+    valid_token_ids = np.array([10, 20, 30, 40], dtype=np.int64)
+    prefix_text = "p1 p2 p3"  # len 3
+    with pytest.raises(
+        AssertionError, match=r"target_len \(2\) must be > prefix_len \(3\)\. This helper generates suffix tokens"
+    ):
+        generate_random_exact_length_text(
+            rng=rng,
+            valid_token_ids=valid_token_ids,
+            tokenizer=tokenizer,
+            target_len=2,
+            prefix_text=prefix_text,
+        )

--- a/tests/datagen/test_random_datagen.py
+++ b/tests/datagen/test_random_datagen.py
@@ -1,0 +1,77 @@
+from inference_perf.apis import CompletionAPIData, LazyLoadInferenceAPIData
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.datagen.random_datagen import RandomDataGenerator
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from typing import Any
+
+
+class DummyTokenizer:
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def encode(self, text: str) -> list[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return [4, 5, 6]
+
+    def decode(self, tokens: list[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+
+class DummyCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return DummyTokenizer()
+
+    def count_tokens(self, text: str) -> int:
+        return len(text.split())
+
+
+def test_random_datagen_yields_string() -> None:
+    api_config = APIConfig(type=APIType.Completion, streaming=True)
+    data_config = DataConfig(
+        type=DataGenType.Random,
+        input_distribution=Distribution(min=10, max=20, mean=15, std_dev=2, total_count=5),
+        output_distribution=Distribution(min=5, max=10, mean=7, std_dev=1, total_count=5),
+    )
+    tokenizer = DummyCustomTokenizer()
+
+    generator = RandomDataGenerator(api_config, data_config, tokenizer)
+
+    # RandomDataGenerator uses LazyLoadDataMixin, so get_data() yields LazyLoadInferenceAPIData
+    data_gen = generator.get_data()
+    lazy_data = next(data_gen)
+    assert isinstance(lazy_data, LazyLoadInferenceAPIData)
+
+    # Load the real data
+    real_data = generator.load_lazy_data(lazy_data)
+    assert isinstance(real_data, CompletionAPIData)
+
+    # Verify prompt is str
+    assert isinstance(real_data.prompt, str)
+    assert len(real_data.prompt) > 0
+
+
+def test_random_datagen_excludes_special_tokens() -> None:
+    api_config = APIConfig(type=APIType.Completion, streaming=True)
+    data_config = DataConfig(
+        type=DataGenType.Random,
+        input_distribution=Distribution(min=10, max=20, mean=15, std_dev=2, total_count=5),
+        output_distribution=Distribution(min=5, max=10, mean=7, std_dev=1, total_count=5),
+    )
+    tokenizer = DummyCustomTokenizer()
+
+    generator = RandomDataGenerator(api_config, data_config, tokenizer)
+    data_gen = generator.get_data()
+    lazy_data = next(data_gen)
+    assert isinstance(lazy_data, LazyLoadInferenceAPIData)
+    real_data = generator.load_lazy_data(lazy_data)
+
+    assert isinstance(real_data, CompletionAPIData)
+    # Verify no special tokens in prompt by encoding it back
+    encoded_ids = tokenizer.get_tokenizer().encode(real_data.prompt)
+    for token in encoded_ids:
+        assert token not in [1, 2, 3]

--- a/tests/datagen/test_shared_prefix.py
+++ b/tests/datagen/test_shared_prefix.py
@@ -1,0 +1,77 @@
+from inference_perf.datagen.shared_prefix_datagen import SharedPrefixDataGenerator
+from inference_perf.config import APIConfig, DataConfig, SharedPrefix, APIType, DataGenType
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from typing import Any
+
+
+class MockHFTokenizer:
+    vocab_size = 50000
+
+    def decode(self, token_ids: list[int], skip_special_tokens: bool = True) -> str:
+        return " ".join([str(tid) for tid in token_ids])
+
+    def batch_decode(self, token_ids_list: list[list[int]], skip_special_tokens: bool = True) -> list[str]:
+        return [self.decode(ids) for ids in token_ids_list]
+
+
+class MockCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return MockHFTokenizer()
+
+    def count_tokens(self, text: str) -> int:
+        return len(text.split())
+
+
+def test_shared_prefix_length_single_turn() -> None:
+    # Setup config
+    api_config = APIConfig(type=APIType.Completion)
+
+    shared_prefix_cfg = SharedPrefix(
+        num_groups=1,
+        num_prompts_per_group=10,
+        system_prompt_len=64,
+        question_len=32,
+        output_len=16,
+        enable_multi_turn_chat=False,
+    )
+
+    config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=shared_prefix_cfg)
+
+    tokenizer = MockCustomTokenizer()
+
+    # Initialize generator
+    generator = SharedPrefixDataGenerator(api_config, config, tokenizer)
+
+    # Verify prompts are strings and have correct length
+    assert len(generator.prompts) == 10
+    for prompt in generator.prompts:
+        assert isinstance(prompt, str)
+        # Length should be exactly system_prompt_len (64) + question_len (32) = 96
+        assert tokenizer.count_tokens(prompt) == 96
+
+
+def test_shared_prefix_length_multi_turn() -> None:
+    # Setup config for multi-turn
+    api_config = APIConfig(type=APIType.Completion)
+
+    shared_prefix_cfg = SharedPrefix(
+        num_groups=1,
+        num_prompts_per_group=10,
+        system_prompt_len=64,
+        question_len=32,
+        output_len=16,
+        enable_multi_turn_chat=True,
+    )
+
+    config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=shared_prefix_cfg)
+
+    tokenizer = MockCustomTokenizer()
+
+    generator = SharedPrefixDataGenerator(api_config, config, tokenizer)
+
+    assert len(generator.prompts) == 10
+    for prompt in generator.prompts:
+        assert isinstance(prompt, str)

--- a/tests/datagen/test_shared_prefix_datagen.py
+++ b/tests/datagen/test_shared_prefix_datagen.py
@@ -14,6 +14,7 @@
 
 import pytest
 from unittest.mock import MagicMock
+from typing import Any
 
 from inference_perf.config import (
     APIConfig,
@@ -39,6 +40,18 @@ def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
     hf_tok.decode = MagicMock(side_effect=lambda ids, **kw: f"text_{len(ids)}")
     hf_tok.batch_decode = MagicMock(side_effect=lambda batch, **kw: [f"text_{len(ids)}" for ids in batch])
     mock_tokenizer.get_tokenizer.return_value = hf_tok
+
+    def count_tokens(text: str) -> int:
+        parts = text.split()
+        total = 0
+        for p in parts:
+            if p.startswith("text_"):
+                total += int(p[5:])
+            else:
+                total += 1
+        return total
+
+    mock_tokenizer.count_tokens.side_effect = count_tokens
     return mock_tokenizer
 
 
@@ -218,4 +231,60 @@ def test_shared_prefix_datagen_token_counts(
 
         # The actual token count might be slightly different due to the space
         # and how tokens are combined. We'll check if it's very close.
-        assert abs(len(token_ids) - expected_min_len) <= 5, f"Prompt: '{prompt}', Tokens: {len(token_ids)}"
+        assert len(token_ids) == expected_min_len, (
+            f"Prompt: '{prompt}', Tokens: {len(token_ids)}, Expected: {expected_min_len}"
+        )
+
+
+# --- Tests from shared-prefix-fix (Dummy Tokenizer based) ---
+
+
+class DummyTokenizer:
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def encode(self, text: str) -> list[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return [4, 5, 6]
+
+    def decode(self, tokens: list[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+    def batch_decode(self, sequences: list[list[int]], **kwargs: Any) -> list[str]:
+        return [self.decode(seq) for seq in sequences]
+
+
+class DummyCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return DummyTokenizer()
+
+    def count_tokens(self, text: str) -> int:
+        return len(text.split())
+
+
+def test_shared_prefix_datagen_excludes_special_tokens() -> None:
+    api_config = APIConfig(type=APIType.Completion, streaming=True)
+    data_config = DataConfig(
+        type=DataGenType.SharedPrefix,
+        shared_prefix=SharedPrefix(
+            num_groups=2,
+            num_prompts_per_group=3,
+            system_prompt_len=10,
+            question_len=20,
+            output_len=15,
+            enable_multi_turn_chat=False,
+        ),
+    )
+    tokenizer = DummyCustomTokenizer()
+
+    generator = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
+
+    # Verify token IDs generated do not contain special tokens
+    tokens = generator._generate_random_token_ids(100)
+    for token in tokens:
+        assert token not in [1, 2, 3]

--- a/tests/datagen/test_synthetic_datagen.py
+++ b/tests/datagen/test_synthetic_datagen.py
@@ -1,0 +1,53 @@
+from inference_perf.apis import CompletionAPIData, LazyLoadInferenceAPIData
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.datagen.synthetic_datagen import SyntheticDataGenerator
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from typing import Any
+
+
+class DummyTokenizer:
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def encode(self, text: str) -> list[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return [4, 5, 6] * 10
+
+    def decode(self, tokens: list[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+
+class DummyCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return DummyTokenizer()
+
+    def count_tokens(self, text: str) -> int:
+        return len(text.split())
+
+
+def test_synthetic_datagen_yields_string() -> None:
+    api_config = APIConfig(type=APIType.Completion)
+    data_config = DataConfig(
+        type=DataGenType.Synthetic,
+        input_distribution=Distribution(min=10, max=20, mean=15, std_dev=2, total_count=5),
+        output_distribution=Distribution(min=5, max=10, mean=7, std_dev=1, total_count=5),
+    )
+    tokenizer = DummyCustomTokenizer()
+
+    generator = SyntheticDataGenerator(api_config, data_config, tokenizer)
+
+    # SyntheticDataGenerator uses LazyLoadDataMixin
+    data_gen = generator.get_data()
+    lazy_data = next(data_gen)
+    assert isinstance(lazy_data, LazyLoadInferenceAPIData)
+
+    real_data = generator.load_lazy_data(lazy_data)
+    assert isinstance(real_data, CompletionAPIData)
+
+    assert isinstance(real_data.prompt, str)
+    assert len(real_data.prompt) > 0

--- a/tests/loadgen/test_multi_turn_hang.py
+++ b/tests/loadgen/test_multi_turn_hang.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 import unittest
 from unittest.mock import MagicMock
 from typing import Any
@@ -23,6 +24,11 @@ def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
     hf_tok.decode = MagicMock(side_effect=lambda ids, **kw: f"text_{len(ids)}")
     hf_tok.batch_decode = MagicMock(side_effect=lambda batch, **kw: [f"text_{len(ids)}" for ids in batch])
     mock_tokenizer.get_tokenizer.return_value = hf_tok
+    # Match the decode mock's "text_N" format so count_tokens returns a real int
+    # (the new exact-length datagen path compares this against target_len).
+    mock_tokenizer.count_tokens = MagicMock(
+        side_effect=lambda text: sum(int(n) for n in re.findall(r"text_(\d+)", text)) if isinstance(text, str) else 0
+    )
     return mock_tokenizer
 
 

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -50,9 +50,11 @@ class TestTraceReplay:
             # Test 2: Generate data with matching token counts
             mock_tokenizer = Mock()
             mock_tokenizer_obj = Mock()
-            mock_tokenizer_obj.decode.return_value = "test prompt"
+            mock_tokenizer_obj.decode.side_effect = lambda tokens, **kwargs: " ".join(map(str, tokens))
             mock_tokenizer_obj.vocab_size = 1000
+            mock_tokenizer_obj.all_special_ids = []
             mock_tokenizer.get_tokenizer.return_value = mock_tokenizer_obj
+            mock_tokenizer.count_tokens.side_effect = lambda text: len(text.split())
 
             api_config = APIConfig(type=APIType.Completion)
             trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.AZURE_PUBLIC_DATASET)


### PR DESCRIPTION
Addresses: https://github.com/kubernetes-sigs/inference-perf/issues/230 and https://github.com/kubernetes-sigs/inference-perf/issues/364

Changes:
* Chat API: update the prompt token length calculation to sum the tokens of each message individually.
* Random Data Gen: migrated to an iterative generation loop to ensure prompts tokenize to the exact target length.
* Both APIs: Properly filter out special tokens during random token generation, which was causing the length inflation.
* Datagen prompt lengths assured via fuzz testing.

Notes:
* [SGLang implements the OpenAI API spec](https://docs.sglang.io/basic_usage/openai_api_completions.html#id3) [same with TGI](https://huggingface.co/blog/tgi-messages-api) so these model servers extending `openAIModelServerClient` is correct and theres no risk of breakages.
