### PR TITLE
Make per-stage progress visible in non-TTY logs

### DIFF
--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -76,6 +76,8 @@ from rich.progress import (
 )
 import signal
 
+from inference_perf.logger import get_console
+
 logger = logging.getLogger(__name__)
 
 
@@ -713,7 +715,7 @@ class LoadGenerator:
         concurrency_level: Optional[int] = None,
         progress_ctx: Optional[Progress] = None,
     ) -> None:
-        logger.debug("Stage %d - run started", stage_id)
+        logger.info("Stage %d - run started", stage_id)
 
         if timeout is not None and cancel_signal is None:
             raise Exception("run_stage timeout requires cancel_signal to be not None!")
@@ -810,9 +812,7 @@ class LoadGenerator:
             status=stage_status,
             concurrency_level=concurrency_level,
         )
-        logger.debug(
-            "Stage %d - run completed" if stage_status == StageStatus.COMPLETED else "Stage %d - run failed", stage_id
-        )
+        logger.info("Stage %d - run completed" if stage_status == StageStatus.COMPLETED else "Stage %d - run failed", stage_id)
 
     async def preprocess(
         self,
@@ -976,6 +976,9 @@ class LoadGenerator:
             MofNCompleteColumn(),
             TimeRemainingColumn(),
             TimeElapsedColumn(),
+            console=get_console(),
+            redirect_stdout=True,
+            redirect_stderr=True,
         ) as progress:
             overall_task = progress.add_task(description="Overall Progress", total=len(self.stages))
             for stage_id, stage in enumerate(self.stages):
@@ -1056,6 +1059,9 @@ class LoadGenerator:
             MofNCompleteColumn(),
             TimeRemainingColumn(),
             TimeElapsedColumn(),
+            console=get_console(),
+            redirect_stdout=True,
+            redirect_stderr=True,
         ) as progress:
             overall_task = progress.add_task(description="Overall Progress", total=len(self.stages))
 

--- a/inference_perf/logger.py
+++ b/inference_perf/logger.py
@@ -14,6 +14,17 @@
 
 import logging
 import sys
+from typing import Optional
+
+from rich.console import Console
+from rich.logging import RichHandler
+
+_console: Optional[Console] = None
+
+
+def get_console() -> Optional[Console]:
+    """Shared Console so RichHandler logs don't tear the Progress bar. None in non-TTY."""
+    return _console
 
 
 def setup_logging(level: str) -> None:
