### PR TITLE
Fix TPOT/TTFT/ITL skew from non-content SSE events

### DIFF
--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -29,6 +29,7 @@ class StreamedInferenceResponseInfo(BaseModel):
     chunk_times: List[float] = []
     output_tokens: int = 0
     output_token_times: List[float] = []
+    server_usage: Optional[dict[str, Any]] = None
 
 
 class InferenceInfo(BaseModel):

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -55,7 +55,7 @@ class ChatCompletionAPIData(InferenceAPIData):
     ) -> InferenceInfo:
         if config.streaming:
             # Use shared streaming parser with chat-specific content extraction
-            output_text, message_times, raw_content, response_chunks = await parse_sse_stream(
+            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
 
@@ -66,9 +66,10 @@ class ChatCompletionAPIData(InferenceAPIData):
                 input_tokens=prompt_len,
                 response_info=StreamedInferenceResponseInfo(
                     response_chunks=response_chunks,
-                    chunk_times=message_times,
+                    chunk_times=chunk_times,
                     output_tokens=output_len,
-                    output_token_times=message_times,
+                    output_token_times=chunk_times,
+                    server_usage=server_usage,
                 ),
                 lora_adapter=lora_adapter,
                 extra_info={"raw_response": raw_content},

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -52,7 +52,7 @@ class CompletionAPIData(InferenceAPIData):
     ) -> InferenceInfo:
         if config.streaming:
             # Use shared streaming parser with completion-specific content extraction
-            output_text, message_times, raw_content, response_chunks = await parse_sse_stream(
+            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("text")
             )
 
@@ -62,9 +62,10 @@ class CompletionAPIData(InferenceAPIData):
                 input_tokens=prompt_len,
                 response_info=StreamedInferenceResponseInfo(
                     response_chunks=response_chunks,
-                    chunk_times=message_times,
+                    chunk_times=chunk_times,
                     output_tokens=output_len,
-                    output_token_times=message_times,
+                    output_token_times=chunk_times,
+                    server_usage=server_usage,
                 ),
                 lora_adapter=lora_adapter,
                 extra_info={"raw_response": raw_content},

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -28,7 +28,7 @@ from aiohttp import ClientResponse
 
 async def parse_sse_stream(
     response: ClientResponse, extract_content: Callable[[dict[str, Any]], Optional[str]]
-) -> Tuple[str, List[float], str, List[str]]:
+) -> Tuple[str, List[float], str, List[str], Optional[dict[str, Any]]]:
     """
     Parse Server-Sent Events (SSE) stream and extract content.
 
@@ -44,24 +44,24 @@ async def parse_sse_stream(
                         Example: lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
 
     Returns:
-        Tuple of (output_text, chunk_times, raw_content, response_chunks) where:
+        Tuple of (output_text, chunk_times, raw_content, response_chunks, server_usage):
         - output_text: The concatenated text content from all chunks
-        - chunk_times: List of timestamps when each message was received
+        - chunk_times: Timestamps for content-bearing chunks only. Role-only
+          deltas, usage-only chunks, [DONE] signals, and unparseable messages
+          are excluded so they don't corrupt downstream TPOT/TTFT/ITL.
         - raw_content: The raw string content of the stream
-        - response_chunks: List of raw JSON strings from data: lines (for token interpolation)
-
-    Example:
-        # For chat completions
-        output_text, times, raw, chunks = await parse_sse_stream(
-            response,
-            lambda d: d.get("choices", [{}])[0].get("delta", {}).get("content")
-        )
+        - response_chunks: Raw JSON strings of content-bearing chunks, 1:1 with
+          chunk_times.
+        - server_usage: Last-seen `usage` dict from any chunk that carried one
+          (e.g. trailing `{"choices":[],"usage":{...}}` when stream_options
+          include_usage=true). None if the server didn't emit usage.
     """
     output_text = ""
     chunk_times: List[float] = []
     buffer = b""
     raw_content = b""
     response_chunks: List[str] = []
+    server_usage: Optional[dict[str, Any]] = None
 
     async for chunk in response.content.iter_any():
         raw_content += chunk
