### PR TITLE
Add E2e testing for Prometheus Querying and Report Contents

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -11,3 +11,72 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from pathlib import Path
+import subprocess
+import tempfile
+import time
+import pytest
+import requests
+
+
+@pytest.fixture(scope="module")
+def prometheus_server():
+    """Starts a lightweight ephemeral Prometheus instance."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        config_path = tmp_path / "prometheus.yml"
+
+        # Write minimal config pointing to the simulator
+        config_path.write_text(
+            """
+global:
+  scrape_interval: 5s
+scrape_configs:
+  - job_name: 'llm-d-inference-sim'
+    static_configs:
+      - targets: ['127.0.0.1:18000', '127.0.0.1:18001']
+""",
+            encoding="utf-8",
+        )
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        # Start prometheus
+        proc = subprocess.Popen(
+            [
+                "prometheus",
+                f"--config.file={config_path}",
+                f"--storage.tsdb.path={data_dir}",
+                "--web.listen-address=127.0.0.1:9090",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        # Wait for ready
+        ready = False
+        for _ in range(30):
+            try:
+                resp = requests.get("http://127.0.0.1:9090/-/ready", timeout=1)
+                if resp.status_code == 200:
+                    ready = True
+                    break
+            except Exception:
+                pass
+            time.sleep(1)
+
+        if not ready:
+            proc.terminate()
+            stdout, _ = proc.communicate()
+            raise Exception(f"Prometheus failed to become ready. Output:\n{stdout.decode()}")
+
+        yield "http://127.0.0.1:9090"
+
+        # Teardown
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/e2e/tests/test_llm_d_inference_sim.py
+++ b/e2e/tests/test_llm_d_inference_sim.py
@@ -133,8 +133,7 @@ async def test_completion_successful_run(data: dict, load: dict):
                         "per_request": True,
                     },
                 },
-            },
-            extra_env={"PYTHONPATH": "/workspace"}
+            }
         )
 
     assert result.success, "Benchmark failed"

--- a/e2e/tests/test_llm_d_inference_sim.py
+++ b/e2e/tests/test_llm_d_inference_sim.py
@@ -133,7 +133,8 @@ async def test_completion_successful_run(data: dict, load: dict):
                         "per_request": True,
                     },
                 },
-            }
+            },
+            extra_env={"PYTHONPATH": "/workspace"}
         )
 
     assert result.success, "Benchmark failed"

--- a/e2e/tests/test_metrics_fallback.py
+++ b/e2e/tests/test_metrics_fallback.py
@@ -1,0 +1,180 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import http.server
+import json
+import pathlib
+import sys
+import threading
+import pytest
+
+from utils.benchmark import run_benchmark_minimal
+from test_prometheus import is_prometheus_available
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.resolve()
+MAIN_PY_PATH = PROJECT_ROOT / "inference_perf" / "main.py"
+
+
+class MockHandler(http.server.BaseHTTPRequestHandler):
+    metric_name = "vllm:request_success"
+    success_count = 0
+
+    @classmethod
+    def reset(cls, metric_name: str) -> None:
+        cls.metric_name = metric_name
+        cls.success_count = 0
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+        elif self.path == "/metrics":
+            body = (
+                f"# HELP {self.metric_name} Count of successfully processed requests.\n"
+                f"# TYPE {self.metric_name} counter\n"
+                f'{self.metric_name}{{model_name="facebook/opt-125m"}} {float(MockHandler.success_count)}\n'
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(body.encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if self.path == "/v1/completions":
+            MockHandler.success_count += 1
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            response = {
+                "id": "cmpl-mock",
+                "object": "text_completion",
+                "created": 12345,
+                "model": "facebook/opt-125m",
+                "choices": [{"text": " mock response", "finish_reason": "length"}],
+                "usage": {"prompt_tokens": 1, "total_tokens": 5, "completion_tokens": 4},
+            }
+            self.wfile.write(json.dumps(response).encode("utf-8"))
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        return
+
+
+def start_mock_server(port: int, metric_name: str) -> http.server.HTTPServer:
+    MockHandler.reset(metric_name)
+    server = http.server.HTTPServer(("127.0.0.1", port), MockHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return server
+
+
+def _benchmark_config(prometheus_url: str, port: int) -> dict:
+    return {
+        "data": {
+            "type": "shared_prefix",
+            "shared_prefix": {
+                "num_groups": 1,
+                "num_prompts_per_group": 5,
+                "system_prompt_len": 10,
+                "question_len": 10,
+                "output_len": 10,
+            },
+        },
+        "load": {
+            "type": "constant",
+            "stages": [{"rate": 1, "duration": 15}],
+            "num_workers": 1,
+        },
+        "api": {
+            "type": "completion",
+            "streaming": True,
+        },
+        "server": {
+            "type": "vllm",
+            "model_name": "facebook/opt-125m",
+            "base_url": f"http://127.0.0.1:{port}",
+            "ignore_eos": True,
+        },
+        "tokenizer": {
+            "pretrained_model_name_or_path": "facebook/opt-125m",
+        },
+        "metrics": {
+            "type": "prometheus",
+            "prometheus": {
+                "url": prometheus_url,
+                "scrape_interval": 5,
+            },
+        },
+        "report": {
+            "prometheus": {
+                "summary": True,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_prometheus_available(), reason="local environment missing prometheus")
+async def test_legacy_metric_name(prometheus_server):
+    """Verifies that inference-perf can collect metrics using the legacy name 'vllm:request_success'."""
+    server = start_mock_server(18000, "vllm:request_success")
+
+    try:
+        result = await run_benchmark_minimal(
+            _benchmark_config(prometheus_server, 18000),
+            executable=[sys.executable, str(MAIN_PY_PATH)],
+            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
+        )
+
+        assert result.success, f"Benchmark failed: {result.stdout}"
+        assert "summary_prometheus_metrics.json" in result.reports
+        report = result.reports["summary_prometheus_metrics.json"]
+        assert "successes" in report
+        success_count = report["successes"]["request_success_count"]
+        assert success_count > 0, f"Expected non-zero success count from mock, got {success_count}"
+
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_prometheus_available(), reason="local environment missing prometheus")
+async def test_new_metric_name(prometheus_server):
+    """Verifies that inference-perf can collect metrics using the new name 'vllm:request_success_total'."""
+    server = start_mock_server(18001, "vllm:request_success_total")
+
+    try:
+        result = await run_benchmark_minimal(
+            _benchmark_config(prometheus_server, 18001),
+            executable=[sys.executable, str(MAIN_PY_PATH)],
+            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
+        )
+
+        assert result.success, f"Benchmark failed: {result.stdout}"
+        assert "summary_prometheus_metrics.json" in result.reports
+        report = result.reports["summary_prometheus_metrics.json"]
+        assert "successes" in report
+        success_count = report["successes"]["request_success_count"]
+        assert success_count > 0, f"Expected non-zero success count from mock, got {success_count}"
+
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/e2e/tests/test_prometheus.py
+++ b/e2e/tests/test_prometheus.py
@@ -1,0 +1,185 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import sys
+import shutil
+import subprocess
+import time
+from pathlib import Path
+import pytest
+import requests
+
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
+from utils.benchmark import run_benchmark_minimal
+from utils.testdata import extract_tarball
+
+TEST_MODEL_NAME = "google/gemma-3-270m"
+TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+
+
+def is_prometheus_available() -> bool:
+    return shutil.which("prometheus") is not None
+
+
+@pytest.fixture(scope="module")
+def prometheus_server():
+    """Starts a lightweight ephemeral Prometheus instance."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        config_path = tmp_path / "prometheus.yml"
+
+        # Write minimal config pointing to the simulator
+        config_path.write_text(
+            """
+global:
+  scrape_interval: 1s
+scrape_configs:
+  - job_name: 'llm-d-inference-sim'
+    static_configs:
+      - targets: ['127.0.0.1:18000']
+""",
+            encoding="utf-8",
+        )
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        # Start prometheus
+        proc = subprocess.Popen(
+            [
+                "prometheus",
+                f"--config.file={config_path}",
+                f"--storage.tsdb.path={data_dir}",
+                "--web.listen-address=127.0.0.1:9090",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        # Wait for ready
+        ready = False
+        for _ in range(30):
+            try:
+                resp = requests.get("http://127.0.0.1:9090/-/ready", timeout=1)
+                if resp.status_code == 200:
+                    ready = True
+                    break
+            except Exception:
+                pass
+            time.sleep(1)
+
+        if not ready:
+            proc.terminate()
+            stdout, _ = proc.communicate()
+            raise Exception(f"Prometheus failed to become ready. Output:\n{stdout.decode()}")
+
+        yield "http://127.0.0.1:9090"
+
+        # Teardown
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+@pytest.mark.skipif(not is_prometheus_available(), reason="local environment missing prometheus")
+async def test_prometheus_metrics_collection(prometheus_server):
+    """Verifies that inference-perf can collect metrics from Prometheus."""
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+
+    prometheus_url = prometheus_server
+
+    async with LLMDInferenceSimRunner(model_name, port=18000) as sim:
+        # Run a short benchmark
+        result = await run_benchmark_minimal(
+            {
+                "data": {
+                    "type": "shared_prefix",
+                    "shared_prefix": {
+                        "num_groups": 1,
+                        "num_prompts_per_group": 25,
+                        "system_prompt_len": 512,
+                        "question_len": 256,
+                        "output_len": 256,
+                    },
+                },
+                "load": {
+                    "type": "constant",
+                    "stages": [{"rate": 5, "duration": 5}],
+                    "num_workers": 1,
+                },
+                "api": {
+                    "type": "completion",
+                    "streaming": True,
+                },
+                "server": {
+                    "type": "vllm",
+                    "model_name": model_name,
+                    "base_url": f"http://127.0.0.1:{sim.port}",
+                    "ignore_eos": True,
+                },
+                "tokenizer": {
+                    "pretrained_model_name_or_path": str(model_path),
+                },
+                "metrics": {
+                    "type": "prometheus",
+                    "prometheus": {
+                        "url": prometheus_url,
+                        "scrape_interval": 1,
+                    },
+                },
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                    },
+                    "prometheus": {
+                        "summary": True,
+                    },
+                },
+            },
+            executable=[sys.executable, "/workspace/inference_perf/main.py"],
+            extra_env={"PYTHONPATH": "/workspace"}
+        )
+
+    if not result.success:
+        print(f"Simulator Stdout:\n{sim.stdout}")
+    assert result.success, f"Benchmark failed with output:\n{result.stdout}"
+
+    # Check if Prometheus metrics report was generated
+    assert result.reports, "No reports generated"
+    
+    report_names = list(result.reports.keys())
+    print(f"Generated reports: {report_names}")
+    
+    assert "summary_prometheus_metrics.json" in result.reports, f"Missing prometheus report in {report_names}"
+    
+    prom_report = result.reports["summary_prometheus_metrics.json"]
+    assert prom_report, "Prometheus report is empty"
+    assert isinstance(prom_report, dict), "Report should be a dictionary"
+    
+    print(f"Prometheus Report Content:\n{json.dumps(prom_report, indent=2)}")
+    
+    lifecycle_report = result.reports.get("summary_lifecycle_metrics.json")
+    if lifecycle_report:
+        print(f"Lifecycle Report Content:\n{json.dumps(lifecycle_report, indent=2)}")
+        if lifecycle_report.get("failures", {}).get("count", 0) > 0:
+            print(f"Benchmark Stdout:\n{result.stdout}")

