### PR TITLE
Update catalog to capture multi-turn tool calling

### DIFF
--- a/workload-catalog/batch-summarization-rag/inference-perf.yaml
+++ b/workload-catalog/batch-summarization-rag/inference-perf.yaml
@@ -1,15 +1,15 @@
 load:
   type: concurrent
   stages:
-  - num_requests: 60
+  - num_requests: 450
     concurrency_level: 6
-  - num_requests: 120
+  - num_requests: 450
     concurrency_level: 12
-  - num_requests: 180
+  - num_requests: 450
     concurrency_level: 18
-  - num_requests: 240
+  - num_requests: 450
     concurrency_level: 24
-  - num_requests: 300
+  - num_requests: 450
     concurrency_level: 30
   num_workers: 1
 api:
@@ -20,26 +20,23 @@ server:
   model_name: google/gemma-3-1b-it
   base_url: http://localhost:8000
 data:
-  type: shared_prefix
-  shared_prefix:
-    num_groups: 10
-    num_prompts_per_group: 1
-    enable_multi_turn_chat: false
-    system_prompt_len:
-      min: 500
-      max: 500
-      mean: 500.0
-      std_dev: 0.0
+  type: conversation_replay
+  conversation_replay:
+    seed: 42
+    num_conversations: 30
+    shared_system_prompt_len: 500
+    turns_per_conversation:
+      type: fixed
+      mean: 1
+    input_tokens_per_turn:
       type: normal
-    question_len:
       min: 1000
       max: 80000
-      mean: 15000.0
-      std_dev: 22000.0
+      mean: 15000
+      std_dev: 22000
+    output_tokens_per_turn:
       type: normal
-    output_len:
       min: 50
       max: 2000
-      mean: 500.0
-      std_dev: 300.0
-      type: normal
+      mean: 500
+      std_dev: 300

--- a/workload-catalog/batch-synthetic-data-generation/inference-perf.yaml
+++ b/workload-catalog/batch-synthetic-data-generation/inference-perf.yaml
@@ -1,15 +1,15 @@
 load:
   type: concurrent
   stages:
-  - num_requests: 64
+  - num_requests: 160
     concurrency_level: 8
-  - num_requests: 128
+  - num_requests: 160
     concurrency_level: 16
-  - num_requests: 192
+  - num_requests: 160
     concurrency_level: 24
-  - num_requests: 256
+  - num_requests: 160
     concurrency_level: 32
-  - num_requests: 320
+  - num_requests: 160
     concurrency_level: 40
   num_workers: 1
 api:
@@ -20,26 +20,23 @@ server:
   model_name: google/gemma-3-1b-it
   base_url: http://localhost:8000
 data:
-  type: shared_prefix
-  shared_prefix:
-    num_groups: 10
-    num_prompts_per_group: 1
-    enable_multi_turn_chat: false
-    system_prompt_len:
-      min: 2000
-      max: 2000
-      mean: 2000.0
-      std_dev: 0.0
-      type: normal
-    question_len:
+  type: conversation_replay
+  conversation_replay:
+    seed: 42
+    num_conversations: 40
+    shared_system_prompt_len: 2000
+    turns_per_conversation:
+      type: fixed
+      mean: 1
+    input_tokens_per_turn:
+      type: lognormal
       min: 50
       max: 15000
-      mean: 500.0
-      std_dev: 1200.0
-      type: lognormal
-    output_len:
+      mean: 500
+      std_dev: 1200
+    output_tokens_per_turn:
+      type: uniform
       min: 500
       max: 8000
-      mean: 4000.0
-      std_dev: 2500.0
-      type: uniform
+      mean: 4000
+      std_dev: 2500

--- a/workload-catalog/code-generation/inference-perf.yaml
+++ b/workload-catalog/code-generation/inference-perf.yaml
@@ -1,15 +1,15 @@
 load:
   type: concurrent
   stages:
-  - num_requests: 80
+  - num_requests: 120
     concurrency_level: 4
