### PR TITLE
regenerate system prompts per stage in conversation replay

### DIFF
--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -94,7 +94,7 @@ class InferenceAPIData(BaseModel):
     preferred_worker_id: int = -1  # no preferred worker by default
     session_id: Optional[str] = None  # set by loadgen for session-based workloads
     otel_context: Optional[dict[str, str]] = None  # OTEL trace context for distributed tracing
-    stage_idx: int = 0 # stage id
+    stage_idx: int = 0  # stage id
 
     @abstractmethod
     def get_api_type(self) -> APIType:

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -94,6 +94,7 @@ class InferenceAPIData(BaseModel):
     preferred_worker_id: int = -1  # no preferred worker by default
     session_id: Optional[str] = None  # set by loadgen for session-based workloads
     otel_context: Optional[dict[str, str]] = None  # OTEL trace context for distributed tracing
+    stage_idx: int = 0 # stage id
 
     @abstractmethod
     def get_api_type(self) -> APIType:

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -94,7 +94,7 @@ class InferenceAPIData(BaseModel):
     preferred_worker_id: int = -1  # no preferred worker by default
     session_id: Optional[str] = None  # set by loadgen for session-based workloads
     otel_context: Optional[dict[str, str]] = None  # OTEL trace context for distributed tracing
-    stage_idx: int = 0  # stage id
+    stage_id: int = 0  # stage id
 
     @abstractmethod
     def get_api_type(self) -> APIType:

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -37,6 +37,7 @@ of one run) to avoid context accumulating across concurrency levels.
 """
 
 import asyncio
+import hashlib
 import logging
 from dataclasses import dataclass, field
 from typing import Generator, List, Optional
@@ -218,8 +219,13 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         # system_prompt the conversation was built around.
         expected_session_id = self.user_sessions[conv_idx].user_session_id
         if expected_session_id not in LocalUserSession._instances:
-            # Regenerate the entire system prompt for this stage
-            bp.system_prompt = self._generate_random_token_text(bp.system_prompt_tokens)
+            # Regenerate the entire system prompt for this stage using a derived stable seed.
+            seed_str = f"{self.cr_config.seed}_stage_{data.stage_idx}"
+            hash_digest = hashlib.sha256(seed_str.encode('utf-8')).digest()
+            derived_seed = int.from_bytes(hash_digest[:4], byteorder='little')
+            local_rng = np.random.default_rng(derived_seed)
+            
+            bp.system_prompt = self._generate_random_token_text(bp.system_prompt_tokens, rng=local_rng)
             self.user_sessions[conv_idx] = self._new_session(
                 user_session_id=expected_session_id,
                 context=bp.system_prompt,
@@ -289,13 +295,14 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         arr = sample_from_distribution(dist, count, rng=self.rng)
         return [int(v) for v in arr]
 
-    def _generate_random_token_text(self, num_tokens: int) -> str:
+    def _generate_random_token_text(self, num_tokens: int, rng: Optional[np.random.Generator] = None) -> str:
         """Generate random text that is approximately ``num_tokens`` long."""
         if num_tokens <= 0:
             return ""
         assert self.tokenizer is not None
         hf_tokenizer = self.tokenizer.get_tokenizer()
-        token_ids = self.rng.integers(0, self.vocab_size, size=num_tokens).tolist()
+        use_rng = rng if rng is not None else self.rng
+        token_ids = use_rng.integers(0, self.vocab_size, size=num_tokens).tolist()
         return str(hf_tokenizer.decode(token_ids, skip_special_tokens=True))
 
     def _build_conversations(self) -> None:

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -221,10 +221,10 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         if expected_session_id not in LocalUserSession._instances:
             # Regenerate the entire system prompt for this stage using a derived stable seed.
             seed_str = f"{self.cr_config.seed}_stage_{data.stage_idx}"
-            hash_digest = hashlib.sha256(seed_str.encode('utf-8')).digest()
-            derived_seed = int.from_bytes(hash_digest[:4], byteorder='little')
+            hash_digest = hashlib.sha256(seed_str.encode("utf-8")).digest()
+            derived_seed = int.from_bytes(hash_digest[:4], byteorder="little")
             local_rng = np.random.default_rng(derived_seed)
-            
+
             bp.system_prompt = self._generate_random_token_text(bp.system_prompt_tokens, rng=local_rng)
             self.user_sessions[conv_idx] = self._new_session(
                 user_session_id=expected_session_id,

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -126,6 +126,7 @@ class ConversationBlueprint:
     conversation_id: int
     num_turns: int
     system_prompt: str
+    system_prompt_tokens: int
     turn_prompts: List[str] = field(default_factory=list)
     turn_output_lens: List[int] = field(default_factory=list)
     turn_tool_call_latencies: List[float] = field(default_factory=list)
@@ -217,11 +218,13 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         # system_prompt the conversation was built around.
         expected_session_id = self.user_sessions[conv_idx].user_session_id
         if expected_session_id not in LocalUserSession._instances:
+            # Regenerate the entire system prompt for this stage
+            bp.system_prompt = self._generate_random_token_text(bp.system_prompt_tokens)
             self.user_sessions[conv_idx] = self._new_session(
                 user_session_id=expected_session_id,
                 context=bp.system_prompt,
             )
-            logger.debug("Slot %d: re-primed cleared session %s", conv_idx, expected_session_id)
+            logger.debug("Slot %d: refreshed system prompt and re-primed session %s", conv_idx, expected_session_id)
 
         # Closed-loop replenishment: when a conversation finishes all its turns,
         # reset the session so the slot immediately starts a fresh conversation.
@@ -366,6 +369,7 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
                 conversation_id=conv_id,
                 num_turns=num_turns,
                 system_prompt=system_prompt,
+                system_prompt_tokens=cfg.shared_system_prompt_len + dynamic_lens[conv_id],
                 turn_prompts=turn_prompts,
                 turn_output_lens=turn_output_lens_list,
                 turn_tool_call_latencies=turn_tool_latencies,

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -128,6 +128,7 @@ class ConversationBlueprint:
     num_turns: int
     system_prompt: str
     system_prompt_tokens: int
+    dynamic_system_prompt: str = ""
     turn_prompts: List[str] = field(default_factory=list)
     turn_output_lens: List[int] = field(default_factory=list)
     turn_tool_call_latencies: List[float] = field(default_factory=list)
@@ -179,6 +180,10 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         # Seeded RNG for deterministic generation
         self.rng = np.random.default_rng(self.cr_config.seed)
 
+        # Cache for the currently active stage's shared system prompt
+        self._current_stage_id: Optional[int] = None
+        self._current_shared_prompt: Optional[str] = None
+
         # Build conversation blueprints
         self.blueprints: List[ConversationBlueprint] = []
         self.user_sessions: List[LocalUserSession] = []
@@ -219,13 +224,10 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         # system_prompt the conversation was built around.
         expected_session_id = self.user_sessions[conv_idx].user_session_id
         if expected_session_id not in LocalUserSession._instances:
-            # Regenerate the entire system prompt for this stage using a derived stable seed.
-            seed_str = f"{self.cr_config.seed}_stage_{data.stage_idx}"
-            hash_digest = hashlib.sha256(seed_str.encode("utf-8")).digest()
-            derived_seed = int.from_bytes(hash_digest[:4], byteorder="little")
-            local_rng = np.random.default_rng(derived_seed)
+            # Get or generate the shared system prompt for this stage.
+            shared_prompt = self._get_or_generate_shared_prompt(data.stage_id)
+            bp.system_prompt = self._build_system_prompt(shared_prompt, bp.dynamic_system_prompt)
 
-            bp.system_prompt = self._generate_random_token_text(bp.system_prompt_tokens, rng=local_rng)
             self.user_sessions[conv_idx] = self._new_session(
                 user_session_id=expected_session_id,
                 context=bp.system_prompt,
@@ -290,6 +292,34 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         LocalUserSession._instances[user_session_id] = session
         return session
 
+    def _get_or_generate_shared_prompt(self, stage_id: int) -> str:
+        """Get or generate the shared system prompt prefix for a specific stage using a derived stable seed."""
+        if self._current_shared_prompt is None or self._current_stage_id != stage_id:
+            if stage_id == 0:
+                # BACKWARDS COMPATIBILITY: Stage 0 must use the shared global self.rng
+                # to maintain the exact sequence of calls at startup, ensuring existing
+                # benchmark seeds generate identical conversation blueprints.
+                self._current_shared_prompt = self._generate_random_token_text(
+                    self.cr_config.shared_system_prompt_len
+                )
+            else:
+                # Later stages derive their seed stably from the base seed and stage ID.
+                # This happens dynamically at runtime (post-setup) and uses local isolated RNGs.
+                seed_str = f"{self.cr_config.seed}_stage_{stage_id}"
+                hash_digest = hashlib.sha256(seed_str.encode("utf-8")).digest()
+                derived_seed = int.from_bytes(hash_digest[:4], byteorder="little")
+                local_rng = np.random.default_rng(derived_seed)
+
+                self._current_shared_prompt = self._generate_random_token_text(
+                    self.cr_config.shared_system_prompt_len, rng=local_rng
+                )
+            self._current_stage_id = stage_id
+        return self._current_shared_prompt
+
+    def _build_system_prompt(self, shared_prompt: str, dynamic_prompt: str) -> str:
+        """Combine shared prompt prefix and dynamic prompt suffix with a space."""
+        return f"{shared_prompt} {dynamic_prompt}" if dynamic_prompt else shared_prompt
+
     def _sample_distribution(self, dist: Distribution, count: int) -> List[int]:
         """Sample ``count`` values from a Distribution."""
         arr = sample_from_distribution(dist, count, rng=self.rng)
@@ -321,8 +351,8 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         else:
             dynamic_lens = [0] * n
 
-        # Generate shared system prompt once
-        shared_prompt_text = self._generate_random_token_text(cfg.shared_system_prompt_len)
+        # Generate shared system prompt once (for stage 0)
+        shared_prompt_text = self._get_or_generate_shared_prompt(0)
 
         total_turns = sum(turn_counts)
         logger.info(
@@ -359,7 +389,7 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
 
             # Two-part system prompt: shared prefix + dynamic suffix
             dynamic_text = self._generate_random_token_text(dynamic_lens[conv_id])
-            system_prompt = shared_prompt_text + " " + dynamic_text if dynamic_text else shared_prompt_text
+            system_prompt = self._build_system_prompt(shared_prompt_text, dynamic_text)
 
             # Generate turn prompts via batch decode
             turn_input_lens = all_input_lens[turn_offset : turn_offset + num_turns]
@@ -377,6 +407,7 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
                 num_turns=num_turns,
                 system_prompt=system_prompt,
                 system_prompt_tokens=cfg.shared_system_prompt_len + dynamic_lens[conv_id],
+                dynamic_system_prompt=dynamic_text,
                 turn_prompts=turn_prompts,
                 turn_output_lens=turn_output_lens_list,
                 turn_tool_call_latencies=turn_tool_latencies,

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -18,7 +18,7 @@ from inference_perf.utils.trace_reader import AzurePublicDatasetReader
 from inference_perf.utils.request_queue import RequestQueue
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
 from inference_perf.datagen import DataGenerator, SessionGenerator, LazyLoadDataMixin
-from inference_perf.apis import InferenceAPIData, LazyLoadInferenceAPIData
+from inference_perf.apis import InferenceAPIData
 from inference_perf.apis.user_session import LocalUserSession
 from inference_perf.client.modelserver import ModelServerClient
 from inference_perf.client.modelserver.otel_instrumentation import get_otel_instrumentation

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -18,7 +18,7 @@ from inference_perf.utils.trace_reader import AzurePublicDatasetReader
 from inference_perf.utils.request_queue import RequestQueue
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
 from inference_perf.datagen import DataGenerator, SessionGenerator, LazyLoadDataMixin
-from inference_perf.apis import InferenceAPIData
+from inference_perf.apis import InferenceAPIData, LazyLoadInferenceAPIData
 from inference_perf.apis.user_session import LocalUserSession
 from inference_perf.client.modelserver import ModelServerClient
 from inference_perf.client.modelserver.otel_instrumentation import get_otel_instrumentation
@@ -218,6 +218,7 @@ class Worker(mp.Process):
 
                 try:
                     stage_id, request, request_time, lora_adapter = item
+                    request.stage_idx = stage_id
                     request_data = LazyLoadDataMixin.get_request(self.datagen, request)
                 except Exception as e:
                     logger.error(f"[Worker {self.id}] Failed to get request: {e}", exc_info=True)
@@ -1081,6 +1082,7 @@ class LoadGenerator:
                     for count, (data, time_index) in enumerate(zip(self.datagen.get_data(), time_generator, strict=True)):
                         if progress and stage_task:
                             progress.update(stage_task, completed=count + 1)
+                        data.stage_idx = stage_id
                         request_data = LazyLoadDataMixin.get_request(self.datagen, data)
                         lora_adapter = self._get_lora_adapter()
                         if cb := next((cb for cb in self.circuit_breakers if cb.is_open()), None):

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -218,7 +218,6 @@ class Worker(mp.Process):
 
                 try:
                     stage_id, request, request_time, lora_adapter = item
-                    request.stage_idx = stage_id
                     request_data = LazyLoadDataMixin.get_request(self.datagen, request)
                 except Exception as e:
                     logger.error(f"[Worker {self.id}] Failed to get request: {e}", exc_info=True)
@@ -529,9 +528,10 @@ class LoadGenerator:
                 if worker_id >= 0:
                     worker_id = worker_id % active_workers
 
-                # Stamp session_id and OTEL context so workers can use them
+                # Stamp session_id, OTEL context, and stage_id so workers/generators can use them
                 lazy_data.session_id = session_id
                 lazy_data.otel_context = context_dict  # Embed OTEL context in data
+                lazy_data.stage_id = stage_id
 
                 event_time = time.perf_counter()
                 queue_data = RequestQueueData(stage_id, lazy_data, event_time, lora_adapter)
@@ -748,6 +748,7 @@ class LoadGenerator:
 
         for _ in range(num_requests):
             request_data = next(data_generator)
+            request_data.stage_id = stage_id
             lora_adapter = self._get_lora_adapter()
             worker_id = request_data.preferred_worker_id
             if worker_id >= 0:
@@ -1082,7 +1083,7 @@ class LoadGenerator:
                     for count, (data, time_index) in enumerate(zip(self.datagen.get_data(), time_generator, strict=True)):
                         if progress and stage_task:
                             progress.update(stage_task, completed=count + 1)
-                        data.stage_idx = stage_id
+                        data.stage_id = stage_id
                         request_data = LazyLoadDataMixin.get_request(self.datagen, data)
                         lora_adapter = self._get_lora_adapter()
                         if cb := next((cb for cb in self.circuit_breakers if cb.is_open()), None):

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -238,9 +238,9 @@ class TestConversationReplayDataGenerator:
         mock_tok = _make_mock_tokenizer()
         texts = [f"text_{i}" for i in range(100)]
         mock_tok.get_tokenizer().decode.side_effect = texts
-        
+
         gen = ConversationReplayDataGenerator(api_config, data_config, mock_tok)
-        
+
         last_contexts = {i: "" for i in range(3)}
 
         for _ in range(3):
@@ -300,8 +300,8 @@ class TestConversationReplayDataGenerator:
             output_tokens_per_turn=Distribution(type="fixed", min=10, max=10, mean=10, std_dev=0),
         )
         data_config = DataConfig(type=DataGenType.ConversationReplay, conversation_replay=cr_config)
-        
-        def make_deterministic_mock_tok():
+
+        def make_deterministic_mock_tok() -> MagicMock:
             mock_tok = MagicMock()
             hf_tok = MagicMock()
             hf_tok.vocab_size = 32000
@@ -314,9 +314,9 @@ class TestConversationReplayDataGenerator:
         # Stage 0
         gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
         context1_stage0 = LocalUserSession._instances["conv_0"].context
-        
+
         LocalUserSession.clear_instances()
-        
+
         # Stage 1
         gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_idx=1))
         context1_stage1 = LocalUserSession._instances["conv_0"].context
@@ -329,19 +329,19 @@ class TestConversationReplayDataGenerator:
         # Stage 0
         gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
         context2_stage0 = LocalUserSession._instances["conv_0"].context
-        
+
         LocalUserSession.clear_instances()
-        
+
         # Stage 1
         gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_idx=1))
         context2_stage1 = LocalUserSession._instances["conv_0"].context
 
         # Verify reproducibility across runs for Stage 0
         assert context1_stage0 == context2_stage0
-        
+
         # Verify reproducibility across runs for Stage 1
         assert context1_stage1 == context2_stage1
-        
+
         # Verify that prompts are DIFFERENT across stages within Run 2
         assert context2_stage0 != context2_stage1
 
@@ -357,8 +357,8 @@ class TestConversationReplayDataGenerator:
             output_tokens_per_turn=Distribution(type="fixed", min=10, max=10, mean=10, std_dev=0),
         )
         data_config = DataConfig(type=DataGenType.ConversationReplay, conversation_replay=cr_config)
-        
-        def make_deterministic_mock_tok():
+
+        def make_deterministic_mock_tok() -> MagicMock:
             mock_tok = MagicMock()
             hf_tok = MagicMock()
             hf_tok.vocab_size = 32000
@@ -367,14 +367,14 @@ class TestConversationReplayDataGenerator:
             return mock_tok
 
         gen = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
-        
+
         # Stage 0
         gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
         gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_idx=0))
-        
+
         context_conv0 = LocalUserSession._instances["conv_0"].context
         context_conv1 = LocalUserSession._instances["conv_1"].context
-        
+
         assert context_conv0 == context_conv1
 
 

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -287,6 +287,96 @@ class TestConversationReplayDataGenerator:
             # All within bounds
             assert all(1 <= lat <= 30 for lat in bp.turn_tool_call_latencies)
 
+    def test_reproducibility_across_runs_with_stages(self) -> None:
+        """Verify that two independent runs with the same seed generate
+        the same system prompt for the same stage."""
+        api_config = APIConfig(type=APIType.Completion)
+        cr_config = ConversationReplayConfig(
+            seed=42,
+            num_conversations=2,
+            shared_system_prompt_len=50,
+            turns_per_conversation=Distribution(type="fixed", min=1, max=1, mean=1, std_dev=0),
+            input_tokens_per_turn=Distribution(type="fixed", min=10, max=10, mean=10, std_dev=0),
+            output_tokens_per_turn=Distribution(type="fixed", min=10, max=10, mean=10, std_dev=0),
+        )
+        data_config = DataConfig(type=DataGenType.ConversationReplay, conversation_replay=cr_config)
+        
+        def make_deterministic_mock_tok():
+            mock_tok = MagicMock()
+            hf_tok = MagicMock()
+            hf_tok.vocab_size = 32000
+            hf_tok.decode.side_effect = lambda ids, **kwargs: f"decoded_{ids}"
+            mock_tok.get_tokenizer.return_value = hf_tok
+            return mock_tok
+
+        # Run 1
+        gen1 = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
+        # Stage 0
+        gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
+        context1_stage0 = LocalUserSession._instances["conv_0"].context
+        
+        LocalUserSession.clear_instances()
+        
+        # Stage 1
+        gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_idx=1))
+        context1_stage1 = LocalUserSession._instances["conv_0"].context
+
+        # Isolate Run 2
+        LocalUserSession.clear_instances()
+
+        # Run 2
+        gen2 = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
+        # Stage 0
+        gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
+        context2_stage0 = LocalUserSession._instances["conv_0"].context
+        
+        LocalUserSession.clear_instances()
+        
+        # Stage 1
+        gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_idx=1))
+        context2_stage1 = LocalUserSession._instances["conv_0"].context
+
+        # Verify reproducibility across runs for Stage 0
+        assert context1_stage0 == context2_stage0
+        
+        # Verify reproducibility across runs for Stage 1
+        assert context1_stage1 == context2_stage1
+        
+        # Verify that prompts are DIFFERENT across stages within Run 2
+        assert context2_stage0 != context2_stage1
+
+    def test_shared_system_prompt_within_stage(self) -> None:
+        """Verify that different conversations in the same stage have the same system prompt."""
+        api_config = APIConfig(type=APIType.Completion)
+        cr_config = ConversationReplayConfig(
+            seed=42,
+            num_conversations=2,
+            shared_system_prompt_len=50,
+            turns_per_conversation=Distribution(type="fixed", min=1, max=1, mean=1, std_dev=0),
+            input_tokens_per_turn=Distribution(type="fixed", min=10, max=10, mean=10, std_dev=0),
+            output_tokens_per_turn=Distribution(type="fixed", min=10, max=10, mean=10, std_dev=0),
+        )
+        data_config = DataConfig(type=DataGenType.ConversationReplay, conversation_replay=cr_config)
+        
+        def make_deterministic_mock_tok():
+            mock_tok = MagicMock()
+            hf_tok = MagicMock()
+            hf_tok.vocab_size = 32000
+            hf_tok.decode.side_effect = lambda ids, **kwargs: f"decoded_{ids}"
+            mock_tok.get_tokenizer.return_value = hf_tok
+            return mock_tok
+
+        gen = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
+        
+        # Stage 0
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_idx=0))
+        
+        context_conv0 = LocalUserSession._instances["conv_0"].context
+        context_conv1 = LocalUserSession._instances["conv_1"].context
+        
+        assert context_conv0 == context_conv1
+
 
 class TestDistributionExtensions:
     def test_lognormal_distribution(self) -> None:

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -211,41 +211,45 @@ class TestConversationReplayDataGenerator:
         assert isinstance(result, _ConversationReplayAPIData)
         assert result.tool_call_latency_sec == 5.0
 
-    def test_load_lazy_data_reprimes_after_clear_instances(self) -> None:
+    def test_load_lazy_data_regenerates_after_clear_instances(self) -> None:
         """After LoadGenerator clears the session registry between stages,
