### PR TITLE
fix: streaming response body consumed before SSE parser

### DIFF
--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -290,10 +290,10 @@ class openAIModelServerClientSession(ModelServerClientSession):
                 async with self.session.post(self.client.uri + data.get_route(), headers=headers, data=request_data) as resp:
                     response = resp
                     try:
-                        # Read response body once to avoid double-read issue
-                        response_content = await response.text()
-
                         if response.status == 200:
+                            # Process response before reading the body so streaming
+                            # parsers (SSE) can iterate response.content. Reading
+                            # response.text() first would consume the stream.
                             response_info = await data.process_response(
                                 response=response,
                                 config=self.client.api_config,
@@ -301,6 +301,9 @@ class openAIModelServerClientSession(ModelServerClientSession):
                                 lora_adapter=lora_adapter,
                             )
                         else:
+                            # Read body for error responses (not streamed)
+                            response_content = await response.text()
+
                             # Handle HTTP error responses (status != 200).
                             #
                             # For OTel trace replay, process_failure() is called to:

--- a/tests/test_streaming_response_order.py
+++ b/tests/test_streaming_response_order.py
@@ -1,0 +1,93 @@
+"""Tests for the streaming response fix in openai_client.py.
+
+Verifies that process_response() is called before the response body is consumed,
+so the SSE streaming parser can iterate response.content.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.config import APIConfig, APIType
+
+
+class FakeStreamingResponse:
+    """Simulates an aiohttp streaming response that tracks read order."""
+
+    def __init__(self, chunks: list[bytes]):
+        self.status = 200
+        self.headers = {"content-type": "text/event-stream"}
+        self._chunks = chunks
+        self._text_called = False
+        self._iter_called = False
+        self.content = self._make_content()
+
+    def _make_content(self) -> MagicMock:
+        content = MagicMock()
+
+        async def iter_any() -> AsyncMock:
+            self._iter_called = True
+            if self._text_called:
+                # Stream already consumed by text()
+                return
+            for chunk in self._chunks:
+                yield chunk
+
+        content.iter_any = iter_any
+        return content
+
+    async def text(self) -> str:
+        self._text_called = True
+        return b"".join(self._chunks).decode()
+
+
+@pytest.mark.asyncio
+async def test_streaming_parser_receives_content() -> None:
+    """The SSE parser should receive chunks when streaming is enabled."""
+    sse_data = (
+        b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'
+        b'data: {"choices":[{"delta":{"content":" world"}}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+
+    response = FakeStreamingResponse([sse_data])
+    config = APIConfig(type=APIType.Chat, streaming=True)
+
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text: len(text.split()))
+
+    data = ChatCompletionAPIData(
+        messages=[ChatMessage(role="user", content="test")],
+        max_tokens=100,
+    )
+
+    info = await data.process_response(response, config, tokenizer)
+
+    assert info.output_tokens > 0, "Output tokens should be > 0 when streaming content is present"
+    assert response._iter_called, "Streaming iterator should have been called"
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_reads_body() -> None:
+    """Non-streaming responses should parse JSON body directly."""
+    config = APIConfig(type=APIType.Chat, streaming=False)
+
+    response = MagicMock()
+    response.status = 200
+    response.json = AsyncMock(
+        return_value={"choices": [{"message": {"content": "Hello world"}}]}
+    )
+
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(return_value=2)
+
+    data = ChatCompletionAPIData(
+        messages=[ChatMessage(role="user", content="test")],
+        max_tokens=100,
+    )
+
+    info = await data.process_response(response, config, tokenizer)
+
+    assert info.output_tokens == 2


### PR DESCRIPTION
## Summary

`response.text()` in `openai_client.py:294` consumes the entire streaming response body before `process_response()` can iterate it via `parse_sse_stream()`. This causes:
- `output_tokens` always 0
- TTFT, ITL, TPOT all null
- `output_token_times` empty

## Root Cause

In `openAIModelServerClientSession.process_request()`, the response body is read eagerly:
```python
response_content = await response.text()  # consumes the stream

if response.status == 200:
    response_info = await data.process_response(response, ...)  # stream already empty
```

When `streaming=True`, `process_response()` calls `parse_sse_stream()` which tries to iterate `response.content.iter_any()` — but the content is already consumed.

## Fix

Call `process_response()` first for 200 responses so the SSE parser can iterate the stream. Read the body only for error responses (which are not streamed).

## Testing

Tested with OTel trace replay against vLLM (Nemotron Nano 30B on 4xH200):
- Before: output_tokens=0, TTFT=null, ITL=null across all stages
- After: output_tokens ~600/request, TTFT ~435ms, ITL ~4.4ms, TPOT ~5.5ms at 10 concurrent sessions