### PR TITLE
Fix Multi Turn Chat Hang

### DIFF
--- a/inference_perf/apis/user_session.py
+++ b/inference_perf/apis/user_session.py
@@ -28,14 +28,36 @@ class LocalUserSession:
     user_session_id: str
     context: str
 
+    _instances: dict[str, "LocalUserSession"] = {}
+
     def __init__(self, user_session_id: str, context: str = ""):
         self.user_session_id = user_session_id
         self.contexts = context if context else ""
         self._current_round = 0
-        self._in_flight: asyncio.Lock = asyncio.Lock()
-        self._waiting_rounds: asyncio.Queue[asyncio.Future[bool]] = asyncio.Queue()
+        self._in_flight: Optional[asyncio.Lock] = None
+        self._waiting_rounds: Optional[asyncio.Queue[asyncio.Future[bool]]] = None
+
+    @classmethod
+    def get_instance(cls, user_session_id: str) -> "LocalUserSession":
+        if user_session_id not in cls._instances:
+            cls._instances[user_session_id] = LocalUserSession(user_session_id)
+        return cls._instances[user_session_id]
+
+    @classmethod
+    def clear_instances(cls) -> None:
+        cls._instances.clear()
+
+    def _ensure_initialized(self) -> None:
+        if self._in_flight is None:
+            self._in_flight = asyncio.Lock()
+        if self._waiting_rounds is None:
+            self._waiting_rounds = asyncio.Queue()
 
     async def get_context(self, round: int) -> str:
+        self._ensure_initialized()
+        assert self._waiting_rounds is not None
+        assert self._in_flight is not None
+
         if not self._waiting_rounds.empty() or self._in_flight.locked():
             # entering waiting queue
             future: asyncio.Future[bool] = asyncio.Future()
@@ -48,6 +70,10 @@ class LocalUserSession:
     def update_context(self, response: str) -> None:
         self.contexts = response
 
+        self._ensure_initialized()
+        assert self._waiting_rounds is not None
+        assert self._in_flight is not None
+
         if not self._waiting_rounds.empty():
             future = self._waiting_rounds.get_nowait()
             future.set_result(True)
@@ -57,8 +83,12 @@ class LocalUserSession:
 
 class UserSessionCompletionAPIData(CompletionAPIData):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    user_session: LocalUserSession = Field(exclude=True)
+    user_session_id: str = Field(exclude=True)
     target_round: int