--- a/e2e/tests/test_prometheus.py
+++ b/e2e/tests/test_prometheus.py
@@ -13,19 +13,20 @@
 # limitations under the License.
 
 import json
+import pathlib
 import re
-import os
-import sys
 import shutil
-import subprocess
-import time
-from pathlib import Path
+import sys
+
 import pytest
 import requests
 
-from utils.llm_d_inference_sim import LLMDInferenceSimRunner
 from utils.benchmark import run_benchmark_minimal
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
 from utils.testdata import extract_tarball
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.resolve()
+MAIN_PY_PATH = PROJECT_ROOT / "inference_perf" / "main.py"
 
 TEST_MODEL_NAME = "google/gemma-3-270m"
 TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
@@ -33,70 +34,6 @@ TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
 
 def is_prometheus_available() -> bool:
     return shutil.which("prometheus") is not None
-
-
-@pytest.fixture(scope="module")
-def prometheus_server():
-    """Starts a lightweight ephemeral Prometheus instance."""
-    import tempfile
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_path = Path(tmpdir)
-        config_path = tmp_path / "prometheus.yml"
-
-        # Write minimal config pointing to the simulator
-        config_path.write_text(
-            """
-global:
-  scrape_interval: 1s
-scrape_configs:
-  - job_name: 'llm-d-inference-sim'
-    static_configs:
-      - targets: ['127.0.0.1:18000']
-""",
-            encoding="utf-8",
-        )
-
-        data_dir = tmp_path / "data"
-        data_dir.mkdir()
-
-        # Start prometheus
-        proc = subprocess.Popen(
-            [
-                "prometheus",
-                f"--config.file={config_path}",
-                f"--storage.tsdb.path={data_dir}",
-                "--web.listen-address=127.0.0.1:9090",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-
-        # Wait for ready
-        ready = False
-        for _ in range(30):
-            try:
-                resp = requests.get("http://127.0.0.1:9090/-/ready", timeout=1)
-                if resp.status_code == 200:
-                    ready = True
-                    break
-            except Exception:
-                pass
-            time.sleep(1)
-
-        if not ready:
-            proc.terminate()
-            stdout, _ = proc.communicate()
-            raise Exception(f"Prometheus failed to become ready. Output:\n{stdout.decode()}")
-
-        yield "http://127.0.0.1:9090"
-
-        # Teardown
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
 
 
 @pytest.mark.asyncio
@@ -125,7 +62,7 @@ async def test_prometheus_metrics_collection(prometheus_server):
                 },
                 "load": {
                     "type": "constant",
-                    "stages": [{"rate": 5, "duration": 5}],
+                    "stages": [{"rate": 5, "duration": 30}],
                     "num_workers": 1,
                 },
                 "api": {
@@ -157,53 +94,162 @@ async def test_prometheus_metrics_collection(prometheus_server):
                     },
                 },
             },