-        load_lazy_data must re-register the session with its original
-        system_prompt so subsequent requests still send the full context."""
+        load_lazy_data must regenerate the system_prompt for the slot."""
         api_config, data_config = _make_config(num_conversations=3)
         gen = ConversationReplayDataGenerator(api_config, data_config, _make_mock_tokenizer())
 
         original_contexts = {bp.conversation_id: bp.system_prompt for bp in gen.blueprints}
         assert all(f"conv_{i}" in LocalUserSession._instances for i in range(3))
 
-        # Simulate LoadGenerator's between-stage cleanup (PR #459).
+        # Simulate LoadGenerator's between-stage cleanup.
         LocalUserSession.clear_instances()
         assert LocalUserSession._instances == {}
 
-        # First request after the clear should re-prime the slot it touches.
+        # First request after the clear should re-prime the slot it touches AND regenerate prompt.
         gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1))
 
         assert "conv_1" in LocalUserSession._instances
-        assert LocalUserSession._instances["conv_1"].context == original_contexts[1]
-        # Other slots are re-primed lazily on their own first request, not eagerly.
-        assert "conv_0" not in LocalUserSession._instances
-        assert "conv_2" not in LocalUserSession._instances
+        # It should be different from original
+        assert LocalUserSession._instances["conv_1"].context != original_contexts[1]
 