@@ -23,19 +34,33 @@ def setup_logging(level: str) -> None:
     Args:
         level: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
     """
+    global _console
+
     numeric_level = getattr(logging, level.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError(f"Invalid log level: {level}")
 
-    # Use detailed format for DEBUG level, original format for others
-    if numeric_level == logging.DEBUG:
-        log_format = "%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(funcName)s - %(message)s"
+    handler: logging.Handler
+    if sys.stdout.isatty():
+        _console = Console()
+        handler = RichHandler(
+            console=_console,
+            show_path=numeric_level == logging.DEBUG,
+            rich_tracebacks=True,
+            markup=False,
+        )
+        log_format = "%(name)s - %(message)s"
     else:
-        log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        _console = None
+        handler = logging.StreamHandler(sys.stdout)
+        if numeric_level == logging.DEBUG:
+            log_format = "%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(funcName)s - %(message)s"
+        else:
+            log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
     logging.basicConfig(
         level=numeric_level,
         format=log_format,
-        handlers=[logging.StreamHandler(sys.stdout)],
+        handlers=[handler],
         force=True,
     )

--- a/tests/required/loadgen/test_load_generator_stage_logs.py
+++ b/tests/required/loadgen/test_load_generator_stage_logs.py
@@ -1,0 +1,149 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for #486: stage start/end must log at INFO so non-TTY runs see progress."""
+
+import io
+import multiprocessing as mp
+import unittest
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+
+from inference_perf.apis import InferenceAPIData
+from inference_perf.config import LoadConfig, LoadType, StandardLoadStage
+from inference_perf.datagen import DataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+
+
+def _make_load_generator() -> LoadGenerator:
+    mock_datagen = MagicMock(spec=DataGenerator)
+    mock_datagen.trace = None
+    mock_data = MagicMock(spec=InferenceAPIData)
+    mock_data.preferred_worker_id = -1
+    mock_datagen.get_data.return_value = iter([mock_data])
+    mock_datagen.is_preferred_worker_requested.return_value = False
+
+    load_config = LoadConfig(
+        type=LoadType.CONSTANT,
+        stages=[StandardLoadStage(rate=1.0, duration=1)],
+        num_workers=1,
+        worker_max_concurrency=10,
+    )
+    with patch("inference_perf.loadgen.load_generator.get_circuit_breaker"):
+        return LoadGenerator(mock_datagen, load_config)
+
+
+class TestRunStageProgressLogs(unittest.IsolatedAsyncioTestCase):
+    @patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock)
+    async def test_run_stage_logs_start_and_end_at_info(self, mock_sleep: AsyncMock) -> None:
+        """Stage start and end log at INFO so non-TTY runs see progress."""
+        load_generator = _make_load_generator()
+
+        finished_counter = mp.Value("i", 0)
+
+        async def advance_counter(*_args: Any, **_kwargs: Any) -> None:
+            # Exit the wait loop after one iteration.
+            finished_counter.value = 1
+
+        mock_sleep.side_effect = advance_counter
+
+        request_queue = MagicMock()
+        request_queue.put = MagicMock()
+        request_queue.join = MagicMock()
+
+        with self.assertLogs("inference_perf.loadgen.load_generator", level="INFO") as cm:
+            await load_generator.run_stage(
+                stage_id=7,
+                rate=1.0,
+                duration=1,
+                request_queue=request_queue,
+                active_requests_counter=mp.Value("i", 0),
+                finished_requests_counter=finished_counter,
+                request_phase=mp.Event(),
+                cancel_signal=None,
+                progress_ctx=None,
+            )
+
+        messages = "\n".join(cm.output)
+        self.assertIn("Stage 7 - run started", messages, "stage start must be logged at INFO")
+        self.assertIn("Stage 7 - run completed", messages, "stage completion must be logged at INFO")
+
+    @patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock)
+    async def test_run_stage_emits_logs_and_progress_bar(self, mock_sleep: AsyncMock) -> None:
+        """With a Progress context, both the bar renders and INFO logs are emitted."""
+        load_generator = _make_load_generator()
+
+        finished_counter = mp.Value("i", 0)
+
+        async def advance_counter(*_args: Any, **_kwargs: Any) -> None:
+            finished_counter.value = 1
+
+        mock_sleep.side_effect = advance_counter
+
+        request_queue = MagicMock()
+        request_queue.put = MagicMock()
+        request_queue.join = MagicMock()
+
+        # force_terminal makes Progress render under pytest; record buffers frames.
+        console = Console(file=io.StringIO(), force_terminal=True, width=120, record=True)
+        progress = Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            MofNCompleteColumn(),
+            TimeRemainingColumn(),
+            TimeElapsedColumn(),
+            console=console,
+            redirect_stdout=True,
+            redirect_stderr=True,
+        )
+
+        with self.assertLogs("inference_perf.loadgen.load_generator", level="INFO") as cm:
+            with progress:
+                await load_generator.run_stage(
+                    stage_id=7,
+                    rate=1.0,
+                    duration=1,
+                    request_queue=request_queue,
+                    active_requests_counter=mp.Value("i", 0),
+                    finished_requests_counter=finished_counter,
+                    request_phase=mp.Event(),
+                    cancel_signal=None,
+                    progress_ctx=progress,
+                )
+
+        log_messages = "\n".join(cm.output)
+        self.assertIn("Stage 7 - run started", log_messages)
+        self.assertIn("Stage 7 - run completed", log_messages)
+
+        rendered = console.export_text()
+        self.assertIn(
+            "Stage 7 Requests",
+            rendered,
+            "progress bar task description must appear in rendered output",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses: #486

From local testing:
```
[05/15/26 17:09:33] INFO     inference_perf.loadgen.load_generator - Stage 0 - run started                                                                                       
Overall Progress ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% 0/3   -:--:-- 0:00:07
Stage 0 Requests ━━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━  52% 21/40 0:00:05 0:00:07
```

```
[05/15/26 17:09:33] INFO     inference_perf.loadgen.load_generator - Stage 0 - run started                                                                                       
[05/15/26 17:09:43] INFO     inference_perf.loadgen.load_generator - Stage 0 - run completed                                                                                     
[05/15/26 17:09:44] INFO     inference_perf.loadgen.load_generator - Stage 1 - run started                                                                                       
Overall Progress ━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━  33% 1/3   -:--:-- 0:00:19
Stage 1 Requests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━━━  85% 34/40 0:00:02 0:00:08
```