-  - num_requests: 160
+  - num_requests: 120
     concurrency_level: 8
-  - num_requests: 240
+  - num_requests: 120
     concurrency_level: 12
-  - num_requests: 320
+  - num_requests: 120
     concurrency_level: 16
-  - num_requests: 400
+  - num_requests: 120
     concurrency_level: 20
   num_workers: 1
 api:
@@ -20,26 +20,38 @@ server:
   model_name: google/gemma-3-1b-it
   base_url: http://localhost:8000
 data:
-  type: shared_prefix
-  shared_prefix:
-    num_groups: 10
-    num_prompts_per_group: 6
-    enable_multi_turn_chat: true
-    system_prompt_len:
-      min: 3000
-      max: 3000
-      mean: 3000.0
-      std_dev: 0.0
+  type: conversation_replay
+  conversation_replay:
+    seed: 42
+    num_conversations: 20
+    shared_system_prompt_len: 3000
+    dynamic_system_prompt_len:
+      type: uniform
+      min: 15000
+      max: 120000
+      mean: 55000
+      std_dev: 25000
+    turns_per_conversation:
       type: normal
-    question_len:
+      min: 2
+      max: 20
+      mean: 6
+      std_dev: 3.5
+    input_tokens_per_turn:
+      type: lognormal
       min: 100
       max: 10000
-      mean: 1500.0
-      std_dev: 1200.0
+      mean: 1500
+      std_dev: 1200
+    output_tokens_per_turn:
       type: lognormal
-    output_len:
       min: 50
       max: 4000
-      mean: 800.0
-      std_dev: 600.0
+      mean: 800
+      std_dev: 600
+    tool_call_latency_sec:
       type: lognormal
+      min: 15
+      max: 120
+      mean: 45
+      std_dev: 25

--- a/workload-catalog/deep-research/inference-perf.yaml
+++ b/workload-catalog/deep-research/inference-perf.yaml
@@ -1,15 +1,15 @@
 load:
   type: concurrent
   stages:
-  - num_requests: 15
+  - num_requests: 50
     concurrency_level: 1
-  - num_requests: 30
+  - num_requests: 50
     concurrency_level: 2
-  - num_requests: 45
+  - num_requests: 50
     concurrency_level: 3
-  - num_requests: 60
+  - num_requests: 50
     concurrency_level: 4
-  - num_requests: 75
+  - num_requests: 50
     concurrency_level: 5
   num_workers: 1
 api:
@@ -20,26 +20,38 @@ server:
   model_name: google/gemma-3-1b-it
   base_url: http://localhost:8000
 data:
-  type: shared_prefix
-  shared_prefix:
-    num_groups: 10
-    num_prompts_per_group: 15
-    enable_multi_turn_chat: true
-    system_prompt_len:
+  type: conversation_replay
+  conversation_replay:
+    seed: 42
+    num_conversations: 5
+    shared_system_prompt_len: 2000
+    dynamic_system_prompt_len:
+      type: lognormal
       min: 2000
-      max: 2000
-      mean: 2000.0
-      std_dev: 0.0
+      max: 150000
+      mean: 45000
+      std_dev: 35000
+    turns_per_conversation:
       type: normal
-    question_len:
+      min: 2
+      max: 50
+      mean: 15
+      std_dev: 8.5
+    input_tokens_per_turn:
+      type: lognormal
       min: 500
       max: 15000
-      mean: 3000.0
-      std_dev: 2500.0
-      type: lognormal
-    output_len:
+      mean: 3000
+      std_dev: 2500
+    output_tokens_per_turn:
+      type: normal
       min: 50
       max: 4000
-      mean: 300.0
-      std_dev: 850.0
+      mean: 300
+      std_dev: 850
+    tool_call_latency_sec:
       type: normal
+      min: 5
+      max: 60
+      mean: 25
+      std_dev: 12

