### PR TITLE
feat: add benchmark_time_seconds to metrics report

### DIFF
--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -57,6 +57,7 @@ def summarize(items: List[float], percentiles: List[float]) -> Optional[dict[str
 
 
 class ResponsesSummary(BaseModel):
+    benchmark_time_seconds: float
     load_summary: dict[str, Any]
     successes: dict[str, Any]
     failures: dict[str, Any]
@@ -177,6 +178,7 @@ def calculate_slo_metrics(
 
 def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummary:
     return ResponsesSummary(
+        benchmark_time_seconds=0.0,
         load_summary={},  # model server doesn't report failed requests
         failures={},
         successes={
@@ -445,6 +447,7 @@ def summarize_requests(
     if slo_metrics:
         successes_dict["slo_metrics"] = slo_metrics
     return ResponsesSummary(
+        benchmark_time_seconds=total_time,
         load_summary=load_summary,
         successes=successes_dict,
         failures={

--- a/tests/analysis/test_analyze.py
+++ b/tests/analysis/test_analyze.py
@@ -25,6 +25,7 @@ from inference_perf.reportgen.base import ResponsesSummary
 @pytest.fixture
 def mock_report_data() -> ResponsesSummary:
     return ResponsesSummary(
+        benchmark_time_seconds=31.42,
         load_summary={
             "count": 60,
             "schedule_delay": {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,6 +221,7 @@ def test_prometheus_client_config_validation() -> None:
     with pytest.raises(ValueError, match="Exactly one of 'url' or 'google_managed' must be set"):
         PrometheusClientConfig(google_managed=False)
 
+
 def test_shared_prefix_inline_distribution() -> None:
     config = Config.model_validate(
         {

--- a/tests/utils/test_distribution.py
+++ b/tests/utils/test_distribution.py
@@ -32,17 +32,13 @@ class TestSampleFromDistribution:
         assert abs(result.mean() - 200.0) < 5.0
 
     def test_skew_normal_within_bounds(self) -> None:
-        config = Distribution(
-            type=DistributionType.SKEW_NORMAL, mean=200.0, min=10, max=2000, std_dev=80.0, skew=2.5
-        )
+        config = Distribution(type=DistributionType.SKEW_NORMAL, mean=200.0, min=10, max=2000, std_dev=80.0, skew=2.5)
         result = sample_from_distribution(config, 1000, rng=np.random.default_rng(42))
         assert result.min() >= 10
         assert result.max() <= 2000
 
     def test_skew_normal_positive_skew_has_right_tail(self) -> None:
-        config = Distribution(
-            type=DistributionType.SKEW_NORMAL, mean=100.0, min=0, max=1000, std_dev=50.0, skew=5.0
-        )
+        config = Distribution(type=DistributionType.SKEW_NORMAL, mean=100.0, min=0, max=1000, std_dev=50.0, skew=5.0)
         result = sample_from_distribution(config, 10000, rng=np.random.default_rng(42))
         # With positive skew, the median should be less than the mean of the samples
         median = float(np.median(result))
@@ -50,9 +46,7 @@ class TestSampleFromDistribution:
         assert median <= mean
 
     def test_skew_normal_zero_skew_approximates_normal(self) -> None:
-        config_skew = Distribution(
-            type=DistributionType.SKEW_NORMAL, mean=500.0, min=0, max=1000, std_dev=100.0, skew=0.0
-        )
+        config_skew = Distribution(type=DistributionType.SKEW_NORMAL, mean=500.0, min=0, max=1000, std_dev=100.0, skew=0.0)
         config_normal = Distribution(type=DistributionType.NORMAL, mean=500.0, min=0, max=1000, std_dev=100.0)
         rng1 = np.random.default_rng(42)
         rng2 = np.random.default_rng(42)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

# PR Template

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
This PRs introduces a report field that shows the total benchmark time (for the whole run, per stage, etc.), allowing comparisons between benchmark runs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #425 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A `benchmark_time_seconds` field is now available in the metrics report generated.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

# Testing
Testing was done with a modified default config.yml seen below

<details>
<summary>Click to expand functional test output</summary>


```bash
$ pdm run python3 inference_perf/main.py -c config.yml
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
2026-04-10 16:00:12,136 - inference_perf.config - INFO - Using configuration from: config.yml
2026-04-10 16:00:12,142 - inference_perf.config - INFO - Benchmarking with the following config:

api:
  type: completion
  streaming: true
  headers: null
  slo_unit: null
  slo_tpot_header: null
  slo_ttft_header: null
  response_format: null
data:
  type: random
  path: null
  input_distribution:
    min: 10
    max: 100
    mean: 50
    std_dev: 10
  output_distribution:
    min: 10
    max: 100
    mean: 50
    std_dev: 10
  shared_prefix: null
  trace: null
  otel_trace_replay: null
load:
  type: constant
  interval: 1.0
  stages:
  - !!python/object:inference_perf.config.StandardLoadStage
    __dict__:
      rate: 1.0
      duration: 30
      num_requests: null
      concurrency_level: null
    __pydantic_extra__: null
    __pydantic_fields_set__: !!set
      duration: null
      rate: null
    __pydantic_private__: null
  sweep: null
  num_workers: 16
  worker_max_concurrency: 100
  worker_max_tcp_connections: 2500
  trace: null
  circuit_breakers: []
  request_timeout: null
  lora_traffic_split: null
  base_seed: 1775851210334
metrics:
  type: prometheus
  prometheus:
    url: http://localhost:9090
    scrape_interval: 15
report:
  request_lifecycle:
    summary: true
    per_stage: true
    per_request: false
    per_adapter: true
    per_adapter_stage: false
    percentiles:
    - 0.1
    - 1.0
    - 5.0
    - 10.0
    - 25.0
    - 50.0
    - 75.0
    - 90.0
    - 95.0
    - 99.0
    - 99.9
  prometheus:
    summary: true
    per_stage: false
  session_lifecycle:
    summary: true
    per_stage: true
    per_session: false
storage:
  local_storage:
    path: reports-20260410-160010
    report_file_prefix: null
  google_cloud_storage: null
  simple_storage_service: null
server:
  type: vllm
  model_name: HuggingFaceTB/SmolLM2-135M-Instruct
  base_url: http://0.0.0.0:8000
  ignore_eos: true
tokenizer:
  pretrained_model_name_or_path: HuggingFaceTB/SmolLM2-135M-Instruct
circuit_breakers: null


2026-04-10 16:00:12,142 - inference_perf.client.filestorage.local - INFO - Report files will be stored at: reports-20260410-160010
Overall Progress ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 1/1 0:00:00 0:00:32
2026-04-10 16:00:45,691 - inference_perf.reportgen.base - INFO - Generating Reports...
2026-04-10 16:01:02,711 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=avg_over_time%28vllm%3Anum_requests_waiting%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,712 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=avg_over_time%28vllm%3Anum_requests_running%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,713 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Atime_to_first_token_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Atime_to_first_token_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,714 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Atime_to_first_token_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,714 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Atime_to_first_token_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,715 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Atime_to_first_token_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,715 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_time_per_output_token_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_time_per_output_token_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,716 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_time_per_output_token_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,717 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_time_per_output_token_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,717 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_time_per_output_token_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,718 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Ainter_token_latency_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Ainter_token_latency_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,719 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Ainter_token_latency_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,719 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Ainter_token_latency_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,720 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Ainter_token_latency_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,721 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=avg_over_time%28rate%28vllm%3Aprompt_tokens%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%5B50s%3A50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,721 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Aprompt_tokens%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,722 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=avg_over_time%28rate%28vllm%3Ageneration_tokens%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%5B50s%3A50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,722 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Ageneration_tokens%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,723 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Arequest_success%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,724 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_success%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,724 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Arequest_success%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,725 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Ae2e_request_latency_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Ae2e_request_latency_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,726 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Ae2e_request_latency_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,726 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Ae2e_request_latency_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,727 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Ae2e_request_latency_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,728 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=avg_over_time%28vllm%3Akv_cache_usage_perc%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,729 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=quantile_over_time%280.5%2C+vllm%3Akv_cache_usage_perc%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,729 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=quantile_over_time%280.9%2C+vllm%3Akv_cache_usage_perc%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,730 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=quantile_over_time%280.99%2C+vllm%3Akv_cache_usage_perc%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,731 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Anum_preemptions%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,731 - inference_perf.client.metricsclient.prometheus_client.base - WARNING - Metric metadata is not present for metric: num_requests_swapped. Skipping this metric.
2026-04-10 16:01:02,731 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Aprefix_cache_hits%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,732 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Aprefix_cache_queries%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,733 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_queue_time_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_queue_time_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,734 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_queue_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,734 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_queue_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,735 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_queue_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,736 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_inference_time_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_inference_time_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,736 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_inference_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,737 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_inference_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,738 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_inference_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,738 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_prefill_time_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_prefill_time_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,739 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_prefill_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,740 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_prefill_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,741 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_prefill_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,741 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_decode_time_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_decode_time_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,742 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_decode_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,743 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_decode_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,743 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_decode_time_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,744 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_prompt_tokens_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_prompt_tokens_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,745 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_prompt_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,746 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_prompt_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,746 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_prompt_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,747 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_generation_tokens_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_generation_tokens_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,747 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_generation_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,748 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_generation_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,749 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_generation_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,750 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_max_num_generation_tokens_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_max_num_generation_tokens_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,750 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_max_num_generation_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,751 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_max_num_generation_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,752 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_max_num_generation_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,752 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_params_n_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_params_n_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,753 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_params_n_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,754 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_params_n_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,754 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_params_n_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,755 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_params_max_tokens_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_params_max_tokens_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,756 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_params_max_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,756 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_params_max_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,757 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_params_max_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,758 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Aiteration_tokens_total_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Aiteration_tokens_total_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,758 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Aiteration_tokens_total_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,759 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Aiteration_tokens_total_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,760 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Aiteration_tokens_total_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,760 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Aprompt_tokens_cached%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,761 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Aprompt_tokens_recomputed%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,762 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Aexternal_prefix_cache_hits%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,762 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Aexternal_prefix_cache_queries%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,763 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Amm_cache_hits%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,764 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Amm_cache_queries%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,764 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28increase%28vllm%3Acorrupted_requests%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,765 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Arequest_prefill_kv_computed_tokens_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Arequest_prefill_kv_computed_tokens_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,766 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Arequest_prefill_kv_computed_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,766 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Arequest_prefill_kv_computed_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,767 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Arequest_prefill_kv_computed_tokens_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,768 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Akv_block_idle_before_evict_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Akv_block_idle_before_evict_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,769 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Akv_block_idle_before_evict_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,769 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Akv_block_idle_before_evict_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,770 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Akv_block_idle_before_evict_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,771 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Akv_block_lifetime_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Akv_block_lifetime_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,771 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Akv_block_lifetime_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,772 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Akv_block_lifetime_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,773 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Akv_block_lifetime_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,774 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=sum%28rate%28vllm%3Akv_block_reuse_gap_seconds_sum%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%2F+%28sum%28rate%28vllm%3Akv_block_reuse_gap_seconds_count%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+%3E+0%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,775 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.5%2C+sum%28rate%28vllm%3Akv_block_reuse_gap_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,775 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.9%2C+sum%28rate%28vllm%3Akv_block_reuse_gap_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,776 - inference_perf.client.metricsclient.prometheus_client.base - ERROR - error executing query: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /api/v1/query?query=histogram_quantile%280.99%2C+sum%28rate%28vllm%3Akv_block_reuse_gap_seconds_bucket%7Bmodel_name%3D%27HuggingFaceTB%2FSmolLM2-135M-Instruct%27%7D%5B50s%5D%29%29+by+%28le%29%29&time=1775851262.7107637 (Caused by NewConnectionError("HTTPConnection(host='localhost', port=9090): Failed to establish a new connection: [Errno 111] Connection refused"))
2026-04-10 16:01:02,777 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20260410-160010/summary_lifecycle_metrics.json
2026-04-10 16:01:02,777 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20260410-160010/stage_0_lifecycle_metrics.json
2026-04-10 16:01:02,778 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20260410-160010/summary_prometheus_metrics.json
2026-04-10 16:01:02,781 - inference_perf.client.filestorage.local - INFO - Report saved to: reports-20260410-160010/config.yaml
                                                                    Inference Performance Summary                                                                     
┏━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃       ┃          ┃               ┃            ┃ TTFT Mean ┃ TTFT Med ┃ TTFT P90 ┃ ITL Mean ┃ ITL Med ┃ ITL P90 ┃       ┃             ┃              ┃              ┃
┃ Stage ┃ Req Rate ┃ Achieved Rate ┃ Error Rate ┃      (ms) ┃     (ms) ┃     (ms) ┃     (ms) ┃    (ms) ┃    (ms) ┃ Req/s ┃ In Tokens/s ┃ Out Tokens/s ┃ Tot Tokens/s ┃
┡━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│     0 │      1.0 │           1.0 │       0.0% │      68.9 │     25.0 │     45.6 │      2.2 │     2.3 │     2.7 │   1.0 │        50.0 │         45.3 │         95.3 │
└───────┴──────────┴───────────────┴────────────┴───────────┴──────────┴──────────┴──────────┴─────────┴─────────┴───────┴─────────────┴──────────────┴──────────────┘
                                 Token Length Aggregates                                 
┏━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Stage ┃ Prompt Mean ┃ Prompt Med ┃ Prompt P90 ┃ Output Mean ┃ Output Med ┃ Output P90 ┃
┡━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│     0 │        50.0 │       49.0 │       62.4 │        45.4 │       45.5 │       55.0 │
└───────┴─────────────┴────────────┴────────────┴─────────────┴────────────┴────────────┘
```

[config.yaml](https://github.com/user-attachments/files/26639152/config.yaml)
[stage_0_lifecycle_metrics.json](https://github.com/user-attachments/files/26639154/stage_0_lifecycle_metrics.json)
[summary_lifecycle_metrics.json](https://github.com/user-attachments/files/26639155/summary_lifecycle_metrics.json)
[summary_prometheus_metrics.json](https://github.com/user-attachments/files/26639156/summary_prometheus_metrics.json)


</details>

