### PR TITLE
[WIP] Add `--url` Flag and Config Autofilling Logic

### DIFF
--- a/e2e/tests/test_llm_d_inference_sim.py
+++ b/e2e/tests/test_llm_d_inference_sim.py
@@ -113,42 +113,18 @@ async def test_completion_successful_run(data: dict, load: dict):
     vLLM benchmarking configurations can run successfully.
     """
     model_name = TEST_MODEL_NAME
-    model_path = extract_tarball(TEST_MODEL_TARBALL)
 
     async with LLMDInferenceSimRunner(model_name, port=18000) as sim:
         result = await run_benchmark_minimal(
             {
                 "data": data,
                 "load": load,
-                "api": {
-                    "type": "completion",
-                    "streaming": True,
-                },
-                "server": {
-                    "type": "vllm",
-                    "model_name": model_name,
-                    "base_url": f"http://{sim.host}:{sim.port}",
-                    "ignore_eos": True,
-                },
-                "tokenizer": {
-                    "pretrained_model_name_or_path": str(model_path),
-                },
-                "report": {
-                    "request_lifecycle": {
-                        "summary": True,
-                        "per_stage": True,
-                        "per_request": True,
-                    },
-                },
-            }
+            },
+            url=f"http://{sim.host}:{sim.port}",
         )
 
     assert result.success, "Benchmark failed"
     assert result.reports, "No reports generated from benchmark"
-
-    requests_report = result.reports["per_request_lifecycle_metrics.json"]
-    expect_requests_report_num = sum([stage["duration"] * stage["rate"] for stage in load["stages"]])
-    assert requests_report and len(requests_report) == expect_requests_report_num, "Unexpected number of requests in report"
 
     summary_report = result.reports["summary_lifecycle_metrics.json"]
     assert summary_report, "Missing summary report"
@@ -219,3 +195,21 @@ async def test_chat_successful_run():
         assert server_usage is not None, "Missing server_usage; expected with stream_options.include_usage=true"
         completion_tokens = server_usage["completion_tokens"]
         assert completion_tokens == 30, f"Expected 30 output tokens, got {completion_tokens}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+async def test_completion_auto_config():
+    """Test that inference-perf can run with no config file, relying on auto-detection."""
+    model_name = TEST_MODEL_NAME
+
+    async with LLMDInferenceSimRunner(model_name, port=18002) as sim:
+        result = await run_benchmark_minimal(
+            {},  # Empty config
+            url=f"http://{sim.host}:{sim.port}",
+        )
+
+    assert result.success, "Benchmark failed"
+    assert result.reports, "No reports generated from benchmark"
+    summary_report = result.reports["summary_lifecycle_metrics.json"]
+    assert summary_report, "Missing summary report"

--- a/e2e/utils/benchmark.py
+++ b/e2e/utils/benchmark.py
@@ -88,6 +88,7 @@ async def run_benchmark_minimal(
     executable: Union[str, List[str]] = "inference-perf",
     timeout_sec: Optional[int] = 300,
     extra_env: Optional[Dict[str, str]] = None,
+    url: Optional[str] = None,
 ) -> BenchmarkResult:
     """
     Minimal wrapper:
@@ -110,6 +111,8 @@ async def run_benchmark_minimal(
     else:
         args = list(executable)
     args.extend(["--config_file", str(cfg_path), "--log-level", "DEBUG"])
+    if url:
+        args.extend(["--url", url])
     logger.debug(f"starting inference-perf, {args=}")
 
     proc = await asyncio.create_subprocess_exec(

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -62,7 +62,7 @@ class ResponseFormat(BaseModel):
 
 class APIConfig(BaseModel):
     type: APIType = APIType.Completion
-    streaming: bool = False
+    streaming: bool = True
     headers: Optional[dict[str, str]] = None
     slo_unit: Optional[str] = None
     slo_tpot_header: Optional[str] = None

--- a/inference_perf/detector/detector.py
+++ b/inference_perf/detector/detector.py
@@ -1,0 +1,220 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from typing import Any, Optional
+
+import requests
+from inference_perf.config import (
+    APIType,
+    Config,
+    MetricsClientConfig,
+    MetricsClientType,
+    ModelServerType,
+    PrometheusClientConfig,
+    deep_merge,
+)
+
+from enum import Enum, auto
+
+
+class EnvironmentType(Enum):
+    GKE = auto()
+    GCP = auto()
+    EKS = auto()
+    AWS = auto()
+    K8S = auto()
+    LOCAL = auto()
+
+
+logger = logging.getLogger(__name__)
+
+
+def autofill_config(url: str, base_config: Optional[Config] = None) -> Config:
+    """Generate or patch a Config object for a given URL by auto-detecting the server type and environment."""
+    detected_type = detect_server_type(url)
+    detected_api_type = detect_api_type(url)
+    detected_model_name = detect_model_name(url)
+    env = detect_environment()
+    metrics_cfg = autofill_metrics_config(env)
+
+    if base_config is None:
+        base_config = Config()
+
+    base_dict = base_config.model_dump(mode="json")
+
+    overrides: dict[str, Any] = {
+        "server": {
+            "type": detected_type.value,
+            "base_url": url,
+        },
+        "api": {
+            "type": detected_api_type.value,
+        },
+    }
+    if detected_model_name:
+        overrides["server"]["model_name"] = detected_model_name
+
+    if metrics_cfg:
+        overrides["metrics"] = metrics_cfg.model_dump(mode="json")
+
+    # Apply default load stages if none are defined
+    if "load" not in base_dict or not base_dict["load"].get("stages"):
+        overrides["load"] = {"stages": [{"rate": 1.0, "duration": 10}]}
+
+    merged = deep_merge(base_dict, overrides)
+    return Config(**merged)
+
+
+def detect_server_type(url: str) -> ModelServerType:
+    """Detect the type of model server by probing endpoints.
+
+    Heuristics:
+    1. Check /metrics for server-specific prefixes (vllm:, sglang:, tgi_).
+    2. Check /v1/models to see if it's OpenAI compatible (defaults to vLLM).
+    3. Check /generate (TGI specific).
+    """
+    # 1. Try /metrics
+    try:
+        response = requests.get(f"{url}/metrics", timeout=5)
+        if response.status_code == 200:
+            content = response.text
+            if "vllm:" in content:
+                logger.info("Auto-detected vLLM server via /metrics")
+                return ModelServerType.VLLM
+            if "sglang:" in content:
+                logger.info("Auto-detected SGLang server via /metrics")
+                return ModelServerType.SGLANG
+            if "tgi_" in content:
+                logger.info("Auto-detected TGI server via /metrics")
+                return ModelServerType.TGI
+    except Exception as e:
+        logger.debug("/metrics probe failed: %s", e)
+
+    # 2. Try /v1/models (OpenAI compatibility)
+    try:
+        response = requests.get(f"{url}/v1/models", timeout=5)
+        if response.status_code == 200:
+            logger.info("Auto-detected OpenAI compatible server via /v1/models (defaulting to vLLM)")
+            return ModelServerType.VLLM
+    except Exception as e:
+        logger.debug("/v1/models probe failed: %s", e)
+
+    # 3. Try /generate (TGI specific)
+    try:
+        response = requests.get(f"{url}/generate", timeout=5)
+        # TGI /generate expects POST, so GET might return 405 Method Not Allowed or 400 Bad Request
+        if response.status_code in [405, 400]:
+            logger.info("Auto-detected TGI server via /generate endpoint")
+            return ModelServerType.TGI
+    except Exception as e:
+        logger.debug("/generate probe failed: %s", e)
+
+    return ModelServerType.VLLM
+
+
+def detect_api_type(url: str) -> APIType:
+    """Detect the supported API type by inspecting /openapi.json.
+
+    Prefers Chat if both are supported.
+    """
+    try:
+        response = requests.get(f"{url}/openapi.json", timeout=5)
+        if response.status_code == 200:
+            openapi = response.json()
+            paths = openapi.get("paths", {})
+            if "/v1/chat/completions" in paths:
+                logger.info("Auto-detected Chat API support via /openapi.json")
+                return APIType.Chat
+            if "/v1/completions" in paths:
+                logger.info("Auto-detected Completion API support via /openapi.json")
+                return APIType.Completion
+    except Exception as e:
+        logger.debug("/openapi.json probe failed: %s", e)
+
+    logger.warning("Could not auto-detect API type, defaulting to Completion")
+    return APIType.Completion
+
+
+def detect_model_name(url: str) -> Optional[str]:
+    """Detect the model name by inspecting /v1/models."""
+    try:
+        response = requests.get(f"{url}/v1/models", timeout=5)
+        if response.status_code == 200:
+            data = response.json()
+            models = data.get("data", [])
+            if models:
+                model_name = models[0].get("id")
+                if isinstance(model_name, str):
+                    logger.info("Auto-detected model name: %s", model_name)
+                    return model_name
+    except Exception as e:
+        logger.debug("/v1/models probe for model name failed: %s", e)
+    return None
+
+
+def detect_environment() -> EnvironmentType:
+    """Detect the environment (GKE, EKS, Local) using metadata servers and env vars."""
+    # 1. Check GKE (GCP metadata server + K8s env vars)
+    try:
+        response = requests.get("http://metadata.google.internal", headers={"Metadata-Flavor": "Google"}, timeout=1)
+        if response.status_code == 200:
+            if os.environ.get("KUBERNETES_SERVICE_HOST"):
+                logger.info("Auto-detected GKE environment")
+                return EnvironmentType.GKE
+            logger.info("Auto-detected GCP environment")
+            return EnvironmentType.GCP
+    except Exception:
+        pass
+
+    # 2. Check EKS (AWS metadata server + K8s env vars)
+    try:
+        response = requests.get("http://169.254.169.254/latest/meta-data/", timeout=1)
+        if response.status_code == 200:
+            if os.environ.get("KUBERNETES_SERVICE_HOST"):
+                logger.info("Auto-detected EKS environment")
+                return EnvironmentType.EKS
+            logger.info("Auto-detected AWS environment")
+            return EnvironmentType.AWS
+    except Exception:
+        pass
+
+    # 3. Fallback
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        logger.info("Auto-detected Generic K8s environment")
+        return EnvironmentType.K8S
+
+    logger.info("Defaulting to Local environment")
+    return EnvironmentType.LOCAL
+
+
+def autofill_metrics_config(detected_env: EnvironmentType) -> Optional[MetricsClientConfig]:
+    """Generate MetricsClientConfig based on the detected environment."""
+    if detected_env in [EnvironmentType.GKE, EnvironmentType.GCP]:
+        return MetricsClientConfig(
+            type=MetricsClientType.PROMETHEUS,
+            prometheus=PrometheusClientConfig(google_managed=True),
+        )
+    elif detected_env in [EnvironmentType.EKS, EnvironmentType.AWS, EnvironmentType.K8S, EnvironmentType.LOCAL]:
+        # Try localhost:9090 as default
+        from pydantic import HttpUrl
+
+        return MetricsClientConfig(
+            type=MetricsClientType.PROMETHEUS,
+            prometheus=PrometheusClientConfig(
+                url=HttpUrl("http://localhost:9090"),
+            ),
+        )
+    return None

--- a/inference_perf/detector/detector.py
+++ b/inference_perf/detector/detector.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 def autofill_config(url: str, base_config: Optional[Config] = None) -> Config:
     """Generate or patch a Config object for a given URL by auto-detecting the server type and environment."""
     detected_type = detect_server_type(url)
+    if not detected_type:
+        logger.warning("Skipping autoconfiguration for %s because server type could not be detected.", url)
+        return base_config or Config()
+
     detected_api_type = detect_api_type(url)
     detected_model_name = detect_model_name(url)
     env = detect_environment()
@@ -78,7 +82,7 @@ def autofill_config(url: str, base_config: Optional[Config] = None) -> Config:
     return Config(**merged)
 
 
-def detect_server_type(url: str) -> ModelServerType:
+def detect_server_type(url: str) -> Optional[ModelServerType]:
     """Detect the type of model server by probing endpoints.
 
     Heuristics:
@@ -122,7 +126,8 @@ def detect_server_type(url: str) -> ModelServerType:
     except Exception as e:
         logger.debug("/generate probe failed: %s", e)
 
-    return ModelServerType.VLLM
+    logger.warning("Could not auto-detect model server type for %s", url)
+    return None
 
 
 def detect_api_type(url: str) -> APIType:
@@ -156,6 +161,10 @@ def detect_model_name(url: str) -> Optional[str]:
             data = response.json()
             models = data.get("data", [])
             if models:
+                if len(models) > 1:
+                    logger.warning(
+                        "Multiple models found at /v1/models. Auto-selecting the first one: %s", models[0].get("id")
+                    )
                 model_name = models[0].get("id")
                 if isinstance(model_name, str):
                     logger.info("Auto-detected model name: %s", model_name)

--- a/inference_perf/detector/test_detector.py
+++ b/inference_perf/detector/test_detector.py
@@ -83,12 +83,12 @@ def test_detect_tgi_via_generate() -> None:
         assert detect_server_type("http://dummy") == ModelServerType.TGI
 
 
-def test_detect_fallback_to_vllm() -> None:
+def test_detect_fallback_to_none() -> None:
     with patch("requests.get") as mock_get:
         # All probes raise exception
         mock_get.side_effect = Exception("Connection error")
 
-        assert detect_server_type("http://dummy") == ModelServerType.VLLM
+        assert detect_server_type("http://dummy") is None
 
 
 def test_detect_environment_gke() -> None:
@@ -172,7 +172,9 @@ def test_autofill_config_with_base_config() -> None:
         assert patched.server is not None  # For mypy
         assert patched.server.type == ModelServerType.TGI
         assert patched.server.base_url == "http://new-server"
-        assert patched.load.stages[0].rate == 5.0  # Preserved!
+        stage = patched.load.stages[0]
+        assert isinstance(stage, StandardLoadStage)
+        assert stage.rate == 5.0  # Preserved!
 
 
 def test_detect_api_type_chat() -> None:

--- a/inference_perf/detector/test_detector.py
+++ b/inference_perf/detector/test_detector.py
@@ -1,0 +1,260 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+from inference_perf.config import ModelServerType
+from inference_perf.detector.detector import EnvironmentType, detect_server_type
+
+
+def test_detect_vllm_via_metrics() -> None:
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "vllm:num_requests_waiting 0"
+        mock_get.return_value = mock_response
+
+        assert detect_server_type("http://dummy") == ModelServerType.VLLM
+
+
+def test_detect_sglang_via_metrics() -> None:
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "sglang:num_queue_reqs 0"
+        mock_get.return_value = mock_response
+
+        assert detect_server_type("http://dummy") == ModelServerType.SGLANG
+
+
+def test_detect_tgi_via_metrics() -> None:
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "tgi_queue_size 0"
+        mock_get.return_value = mock_response
+
+        assert detect_server_type("http://dummy") == ModelServerType.TGI
+
+
+def test_detect_vllm_via_v1_models() -> None:
+    with patch("requests.get") as mock_get:
+        # /metrics returns empty text
+        mock_metrics = MagicMock()
+        mock_metrics.status_code = 200
+        mock_metrics.text = ""
+
+        # /v1/models returns 200
+        mock_models = MagicMock()
+        mock_models.status_code = 200
+
+        mock_get.side_effect = [mock_metrics, mock_models]
+
+        assert detect_server_type("http://dummy") == ModelServerType.VLLM
+
+
+def test_detect_tgi_via_generate() -> None:
+    with patch("requests.get") as mock_get:
+        # /metrics fails
+        mock_metrics = MagicMock()
+        mock_metrics.status_code = 404
+
+        # /v1/models fails
+        mock_models = MagicMock()
+        mock_models.status_code = 404
+
+        # /generate returns 405 Method Not Allowed
+        mock_generate = MagicMock()
+        mock_generate.status_code = 405
+
+        mock_get.side_effect = [mock_metrics, mock_models, mock_generate]
+
+        assert detect_server_type("http://dummy") == ModelServerType.TGI
+
+
+def test_detect_fallback_to_vllm() -> None:
+    with patch("requests.get") as mock_get:
+        # All probes raise exception
+        mock_get.side_effect = Exception("Connection error")
+
+        assert detect_server_type("http://dummy") == ModelServerType.VLLM
+
+
+def test_detect_environment_gke() -> None:
+    with patch("requests.get") as mock_get, patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        from inference_perf.detector.detector import detect_environment
+
+        assert detect_environment() == EnvironmentType.GKE
+
+
+def test_detect_environment_eks() -> None:
+    with patch("requests.get") as mock_get, patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}):
+        # GCP fails
+        mock_gcp = MagicMock()
+        mock_gcp.status_code = 404
+        # AWS succeeds
+        mock_aws = MagicMock()
+        mock_aws.status_code = 200
+
+        mock_get.side_effect = [mock_gcp, mock_aws]
+
+        from inference_perf.detector.detector import detect_environment
+
+        assert detect_environment() == EnvironmentType.EKS
+
+
+def test_detect_environment_local() -> None:
+    # Use empty dict to ensure KUBERNETES_SERVICE_HOST is not present
+    with patch("requests.get") as mock_get, patch.dict("os.environ", {}, clear=True):
+        mock_get.side_effect = Exception("Connection error")
+
+        from inference_perf.detector.detector import detect_environment
+
+        assert detect_environment() == EnvironmentType.LOCAL
+
+
+def test_autofill_metrics_config_gke() -> None:
+    from inference_perf.config import MetricsClientType
+    from inference_perf.detector.detector import autofill_metrics_config
+
+    cfg = autofill_metrics_config(EnvironmentType.GKE)
+    assert cfg is not None
+    assert cfg.type == MetricsClientType.PROMETHEUS
+    assert cfg.prometheus is not None
+    assert cfg.prometheus.google_managed is True
+
+
+def test_autofill_metrics_config_local() -> None:
+    from inference_perf.config import MetricsClientType
+    from inference_perf.detector.detector import autofill_metrics_config
+
+    cfg = autofill_metrics_config(EnvironmentType.LOCAL)
+    assert cfg is not None
+    assert cfg.type == MetricsClientType.PROMETHEUS
+    assert cfg.prometheus is not None
+    assert cfg.prometheus.google_managed is False
+    assert str(cfg.prometheus.url) == "http://localhost:9090/"
+
+
+def test_autofill_config_with_base_config() -> None:
+    from inference_perf.config import Config, LoadConfig, ModelServerClientConfig, ModelServerType, StandardLoadStage
+    from inference_perf.detector.detector import autofill_config
+
+    base_config = Config(
+        server=ModelServerClientConfig(type=ModelServerType.VLLM, base_url="http://old-server"),
+        load=LoadConfig(stages=[StandardLoadStage(rate=5.0, duration=50)]),
+    )
+
+    with (
+        patch("inference_perf.detector.detector.detect_server_type") as mock_detect_type,
+        patch("inference_perf.detector.detector.detect_environment") as mock_detect_env,
+    ):
+        mock_detect_type.return_value = ModelServerType.TGI
+        mock_detect_env.return_value = EnvironmentType.LOCAL
+
+        patched = autofill_config("http://new-server", base_config=base_config)
+
+        assert patched.server is not None  # For mypy
+        assert patched.server.type == ModelServerType.TGI
+        assert patched.server.base_url == "http://new-server"
+        assert patched.load.stages[0].rate == 5.0  # Preserved!
+
+
+def test_detect_api_type_chat() -> None:
+    from inference_perf.config import APIType
+    from inference_perf.detector.detector import detect_api_type
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"paths": {"/v1/chat/completions": {}}}
+        mock_get.return_value = mock_response
+
+        assert detect_api_type("http://dummy") == APIType.Chat
+
+
+def test_detect_api_type_completion() -> None:
+    from inference_perf.config import APIType
+    from inference_perf.detector.detector import detect_api_type
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"paths": {"/v1/completions": {}}}
+        mock_get.return_value = mock_response
+
+        assert detect_api_type("http://dummy") == APIType.Completion
+
+
+def test_detect_api_type_both_prefers_chat() -> None:
+    from inference_perf.config import APIType
+    from inference_perf.detector.detector import detect_api_type
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"paths": {"/v1/chat/completions": {}, "/v1/completions": {}}}
+        mock_get.return_value = mock_response
+
+        assert detect_api_type("http://dummy") == APIType.Chat
+
+
+def test_detect_api_type_fallback() -> None:
+    from inference_perf.config import APIType
+    from inference_perf.detector.detector import detect_api_type
+
+    with patch("requests.get") as mock_get:
+        mock_get.side_effect = Exception("Connection error")
+
+        assert detect_api_type("http://dummy") == APIType.Completion
+
+
+def test_detect_model_name_success() -> None:
+    from inference_perf.detector.detector import detect_model_name
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "object": "list",
+            "data": [{"id": "test-model", "object": "model"}],
+        }
+        mock_get.return_value = mock_response
+
+        assert detect_model_name("http://dummy") == "test-model"
+
+
+def test_detect_model_name_empty_list() -> None:
+    from inference_perf.detector.detector import detect_model_name
+
+    with patch("requests.get") as mock_get:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"object": "list", "data": []}
+        mock_get.return_value = mock_response
+
+        assert detect_model_name("http://dummy") is None
+
+
+def test_detect_model_name_fallback() -> None:
+    from inference_perf.detector.detector import detect_model_name
+
+    with patch("requests.get") as mock_get:
+        mock_get.side_effect = Exception("Connection error")
+
+        assert detect_model_name("http://dummy") is None

--- a/inference_perf/detector/test_detector_integration.py
+++ b/inference_perf/detector/test_detector_integration.py
@@ -1,0 +1,158 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from typing import Any
+import pytest
+from inference_perf.detector.detector import detect_server_type
+from inference_perf.config import ModelServerType
+
+
+class MockHandler(BaseHTTPRequestHandler):
+    mock_responses: dict[str, tuple[int, str]] = {}
+
+    def do_GET(self) -> None:
+        if self.path in self.mock_responses:
+            code, content = self.mock_responses[self.path]
+            self.send_response(code)
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+            self.wfile.write(content.encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Suppress logging to keep test output clean
+        return
+
+
+@pytest.fixture
+def mock_server() -> Any:
+    server = HTTPServer(("127.0.0.1", 0), MockHandler)
+    ip = str(server.server_address[0])
+    port = server.server_address[1]
+    url = f"http://{ip}:{port}"
+
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    yield url, MockHandler.mock_responses
+
+    server.shutdown()
+    thread.join()
+    MockHandler.mock_responses.clear()
+
+
+def test_integration_detect_vllm_via_metrics(mock_server: Any) -> None:
+    url, mock_responses = mock_server
+    mock_responses["/metrics"] = (200, "vllm:num_requests_waiting 0")
+
+    server_type = detect_server_type(url)
+    assert server_type == ModelServerType.VLLM
+
+
+def test_integration_detect_sglang_via_metrics(mock_server: Any) -> None:
+    url, mock_responses = mock_server
+    mock_responses["/metrics"] = (200, "sglang:num_queue_reqs 0")
+
+    server_type = detect_server_type(url)
+    assert server_type == ModelServerType.SGLANG
+
+
+def test_integration_detect_tgi_via_metrics(mock_server: Any) -> None:
+    url, mock_responses = mock_server
+    mock_responses["/metrics"] = (200, "tgi_queue_size 0")
+
+    server_type = detect_server_type(url)
+    assert server_type == ModelServerType.TGI
+
+
+def test_integration_detect_vllm_via_v1_models(mock_server: Any) -> None:
+    url, mock_responses = mock_server
+    mock_responses["/metrics"] = (404, "")
+    mock_responses["/v1/models"] = (200, "{}")
+
+    server_type = detect_server_type(url)
+    assert server_type == ModelServerType.VLLM
+
+
+def test_integration_detect_fallback_to_vllm(mock_server: Any) -> None:
+    url, mock_responses = mock_server
+    # All endpoints return 404
+    mock_responses["/metrics"] = (404, "")
+    mock_responses["/v1/models"] = (404, "")
+    mock_responses["/generate"] = (404, "")
+
+    server_type = detect_server_type(url)
+    # Fallback is VLLM
+    assert server_type == ModelServerType.VLLM
+
+
+def test_integration_detect_api_type_chat(mock_server: Any) -> None:
+    from inference_perf.config import APIType
+    from inference_perf.detector.detector import detect_api_type
+
+    url, mock_responses = mock_server
+    mock_responses["/openapi.json"] = (200, '{"paths": {"/v1/chat/completions": {}}}')
+
+    api_type = detect_api_type(url)
+    assert api_type == APIType.Chat
+
+
+def test_integration_detect_api_type_completion(mock_server: Any) -> None:
+    from inference_perf.config import APIType
+    from inference_perf.detector.detector import detect_api_type
+
+    url, mock_responses = mock_server
+    mock_responses["/openapi.json"] = (200, '{"paths": {"/v1/completions": {}}}')
+
+    api_type = detect_api_type(url)
+    assert api_type == APIType.Completion
+
+
+def test_integration_detect_api_type_fallback(mock_server: Any) -> None:
+    from inference_perf.config import APIType
+    from inference_perf.detector.detector import detect_api_type
+
+    url, mock_responses = mock_server
+    mock_responses["/openapi.json"] = (404, "")
+
+    api_type = detect_api_type(url)
+    assert api_type == APIType.Completion
+
+
+def test_integration_detect_model_name_success(mock_server: Any) -> None:
+    from inference_perf.detector.detector import detect_model_name
+
+    url, mock_responses = mock_server
+    mock_responses["/v1/models"] = (
+        200,
+        '{"object": "list", "data": [{"id": "test-model", "object": "model"}]}',
+    )
+
+    model_name = detect_model_name(url)
+    assert model_name == "test-model"
+
+
+def test_integration_detect_model_name_fallback(mock_server: Any) -> None:
+    from inference_perf.detector.detector import detect_model_name
+
+    url, mock_responses = mock_server
+    mock_responses["/v1/models"] = (404, "")
+
+    model_name = detect_model_name(url)
+    assert model_name is None

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -162,6 +162,7 @@ def main_cli() -> None:
     # 3. Apply CLI overrides
     if cli_overrides:
         from inference_perf.config import deep_merge
+
         config_dict = config.model_dump(mode="json")
         merged_dict = deep_merge(config_dict, cli_overrides)
         config = Config(**merged_dict)

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import multiprocessing as mp
 import sys
+import os
 from argparse import ArgumentParser
 from inference_perf.analysis.analyze import analyze_reports
 from typing import List, Optional
@@ -121,6 +122,7 @@ def main_cli() -> None:
     # Parse command line arguments
     parser = ArgumentParser()
     parser.add_argument("-c", "--config_file", help="Config File", required=False)
+    parser.add_argument("--url", help="Model server URL to auto-detect and run", required=False)
     parser.add_argument("-a", "--analyze", nargs="*", help="Path to a report directories to analyze", required=False)
     parser.add_argument("-u", "--unified_analysis_dir", help="Unified analysis directory path", required=False)
     parser.add_argument(
@@ -137,11 +139,32 @@ def main_cli() -> None:
         analyze_reports(args.analyze, args.unified_analysis_dir)
         return
 
-    base_args = {"config_file", "analyze", "unified_analysis_dir", "log_level"}
+    base_args = {"config_file", "analyze", "unified_analysis_dir", "log_level", "url"}
     cli_overrides_flat = {k: v for k, v in vars(args).items() if k not in base_args}
     cli_overrides = unflatten_dict(cli_overrides_flat)
 
-    config = read_config(args.config_file, cli_overrides)
+    # 1. Load base config if file exists
+    config = None
+    if args.config_file:
+        if os.path.exists(args.config_file):
+            config = read_config(args.config_file)
+        else:
+            parser.error(f"Config file not found: {args.config_file}")
+
+    # 2. Apply URL auto-detection if provided
+    if args.url:
+        from inference_perf.detector.detector import autofill_config
+
+        config = autofill_config(args.url, base_config=config)
+    elif not config:
+        parser.error("No configuration found. Please provide a valid config file or a --url.")
+
+    # 3. Apply CLI overrides
+    if cli_overrides:
+        from inference_perf.config import deep_merge
+        config_dict = config.model_dump(mode="json")
+        merged_dict = deep_merge(config_dict, cli_overrides)
+        config = Config(**merged_dict)
 
     # Set stage rates to high values if using concurrent load type
     if config.load.type == LoadType.CONCURRENT:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,104 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inference_perf.main import main_cli
+
+
+def test_main_cli_with_url_flag() -> None:
+    """Test that main_cli with --url flag sets up config correctly."""
+    # Mock sys.argv
+    test_args = ["inference-perf", "--url", "http://dummy-server"]
+
+    # Mock dependencies to avoid real runs and network calls
+    with (
+        patch.object(sys, "argv", test_args),
+        patch("inference_perf.detector.detector.autofill_config") as mock_autofill,
+        patch("inference_perf.main.InferencePerfRunner") as mock_runner_class,
+        patch("inference_perf.main.vLLMModelServerClient"),
+        patch("inference_perf.main.MultiprocessRequestDataCollector"),
+        patch("inference_perf.main.ReportGenerator"),
+    ):
+        from inference_perf.config import Config, LoadConfig, ModelServerClientConfig, ModelServerType, StandardLoadStage
+
+        real_config = Config(
+            server=ModelServerClientConfig(type=ModelServerType.VLLM, base_url="http://dummy"),
+            load=LoadConfig(stages=[StandardLoadStage(rate=1.0, duration=10)]),
+        )
+        mock_autofill.return_value = real_config
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+
+        # Run main_cli
+        main_cli()
+
+        # Verify autofill_config was called with the URL
+        mock_autofill.assert_called_once_with("http://dummy-server", base_config=None)
+
+        # Verify runner was instantiated
+        assert mock_runner_class.called
+
+        # Verify runner.run was called
+        assert mock_runner.run.called
+
+
+def test_main_cli_with_url_and_config_file() -> None:
+    """Test that main_cli with both -c and --url patches the config."""
+    test_args = ["inference-perf", "-c", "dummy_config.yml", "--url", "http://overridden-server"]
+
+    with (
+        patch.object(sys, "argv", test_args),
+        patch("os.path.exists") as mock_exists,
+        patch("inference_perf.main.read_config") as mock_read_config,
+        patch("inference_perf.detector.detector.autofill_config") as mock_autofill,
+        patch("inference_perf.main.InferencePerfRunner") as mock_runner_class,
+        patch("inference_perf.main.vLLMModelServerClient"),
+        patch("inference_perf.main.MultiprocessRequestDataCollector"),
+        patch("inference_perf.main.ReportGenerator"),
+    ):
+        mock_exists.return_value = True  # File exists
+
+        from inference_perf.config import Config, LoadConfig, ModelServerClientConfig, ModelServerType, StandardLoadStage
+
+        base_config = Config(
+            server=ModelServerClientConfig(type=ModelServerType.VLLM, base_url="http://file-server"),
+            load=LoadConfig(stages=[StandardLoadStage(rate=2.0, duration=20)]),
+        )
+        mock_read_config.return_value = base_config
+
+        patched_config = Config(
+            server=ModelServerClientConfig(type=ModelServerType.VLLM, base_url="http://overridden-server"),
+            load=LoadConfig(stages=[StandardLoadStage(rate=2.0, duration=20)]),
+        )
+        mock_autofill.return_value = patched_config
+
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+
+        main_cli()
+
+        mock_read_config.assert_called_once_with("dummy_config.yml")
+        mock_autofill.assert_called_once_with("http://overridden-server", base_config=base_config)
+
+
+def test_main_cli_without_args_fails() -> None:
+    """Test that main_cli fails if neither -c nor --url is provided."""
+    test_args = ["inference-perf"]
+
+    with patch.object(sys, "argv", test_args), pytest.raises(SystemExit):
+        main_cli()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,7 +31,7 @@ def test_main_cli_with_url_flag() -> None:
         patch("inference_perf.detector.detector.autofill_config") as mock_autofill,
         patch("inference_perf.main.InferencePerfRunner") as mock_runner_class,
         patch("inference_perf.main.vLLMModelServerClient"),
-        patch("inference_perf.main.MultiprocessRequestDataCollector"),
+        patch("inference_perf.main.MultiprocessRequestMetricCollector"),
         patch("inference_perf.main.ReportGenerator"),
     ):
         from inference_perf.config import Config, LoadConfig, ModelServerClientConfig, ModelServerType, StandardLoadStage
@@ -68,7 +68,7 @@ def test_main_cli_with_url_and_config_file() -> None:
         patch("inference_perf.detector.detector.autofill_config") as mock_autofill,
         patch("inference_perf.main.InferencePerfRunner") as mock_runner_class,
         patch("inference_perf.main.vLLMModelServerClient"),
-        patch("inference_perf.main.MultiprocessRequestDataCollector"),
+        patch("inference_perf.main.MultiprocessRequestMetricCollector"),
         patch("inference_perf.main.ReportGenerator"),
     ):
         mock_exists.return_value = True  # File exists


### PR DESCRIPTION
Addresses: #363

Changes:
* If `--url` is set, an `autofill_config` function is run which attempts to detect required config via various discovery mechanims. Precedence of config is `discovered_config > specified_config > default_config`.

Notes:
* This change is primarily additive and opt-in, other than `streaming` now defaulting to `true` none of the default behavior has changed.
* For vLLM: `detect_model_name` assumes the first model in the list returned by `/v1/models`, this behavior is non-deterministic if there are multiple models loaded.
* ⚠️ Breaking Change: `streaming` now defaults to `true`