-            executable=[sys.executable, "/workspace/inference_perf/main.py"],
-            extra_env={"PYTHONPATH": "/workspace"}
+            executable=[sys.executable, str(MAIN_PY_PATH)],
+            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
         )
-        
+
+        # Verify benchmark succeeded before proceeding
+        assert result.success, f"Benchmark failed with output:\n{result.stdout}"
+
         # Debug and verify metrics exposed by simulator
         try:
             resp = requests.get("http://127.0.0.1:18000/metrics", timeout=1)
             metrics_content = resp.text
             print(f"Simulator Metrics Content:\n{metrics_content}")
-            
-            # Verify simulator recorded 25 successes
-            match = re.search(r'vllm:request_success_total\{.*?\} (\d+)', metrics_content)
-            assert match, "vllm:request_success_total not found in simulator metrics"
+
+            # Verify simulator recorded 150 successes (rate 5 * duration 30)
+            match = re.search(r"vllm:request_success(?:_total)?\{.*?\} (\d+)", metrics_content)
+            assert match, "vllm:request_success(_total) not found in simulator metrics"
             sim_success_count = int(match.group(1))
-            assert sim_success_count == 25, f"Expected 25 successes in simulator metrics, got {sim_success_count}"
-            print("Verified 25 successes in simulator metrics")
+            assert sim_success_count == 150, f"Expected 150 successes in simulator metrics, got {sim_success_count}"
+            print("Verified 150 successes in simulator metrics")
         except Exception as e:
             print(f"Failed to get or verify simulator metrics: {e}")
             raise
 