-    def test_system_prompt_preserved_across_repeated_clears(self) -> None:
-        """Across multiple stage transitions, each re-prime must restore the
-        same system_prompt the blueprint was built with — not a fresh sample."""
+    def test_system_prompt_regenerated_across_repeated_clears(self) -> None:
+        """Across multiple stage transitions, each re-prime must regenerate a fresh system_prompt."""
         api_config, data_config = _make_config(num_conversations=3)
-        gen = ConversationReplayDataGenerator(api_config, data_config, _make_mock_tokenizer())
-        original_contexts = {bp.conversation_id: bp.system_prompt for bp in gen.blueprints}
+        # Use a tokenizer that returns different text each time to verify regeneration
+        mock_tok = _make_mock_tokenizer()
+        texts = [f"text_{i}" for i in range(100)]
+        mock_tok.get_tokenizer().decode.side_effect = texts
+        
+        gen = ConversationReplayDataGenerator(api_config, data_config, mock_tok)
+        
+        last_contexts = {i: "" for i in range(3)}
 
-        for _ in range(4):
+        for _ in range(3):
             LocalUserSession.clear_instances()
             for conv_idx in range(3):
                 gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=conv_idx, preferred_worker_id=conv_idx))
-                assert LocalUserSession._instances[f"conv_{conv_idx}"].context == original_contexts[conv_idx]
+                current_context = LocalUserSession._instances[f"conv_{conv_idx}"].context
+                assert current_context != last_contexts[conv_idx]
+                last_contexts[conv_idx] = current_context
 
     def test_load_lazy_data_does_not_replace_live_session(self) -> None:
         """When the registry still holds the session (mid-stage), load_lazy_data

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tests for ConversationReplayDataGenerator."""
 
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
 from unittest.mock import MagicMock
