### PR TITLE
fix test:e2e:docker `ModuleNotFoundError`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,7 +62,7 @@
               shellHook = ''
                 python -m venv .venv
                 source .venv/bin/activate
-                pdm sync -d --no-self
+                pdm sync -d
               '';
             };
 


### PR DESCRIPTION
Previously, `pdm sync` was configured improperly (with a `--no-self` flag) in the Nix flake `shellHook`. As a result, running the tests in a pure environment will cause Python to not see the `inference_perf` module, failing all tests with this error:

    Traceback (most recent call last):
      File "/workspace/.venv/bin/inference-perf", line 5, in <module>
        from inference_perf import main_cli
    ModuleNotFoundError: No module named 'inference_perf'

Removing this flag fixes the issue. No further workaround is needed.