-    if not result.success:
-        print(f"Simulator Stdout:\n{sim.stdout}")
-    assert result.success, f"Benchmark failed with output:\n{result.stdout}"
-
     # Check if Prometheus metrics report was generated
     assert result.reports, "No reports generated"
-    
+
     report_names = list(result.reports.keys())
     print(f"Generated reports: {report_names}")
-    
+
     assert "summary_prometheus_metrics.json" in result.reports, f"Missing prometheus report in {report_names}"
-    
+
     prom_report = result.reports["summary_prometheus_metrics.json"]
     assert prom_report, "Prometheus report is empty"
     assert isinstance(prom_report, dict), "Report should be a dictionary"
-    
+
     print(f"Prometheus Report Content:\n{json.dumps(prom_report, indent=2)}")
-    
+
     # Assertions on content
-    successes_obj = prom_report.get("successes", {})
-    success_count = successes_obj.get("request_success_count", 0.0)
-    print(f"Asserting request_success_count ({success_count}) is greater than 10")
-    # Due to PromQL increase() extrapolation on short windows, we loosen this assertion
-    assert success_count > 10.0, f"Expected > 10 successes in report due to extrapolation, got {success_count}"
-    
+    assert "successes" in prom_report, "Report missing 'successes' section"
+    successes_obj = prom_report["successes"]
+
+    assert "request_success_count" in successes_obj, "Missing 'request_success_count'"
+    success_count = successes_obj["request_success_count"]
+    print(f"Asserting request_success_count ({success_count}) is greater than 100")
+    assert success_count > 100.0, f"Expected > 100 successes in report, got {success_count}"
+
+    assert "rate" in successes_obj, "Missing 'rate' (requests_per_second)"
+    rps = successes_obj["rate"]
+    print(f"Asserting rate/requests_per_second ({rps}) is reasonable")
+    assert 3.0 < rps < 7.0, f"Expected rate around 5, got {rps}"
+
     lifecycle_report = result.reports.get("summary_lifecycle_metrics.json")
     if lifecycle_report:
         print(f"Lifecycle Report Content:\n{json.dumps(lifecycle_report, indent=2)}")
         if lifecycle_report.get("failures", {}).get("count", 0) > 0:
             print(f"Benchmark Stdout:\n{result.stdout}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+@pytest.mark.skipif(not is_prometheus_available(), reason="local environment missing prometheus")
+async def test_prometheus_metrics_collection_chat(prometheus_server):
+    """Verifies that inference-perf can collect metrics from Prometheus for Chat API."""
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+
+    prometheus_url = prometheus_server
+
+    async with LLMDInferenceSimRunner(model_name, port=18001) as sim:
+        # Run a short benchmark with chat API
+        result = await run_benchmark_minimal(
+            {
+                "data": {
+                    "type": "mock",
+                },
+                "load": {
+                    "type": "constant",
+                    "stages": [{"rate": 5, "duration": 30}],
+                    "num_workers": 1,
+                },
+                "api": {
+                    "type": "chat",
+                    "streaming": True,
+                },
+                "server": {
+                    "type": "vllm",
+                    "model_name": model_name,
+                    "base_url": f"http://127.0.0.1:{sim.port}",
+                    "ignore_eos": True,
+                },
+                "tokenizer": {
+                    "pretrained_model_name_or_path": str(model_path),
+                },
+                "metrics": {
+                    "type": "prometheus",
+                    "prometheus": {
+                        "url": prometheus_url,
+                        "scrape_interval": 5,
+                    },
+                },
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                    },
+                    "prometheus": {
+                        "summary": True,
+                    },
+                },
+            },
+            executable=[sys.executable, str(MAIN_PY_PATH)],
+            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
+        )
+
+        # Verify benchmark succeeded before proceeding
+        assert result.success, f"Benchmark failed with output:\n{result.stdout}"
+
+        # Debug and verify metrics exposed by simulator
+        try:
+            resp = requests.get("http://127.0.0.1:18001/metrics", timeout=1)
+            metrics_content = resp.text
+            print(f"Simulator Metrics Content:\n{metrics_content}")
+
+            # Verify simulator recorded 150 successes
+            match = re.search(r"vllm:request_success(?:_total)?\{.*?\} (\d+)", metrics_content)
+            assert match, "vllm:request_success(_total) not found in simulator metrics"
+            sim_success_count = int(match.group(1))
+            assert sim_success_count == 150, f"Expected 150 successes in simulator metrics, got {sim_success_count}"
+            print("Verified 150 successes in simulator metrics")
+        except Exception as e:
+            print(f"Failed to get or verify simulator metrics: {e}")
+            raise
+
+    # Check if Prometheus metrics report was generated
+    assert result.reports, "No reports generated"
+
+    report_names = list(result.reports.keys())
+    print(f"Generated reports: {report_names}")
+
+    assert "summary_prometheus_metrics.json" in result.reports, f"Missing prometheus report in {report_names}"
+
+    prom_report = result.reports["summary_prometheus_metrics.json"]
+    assert prom_report, "Prometheus report is empty"
+    assert isinstance(prom_report, dict), "Report should be a dictionary"
+
+    print(f"Prometheus Report Content:\n{json.dumps(prom_report, indent=2)}")
+
+    # Assertions on content
+    assert "successes" in prom_report, "Report missing 'successes' section"
+    successes_obj = prom_report["successes"]
+
+    assert "request_success_count" in successes_obj, "Missing 'request_success_count'"
+    success_count = successes_obj["request_success_count"]
+    print(f"Asserting request_success_count ({success_count}) is greater than 100")
+    assert success_count > 100.0, f"Expected > 100 successes in report, got {success_count}"
+
+    assert "rate" in successes_obj, "Missing 'rate' (requests_per_second)"
+    rps = successes_obj["rate"]
+    print(f"Asserting rate/requests_per_second ({rps}) is reasonable")
+    assert 3.0 < rps < 7.0, f"Expected rate around 5, got {rps}"