@@ -49,8 +49,8 @@ def _make_mock_tokenizer(vocab_size: int = 32000) -> MagicMock:
     mock_tokenizer = MagicMock()
     hf_tok = MagicMock()
     hf_tok.vocab_size = vocab_size
-    hf_tok.decode.return_value = "mock decoded text"
-    hf_tok.batch_decode.return_value = ["mock decoded text"]
+    hf_tok.decode.side_effect = lambda ids, **kwargs: f"decoded_{ids}"
+    hf_tok.batch_decode.side_effect = lambda list_ids, **kwargs: [f"decoded_{ids}" for ids in list_ids]
     mock_tokenizer.get_tokenizer.return_value = hf_tok
     return mock_tokenizer
 
@@ -225,7 +225,7 @@ class TestConversationReplayDataGenerator:
         assert LocalUserSession._instances == {}
 
         # First request after the clear should re-prime the slot it touches AND regenerate prompt.
-        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_id=1))
 
         assert "conv_1" in LocalUserSession._instances
         # It should be different from original
@@ -243,10 +243,10 @@ class TestConversationReplayDataGenerator:
 
         last_contexts = {i: "" for i in range(3)}
 
-        for _ in range(3):
+        for stage_idx in range(3):
             LocalUserSession.clear_instances()
             for conv_idx in range(3):
