### PR TITLE
[URGENT] fix: correct `InferenceInfo.output_tokens` access via nested `response_info`

### DIFF
--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -28,9 +28,11 @@ jobs:
 
       - name: Run end-to-end tests
         run: |
+          set -euxo pipefail
           nix develop -c pdm run test:e2e -o log_cli_level=DEBUG |& tee test_e2e.out
 
       - name: Upload test_e2e.out
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test_e2e

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -68,7 +68,7 @@ async def parse_sse_stream(
         buffer += chunk
         while b"\n\n" in buffer:
             message, buffer = buffer.split(b"\n\n", 1)
-            chunk_times.append(time.perf_counter())
+            message_time = time.perf_counter()
             for line in message.split(sep=b"\n"):
                 if line.startswith(b"data:"):
                     data_str = line.removeprefix(b"data: ").strip()
@@ -77,6 +77,7 @@ async def parse_sse_stream(
                     try:
                         data = json.loads(data_str)
                         response_chunks.append(data_str.decode("utf-8", errors="ignore"))
+                        chunk_times.append(message_time)
                         if content := extract_content(data):
                             output_text += content
                     except (json.JSONDecodeError, IndexError):

--- a/inference_perf/client/filestorage/gcs.py
+++ b/inference_perf/client/filestorage/gcs.py
@@ -14,7 +14,7 @@
 import json
 import logging
 from typing import List
-from google.cloud import storage
+import google.cloud.storage as storage
 from google.cloud.exceptions import GoogleCloudError
 from inference_perf.client.filestorage import StorageClient
 from inference_perf.config import GoogleCloudStorageConfig

--- a/inference_perf/client/metricsclient/prometheus_client/google_managed_prometheus_client.py
+++ b/inference_perf/client/metricsclient/prometheus_client/google_managed_prometheus_client.py
@@ -17,6 +17,7 @@ from pydantic import HttpUrl
 from inference_perf.client.metricsclient.prometheus_client.base import PrometheusMetricsClient
 from inference_perf.config import PrometheusClientConfig
 import google.auth
+import google.auth.transport.requests
 
 logger = logging.getLogger(__name__)
 

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -78,7 +78,10 @@ class openAIModelServerClient(ModelServerClient):
             if not supported_models:
                 logger.error("No supported models found")
                 raise Exception("openAI client init failed, no model_name could be found")
-            self.model_name = supported_models[0].get("id")
+            inferred_id = supported_models[0].get("id")
+            if not isinstance(inferred_id, str):
+                raise Exception(f"openAI client init failed, model entry has no string 'id': {supported_models[0]}")
+            self.model_name: str = inferred_id
             logger.info(f"Inferred model {self.model_name}")
             if len(supported_models) > 1:
                 logger.warning(f"More than one supported model found {supported_models}, selecting {self.model_name}")
@@ -151,6 +154,8 @@ class openAIModelServerClient(ModelServerClient):
 
 
 class openAIModelServerClientSession(ModelServerClientSession):
+    client: openAIModelServerClient
+
     def __init__(self, client: openAIModelServerClient):
         timeout = aiohttp.ClientTimeout(total=client.timeout) if client.timeout else aiohttp.helpers.sentinel
         connector = None
@@ -185,21 +190,22 @@ class openAIModelServerClientSession(ModelServerClientSession):
     ) -> None:
         """Record OTEL metrics for the request."""
         if response_info:
-            otel_response_info = {
+            inner = response_info.response_info
+            otel_response_info: Dict[str, Any] = {
                 "prompt_tokens": response_info.input_tokens,
-                "completion_tokens": response_info.output_tokens,
+                "completion_tokens": inner.output_tokens if inner else 0,
                 "total_latency": end_time - start_time,
             }
 
-            # Calculate TTFT if token times are available
-            if response_info.output_token_times and len(response_info.output_token_times) > 0:
-                ttft = response_info.output_token_times[0] - start_time
+            # Calculate TTFT if token times are available (streaming only)
+            if isinstance(inner, StreamedInferenceResponseInfo) and inner.output_token_times:
+                ttft = inner.output_token_times[0] - start_time
                 otel_response_info["time_to_first_token"] = ttft
 
                 # Calculate average TPOT if we have multiple tokens
-                if len(response_info.output_token_times) > 1:
-                    total_decode_time = response_info.output_token_times[-1] - response_info.output_token_times[0]
-                    num_decode_tokens = len(response_info.output_token_times) - 1
+                if len(inner.output_token_times) > 1:
+                    total_decode_time = inner.output_token_times[-1] - inner.output_token_times[0]
+                    num_decode_tokens = len(inner.output_token_times) - 1
                     tpot = total_decode_time / num_decode_tokens if num_decode_tokens > 0 else 0
                     otel_response_info["time_per_output_token"] = tpot
 

--- a/inference_perf/client/modelserver/otel_instrumentation.py
+++ b/inference_perf/client/modelserver/otel_instrumentation.py
@@ -204,7 +204,9 @@ class OTelInstrumentation:
                 logger.info("Created OTEL tracer provider with console exporter")
 
         self.tracer = trace.get_tracer(self.service_name)
-        self._provider = provider  # Store provider for shutdown
+        # The hasattr check above guarantees `provider` exposes the SDK surface
+        # (force_flush, shutdown, add_span_processor); cast so the static type matches.
+        self._provider: "TracerProvider" = cast("TracerProvider", provider)
         logger.info(f"OTEL instrumentation enabled for service: {self.service_name}")
 
     def shutdown(self) -> None:

--- a/inference_perf/client/requestdatacollector/multiprocess.py
+++ b/inference_perf/client/requestdatacollector/multiprocess.py
@@ -16,6 +16,7 @@ import multiprocessing as mp
 
 from asyncio import get_event_loop, create_task
 from contextlib import asynccontextmanager
+from queue import Empty
 from typing import AsyncIterator, Optional
 from functools import partial
 import logging
@@ -44,7 +45,7 @@ class MultiprocessRequestDataCollector(RequestDataCollector):
         while True:
             try:
                 item = await event_loop.run_in_executor(None, get_queue)
-            except mp.queues.Empty:
+            except Empty:
                 continue
 
             if item is None:

--- a/inference_perf/datagen/base.py
+++ b/inference_perf/datagen/base.py
@@ -103,6 +103,14 @@ class DataGenerator(BaseGenerator):
         """Whether this generator supports shared prefix patterns."""
         raise NotImplementedError
 
+    def get_request_count(self) -> int:
+        """Return the total number of requests this generator will produce.
+
+        Only meaningful for trace-driven generators where the count is bounded
+        by the trace. Subclasses that drive load from a trace must override.
+        """
+        raise NotImplementedError
+
 
 class SessionGenerator(BaseGenerator):
     """Session-based trace replay for agentic workloads (TRACE_SESSION_REPLAY load type).

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -57,6 +57,7 @@ from typing import List, Tuple, Optional, NamedTuple, Union, Set, Dict
 from types import FrameType
 import time
 import multiprocessing as mp
+from queue import Empty
 from multiprocessing.synchronize import Event as SyncEvent
 from multiprocessing.sharedctypes import Synchronized
 from concurrent.futures import TimeoutError
@@ -80,7 +81,7 @@ logger = logging.getLogger(__name__)
 
 class RequestQueueData(NamedTuple):
     stage_id: int
-    request_data: Union[InferenceAPIData, int]
+    request_data: InferenceAPIData
     request_time: float
     lora_adapter: Optional[str]
 
@@ -90,7 +91,7 @@ class Worker(mp.Process):
         self,
         id: int,
         client: ModelServerClient,
-        request_queue: mp.Queue,  # type: ignore[type-arg]
+        request_queue: "mp.JoinableQueue[RequestQueueData]",
         datagen: BaseGenerator,
         max_concurrency: int,
         stop_signal: SyncEvent,
@@ -160,7 +161,7 @@ class Worker(mp.Process):
                     logger.debug(f"[Worker {self.id}] timed out getting request from queue")
                     semaphore.release()
                     continue
-                except mp.queues.Empty:
+                except Empty:
                     semaphore.release()
                     continue
                 except Exception as e:
@@ -169,7 +170,7 @@ class Worker(mp.Process):
                     continue
 
                 async def schedule_client(
-                    queue: mp.Queue,  # type: ignore[type-arg]
+                    queue: "mp.JoinableQueue[RequestQueueData]",
                     request_data: InferenceAPIData,
                     request_time: float,
                     stage_id: int,
@@ -350,12 +351,12 @@ class LoadGenerator:
         # For concurrent and constant load types (rate is adjusted in main.py for concurrent load type)
         return ConstantLoadTimer(rate=rate, duration=duration)
 
-    async def drain(self, queue: mp.Queue) -> None:  # type: ignore[type-arg]
+    async def drain(self, queue: "mp.JoinableQueue[RequestQueueData]") -> None:
         while True:
             try:
                 _ = queue.get_nowait()
                 queue.task_done()
-            except mp.queues.Empty:
+            except Empty:
                 if queue.qsize() == 0:
                     logger.debug("Drain finished")
                     return

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -160,7 +160,11 @@ def calculate_goodput_metrics(
         if is_good:
             good_requests_count += 1
             in_tokens = m.info.input_tokens if m.info.input_tokens is not None else 0
-            out_tokens = m.info.output_tokens if m.info.output_tokens is not None else 0
+            out_tokens = (
+                m.info.response_info.output_tokens
+                if m.info.response_info and m.info.response_info.output_tokens is not None
+                else 0
+            )
             good_total_tokens += in_tokens + out_tokens
 
     goodput_percentage = (good_requests_count / total * 100) if total > 0 else 0.0

--- a/inference_perf/utils/request_queue.py
+++ b/inference_perf/utils/request_queue.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import multiprocessing as mp
+from queue import Empty
 from typing import Generic, List, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ class RequestQueue(Generic[T]):
                 try:
                     _ = queue.get_nowait()
                     queue.task_done()
-                except mp.queues.Empty:
+                except Empty:
                     if queue.qsize() == 0:
                         logger.debug("Drain finished")
                         break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ where = ["."]
 include = ["inference_perf*", "deploy*"]
 
 [tool.mypy]
-disable_error_code = ["attr-defined"]
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
@@ -162,6 +161,7 @@ module = [
     "matplotlib.*",
     "boto3.*",
     "opentelemetry.*",
+    "google.cloud.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/apis/test_streaming_parser.py
+++ b/tests/apis/test_streaming_parser.py
@@ -42,10 +42,11 @@ async def test_parse_sse_stream() -> None:
     output_text, chunk_times, raw_content, response_chunks = await parse_sse_stream(mock_response, extract_content)
 
     assert output_text == "Hello world"
-    assert len(chunk_times) == 3
     assert "Hello" in raw_content
     assert "world" in raw_content
     assert "[DONE]" in raw_content
     assert len(response_chunks) == 2
     assert "Hello" in response_chunks[0]
     assert "world" in response_chunks[1]
+    # response_chunks and chunk_times must stay in lockstep — reportgen zips them with strict=True.
+    assert len(chunk_times) == len(response_chunks)

--- a/tests/client/modelserver/test_openai_client.py
+++ b/tests/client/modelserver/test_openai_client.py
@@ -15,7 +15,8 @@ import pytest
 import asyncio
 import aiohttp
 from unittest.mock import AsyncMock, MagicMock
-from inference_perf.client.modelserver.openai_client import openAIModelServerClientSession, ErrorResponseInfo, InferenceInfo
+from inference_perf.client.modelserver.openai_client import openAIModelServerClientSession
+from inference_perf.apis import ErrorResponseInfo, InferenceInfo
 
 
 @pytest.fixture

--- a/tests/loadgen/test_load_generator.py
+++ b/tests/loadgen/test_load_generator.py
@@ -238,8 +238,9 @@ class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
 
     async def test_drain(self) -> None:
         q: RequestQueue[RequestQueueData] = RequestQueue(1)
-        q.put(RequestQueueData(0, 1, 0.0, None), 0)
-        q.put(RequestQueueData(0, 2, 0.0, None), 0)
+        dummy_data = MagicMock(spec=InferenceAPIData)
+        q.put(RequestQueueData(0, dummy_data, 0.0, None), 0)
+        q.put(RequestQueueData(0, dummy_data, 0.0, None), 0)
 
         # Small sleep to let queue populate
         await asyncio.sleep(0.1)

--- a/tests/reportgen/test_calculate_goodput_metrics.py
+++ b/tests/reportgen/test_calculate_goodput_metrics.py
@@ -52,7 +52,7 @@ def test_calculate_goodput_metrics_ttft_constraint() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 
@@ -61,7 +61,7 @@ def test_calculate_goodput_metrics_ttft_constraint() -> None:
     metric2.end_time = 4.0
     metric2.info = Mock()
     metric2.info.input_tokens = 0
-    metric2.info.output_tokens = 20
+    metric2.info.response_info.output_tokens = 20
     metric2.ttft_slo_sec = None
     metric2.tpot_slo_sec = None
 
@@ -89,7 +89,7 @@ def test_calculate_goodput_metrics_total_tokens() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 5
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 
@@ -115,7 +115,7 @@ def test_calculate_goodput_metrics_multiple_constraints() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 
@@ -124,7 +124,7 @@ def test_calculate_goodput_metrics_multiple_constraints() -> None:
     metric2.end_time = 4.0
     metric2.info = Mock()
     metric2.info.input_tokens = 0
-    metric2.info.output_tokens = 20
+    metric2.info.response_info.output_tokens = 20
     metric2.ttft_slo_sec = None
     metric2.tpot_slo_sec = None
 
@@ -148,7 +148,7 @@ def test_calculate_goodput_metrics_itl_constraint() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 
@@ -170,7 +170,7 @@ def test_calculate_goodput_metrics_ntpot_constraint() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 
@@ -192,7 +192,7 @@ def test_calculate_goodput_metrics_request_latency_constraint() -> None:
     metric1.end_time = 0.5
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 
@@ -214,7 +214,7 @@ def test_calculate_goodput_metrics_per_request_override() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = 0.2  # Stricter than global 0.5
     metric1.tpot_slo_sec = None
 
@@ -244,7 +244,7 @@ def test_calculate_goodput_metrics_individual_attainment() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 
@@ -253,7 +253,7 @@ def test_calculate_goodput_metrics_individual_attainment() -> None:
     metric2.end_time = 4.0
     metric2.info = Mock()
     metric2.info.input_tokens = 0
-    metric2.info.output_tokens = 20
+    metric2.info.response_info.output_tokens = 20
     metric2.ttft_slo_sec = None
     metric2.tpot_slo_sec = None
 
@@ -277,7 +277,7 @@ def test_calculate_goodput_metrics_ttft_none_fails() -> None:
     metric1.end_time = 2.0
     metric1.info = Mock()
     metric1.info.input_tokens = 0
-    metric1.info.output_tokens = 10
+    metric1.info.response_info.output_tokens = 10
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
 

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -15,7 +15,9 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock
 from inference_perf.apis import LazyLoadInferenceAPIData
-from inference_perf.datagen.random_datagen import RandomDataGenerator, LazyLoadDataMixin
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.datagen.random_datagen import RandomDataGenerator
+from inference_perf.datagen.base import LazyLoadDataMixin
 from inference_perf.config import APIConfig, DataConfig, APIType, TraceFormat, TraceConfig, DataGenType
 
 
@@ -72,6 +74,9 @@ class TestTraceReplay:
             assert timestamps[2] - timestamps[1] > 0.99
 
             # Token counts preserved
+            assert isinstance(data_list[0], CompletionAPIData)
+            assert isinstance(data_list[1], CompletionAPIData)
+            assert isinstance(data_list[2], CompletionAPIData)
             assert data_list[0].max_tokens == 50
             assert data_list[1].max_tokens == 75
             assert data_list[2].max_tokens == 60


### PR DESCRIPTION
Addresses: #453

Changes:
* Removed `disable_error_code = ["attr-defined"]` from `[tool.mypy]` in `pyproject.toml` and fixed 40 errors it surfaced.
* Added `set -euxo pipefail` to the test step (the previous `... |& tee test_e2e.out` masked failures via tee's exit code) and `if: always()` to the artifact upload so the log is preserved on failure. 
