### PR TITLE
chore: allow virtual address style for s3 storage

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -107,6 +107,9 @@ These command line flags are automatically generated from the internal `Config` 
 | `--storage.simple_storage_service.path` | str | Matches storage.simple_storage_service.path in config |
 | `--storage.simple_storage_service.report_file_prefix` | str | Matches storage.simple_storage_service.report_file_prefix in config |
 | `--storage.simple_storage_service.bucket_name` | str | Matches storage.simple_storage_service.bucket_name in config |
+| `--storage.simple_storage_service.endpoint_url` | str | Matches storage.simple_storage_service.endpoint_url in config |
+| `--storage.simple_storage_service.region_name` | str | Matches storage.simple_storage_service.region_name in config |
+| `--storage.simple_storage_service.addressing_style` | string | Matches storage.simple_storage_service.addressing_style in config |
 | `--server.type` | Enum (vllm, sglang, tgi, mock) | Matches server.type in config |
 | `--server.model_name` | str | Matches server.model_name in config |
 | `--server.base_url` | str | Matches server.base_url in config |

--- a/docs/config.md
+++ b/docs/config.md
@@ -208,6 +208,9 @@ storage:
     bucket_name: "your-bucket-name"   # Required S3 bucket
     path: "reports-{timestamp}"       # Optional path prefix
     report_file_prefix: null          # Optional filename prefix
+    endpoint_url: null                # Optional custom endpoint (e.g. for S3-compatible stores)
+    region_name: null                 # Optional AWS region name
+    addressing_style: null            # Optional: "auto" (default), "virtual", or "path".
 ```
 
 ### Tokenizer

--- a/inference_perf/client/filestorage/s3.py
+++ b/inference_perf/client/filestorage/s3.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 import json
 import logging
-from typing import List
+from typing import Any, List, Optional
 import boto3
+from botocore.config import Config as BotoConfig
 from inference_perf.client.filestorage import StorageClient
 from inference_perf.config import SimpleStorageServiceConfig
 from inference_perf.utils import ReportFile
@@ -22,12 +23,33 @@ from inference_perf.utils import ReportFile
 logger = logging.getLogger(__name__)
 
 
+def _build_boto_config(addressing_style: Optional[str]) -> Optional[BotoConfig]:
+    """Build a botocore Config that honors the configured S3 addressing style.
+
+    Some S3-compatible object stores only accept virtual-hosted style requests
+    (`bucket.host/key`) and reject path-style (`host/bucket/key`) with a
+    `PathStyleRequestNotAllowed` error. Exposing this knob lets users target
+    those backends without relying on environment-specific AWS config files.
+    """
+    if addressing_style is None:
+        return None
+    return BotoConfig(s3={"addressing_style": addressing_style})
+
+
 class SimpleStorageServiceClient(StorageClient):
     def __init__(self, config: SimpleStorageServiceConfig) -> None:
         super().__init__(config=config)
         logger.debug("Created new S3 client")
         self.output_bucket = config.bucket_name
-        self.client = boto3.client("s3")
+        client_kwargs: dict[str, Any] = {}
+        if config.endpoint_url is not None:
+            client_kwargs["endpoint_url"] = config.endpoint_url
+        if config.region_name is not None:
+            client_kwargs["region_name"] = config.region_name
+        boto_config = _build_boto_config(config.addressing_style)
+        if boto_config is not None:
+            client_kwargs["config"] = boto_config
+        self.client = boto3.client("s3", **client_kwargs)
 
     def save_report(self, reports: List[ReportFile]) -> None:
         filenames = [report.get_filename() for report in reports]

--- a/inference_perf/config.py
+++ b/inference_perf/config.py
@@ -17,7 +17,7 @@ from enum import Enum
 from os import cpu_count
 import time
 from math import sqrt
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import yaml
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, HttpUrl, model_validator
@@ -435,6 +435,9 @@ class GoogleCloudStorageConfig(StorageConfigBase):
 
 class SimpleStorageServiceConfig(StorageConfigBase):
     bucket_name: str
+    endpoint_url: Optional[str] = None
+    region_name: Optional[str] = None
+    addressing_style: Optional[Literal["auto", "virtual", "path"]] = None
 
 
 class StorageConfig(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ module = [
     "datasets.*",
     "matplotlib.*",
     "boto3.*",
+    "botocore.*",
     "opentelemetry.*",
 ]
 ignore_missing_imports = true

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ from inference_perf.config import (
     read_config,
     ResponseFormat,
     ResponseFormatType,
+    SimpleStorageServiceConfig,
     StandardLoadStage,
     ConcurrentLoadStage,
     LoadConfig,
@@ -335,6 +336,35 @@ def test_distribution_variance_conversion() -> None:
 def test_distribution_both_variance_and_std_dev_error() -> None:
     with pytest.raises(Exception, match="Specify either"):
         Distribution(type=DistributionType.NORMAL, mean=100.0, std_dev=10.0, variance=100.0)
+
+
+def test_simple_storage_service_config_defaults() -> None:
+    config = SimpleStorageServiceConfig(bucket_name="my-bucket")
+
+    assert config.bucket_name == "my-bucket"
+    assert config.endpoint_url is None
+    assert config.region_name is None
+    assert config.addressing_style is None
+
+
+def test_simple_storage_service_config_accepts_addressing_overrides() -> None:
+    config = SimpleStorageServiceConfig(
+        bucket_name="my-bucket",
+        endpoint_url="https://s3.example.com",
+        region_name="us-east-1",
+        addressing_style="virtual",
+    )
+
+    assert config.endpoint_url == "https://s3.example.com"
+    assert config.region_name == "us-east-1"
+    assert config.addressing_style == "virtual"
+
+
+def test_simple_storage_service_config_rejects_invalid_addressing_style() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SimpleStorageServiceConfig(bucket_name="my-bucket", addressing_style="hosted")
 
 
 def test_goodput_config_parsing() -> None:


### PR DESCRIPTION
Allow the S3 config to accept the configurations needed to upload into S3 compatible services (like [CoreWeave Storage](https://docs.coreweave.com/products/storage/object-storage/about)) which match the S3 spec but require virtual hosted-style URLs