--- a/e2e/tests/test_prometheus.py
+++ b/e2e/tests/test_prometheus.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import json
+import re
 import os
 import sys
 import shutil
@@ -144,7 +145,7 @@ async def test_prometheus_metrics_collection(prometheus_server):
                     "type": "prometheus",
                     "prometheus": {
                         "url": prometheus_url,
-                        "scrape_interval": 1,
+                        "scrape_interval": 5,
                     },
                 },
                 "report": {
@@ -159,6 +160,22 @@ async def test_prometheus_metrics_collection(prometheus_server):
             executable=[sys.executable, "/workspace/inference_perf/main.py"],
             extra_env={"PYTHONPATH": "/workspace"}
         )
+        
+        # Debug and verify metrics exposed by simulator
+        try:
+            resp = requests.get("http://127.0.0.1:18000/metrics", timeout=1)
+            metrics_content = resp.text
+            print(f"Simulator Metrics Content:\n{metrics_content}")
+            
+            # Verify simulator recorded 25 successes
+            match = re.search(r'vllm:request_success_total\{.*?\} (\d+)', metrics_content)
+            assert match, "vllm:request_success_total not found in simulator metrics"
+            sim_success_count = int(match.group(1))
+            assert sim_success_count == 25, f"Expected 25 successes in simulator metrics, got {sim_success_count}"
+            print("Verified 25 successes in simulator metrics")
+        except Exception as e:
+            print(f"Failed to get or verify simulator metrics: {e}")
+            raise
 
     if not result.success:
         print(f"Simulator Stdout:\n{sim.stdout}")
