### PR TITLE
Fix RuntimeError on conversation_replay request failure

### DIFF
--- a/inference_perf/apis/user_session.py
+++ b/inference_perf/apis/user_session.py
@@ -78,7 +78,12 @@ class LocalUserSession:
             future = self._waiting_rounds.get_nowait()
             future.set_result(True)
 
-        self._in_flight.release()
+        # Release defensively: failure paths can call update_context after the
+        # success path already released (e.g. process_response raises post-release,
+        # then process_failure runs), so calling release() unconditionally raises
+        # RuntimeError("Lock is not acquired."). Skip if already released.
+        if self._in_flight.locked():
+            self._in_flight.release()
 
 
 class UserSessionCompletionAPIData(CompletionAPIData):

--- a/tests/loadgen/test_multi_turn_hang.py
+++ b/tests/loadgen/test_multi_turn_hang.py
@@ -128,6 +128,32 @@ class TestMultiTurnHang(unittest.IsolatedAsyncioTestCase):
         except asyncio.TimeoutError:
             self.fail("Should NOT have hung on request 1 after failure release!")
 
+    async def test_update_context_idempotent_on_double_release(self) -> None:
+        """Regression: process_response can release the session lock and then
+        raise (e.g. broken SSE stream after partial parse), causing the outer
+        openai_client handler to invoke process_failure, which calls
+        update_context again. The second release must be a no-op rather than
+        raising RuntimeError("Lock is not acquired."), since that would kill
+        the loadgen task and stall the conversation slot.
+        """
+        session = LocalUserSession("conv_double_release")
+        await session.get_context(0)  # acquire (to_payload)
+        session.update_context("first response")  # first release (process_response success)
+
+        # Second release simulates process_failure being invoked after
+        # process_response already released the lock.
+        try:
+            session.update_context("failure context")
+        except RuntimeError as e:
+            self.fail(f"Second update_context raised: {e}")
+
+        # Lock should be free; next get_context must not hang.
+        try:
+            ctx = await asyncio.wait_for(session.get_context(1), timeout=2.0)
+        except asyncio.TimeoutError:
+            self.fail("get_context hung after double release")
+        self.assertEqual(ctx, "failure context")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When a conversation_replay request fails, both the success and failure paths in openai_client can call `LocalUserSession.update_context` — once when `process_response` raises after partially handling the body, and again when the outer except handler invokes `process_failure`. The second call hit `self._in_flight.release()` on an already-released lock and raised `RuntimeError: Lock is not acquired`, which killed the loadgen task and cascaded into stalled stages once a few conversations hit it.

Make `release()` idempotent: skip it when the lock isn't held. The wake-up signal (`future.set_result(True)`) still fires so any waiter is unblocked normally; the next `get_context` will re-acquire cleanly.

Reproduces with code-generation workload at concurrency >= 4 where some turns time out or return non-200 responses.