### PR TITLE
workaround unexpected sharegpt format change

### DIFF
--- a/e2e/tests/test_llm_d_inference_sim.py
+++ b/e2e/tests/test_llm_d_inference_sim.py
@@ -53,7 +53,14 @@ TEST_SHAREGPT_PATH = os.path.abspath("e2e/testdata/sharegpt.json")
                 "type": "shareGPT",
                 "path": TEST_SHAREGPT_PATH,
             },
-            id="data_sharegpt",
+            id="data_sharegpt_mock",
+        ),
+        pytest.param(
+            {
+                "type": "shareGPT",
+                # omitted to use hf_sharegpt_datagen.py default
+            },
+            id="data_sharegpt_default",
         ),
         pytest.param(
             {

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -17,9 +17,10 @@ from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatComplet
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
 from inference_perf.config import APIConfig, APIType, DataConfig
-from typing import Generator, List, Optional
+from typing import Any, Generator, List, Optional
 from datasets import load_dataset
 import os
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -91,8 +92,8 @@ class HFShareGPTDataGenerator(DataGenerator):
                 continue
 
             try:
-                prompt = data[self.data_key][0].get(self.content_key)
-                completion = data[self.data_key][1].get(self.content_key)
+                prompt = self.get_conversation_turn_content(data, 0)
+                completion = self.get_conversation_turn_content(data, 1)
                 if not prompt:
                     continue
                 completion_tokens = self.tokenizer.count_tokens(completion)
@@ -114,6 +115,23 @@ class HFShareGPTDataGenerator(DataGenerator):
             except (KeyError, TypeError) as e:
                 logger.warning(f"Skipping invalid completion data: {e}")
                 continue
+
+    def get_conversation_turn_content(self, data: Any, turn: int) -> str:
+        conversation = data[self.data_key][turn]
+        if isinstance(conversation, dict):
+            pass
+        elif isinstance(conversation, str):
+            # https://github.com/kubernetes-sigs/inference-perf/issues/429:
+            # The dataset sometimes contains a string containing a JSON
+            # object rather than the object itself for some reason.
+            conversation = json.loads(conversation)
+            assert isinstance(conversation, dict)
+        else:
+            raise Exception(f"Conversation from upstream gave unsupported type: {type(conversation).__name__}")
+
+        s = conversation.get(self.content_key)
+        assert isinstance(s, str)
+        return s
 
     def get_chat_data(self) -> Generator[InferenceAPIData, None, None]:
         while True:

--- a/tests/datagen/test_hf_sharegpt_datagen.py
+++ b/tests/datagen/test_hf_sharegpt_datagen.py
@@ -1,0 +1,53 @@
+import json
+import pytest
+from inference_perf.datagen.hf_sharegpt_datagen import HFShareGPTDataGenerator
+
+
+def test_get_conversation_turn_content_dict() -> None:
+    # We bypass __init__ to avoid actually loading the dataset
+    generator = HFShareGPTDataGenerator.__new__(HFShareGPTDataGenerator)
+    generator.data_key = "conversations"
+    generator.content_key = "value"
+
+    data = {"conversations": [{"from": "human", "value": "madoka"}, {"from": "gpt", "value": "magika"}]}
+
+    assert generator.get_conversation_turn_content(data, 0) == "madoka"
+    assert generator.get_conversation_turn_content(data, 1) == "magika"
+
+
+def test_get_conversation_turn_content_json_string() -> None:
+    generator = HFShareGPTDataGenerator.__new__(HFShareGPTDataGenerator)
+    generator.data_key = "conversations"
+    generator.content_key = "value"
+
+    # https://github.com/kubernetes-sigs/inference-perf/issues/429:
+    # The dataset sometimes contains a string containing a JSON
+    # object rather than the object itself for some reason.
+    data = {
+        "conversations": [
+            json.dumps({"from": "human", "value": "madoka"}),
+            json.dumps({"from": "gpt", "value": "magika"}),
+        ]
+    }
+
+    assert generator.get_conversation_turn_content(data, 0) == "madoka"
+    assert generator.get_conversation_turn_content(data, 1) == "magika"
+
+
+def test_get_conversation_turn_content_unsupported_type() -> None:
+    generator = HFShareGPTDataGenerator.__new__(HFShareGPTDataGenerator)
+    generator.data_key = "conversations"
+    generator.content_key = "value"
+
+    data = {
+        "conversations": [
+            123,  # Invalid type
+            ["madoka"],  # Invalid type
+        ]
+    }
+
+    with pytest.raises(Exception, match="Conversation from upstream gave unsupported type: int"):
+        generator.get_conversation_turn_content(data, 0)
+
+    with pytest.raises(Exception, match="Conversation from upstream gave unsupported type: list"):
+        generator.get_conversation_turn_content(data, 1)


### PR DESCRIPTION
also added an additional test case to ensure that the example `config.yml` at repository root is also covered.

see https://github.com/kubernetes-sigs/inference-perf/issues/429.