@@ -177,6 +194,13 @@ async def test_prometheus_metrics_collection(prometheus_server):
     assert isinstance(prom_report, dict), "Report should be a dictionary"
     
     print(f"Prometheus Report Content:\n{json.dumps(prom_report, indent=2)}")
+    
+    # Assertions on content
+    successes_obj = prom_report.get("successes", {})
+    success_count = successes_obj.get("request_success_count", 0.0)
+    print(f"Asserting request_success_count ({success_count}) is greater than 10")
+    # Due to PromQL increase() extrapolation on short windows, we loosen this assertion
+    assert success_count > 10.0, f"Expected > 10 successes in report due to extrapolation, got {success_count}"
     
     lifecycle_report = result.reports.get("summary_lifecycle_metrics.json")
     if lifecycle_report:

--- a/e2e/utils/benchmark.py
+++ b/e2e/utils/benchmark.py
@@ -85,7 +85,7 @@ async def run_benchmark_minimal(
     config: Union[str, Path, Dict[str, Any]],
     *,
     work_dir: Optional[Union[str, Path]] = None,
-    executable: str = "inference-perf",
+    executable: Union[str, List[str]] = "inference-perf",
     timeout_sec: Optional[int] = 300,
     extra_env: Optional[Dict[str, str]] = None,
 ) -> BenchmarkResult:
@@ -105,7 +105,11 @@ async def run_benchmark_minimal(
     if extra_env:
         env.update({k: str(v) for k, v in extra_env.items()})
 
-    args = [executable, "--config_file", str(cfg_path), "--log-level", "DEBUG"]
+    if isinstance(executable, str):
+        args = [executable]
+    else:
+        args = list(executable)
+    args.extend(["--config_file", str(cfg_path), "--log-level", "DEBUG"])
     logger.debug(f"starting inference-perf, {args=}")
 
     proc = await asyncio.create_subprocess_exec(

--- a/e2e/utils/llm_d_inference_sim.py
+++ b/e2e/utils/llm_d_inference_sim.py
@@ -150,7 +150,8 @@ class LLMDInferenceSimRunner(AsyncContextDecorator):
         assert proc
 
         stdout, _ = await proc.communicate()
-        stdout_pretty = textwrap.indent(stdout.decode(), "  | ")
+        self.stdout = stdout.decode()
+        stdout_pretty = textwrap.indent(self.stdout, "  | ")
         logger.debug(f"server exited with status {proc.returncode}, output:\n{stdout_pretty}")
 
     async def _terminate(self) -> None:

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
                 [
                   llm-d-inference-sim
                   pdm
+                  prometheus
                   python
 
                   # choose either python-lsp-server or pyright:
@@ -60,6 +61,7 @@
                 ];
 
               shellHook = ''
+                export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
                 python -m venv .venv
                 source .venv/bin/activate
                 pdm sync -d

--- a/inference_perf/client/metricsclient/prometheus_client/base.py
+++ b/inference_perf/client/metricsclient/prometheus_client/base.py
@@ -105,7 +105,16 @@ class PrometheusQueryBuilder:
         """
         metric_name = self.model_server_metric.name
         filter = self.model_server_metric.filters
-        return {
+
+        use_selector = False
+        if metric_name.startswith("{") and metric_name.endswith("}"):
+            use_selector = True
+            if filter:
+                selector = f"{metric_name[:-1]},{filter}}}"
+            else:
+                selector = metric_name
+
+        queries = {
             "gauge": {
                 "mean": "avg_over_time(%s{%s}[%.0fs])" % (metric_name, filter, self.duration),
                 "median": "quantile_over_time(0.5, %s{%s}[%.0fs])" % (metric_name, filter, self.duration),
@@ -144,6 +153,32 @@ class PrometheusQueryBuilder:
                 % (metric_name, filter, self.duration, self.duration, self.duration),
             },
         }
+
+        if use_selector:
+            queries["gauge"] = {
+                "mean": "avg_over_time(%s[%.0fs])" % (selector, self.duration),
+                "median": "quantile_over_time(0.5, %s[%.0fs])" % (selector, self.duration),
+                "sd": "stddev_over_time(%s[%.0fs])" % (selector, self.duration),
+                "min": "min_over_time(%s[%.0fs])" % (selector, self.duration),
+                "max": "max_over_time(%s[%.0fs])" % (selector, self.duration),
+                "p90": "quantile_over_time(0.9, %s[%.0fs])" % (selector, self.duration),
+                "p99": "quantile_over_time(0.99, %s[%.0fs])" % (selector, self.duration),
+            }
+            queries["counter"] = {
+                "rate": "sum(rate(%s[%.0fs]))" % (selector, self.duration),
+                "increase": "sum(increase(%s[%.0fs]))" % (selector, self.duration),
+                "mean": "avg_over_time(rate(%s[%.0fs])[%.0fs:%.0fs])"
+                % (selector, self.duration, self.duration, self.duration),
+                "max": "max_over_time(rate(%s[%.0fs])[%.0fs:%.0fs])" % (selector, self.duration, self.duration, self.duration),
+                "min": "min_over_time(rate(%s[%.0fs])[%.0fs:%.0fs])" % (selector, self.duration, self.duration, self.duration),
+                "p90": "quantile_over_time(0.9, rate(%s[%.0fs])[%.0fs:%.0fs])"
+                % (selector, self.duration, self.duration, self.duration),
+                "p99": "quantile_over_time(0.99, rate(%s[%.0fs])[%.0fs:%.0fs])"
+                % (selector, self.duration, self.duration, self.duration),
+            }
+            logger.debug(f"Using raw selector for query: {selector}")
+
+        return queries
 
     def build_query(self) -> str:
         """

--- a/inference_perf/client/metricsclient/prometheus_client/google_managed_prometheus_client.py
+++ b/inference_perf/client/metricsclient/prometheus_client/google_managed_prometheus_client.py
@@ -38,7 +38,7 @@ class GoogleManagedPrometheusMetricsClient(PrometheusMetricsClient):
 
     def get_headers(self) -> dict[str, Any]:
         # Prepare an authentication request - helps format the request auth token
-        auth_req = google.auth.transport.requests.Request()
+        auth_req = google.auth.transport.requests.Request()  # type: ignore[no-untyped-call,unused-ignore]
 
         self.credentials.refresh(auth_req)  # type: ignore[no-untyped-call,unused-ignore]
         if not self.credentials.token:

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -176,21 +176,21 @@ class vLLMModelServerClient(openAIModelServerClient):
                 "counter",
                 self.metric_filters,
             ),
-            # Total Requests (using request_success counter in v1)
+            # Total Requests (supports both vllm:request_success and vllm:request_success_total)
             total_requests=ModelServerPrometheusMetric(
-                "vllm:request_success_total",
+                '{__name__=~"vllm:request_success(_total)?"}',
                 "increase",
                 "counter",
                 self.metric_filters,
             ),
             requests_per_second=ModelServerPrometheusMetric(
-                "vllm:request_success_total",
+                '{__name__=~"vllm:request_success(_total)?"}',
                 "rate",
                 "counter",
                 self.metric_filters,
             ),
             request_success_count=ModelServerPrometheusMetric(
-                "vllm:request_success_total",
+                '{__name__=~"vllm:request_success(_total)?"}',
                 "increase",
                 "counter",
                 self.metric_filters,

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -178,19 +178,19 @@ class vLLMModelServerClient(openAIModelServerClient):
             ),
             # Total Requests (using request_success counter in v1)
             total_requests=ModelServerPrometheusMetric(
-                "vllm:request_success",
+                "vllm:request_success_total",
                 "increase",
                 "counter",
                 self.metric_filters,
             ),
             requests_per_second=ModelServerPrometheusMetric(
-                "vllm:request_success",
+                "vllm:request_success_total",
                 "rate",
                 "counter",
                 self.metric_filters,
             ),
             request_success_count=ModelServerPrometheusMetric(
-                "vllm:request_success",
+                "vllm:request_success_total",
                 "increase",
                 "counter",
                 self.metric_filters,


### PR DESCRIPTION
Addresses: https://github.com/kubernetes-sigs/inference-perf/issues/386

Adds a dedicated E2E test for making sure Prometheus metrics are correctly queried by using the llm-d-inference sim and a dedicated ephemeral Prometheus instance. Other small bug fixes.


Note:
* Since `vLLM >= 0.7.0` `request_success_total` is the recommended metric for counting successful requests. Updated the query to cover both cases.