@@ -69,21 +69,24 @@ async def parse_sse_stream(
         while b"\n\n" in buffer:
             message, buffer = buffer.split(b"\n\n", 1)
             message_time = time.perf_counter()
+            done = False
             for line in message.split(sep=b"\n"):
                 if line.startswith(b"data:"):
                     data_str = line.removeprefix(b"data: ").strip()
                     if data_str == b"[DONE]":
+                        done = True
                         break
                     try:
                         data = json.loads(data_str)
-                        response_chunks.append(data_str.decode("utf-8", errors="ignore"))
-                        chunk_times.append(message_time)
+                        if usage := data.get("usage"):
+                            server_usage = usage
                         if content := extract_content(data):
                             output_text += content
+                            chunk_times.append(message_time)
+                            response_chunks.append(data_str.decode("utf-8", errors="ignore"))
                     except (json.JSONDecodeError, IndexError):
                         continue
-            else:
-                continue
-            break
+            if done:
+                break
 
-    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks
+    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage

--- a/inference_perf/datagen/otel_trace_replay_datagen.py
+++ b/inference_perf/datagen/otel_trace_replay_datagen.py
@@ -633,7 +633,7 @@ class OTelChatCompletionAPIData(ChatCompletionAPIData):
 
         if config.streaming:
             # Use shared streaming parser with chat-specific content extraction
-            output_text, output_token_times, raw_content, _ = await parse_sse_stream(
+            output_text, output_token_times, raw_content, _, _ = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -405,7 +405,9 @@ def summarize_requests(
             output_token_times = []
             accumulated_tokens = 0
             parsed_chunks = []
-            expected_output_tokens = None
+            expected_output_tokens = (
+                m.info.response_info.server_usage.get("completion_tokens") if m.info.response_info.server_usage else None
+            )
 
             for chunk_str, chunk_time in zip(
                 m.info.response_info.response_chunks, m.info.response_info.chunk_times, strict=True
@@ -417,8 +419,6 @@ def summarize_requests(
                         text = delta.get("text") or delta.get("delta", {}).get("content")
                         if text:
                             parsed_chunks.append((text, chunk_time))
-                    if usage := data.get("usage"):
-                        expected_output_tokens = usage.get("completion_tokens")
                 except json.JSONDecodeError:
                     continue
 

--- a/tests/apis/test_streaming_parser.py
+++ b/tests/apis/test_streaming_parser.py
@@ -39,9 +39,12 @@ async def test_parse_sse_stream() -> None:
     def extract_content(data: dict[str, Any]) -> Optional[str]:
         return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
 
-    output_text, chunk_times, raw_content, response_chunks = await parse_sse_stream(mock_response, extract_content)
+    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+        mock_response, extract_content
+    )
 
     assert output_text == "Hello world"
+    assert len(chunk_times) == 2
     assert "Hello" in raw_content
     assert "world" in raw_content
     assert "[DONE]" in raw_content
@@ -50,3 +53,48 @@ async def test_parse_sse_stream() -> None:
     assert "world" in response_chunks[1]
     # response_chunks and chunk_times must stay in lockstep — reportgen zips them with strict=True.
     assert len(chunk_times) == len(response_chunks)
+    assert server_usage is None
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_timestamps_only_content_events() -> None:
+    """Reproduces issue #392: timestamps must only be recorded for content-bearing
+    SSE events. Role-only first chunks, trailing usage chunks, and [DONE] signals
+    must not appear in chunk_times, since they corrupt TPOT/TTFT/ITL. response_chunks
+    is kept 1:1 aligned with chunk_times so reportgen's strict zip stays valid."""
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    chunks = [
+        # Role-only first chunk — no content yet.
+        b'data: {"choices": [{"delta": {"role": "assistant"}}]}\n\n',
+        # Two content-bearing chunks.
+        b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": " world"}}]}\n\n',
+        # Trailing usage chunk — choices empty, no content.
+        b'data: {"choices": [], "usage": {"prompt_tokens": 5, "completion_tokens": 2}}\n\n',
+        # End-of-stream signal.
+        b"data: [DONE]\n\n",
+    ]
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+
+    mock_content.iter_any = mock_iter_any
+
+    def extract_content(data: dict[str, Any]) -> Optional[str]:
+        return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
+
+    output_text, chunk_times, _, response_chunks, server_usage = await parse_sse_stream(mock_response, extract_content)
+
+    assert output_text == "Hello world"
+    assert len(chunk_times) == 2, (
+        f"expected 2 timestamps for content-bearing chunks, got {len(chunk_times)} "
+        "(role-only, usage, or [DONE] events leaking into chunk_times)"
+    )
+    assert len(response_chunks) == len(chunk_times), "response_chunks must stay 1:1 aligned with chunk_times"
+    assert server_usage == {"prompt_tokens": 5, "completion_tokens": 2}, (
+        "usage info from a content-less chunk should still be surfaced separately"
+    )

--- a/tests/reportgen/test_summarize_requests.py
+++ b/tests/reportgen/test_summarize_requests.py
@@ -89,9 +89,9 @@ def test_summarize_requests_token_mismatch() -> None:
             response_chunks=[
                 '{"choices": [{"text": "hello"}]}',
                 '{"choices": [{"text": "world"}]}',
-                '{"usage": {"completion_tokens": 6}}',
             ],
-            chunk_times=[1.0, 2.0, 3.0],
+            chunk_times=[1.0, 2.0],
+            server_usage={"completion_tokens": 6},
         ),
     )
 


### PR DESCRIPTION
Addresses #392 

Changes:
* Moves SSE timestamp recording inside the per-chunk content check in [streaming_parser.py](vscode-webview://1s9pjpbdrcbq2drc9mh5jgvmatcg2ba038os545pc7va1oo0aa63/inference_perf/apis/streaming_parser.py), so `[DONE]`, role-only, and usage-only chunks no longer pollute `chunk_times` (and TPOT/TTFT/ITL by extension). Keeps `chunk_times` and response_chunks 1:1 aligned, which closes a latent `zip(strict=True)` mismatch in reportgen.
* Adds a `server_usage` field on `StreamedInferenceResponseInfo` so reportgen's `token_count_mismatches` diagnostic still works after `usage` chunks are filtered out of `response_chunks`.