-                gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=conv_idx, preferred_worker_id=conv_idx))
+                gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=conv_idx, preferred_worker_id=conv_idx, stage_id=stage_idx))
                 current_context = LocalUserSession._instances[f"conv_{conv_idx}"].context
                 assert current_context != last_contexts[conv_idx]
                 last_contexts[conv_idx] = current_context
@@ -312,13 +312,13 @@ class TestConversationReplayDataGenerator:
         # Run 1
         gen1 = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
         # Stage 0
-        gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
+        gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_id=0))
         context1_stage0 = LocalUserSession._instances["conv_0"].context
 
         LocalUserSession.clear_instances()
 
         # Stage 1
-        gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_idx=1))
+        gen1.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_id=1))
         context1_stage1 = LocalUserSession._instances["conv_0"].context
 
         # Isolate Run 2
@@ -327,13 +327,13 @@ class TestConversationReplayDataGenerator:
         # Run 2
         gen2 = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
         # Stage 0
-        gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
+        gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_id=0))
         context2_stage0 = LocalUserSession._instances["conv_0"].context
 
         LocalUserSession.clear_instances()
 
         # Stage 1
-        gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_idx=1))
+        gen2.load_lazy_data(LazyLoadInferenceAPIData(data_index=2, preferred_worker_id=0, stage_id=1))
         context2_stage1 = LocalUserSession._instances["conv_0"].context
 
         # Verify reproducibility across runs for Stage 0
