### PR TITLE
Update chat to completion for workload catalog

### DIFF
--- a/workload-catalog/code-generation/inference-perf.yaml
+++ b/workload-catalog/code-generation/inference-perf.yaml
@@ -13,7 +13,7 @@ load:
     concurrency_level: 20
   num_workers: 1
 api:
-  type: chat
+  type: completion
   streaming: true
 server:
   type: vllm

--- a/workload-catalog/deep-research/inference-perf.yaml
+++ b/workload-catalog/deep-research/inference-perf.yaml
@@ -13,7 +13,7 @@ load:
     concurrency_level: 5
   num_workers: 1
 api:
-  type: chat
+  type: completion
   streaming: true
 server:
   type: vllm

--- a/workload-catalog/interactive-chat/inference-perf.yaml
+++ b/workload-catalog/interactive-chat/inference-perf.yaml
@@ -13,7 +13,7 @@ load:
     concurrency_level: 50
   num_workers: 1
 api:
-  type: chat
+  type: completion
   streaming: true
 server:
   type: vllm


### PR DESCRIPTION
Workload catalog examples have shared prefix datagen using chat API. Since it is not supported, moving them to completion.