--- a/workload-catalog/interactive-chat/inference-perf.yaml
+++ b/workload-catalog/interactive-chat/inference-perf.yaml
@@ -1,15 +1,15 @@
 load:
   type: concurrent
   stages:
-  - num_requests: 600
+  - num_requests: 300
     concurrency_level: 10
-  - num_requests: 1200
+  - num_requests: 300
     concurrency_level: 20
-  - num_requests: 1800
+  - num_requests: 300
     concurrency_level: 30
-  - num_requests: 2400
+  - num_requests: 300
     concurrency_level: 40
-  - num_requests: 3000
+  - num_requests: 300
     concurrency_level: 50
   num_workers: 1
 api:
@@ -20,26 +20,38 @@ server:
   model_name: google/gemma-3-1b-it
   base_url: http://localhost:8000
 data:
-  type: shared_prefix
-  shared_prefix:
-    num_groups: 10
-    num_prompts_per_group: 4
-    enable_multi_turn_chat: true
-    system_prompt_len:
-      min: 1000
-      max: 1000
-      mean: 1000.0
-      std_dev: 0.0
-      type: normal
-    question_len:
-      min: 10
-      max: 1000
-      mean: 50.0
-      std_dev: 40.0
+  type: conversation_replay
+  conversation_replay:
+    seed: 42
+    num_conversations: 50
+    shared_system_prompt_len: 1000
+    dynamic_system_prompt_len:
       type: lognormal
-    output_len:
+      min: 500
+      max: 15000
+      mean: 4000
+      std_dev: 2500
+    turns_per_conversation:
+      type: lognormal
+      min: 1
+      max: 15
+      mean: 4
+      std_dev: 2.5
+    input_tokens_per_turn:
+      type: lognormal
       min: 10
       max: 1000
-      mean: 300.0
-      std_dev: 150.0
+      mean: 50
+      std_dev: 40
+    output_tokens_per_turn:
       type: normal
+      min: 10
+      max: 1000
+      mean: 300
+      std_dev: 150
+    tool_call_latency_sec:
+      type: lognormal
+      min: 5
+      max: 300
+      mean: 45
+      std_dev: 40

--- a/workload-catalog/reasoning/inference-perf.yaml
+++ b/workload-catalog/reasoning/inference-perf.yaml
@@ -1,15 +1,15 @@
 load:
   type: concurrent
   stages:
-  - num_requests: 8
+  - num_requests: 20
     concurrency_level: 2
-  - num_requests: 16
+  - num_requests: 20
     concurrency_level: 4
-  - num_requests: 24
+  - num_requests: 20
     concurrency_level: 6
-  - num_requests: 32
+  - num_requests: 20
     concurrency_level: 8
-  - num_requests: 40
+  - num_requests: 20
     concurrency_level: 10
   num_workers: 1
 api:
@@ -20,26 +20,23 @@ server:
   model_name: google/gemma-3-1b-it
   base_url: http://localhost:8000
 data:
-  type: shared_prefix
-  shared_prefix:
-    num_groups: 10
-    num_prompts_per_group: 1
-    enable_multi_turn_chat: false
-    system_prompt_len:
-      min: 250
-      max: 250
-      mean: 250.0
-      std_dev: 0.0
-      type: normal
-    question_len:
+  type: conversation_replay
+  conversation_replay:
+    seed: 42
+    num_conversations: 10
+    shared_system_prompt_len: 250
+    turns_per_conversation:
+      type: fixed
+      mean: 1
+    input_tokens_per_turn:
+      type: lognormal
       min: 100
       max: 5000
-      mean: 1000.0
-      std_dev: 800.0
+      mean: 1000
+      std_dev: 800
+    output_tokens_per_turn:
       type: lognormal
-    output_len:
       min: 500
       max: 32000
-      mean: 8000.0
-      std_dev: 6500.0
-      type: lognormal
+      mean: 8000
+      std_dev: 6500


### PR DESCRIPTION
This change updates the workload-catalog to use the new conversation-replay datagen so we can include tool calling turns and delays in a configurable manner. 