+
+    @property
+    def user_session(self) -> LocalUserSession:
+        return LocalUserSession.get_instance(self.user_session_id)
 
     async def to_payload(
         self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
@@ -72,7 +102,7 @@ class UserSessionCompletionAPIData(CompletionAPIData):
         return await super().to_payload(effective_model_name, max_tokens, ignore_eos, streaming)
 
     def update_inference_info(self, inference_info: InferenceInfo) -> None:
-        inference_info.extra_info["user_session"] = self.user_session.user_session_id
+        inference_info.extra_info["user_session"] = self.user_session_id
         inference_info.extra_info["chat_round"] = self.user_session._current_round
 
     async def process_response(

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -28,7 +28,6 @@ import logging
 import requests
 import ssl
 
-from ...datagen.otel_trace_replay_datagen import OTelChatCompletionAPIData
 
 logger = logging.getLogger(__name__)
 
@@ -321,11 +320,10 @@ class openAIModelServerClientSession(ModelServerClientSession):
                             # This ensures that if request X fails and request Y depends on X's output,
                             # Y raises EventFailedError and skips rather than hanging indefinitely.
                             #
-                            # Note: The original code only logged errors for non-200 responses without
-                            # calling process_failure(). This special handling for OTelChatCompletionAPIData
-                            # ensures proper failure propagation in trace replay scenarios.
-
-                            if isinstance(data, OTelChatCompletionAPIData) and response is not None:
+                            # Note: We call process_failure() for all data types on non-200 responses
+                            # to ensure proper state cleanup (e.g. releasing locks in multi-turn chat)
+                            # and failure propagation.
+                            if response is not None:
                                 error = ErrorResponseInfo(
                                     error_msg=response_content,
                                     error_type=f"HTTP Error {response.status}",

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -122,7 +122,7 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
             return UserSessionCompletionAPIData(
                 prompt=self.prompts[i],
                 max_tokens=output_len,
-                user_session=self.user_sessions[user_id],
+                user_session_id=self.user_sessions[user_id].user_session_id,
                 target_round=round,
             )
         else:

--- a/tests/loadgen/test_multi_turn_hang.py
+++ b/tests/loadgen/test_multi_turn_hang.py
@@ -1,0 +1,133 @@
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+from typing import Any
+
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    DataConfig,
+    DataGenType,
+    SharedPrefix,
+)
+from inference_perf.datagen.shared_prefix_datagen import SharedPrefixDataGenerator
+from inference_perf.datagen.base import LazyLoadDataMixin
+from inference_perf.apis import LazyLoadInferenceAPIData
+from inference_perf.apis.user_session import LocalUserSession
+
+
+def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
+    mock_tokenizer = MagicMock()
+    hf_tok = MagicMock()
+    hf_tok.vocab_size = vocab_size
+    hf_tok.decode = MagicMock(side_effect=lambda ids, **kw: f"text_{len(ids)}")
+    hf_tok.batch_decode = MagicMock(side_effect=lambda batch, **kw: [f"text_{len(ids)}" for ids in batch])
+    mock_tokenizer.get_tokenizer.return_value = hf_tok
+    return mock_tokenizer
+
+
+class TestMultiTurnHang(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        try:
+            LocalUserSession.clear_instances()
+        except AttributeError:
+            pass
+
+    async def test_worker_simulation_no_hang(self) -> None:
+        sp = SharedPrefix(
+            num_groups=1,
+            num_prompts_per_group=5,
+            enable_multi_turn_chat=True,
+            seed=42,
+            system_prompt_len=10,
+            question_len=10,
+            output_len=10,
+        )
+        api_config = APIConfig(type=APIType.Completion)
+        data_config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=sp)
+
+        datagen = SharedPrefixDataGenerator(api_config, data_config, _make_mock_tokenizer())
+
+        # Simulate Worker 0 processing requests for session 0
+        # Request 0 (round 0)
+        lazy_data_0 = LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0)
+        data_0 = LazyLoadDataMixin.get_request(datagen, lazy_data_0)
+
+        # Request 1 (round 1) - Use data_index=5 to map to same user_id (0)
+        lazy_data_1 = LazyLoadInferenceAPIData(data_index=5, preferred_worker_id=0)
+        data_1 = LazyLoadDataMixin.get_request(datagen, lazy_data_1)
+
+        # Simulate IPC serialization/deserialization (Pydantic copying behavior)
+        import pickle
+
+        data_0 = pickle.loads(pickle.dumps(data_0))
+        data_1 = pickle.loads(pickle.dumps(data_1))
+
+        # Assert instances are identical (Registry working)
+        self.assertIs(data_0.user_session, data_1.user_session)
+
+        await data_0.to_payload("model", 10, True, False)
+        print("Processed request 0 payload (Lock acquired)")
+
+        # Simulate successful response processing for request 0
+        mock_response = MagicMock()
+        mock_json_fut: asyncio.Future[Any] = asyncio.Future()
+        mock_json_fut.set_result({"choices": [{"text": "bot response"}]})
+        mock_response.json = MagicMock(return_value=mock_json_fut)
+
+        await data_0.process_response(mock_response, api_config, datagen.tokenizer)
+        print("Processed request 0 response (Lock released)")
+
+        # This should NOT hang now!
+        try:
+            await asyncio.wait_for(data_1.to_payload("model", 10, True, False), timeout=2.0)
+            print("Processed request 1 payload successfully (No hang!)")
+        except asyncio.TimeoutError:
+            self.fail("Should NOT have hung on request 1 after release!")
+
+    async def test_worker_simulation_failure_no_hang(self) -> None:
+        sp = SharedPrefix(
+            num_groups=1,
+            num_prompts_per_group=5,
+            enable_multi_turn_chat=True,
+            seed=42,
+            system_prompt_len=10,
+            question_len=10,
+            output_len=10,
+        )
+        api_config = APIConfig(type=APIType.Completion)
+        data_config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=sp)
+
+        datagen = SharedPrefixDataGenerator(api_config, data_config, _make_mock_tokenizer())
+
+        lazy_data_0 = LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0)
+        data_0 = LazyLoadDataMixin.get_request(datagen, lazy_data_0)
+
+        lazy_data_1 = LazyLoadInferenceAPIData(data_index=5, preferred_worker_id=0)
+        data_1 = LazyLoadDataMixin.get_request(datagen, lazy_data_1)
+
+        # Simulate IPC serialization/deserialization (Pydantic copying behavior)
+        import pickle
+
+        data_0 = pickle.loads(pickle.dumps(data_0))
+        data_1 = pickle.loads(pickle.dumps(data_1))
+
+        # Assert instances are identical (Registry working)
+        self.assertIs(data_0.user_session, data_1.user_session)
+
+        await data_0.to_payload("model", 10, True, False)
+
+        # Simulate failure processing for request 0
+        await data_0.process_failure(None, api_config, datagen.tokenizer, Exception("Simulated failure"))
+        print("Processed request 0 failure (Lock released)")
+
+        # This should NOT hang now!
+        try:
+            await asyncio.wait_for(data_1.to_payload("model", 10, True, False), timeout=2.0)
+            print("Processed request 1 payload successfully after failure (No hang!)")
+        except asyncio.TimeoutError:
+            self.fail("Should NOT have hung on request 1 after failure release!")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses: https://github.com/kubernetes-sigs/inference-perf/issues/435

Benchmarks involving multi-turn chat (enable_multi_turn_chat: true) would frequently hang at the end. This was caused by:

* Loss of locking sharing: Pydantic copied LocalUserSession objects across process boundaries, breaking the asyncio.Lock sharing required for sequential turn processing.
* Failure to release locks on error: Non-200 HTTP responses did not trigger failure processing, leaving locks acquired indefinitely.

Solution
* Implemented a process-local instances registry for LocalUserSession to ensure a single shared instance per session ID within a process.
* Refactored UserSessionCompletionAPIData to use session IDs rather than objects to prevent Pydantic copying.
* Deferred lock initialization to bound them properly to the worker's event loop.
* Ensured process_failure is called on non-200 responses to always release locks.
* Added regression tests simulating IPC to verify behavior.

Verification
* Reproduction tests fail without the changes and pass with them.
* Existing data generation tests pass without regression.