### PR TITLE
Surface prompt cache token metrics in lifecycle summary

### DIFF
--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -64,6 +64,26 @@ def summarize(items: List[float], percentiles: List[float]) -> Optional[dict[str
     return result
 
 
+def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric]) -> dict[str, float]:
+    prompt_tokens_total = 0.0
+    prompt_tokens_cached = 0.0
+
+    for metric in metrics:
+        response_metrics = metric.info.response_metrics
+        server_usage = response_metrics.server_usage if isinstance(response_metrics, StreamedResponseMetrics) else None
+        prompt_tokens = server_usage.get("prompt_tokens") if server_usage else metric.info.request_metrics.text.input_tokens
+        prompt_tokens_details = server_usage.get("prompt_tokens_details", {}) if server_usage else {}
+
+        prompt_tokens_total += safe_float(prompt_tokens)
+        prompt_tokens_cached += safe_float(prompt_tokens_details.get("cached_tokens"))
+
+    return {
+        "total": prompt_tokens_total,
+        "cached": prompt_tokens_cached,
+        "uncached": max(prompt_tokens_total - prompt_tokens_cached, 0.0),
+    }
+
+
 class ResponsesSummary(BaseModel):
     benchmark_time_seconds: float
     load_summary: dict[str, Any]
@@ -567,6 +587,7 @@ def summarize_requests(
             "seconds": summarize([safe_float(inst.seconds) for inst in all_audios], percentiles),
             "bytes": summarize([safe_float(inst.bytes) for inst in all_audios], percentiles),
         },
+        "prompt_tokens": summarize_prompt_token_usage(all_successful),
         "output_len": summarize(
             [
                 float(v)

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -128,3 +128,29 @@ def test_summarize_requests_multiple_tokens_same_timestamp() -> None:
 
     assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
     assert metric.info.response_metrics.output_token_times == [1.0, 1.0, 1.0]
+
+
+def test_summarize_requests_surfaces_prompt_cache_usage() -> None:
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=10)),
+        response_metrics=StreamedResponseMetrics(
+            output_tokens=2,
+            server_usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "prompt_tokens_details": {"cached_tokens": 6},
+            },
+        ),
+    )
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="test_request", info=info, error=None
+    )
+
+    result = summarize_requests([metric], [50])
+
+    assert result.successes["prompt_tokens"] == {
+        "total": 10.0,
+        "cached": 6.0,
+        "uncached": 4.0,
+    }


### PR DESCRIPTION
Fixes #467.

## Summary
- add `successes.prompt_tokens` with total/cached/uncached counts in request lifecycle summaries
- read vLLM/OpenAI-compatible `usage.prompt_tokens_details.cached_tokens` from streamed `server_usage`
- cover the summary output with a focused unit test

## Validation
- `uv run --group lint ruff format --check inference_perf tests scripts`
- `uv run --group lint ruff check`
- `uv run --group lint --group test --group types mypy --strict ./inference_perf ./tests`
- `uv run --extra analysis --group test pytest tests`