@@ -369,15 +369,93 @@ class TestConversationReplayDataGenerator:
         gen = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
 
         # Stage 0
-        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_idx=0))
-        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_idx=0))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_id=0))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_id=0))
 
-        context_conv0 = LocalUserSession._instances["conv_0"].context
-        context_conv1 = LocalUserSession._instances["conv_1"].context
+        context_conv0_s0 = LocalUserSession._instances["conv_0"].context
+        context_conv1_s0 = LocalUserSession._instances["conv_1"].context
+        assert context_conv0_s0 == context_conv1_s0
 
-        assert context_conv0 == context_conv1
+        # Transition to Stage 1
+        LocalUserSession.clear_instances()
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_id=1))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_id=1))
 
+        context_conv0_s1 = LocalUserSession._instances["conv_0"].context
+        context_conv1_s1 = LocalUserSession._instances["conv_1"].context
+        
+        # Verify they are still identical in Stage 1
+        assert context_conv0_s1 == context_conv1_s1
+        # Verify Stage 1 prompt is different from Stage 0 prompt
+        assert context_conv0_s1 != context_conv0_s0
 
+    def test_unique_system_prompt_within_stage_after_clear(self) -> None:
+        """Verify that different conversations with dynamic_system_prompt_len get unique system prompts after stage clear."""
+        api_config, data_config = _make_config(num_conversations=2)
+        def make_deterministic_mock_tok() -> MagicMock:
+            mock_tok = MagicMock()
+            hf_tok = MagicMock()
+            hf_tok.vocab_size = 32000
+            hf_tok.decode.side_effect = lambda ids, **kwargs: f"decoded_{ids}"
+            mock_tok.get_tokenizer.return_value = hf_tok
+            return mock_tok
+
+        gen = ConversationReplayDataGenerator(api_config, data_config, make_deterministic_mock_tok())
+
+        # Stage 0 runtime priming
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_id=0))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_id=0))
+
+        context_conv0_s0 = LocalUserSession._instances["conv_0"].context
+        context_conv1_s0 = LocalUserSession._instances["conv_1"].context
+        assert context_conv0_s0 != context_conv1_s0
+
+        # Simulate stage transition by clearing instances and moving to Stage 1
+        LocalUserSession.clear_instances()
+
+        # Load lazy data for both conversations for Stage 1
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_id=1))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_id=1))
+
+        context_conv0_s1 = LocalUserSession._instances["conv_0"].context
+        context_conv1_s1 = LocalUserSession._instances["conv_1"].context
+
+        # 1. The system prompts in Stage 1 should still be different from each other
+        assert context_conv0_s1 != context_conv1_s1
+        
+        # 2. Stage 1 prompts should also be different from their Stage 0 versions (new stage prefix)
+        assert context_conv0_s1 != context_conv0_s0
+        assert context_conv1_s1 != context_conv1_s0
+
+    def test_shared_system_prompt_cached_per_stage(self) -> None:
+        """Verify that the shared system prompt is only generated once per stage and cached."""
+        api_config, data_config = _make_config(num_conversations=2)
+        mock_tok = _make_mock_tokenizer()
+
+        # Track how many times decode is called.
+        decode_count = 0
+
+        def counting_decode(ids: Any, **kwargs: Any) -> str:
+            nonlocal decode_count
+            decode_count += 1
+            return f"decoded_{ids}"
+
+        mock_tok.get_tokenizer().decode.side_effect = counting_decode
+
+        gen = ConversationReplayDataGenerator(api_config, data_config, mock_tok)
+
+        # Reset decode count after initialization
+        decode_count = 0
+
+        # Simulate stage transition
+        LocalUserSession.clear_instances()
+
+        # Retrieve two sessions in the same stage
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0, stage_id=5))
+        gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=1, preferred_worker_id=1, stage_id=5))
+
+        # Decode should have been called exactly once for the shared prompt across both slot re-primes.
+        assert decode_count == 1
 class TestDistributionExtensions:
     def test_lognormal_distribution(self) -> None:
         rng = np.random.default_rng(42)


### PR DESCRIPTION
Fixes: #479

This PR updates the ConversationReplayDataGenerator to automatically regenerate system prompts at the start of every new benchmark stage.