### PR TITLE
fix: shared_prefix off-by-one by composing at token level

### DIFF
--- a/inference_perf/datagen/datagen_utils.py
+++ b/inference_perf/datagen/datagen_utils.py
@@ -63,23 +63,13 @@ def random_token_ids(rng: np.random.Generator, valid_token_ids: np.ndarray, leng
 
 
 def build_word_start_token_ids(tokenizer: CustomTokenizer, valid_token_ids: np.ndarray) -> np.ndarray:
-    """Subset of valid_token_ids whose decoded form starts with whitespace.
+    """Token IDs whose decoded form starts with whitespace.
 
-    Pinning the first token of a generated suffix to this subset guarantees
-    the BPE/SentencePiece tokenizer treats the prefix and suffix as separate
-    word segments — no merge across the boundary. This preserves two
-    invariants simultaneously when composing prompts as
-    ``decode(prefix_ids + suffix_ids)``:
-
-      1. The full prompt retokenizes to exactly ``len(prefix_ids) +
-         len(suffix_ids)`` (no boundary inflation that would otherwise cause
-         off-by-one length mismatches — see #490).
-      2. The first ``len(prefix_ids)`` server-side tokens are stable across
-         different suffixes within the same group, so prefix-cache hits are
-         reliable.
-
-    If the tokenizer has no word-start tokens (unusual — major BPE and
-    SentencePiece tokenizers all do), falls back to ``valid_token_ids``.
+    Used to pin the first token of a suffix when appending it to a prefix:
+    a whitespace-prefixed token prevents BPE merges across the boundary,
+    so ``len(decode(prefix_ids + suffix_ids))`` retokenizes exactly and the
+    prefix's server-side tokens stay stable. Falls back to the full vocab
+    when no such tokens exist.
     """
     hf_tokenizer = tokenizer.get_tokenizer()
     word_starts: List[int] = []
@@ -98,27 +88,12 @@ def converge_to_exact_length_text(
     initial_tokens: List[int],
     adjust_tokens_fn: Callable[[List[int], int, int], List[int]],
 ) -> Tuple[str, List[int]]:
-    """Generates a string that tokenizes to exactly target_len.
+    """Generate text tokenizing to exactly target_len; return (text, ids).
 
-    Args:
-        tokenizer: The custom tokenizer.
-        target_len: The target token length.
-        initial_tokens: The initial list of token IDs to start with.
-        adjust_tokens_fn: A callback function to adjust the token list when the
-          length doesn't match. It takes (current_tokens, current_len,
-          target_len) and returns new_tokens.
-
-    Returns:
-        A tuple of (decoded_text, token_ids). The token_ids are the underlying
-        ids that produced ``decoded_text``; callers that want to compose this
-        text with another generated chunk should concatenate the ids and
-        decode once, rather than concatenating decoded strings (which
-        re-tokenizes across the boundary and can shift the count).
-
-    Raises:
-        ValueError: If we cannot land on exactly `target_len` within the
-          iteration budget. Usually a configuration mismatch where the
-          tokenizer differs from the one the model server is running.
+    ``adjust_tokens_fn`` takes ``(current_tokens, current_len, target_len)``
+    and returns new tokens. The returned ids let callers compose with another
+    chunk at the token level instead of by string concat (which would
+    re-tokenize across the boundary).
     """
     if target_len <= 0:
         return "", []
@@ -153,11 +128,7 @@ def generate_random_exact_length_text(
     tokenizer: CustomTokenizer,
     target_len: int,
 ) -> Tuple[str, List[int]]:
-    """Generate random text that tokenizes to exactly target_len.
-
-    Returns ``(text, token_ids)`` — see ``converge_to_exact_length_text`` for
-    why both are exposed.
-    """
+    """Generate random text tokenizing to exactly target_len; return (text, ids)."""
     if target_len <= 0:
         return "", []
 

--- a/inference_perf/datagen/datagen_utils.py
+++ b/inference_perf/datagen/datagen_utils.py
@@ -62,48 +62,43 @@ def random_token_ids(rng: np.random.Generator, valid_token_ids: np.ndarray, leng
     return rng.choice(valid_token_ids, size=length).tolist()  # type: ignore[no-any-return]
 
 
+def build_word_start_token_ids(tokenizer: CustomTokenizer, valid_token_ids: np.ndarray) -> np.ndarray:
+    """Token IDs whose decoded form starts with whitespace.
+
+    Used to pin the first token of a suffix when appending it to a prefix:
+    a whitespace-prefixed token prevents BPE merges across the boundary,
+    so ``len(decode(prefix_ids + suffix_ids))`` retokenizes exactly and the
+    prefix's server-side tokens stay stable. Falls back to the full vocab
+    when no such tokens exist.
+    """
+    hf_tokenizer = tokenizer.get_tokenizer()
+    word_starts: List[int] = []
+    for tid in valid_token_ids:
+        decoded = hf_tokenizer.decode([int(tid)], skip_special_tokens=True)
+        if decoded and decoded[0].isspace():
+            word_starts.append(int(tid))
+    if not word_starts:
+        return valid_token_ids
+    return np.array(word_starts, dtype=np.int64)
+
+
 def converge_to_exact_length_text(
     tokenizer: CustomTokenizer,
     target_len: int,
-    prefix_text: str,
     initial_tokens: List[int],
     adjust_tokens_fn: Callable[[List[int], int, int], List[int]],
-) -> str:
-    """Generates a string that tokenizes to exactly target_len, optionally prefixed.
+) -> Tuple[str, List[int]]:
+    """Generate text tokenizing to exactly target_len; return (text, ids).
 
-    Args:
-        tokenizer: The custom tokenizer.
-        target_len: The target token length.
-        prefix_text: Optional prefix to include in the length calculation.
-        initial_tokens: The initial list of token IDs to start with.
-        adjust_tokens_fn: A callback function to adjust the token list when the
-          length doesn't match. It takes (current_tokens, current_len,
-          target_len) and returns new_tokens.
-
-    Raises:
-        ValueError: If we cannot land on exactly `target_len` within the
-          iteration budget. Most often this happens when the tokenizer's BPE
-          merges around the prefix/suffix boundary keep flipping the count by
-          more than one token per adjustment, or when the requested length is
-          near the tokenizer's vocabulary edge cases (e.g. very small
-          target_len with a tokenizer that always prepends a BOS). Mitigation:
-          try a slightly different `target_len`, verify the tokenizer config
-          matches the model server's, or pre-tokenize the prefix once and
-          adjust around it instead of regenerating each iteration.
+    ``adjust_tokens_fn`` takes ``(current_tokens, current_len, target_len)``
+    and returns new tokens. The returned ids let callers compose with another
+    chunk at the token level instead of by string concat (which would
+    re-tokenize across the boundary).
     """
     if target_len <= 0:
-        return ""
+        return "", []
 
     hf_tokenizer = tokenizer.get_tokenizer()
-
-    prefix_len = 0
-    if prefix_text:
-        prefix_len = tokenizer.count_tokens(prefix_text)
-        assert prefix_len < target_len, (
-            f"target_len ({target_len}) must be > prefix_len ({prefix_len}). "
-            f"This helper generates suffix tokens such that prefix_len + suffix_len == target_len; "
-            f"the caller is responsible for choosing target_len with room for a non-empty suffix."
-        )
 
     current_tokens = initial_tokens
 
@@ -112,23 +107,18 @@ def converge_to_exact_length_text(
     for _ in range(max_iterations):
         text = hf_tokenizer.decode(current_tokens, skip_special_tokens=True)
 
-        full_text = prefix_text + " " + text if prefix_text else text
-
-        current_len = tokenizer.count_tokens(full_text)
+        current_len = tokenizer.count_tokens(text)
 
         if current_len == target_len:
-            return full_text if prefix_text else text
+            return text, current_tokens
 
         last_len = current_len
         current_tokens = adjust_tokens_fn(current_tokens, current_len, target_len)
 
     raise ValueError(
         f"Could not generate a prompt of exactly {target_len} tokens after {max_iterations} "
-        f"attempts (got {last_len}). This is usually a configuration mismatch — try one of: "
-        f"(1) increase or decrease the requested length by a few tokens in your data config "
-        f"(e.g. data.input_distribution.mean / .std_dev, or data.shared_prefix.system_prompt_len "
-        f"/ .question_len); (2) ensure tokenizer.pretrained_model_name_or_path matches the model "
-        f"the server is running."
+        f"attempts (got {last_len}). This usually means tokenizer.pretrained_model_name_or_path "
+        f"does not match the model the server is running."
     )
 
 
@@ -137,41 +127,25 @@ def generate_random_exact_length_text(
     valid_token_ids: np.ndarray,
     tokenizer: CustomTokenizer,
     target_len: int,
-    prefix_text: str = "",
-) -> str:
-    """Generate text that tokenizes to exactly target_len, optionally with a prefix.
-
-    Combines random token sampling with the convergence loop in
-    `generate_exact_length_text`. When prefix_text is provided the TOTAL length
-    including prefix will be target_len; the returned string is the full
-    combined text. Otherwise just the generated suffix is returned.
-    """
+) -> Tuple[str, List[int]]:
+    """Generate random text tokenizing to exactly target_len; return (text, ids)."""
     if target_len <= 0:
-        return ""
+        return "", []
 
-    prefix_len = 0
-    if prefix_text:
-        prefix_len = tokenizer.count_tokens(prefix_text)
-        assert prefix_len < target_len, (
-            f"target_len ({target_len}) must be > prefix_len ({prefix_len}). "
-            f"This helper generates suffix tokens such that prefix_len + suffix_len == target_len; "
-            f"the caller is responsible for choosing target_len with room for a non-empty suffix."
-        )
-
-    initial_tokens = random_token_ids(rng, valid_token_ids, target_len - prefix_len)
+    initial_tokens = random_token_ids(rng, valid_token_ids, target_len)
 
     def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
         if current_len < target_len:
             current_tokens.extend(random_token_ids(rng, valid_token_ids, target_len - current_len))
-        else:
-            diff = current_len - target_len
-            current_tokens = current_tokens[:-diff] if len(current_tokens) > diff else current_tokens[:1]
-        return current_tokens
+            return current_tokens
+        diff = current_len - target_len
+        if diff < len(current_tokens):
+            return current_tokens[:-diff]
+        return []
 
     return converge_to_exact_length_text(
         tokenizer=tokenizer,
         target_len=target_len,
-        prefix_text=prefix_text,
         initial_tokens=initial_tokens,
         adjust_tokens_fn=adjust_tokens,
     )

--- a/inference_perf/datagen/datagen_utils.py
+++ b/inference_perf/datagen/datagen_utils.py
@@ -65,45 +65,35 @@ def random_token_ids(rng: np.random.Generator, valid_token_ids: np.ndarray, leng
 def converge_to_exact_length_text(
     tokenizer: CustomTokenizer,
     target_len: int,
-    prefix_text: str,
     initial_tokens: List[int],
     adjust_tokens_fn: Callable[[List[int], int, int], List[int]],
-) -> str:
-    """Generates a string that tokenizes to exactly target_len, optionally prefixed.
+) -> Tuple[str, List[int]]:
+    """Generates a string that tokenizes to exactly target_len.
 
     Args:
         tokenizer: The custom tokenizer.
         target_len: The target token length.
-        prefix_text: Optional prefix to include in the length calculation.
         initial_tokens: The initial list of token IDs to start with.
         adjust_tokens_fn: A callback function to adjust the token list when the
           length doesn't match. It takes (current_tokens, current_len,
           target_len) and returns new_tokens.
 
+    Returns:
+        A tuple of (decoded_text, token_ids). The token_ids are the underlying
+        ids that produced ``decoded_text``; callers that want to compose this
+        text with another generated chunk should concatenate the ids and
+        decode once, rather than concatenating decoded strings (which
+        re-tokenizes across the boundary and can shift the count).
+
     Raises:
         ValueError: If we cannot land on exactly `target_len` within the
-          iteration budget. Most often this happens when the tokenizer's BPE
-          merges around the prefix/suffix boundary keep flipping the count by
-          more than one token per adjustment, or when the requested length is
-          near the tokenizer's vocabulary edge cases (e.g. very small
-          target_len with a tokenizer that always prepends a BOS). Mitigation:
-          try a slightly different `target_len`, verify the tokenizer config
-          matches the model server's, or pre-tokenize the prefix once and
-          adjust around it instead of regenerating each iteration.
+          iteration budget. Usually a configuration mismatch where the
+          tokenizer differs from the one the model server is running.
     """
     if target_len <= 0:
-        return ""
+        return "", []
 
     hf_tokenizer = tokenizer.get_tokenizer()
-
-    prefix_len = 0
-    if prefix_text:
-        prefix_len = tokenizer.count_tokens(prefix_text)
-        assert prefix_len < target_len, (
-            f"target_len ({target_len}) must be > prefix_len ({prefix_len}). "
-            f"This helper generates suffix tokens such that prefix_len + suffix_len == target_len; "
-            f"the caller is responsible for choosing target_len with room for a non-empty suffix."
-        )
 
     current_tokens = initial_tokens
 
@@ -112,23 +102,18 @@ def converge_to_exact_length_text(
     for _ in range(max_iterations):
         text = hf_tokenizer.decode(current_tokens, skip_special_tokens=True)
 
-        full_text = prefix_text + " " + text if prefix_text else text
-
-        current_len = tokenizer.count_tokens(full_text)
+        current_len = tokenizer.count_tokens(text)
 
         if current_len == target_len:
-            return full_text if prefix_text else text
+            return text, current_tokens
 
         last_len = current_len
         current_tokens = adjust_tokens_fn(current_tokens, current_len, target_len)
 
     raise ValueError(
         f"Could not generate a prompt of exactly {target_len} tokens after {max_iterations} "
-        f"attempts (got {last_len}). This is usually a configuration mismatch — try one of: "
-        f"(1) increase or decrease the requested length by a few tokens in your data config "
-        f"(e.g. data.input_distribution.mean / .std_dev, or data.shared_prefix.system_prompt_len "
-        f"/ .question_len); (2) ensure tokenizer.pretrained_model_name_or_path matches the model "
-        f"the server is running."
+        f"attempts (got {last_len}). This usually means tokenizer.pretrained_model_name_or_path "
+        f"does not match the model the server is running."
     )
 
 
@@ -137,41 +122,29 @@ def generate_random_exact_length_text(
     valid_token_ids: np.ndarray,
     tokenizer: CustomTokenizer,
     target_len: int,
-    prefix_text: str = "",
-) -> str:
-    """Generate text that tokenizes to exactly target_len, optionally with a prefix.
+) -> Tuple[str, List[int]]:
+    """Generate random text that tokenizes to exactly target_len.
 
-    Combines random token sampling with the convergence loop in
-    `generate_exact_length_text`. When prefix_text is provided the TOTAL length
-    including prefix will be target_len; the returned string is the full
-    combined text. Otherwise just the generated suffix is returned.
+    Returns ``(text, token_ids)`` — see ``converge_to_exact_length_text`` for
+    why both are exposed.
     """
     if target_len <= 0:
-        return ""
+        return "", []
 
-    prefix_len = 0
-    if prefix_text:
-        prefix_len = tokenizer.count_tokens(prefix_text)
-        assert prefix_len < target_len, (
-            f"target_len ({target_len}) must be > prefix_len ({prefix_len}). "
-            f"This helper generates suffix tokens such that prefix_len + suffix_len == target_len; "
-            f"the caller is responsible for choosing target_len with room for a non-empty suffix."
-        )
-
-    initial_tokens = random_token_ids(rng, valid_token_ids, target_len - prefix_len)
+    initial_tokens = random_token_ids(rng, valid_token_ids, target_len)
 
     def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
         if current_len < target_len:
             current_tokens.extend(random_token_ids(rng, valid_token_ids, target_len - current_len))
-        else:
-            diff = current_len - target_len
-            current_tokens = current_tokens[:-diff] if len(current_tokens) > diff else current_tokens[:1]
-        return current_tokens
+            return current_tokens
+        diff = current_len - target_len
+        if diff < len(current_tokens):
+            return current_tokens[:-diff]
+        return []
 
     return converge_to_exact_length_text(
         tokenizer=tokenizer,
         target_len=target_len,
-        prefix_text=prefix_text,
         initial_tokens=initial_tokens,
         adjust_tokens_fn=adjust_tokens,
     )

--- a/inference_perf/datagen/datagen_utils.py
+++ b/inference_perf/datagen/datagen_utils.py
@@ -62,6 +62,36 @@ def random_token_ids(rng: np.random.Generator, valid_token_ids: np.ndarray, leng
     return rng.choice(valid_token_ids, size=length).tolist()  # type: ignore[no-any-return]
 
 
+def build_word_start_token_ids(tokenizer: CustomTokenizer, valid_token_ids: np.ndarray) -> np.ndarray:
+    """Subset of valid_token_ids whose decoded form starts with whitespace.
+
+    Pinning the first token of a generated suffix to this subset guarantees
+    the BPE/SentencePiece tokenizer treats the prefix and suffix as separate
+    word segments — no merge across the boundary. This preserves two
+    invariants simultaneously when composing prompts as
+    ``decode(prefix_ids + suffix_ids)``:
+
+      1. The full prompt retokenizes to exactly ``len(prefix_ids) +
+         len(suffix_ids)`` (no boundary inflation that would otherwise cause
+         off-by-one length mismatches — see #490).
+      2. The first ``len(prefix_ids)`` server-side tokens are stable across
+         different suffixes within the same group, so prefix-cache hits are
+         reliable.
+
+    If the tokenizer has no word-start tokens (unusual — major BPE and
+    SentencePiece tokenizers all do), falls back to ``valid_token_ids``.
+    """
+    hf_tokenizer = tokenizer.get_tokenizer()
+    word_starts: List[int] = []
+    for tid in valid_token_ids:
+        decoded = hf_tokenizer.decode([int(tid)], skip_special_tokens=True)
+        if decoded and decoded[0].isspace():
+            word_starts.append(int(tid))
+    if not word_starts:
+        return valid_token_ids
+    return np.array(word_starts, dtype=np.int64)
+
+
 def converge_to_exact_length_text(
     tokenizer: CustomTokenizer,
     target_len: int,

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -93,7 +93,8 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
         """Generates a string that tokenizes to exactly target_len."""
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for generating exact length prompts.")
-        return generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len)
+        text, _ = generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len)
+        return text
 
     def get_request_count(self) -> int:
         return min(len(self.input_lengths), len(self.output_lengths))

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -40,6 +40,7 @@ from inference_perf.utils.distribution import sample_from_distribution
 from .base import DataGenerator, LazyLoadDataMixin
 from .datagen_utils import (
     build_word_start_token_ids,
+    converge_to_exact_length_text,
     generate_random_exact_length_text,
     init_vocab_sampling,
     random_token_ids,
@@ -191,13 +192,38 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         return random_token_ids(self.rng, self.valid_token_ids, length)
 
     def _sample_suffix_ids(self, length: int) -> List[int]:
-        """Sample suffix IDs with a word-start first token (see build_word_start_token_ids)."""
+        """Sample suffix IDs decoding to exactly ``length`` tokens, first token word-start.
+
+        The first token is word-start so the suffix decodes with a leading whitespace
+        character, preventing BPE merges across the prefix/suffix boundary. The
+        convergence loop then settles the rest of the suffix to the exact count
+        regardless of random-token roundtrip drift.
+        """
         if length <= 0:
             return []
-        first = [int(self.rng.choice(self.word_start_token_ids))]
-        if length == 1:
-            return first
-        return first + random_token_ids(self.rng, self.valid_token_ids, length - 1)
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for sampling suffix IDs.")
+        initial = [int(self.rng.choice(self.word_start_token_ids))]
+        if length > 1:
+            initial += random_token_ids(self.rng, self.valid_token_ids, length - 1)
+
+        def adjust(current: List[int], current_len: int, target_len: int) -> List[int]:
+            if current_len < target_len:
+                current.extend(random_token_ids(self.rng, self.valid_token_ids, target_len - current_len))
+                return current
+            diff = current_len - target_len
+            # Preserve the word-start first token so the boundary stays stable.
+            if diff < len(current) - 1:
+                return current[:-diff]
+            return current[:1]
+
+        _, ids = converge_to_exact_length_text(
+            tokenizer=self.tokenizer,
+            target_len=length,
+            initial_tokens=initial,
+            adjust_tokens_fn=adjust,
+        )
+        return ids
 
     def _generate_exact_length_text(self, target_len: int) -> Tuple[str, List[int]]:
         """Generates a string + its underlying token IDs, tokenizing to exactly target_len."""

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Dict, Generator, List, Optional, Union
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -184,15 +184,11 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         """Generates a list of random token IDs of a specified length."""
         return random_token_ids(self.rng, self.valid_token_ids, length)
 
-    def _generate_exact_length_text(self, target_len: int, prefix_text: str = "") -> str:
-        """Generates a string that tokenizes to exactly target_len, optionally prefixed.
-
-        If prefix_text is provided, the TOTAL length including prefix will be target_len.
-        Returns the full combined text if prefix_text is provided, else just the generated text.
-        """
+    def _generate_exact_length_text(self, target_len: int) -> Tuple[str, List[int]]:
+        """Generates a string + its underlying token IDs, tokenizing to exactly target_len."""
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for generating exact length prompts.")
-        return generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len, prefix_text)
+        return generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len)
 
     def _generate_prompts(self) -> None:
         """Pre-generates all per-group prefix texts/specs and per-prompt question texts."""
@@ -202,9 +198,16 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.shared_prefix is None:
             raise ValueError("Shared prefix is not available for generating prompts.")
 
+        hf_tokenizer = self.tokenizer.get_tokenizer()
+
         for group_id in range(self.num_groups):
             sys_prompt_len = self.system_prompt_lens_per_group[group_id]
-            shared_prefix_text = self._generate_exact_length_text(sys_prompt_len)
+            # Generate the prefix and keep its token IDs so each prompt can be
+            # built by concatenating tokens, not strings. String concat
+            # ("prefix" + " " + "suffix") re-tokenizes across the BPE boundary
+            # and can shift the count by ±1 token — see #490. Token-level
+            # concat sidesteps the boundary entirely.
+            shared_prefix_text, shared_prefix_ids = self._generate_exact_length_text(sys_prompt_len)
 
             if self.prefix_multimodal:
                 # Sample the prefix-side spec once per group. Bytes are
@@ -215,11 +218,8 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
 
             for prompt_id in range(self.num_prompts_per_group):
                 q_len = self.question_len_list_per_group[group_id][prompt_id]
-                target_total_len = sys_prompt_len + q_len
-
-                # #383's exact-length helper: returns full prefix+question text
-                # whose tokenized length equals target_total_len.
-                full_text = self._generate_exact_length_text(target_total_len, prefix_text=shared_prefix_text)
+                suffix_ids = self._generate_random_token_ids(q_len)
+                full_text = hf_tokenizer.decode(shared_prefix_ids + suffix_ids, skip_special_tokens=True)
 
                 self.prompts.append(full_text)
                 self.prefix_texts.append(shared_prefix_text)

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -72,11 +72,6 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
             raise ValueError("Tokenizer is required for SharedPrefixDataGenerator but was not initialized.")
 
         self.vocab_size, self.special_token_ids, self.valid_token_ids = init_vocab_sampling(self.tokenizer)
-        # Pinning the first suffix token to a word-start token keeps the
-        # prefix/suffix BPE boundary stable: the composed prompt's count is
-        # exact AND the prefix's server-side tokenization is identical across
-        # requests in a group (prefix-cache hits remain reliable). See
-        # build_word_start_token_ids for the full rationale.
         self.word_start_token_ids = build_word_start_token_ids(self.tokenizer, self.valid_token_ids)
 
         if self.shared_prefix is None:
@@ -196,13 +191,7 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         return random_token_ids(self.rng, self.valid_token_ids, length)
 
     def _sample_suffix_ids(self, length: int) -> List[int]:
-        """Sample ``length`` token IDs intended to be appended after a prefix.
-
-        The first token is drawn from the word-start subset so the
-        prefix/suffix BPE boundary cannot merge into surrounding tokens —
-        this is what guarantees both exact composed length and prefix-cache
-        stability (see ``build_word_start_token_ids``).
-        """
+        """Sample suffix IDs with a word-start first token (see build_word_start_token_ids)."""
         if length <= 0:
             return []
         first = [int(self.rng.choice(self.word_start_token_ids))]
@@ -228,11 +217,6 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
 
         for group_id in range(self.num_groups):
             sys_prompt_len = self.system_prompt_lens_per_group[group_id]
-            # Generate the prefix and keep its token IDs so each prompt can be
-            # built by concatenating tokens, not strings. String concat
-            # ("prefix" + " " + "suffix") re-tokenizes across the BPE boundary
-            # and can shift the count by ±1 token — see #490. Token-level
-            # concat sidesteps the boundary entirely.
             shared_prefix_text, shared_prefix_ids = self._generate_exact_length_text(sys_prompt_len)
 
             if self.prefix_multimodal:

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -38,7 +38,12 @@ from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import sample_from_distribution
 
 from .base import DataGenerator, LazyLoadDataMixin
-from .datagen_utils import generate_random_exact_length_text, init_vocab_sampling, random_token_ids
+from .datagen_utils import (
+    build_word_start_token_ids,
+    generate_random_exact_length_text,
+    init_vocab_sampling,
+    random_token_ids,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +72,12 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
             raise ValueError("Tokenizer is required for SharedPrefixDataGenerator but was not initialized.")
 
         self.vocab_size, self.special_token_ids, self.valid_token_ids = init_vocab_sampling(self.tokenizer)
+        # Pinning the first suffix token to a word-start token keeps the
+        # prefix/suffix BPE boundary stable: the composed prompt's count is
+        # exact AND the prefix's server-side tokenization is identical across
+        # requests in a group (prefix-cache hits remain reliable). See
+        # build_word_start_token_ids for the full rationale.
+        self.word_start_token_ids = build_word_start_token_ids(self.tokenizer, self.valid_token_ids)
 
         if self.shared_prefix is None:
             raise ValueError("Shared Prefix config is required for SharedPrefixDataGenerator")
@@ -184,6 +195,21 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         """Generates a list of random token IDs of a specified length."""
         return random_token_ids(self.rng, self.valid_token_ids, length)
 
+    def _sample_suffix_ids(self, length: int) -> List[int]:
+        """Sample ``length`` token IDs intended to be appended after a prefix.
+
+        The first token is drawn from the word-start subset so the
+        prefix/suffix BPE boundary cannot merge into surrounding tokens —
+        this is what guarantees both exact composed length and prefix-cache
+        stability (see ``build_word_start_token_ids``).
+        """
+        if length <= 0:
+            return []
+        first = [int(self.rng.choice(self.word_start_token_ids))]
+        if length == 1:
+            return first
+        return first + random_token_ids(self.rng, self.valid_token_ids, length - 1)
+
     def _generate_exact_length_text(self, target_len: int) -> Tuple[str, List[int]]:
         """Generates a string + its underlying token IDs, tokenizing to exactly target_len."""
         if self.tokenizer is None:
@@ -218,7 +244,7 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
 
             for prompt_id in range(self.num_prompts_per_group):
                 q_len = self.question_len_list_per_group[group_id][prompt_id]
-                suffix_ids = self._generate_random_token_ids(q_len)
+                suffix_ids = self._sample_suffix_ids(q_len)
                 full_text = hf_tokenizer.decode(shared_prefix_ids + suffix_ids, skip_special_tokens=True)
 
                 self.prompts.append(full_text)

--- a/inference_perf/datagen/shared_prefix_datagen.py
+++ b/inference_perf/datagen/shared_prefix_datagen.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Dict, Generator, List, Optional, Union
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -38,7 +38,13 @@ from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.utils.distribution import sample_from_distribution
 
 from .base import DataGenerator, LazyLoadDataMixin
-from .datagen_utils import generate_random_exact_length_text, init_vocab_sampling, random_token_ids
+from .datagen_utils import (
+    build_word_start_token_ids,
+    converge_to_exact_length_text,
+    generate_random_exact_length_text,
+    init_vocab_sampling,
+    random_token_ids,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +73,7 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
             raise ValueError("Tokenizer is required for SharedPrefixDataGenerator but was not initialized.")
 
         self.vocab_size, self.special_token_ids, self.valid_token_ids = init_vocab_sampling(self.tokenizer)
+        self.word_start_token_ids = build_word_start_token_ids(self.tokenizer, self.valid_token_ids)
 
         if self.shared_prefix is None:
             raise ValueError("Shared Prefix config is required for SharedPrefixDataGenerator")
@@ -184,15 +191,45 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         """Generates a list of random token IDs of a specified length."""
         return random_token_ids(self.rng, self.valid_token_ids, length)
 
-    def _generate_exact_length_text(self, target_len: int, prefix_text: str = "") -> str:
-        """Generates a string that tokenizes to exactly target_len, optionally prefixed.
+    def _sample_suffix_ids(self, length: int) -> List[int]:
+        """Sample suffix IDs decoding to exactly ``length`` tokens, first token word-start.
 
-        If prefix_text is provided, the TOTAL length including prefix will be target_len.
-        Returns the full combined text if prefix_text is provided, else just the generated text.
+        The first token is word-start so the suffix decodes with a leading whitespace
+        character, preventing BPE merges across the prefix/suffix boundary. The
+        convergence loop then settles the rest of the suffix to the exact count
+        regardless of random-token roundtrip drift.
         """
+        if length <= 0:
+            return []
+        if self.tokenizer is None:
+            raise ValueError("Tokenizer is required for sampling suffix IDs.")
+        initial = [int(self.rng.choice(self.word_start_token_ids))]
+        if length > 1:
+            initial += random_token_ids(self.rng, self.valid_token_ids, length - 1)
+
+        def adjust(current: List[int], current_len: int, target_len: int) -> List[int]:
+            if current_len < target_len:
+                current.extend(random_token_ids(self.rng, self.valid_token_ids, target_len - current_len))
+                return current
+            diff = current_len - target_len
+            # Preserve the word-start first token so the boundary stays stable.
+            if diff < len(current) - 1:
+                return current[:-diff]
+            return current[:1]
+
+        _, ids = converge_to_exact_length_text(
+            tokenizer=self.tokenizer,
+            target_len=length,
+            initial_tokens=initial,
+            adjust_tokens_fn=adjust,
+        )
+        return ids
+
+    def _generate_exact_length_text(self, target_len: int) -> Tuple[str, List[int]]:
+        """Generates a string + its underlying token IDs, tokenizing to exactly target_len."""
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for generating exact length prompts.")
-        return generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len, prefix_text)
+        return generate_random_exact_length_text(self.rng, self.valid_token_ids, self.tokenizer, target_len)
 
     def _generate_prompts(self) -> None:
         """Pre-generates all per-group prefix texts/specs and per-prompt question texts."""
@@ -202,9 +239,11 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.shared_prefix is None:
             raise ValueError("Shared prefix is not available for generating prompts.")
 
+        hf_tokenizer = self.tokenizer.get_tokenizer()
+
         for group_id in range(self.num_groups):
             sys_prompt_len = self.system_prompt_lens_per_group[group_id]
-            shared_prefix_text = self._generate_exact_length_text(sys_prompt_len)
+            shared_prefix_text, shared_prefix_ids = self._generate_exact_length_text(sys_prompt_len)
 
             if self.prefix_multimodal:
                 # Sample the prefix-side spec once per group. Bytes are
@@ -215,11 +254,8 @@ class SharedPrefixDataGenerator(DataGenerator, LazyLoadDataMixin):
 
             for prompt_id in range(self.num_prompts_per_group):
                 q_len = self.question_len_list_per_group[group_id][prompt_id]
-                target_total_len = sys_prompt_len + q_len
-
-                # #383's exact-length helper: returns full prefix+question text
-                # whose tokenized length equals target_total_len.
-                full_text = self._generate_exact_length_text(target_total_len, prefix_text=shared_prefix_text)
+                suffix_ids = self._sample_suffix_ids(q_len)
+                full_text = hf_tokenizer.decode(shared_prefix_ids + suffix_ids, skip_special_tokens=True)
 
                 self.prompts.append(full_text)
                 self.prefix_texts.append(shared_prefix_text)

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -88,13 +88,13 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
             slice_to_use = min(current_slice_len, len(self.token_ids))
             return self.token_ids[:slice_to_use]
 
-        return converge_to_exact_length_text(
+        text, _ = converge_to_exact_length_text(
             tokenizer=self.tokenizer,
             target_len=target_len,
-            prefix_text="",
             initial_tokens=initial_tokens,
             adjust_tokens_fn=adjust_tokens,
         )
+        return text
 
     def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> InferenceAPIData:
         n = data.data_index

--- a/tests/required/datagen/test_datagen_fuzz.py
+++ b/tests/required/datagen/test_datagen_fuzz.py
@@ -146,3 +146,44 @@ def test_shared_prefix_real_tokenizer_small_question_len(question_len_min: int) 
         seen += 1
         if seen >= n:
             break
+
+
+# Prefix-cache invariant: the BPE-tokenized form of every prompt in a group
+# must agree on its first len(encode(prefix)) tokens. If the suffix's first
+# token were drawn from the full vocab it could merge across the boundary and
+# shift the prefix's tokenization — pinning to word-start tokens prevents
+# that. Exercise gpt2 (the same tokenizer that surfaces the off-by-one count
+# bug under boundary merges) so a regression in the pinning logic would also
+# fail here.
+def test_shared_prefix_server_tokens_stable_across_group() -> None:
+    tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="gpt2"))
+    hf = tokenizer.get_tokenizer()
+    api_config = APIConfig(type=APIType.Completion)
+    shared_prefix_cfg = SharedPrefix(
+        num_groups=3,
+        num_prompts_per_group=30,
+        system_prompt_len=100,
+        question_distribution=Distribution(mean=5.0, std_dev=2.0, min=1, max=15),
+        output_distribution=Distribution(mean=10.0, std_dev=1.0, min=1, max=20),
+        enable_multi_turn_chat=True,
+    )
+    data_config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=shared_prefix_cfg)
+    gen = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
+
+    by_group: dict[int, list[tuple[str, str]]] = {}
+    for prompt, prefix, gid in zip(gen.prompts, gen.prefix_texts, gen.prompt_groups, strict=True):
+        by_group.setdefault(gid, []).append((prompt, prefix))
+
+    for gid, entries in by_group.items():
+        canonical_prefix = entries[0][1]
+        # Server-side tokenization length we care about. Use add_special_tokens=False
+        # so the comparison is over the prefix content itself, not the BOS prefix.
+        canonical_prefix_ids = hf(canonical_prefix, add_special_tokens=False).input_ids
+        n_prefix = len(canonical_prefix_ids)
+        assert n_prefix > 0
+
+        first_n = {tuple(hf(prompt, add_special_tokens=False).input_ids[:n_prefix]) for prompt, _ in entries}
+        assert len(first_n) == 1, (
+            f"group {gid}: prefix tokenization differs across {len(entries)} prompts; "
+            f"got {len(first_n)} distinct token-prefix sequences"
+        )

--- a/tests/required/datagen/test_datagen_fuzz.py
+++ b/tests/required/datagen/test_datagen_fuzz.py
@@ -104,12 +104,8 @@ def test_datagen_length_fuzz(gen_type: DataGenType) -> None:
             assert actual_len == expected_len, f"Failed for {gen_type}, expected {expected_len}, got {actual_len}"
 
 
-# Regression for kubernetes-sigs/inference-perf#490: with a real BPE tokenizer,
-# `shared_prefix` with tiny question lengths used to wedge the convergence loop
-# at target_len+1 because the prefix/suffix boundary inflated the count by one
-# and the adjustment step couldn't shrink past a 1-token suffix. The mock
-# tokenizer used in the test above counts by whitespace so it can't surface
-# this — exercise gpt2 here to cover the boundary case.
+# Regression for #490: real BPE tokenizer + small q_len. Mock tokenizer above
+# tokenizes by whitespace so it cannot expose BPE boundary effects.
 @pytest.mark.parametrize("question_len_min", [1, 2, 3])
 def test_shared_prefix_real_tokenizer_small_question_len(question_len_min: int) -> None:
     tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="gpt2"))
@@ -126,9 +122,6 @@ def test_shared_prefix_real_tokenizer_small_question_len(question_len_min: int) 
 
     gen = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
 
-    # Every generated prompt must tokenize to exactly system_prompt_len + sampled q_len.
-    # We don't know the per-prompt sampled q_len, but we know prefix is constant per group
-    # and full length should be in the valid sampled range.
     for prompt, prefix in zip(gen.prompts, gen.prefix_texts, strict=True):
         prefix_count = tokenizer.count_tokens(prefix)
         full_count = tokenizer.count_tokens(prompt)
@@ -136,7 +129,6 @@ def test_shared_prefix_real_tokenizer_small_question_len(question_len_min: int) 
         assert prefix_count == 100, f"prefix tokenized to {prefix_count}, expected 100"
         assert question_len_min <= q_count <= 20, f"question length {q_count} outside [{question_len_min}, 20]"
 
-    # Also confirm get_data() returns the right shape via load_lazy_data.
     n = 5
     seen = 0
     for lazy in gen.get_data():
@@ -148,13 +140,9 @@ def test_shared_prefix_real_tokenizer_small_question_len(question_len_min: int) 
             break
 
 
-# Prefix-cache invariant: the BPE-tokenized form of every prompt in a group
-# must agree on its first len(encode(prefix)) tokens. If the suffix's first
-# token were drawn from the full vocab it could merge across the boundary and
-# shift the prefix's tokenization — pinning to word-start tokens prevents
-# that. Exercise gpt2 (the same tokenizer that surfaces the off-by-one count
-# bug under boundary merges) so a regression in the pinning logic would also
-# fail here.
+# Prefix-cache invariant: every prompt in a group must tokenize to the same
+# first len(encode(prefix)) tokens. Pinning the suffix's first token to a
+# word-start token is what enforces this.
 def test_shared_prefix_server_tokens_stable_across_group() -> None:
     tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="gpt2"))
     hf = tokenizer.get_tokenizer()
@@ -176,8 +164,6 @@ def test_shared_prefix_server_tokens_stable_across_group() -> None:
 
     for gid, entries in by_group.items():
         canonical_prefix = entries[0][1]
-        # Server-side tokenization length we care about. Use add_special_tokens=False
-        # so the comparison is over the prefix content itself, not the BOS prefix.
         canonical_prefix_ids = hf(canonical_prefix, add_special_tokens=False).input_ids
         n_prefix = len(canonical_prefix_ids)
         assert n_prefix > 0

--- a/tests/required/datagen/test_datagen_fuzz.py
+++ b/tests/required/datagen/test_datagen_fuzz.py
@@ -1,14 +1,16 @@
 import pytest
 from unittest.mock import MagicMock
 import numpy as np
-from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.config import APIConfig, APIType, CustomTokenizerConfig, DataConfig, Distribution, DataGenType
 from inference_perf.apis import LazyLoadInferenceAPIData
 from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.apis.user_session import UserSessionCompletionAPIData
 from inference_perf.datagen.random_datagen import RandomDataGenerator
 from inference_perf.datagen.synthetic_datagen import SyntheticDataGenerator
 from inference_perf.config import SharedPrefix
 from inference_perf.datagen.base import DataGenerator, LazyLoadDataMixin
 from inference_perf.datagen.shared_prefix_datagen import SharedPrefixDataGenerator
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
 def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
@@ -100,3 +102,47 @@ def test_datagen_length_fuzz(gen_type: DataGenType) -> None:
 
             print(f"Type: {gen_type}, Expected: {expected_len}, Actual: {actual_len}")
             assert actual_len == expected_len, f"Failed for {gen_type}, expected {expected_len}, got {actual_len}"
+
+
+# Regression for kubernetes-sigs/inference-perf#490: with a real BPE tokenizer,
+# `shared_prefix` with tiny question lengths used to wedge the convergence loop
+# at target_len+1 because the prefix/suffix boundary inflated the count by one
+# and the adjustment step couldn't shrink past a 1-token suffix. The mock
+# tokenizer used in the test above counts by whitespace so it can't surface
+# this — exercise gpt2 here to cover the boundary case.
+@pytest.mark.parametrize("question_len_min", [1, 2, 3])
+def test_shared_prefix_real_tokenizer_small_question_len(question_len_min: int) -> None:
+    tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="gpt2"))
+    api_config = APIConfig(type=APIType.Completion)
+    shared_prefix_cfg = SharedPrefix(
+        num_groups=3,
+        num_prompts_per_group=50,
+        system_prompt_len=100,
+        question_distribution=Distribution(mean=float(question_len_min + 2), std_dev=2.0, min=question_len_min, max=20),
+        output_distribution=Distribution(mean=10.0, std_dev=1.0, min=1, max=20),
+        enable_multi_turn_chat=True,
+    )
+    data_config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=shared_prefix_cfg)
+
+    gen = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
+
+    # Every generated prompt must tokenize to exactly system_prompt_len + sampled q_len.
+    # We don't know the per-prompt sampled q_len, but we know prefix is constant per group
+    # and full length should be in the valid sampled range.
+    for prompt, prefix in zip(gen.prompts, gen.prefix_texts, strict=True):
+        prefix_count = tokenizer.count_tokens(prefix)
+        full_count = tokenizer.count_tokens(prompt)
+        q_count = full_count - prefix_count
+        assert prefix_count == 100, f"prefix tokenized to {prefix_count}, expected 100"
+        assert question_len_min <= q_count <= 20, f"question length {q_count} outside [{question_len_min}, 20]"
+
+    # Also confirm get_data() returns the right shape via load_lazy_data.
+    n = 5
+    seen = 0
+    for lazy in gen.get_data():
+        if isinstance(lazy, LazyLoadInferenceAPIData):
+            p = gen.load_lazy_data(lazy)
+            assert isinstance(p, UserSessionCompletionAPIData)
+        seen += 1
+        if seen >= n:
+            break

--- a/tests/required/datagen/test_datagen_fuzz.py
+++ b/tests/required/datagen/test_datagen_fuzz.py
@@ -1,14 +1,16 @@
 import pytest
 from unittest.mock import MagicMock
 import numpy as np
-from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.config import APIConfig, APIType, CustomTokenizerConfig, DataConfig, Distribution, DataGenType
 from inference_perf.apis import LazyLoadInferenceAPIData
 from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.apis.user_session import UserSessionCompletionAPIData
 from inference_perf.datagen.random_datagen import RandomDataGenerator
 from inference_perf.datagen.synthetic_datagen import SyntheticDataGenerator
 from inference_perf.config import SharedPrefix
 from inference_perf.datagen.base import DataGenerator, LazyLoadDataMixin
 from inference_perf.datagen.shared_prefix_datagen import SharedPrefixDataGenerator
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
 def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
@@ -100,3 +102,74 @@ def test_datagen_length_fuzz(gen_type: DataGenType) -> None:
 
             print(f"Type: {gen_type}, Expected: {expected_len}, Actual: {actual_len}")
             assert actual_len == expected_len, f"Failed for {gen_type}, expected {expected_len}, got {actual_len}"
+
+
+# Regression for #490: real BPE tokenizer + small q_len. Mock tokenizer above
+# tokenizes by whitespace so it cannot expose BPE boundary effects.
+@pytest.mark.parametrize("question_len_min", [1, 2, 3])
+def test_shared_prefix_real_tokenizer_small_question_len(question_len_min: int) -> None:
+    tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="gpt2"))
+    api_config = APIConfig(type=APIType.Completion)
+    shared_prefix_cfg = SharedPrefix(
+        num_groups=3,
+        num_prompts_per_group=50,
+        system_prompt_len=100,
+        question_distribution=Distribution(mean=float(question_len_min + 2), std_dev=2.0, min=question_len_min, max=20),
+        output_distribution=Distribution(mean=10.0, std_dev=1.0, min=1, max=20),
+        enable_multi_turn_chat=True,
+    )
+    data_config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=shared_prefix_cfg)
+
+    gen = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
+
+    for prompt, prefix in zip(gen.prompts, gen.prefix_texts, strict=True):
+        prefix_count = tokenizer.count_tokens(prefix)
+        full_count = tokenizer.count_tokens(prompt)
+        q_count = full_count - prefix_count
+        assert prefix_count == 100, f"prefix tokenized to {prefix_count}, expected 100"
+        assert question_len_min <= q_count <= 20, f"question length {q_count} outside [{question_len_min}, 20]"
+
+    n = 5
+    seen = 0
+    for lazy in gen.get_data():
+        if isinstance(lazy, LazyLoadInferenceAPIData):
+            p = gen.load_lazy_data(lazy)
+            assert isinstance(p, UserSessionCompletionAPIData)
+        seen += 1
+        if seen >= n:
+            break
+
+
+# Prefix-cache invariant: every prompt in a group must tokenize to the same
+# first len(encode(prefix)) tokens. Pinning the suffix's first token to a
+# word-start token is what enforces this.
+def test_shared_prefix_server_tokens_stable_across_group() -> None:
+    tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="gpt2"))
+    hf = tokenizer.get_tokenizer()
+    api_config = APIConfig(type=APIType.Completion)
+    shared_prefix_cfg = SharedPrefix(
+        num_groups=3,
+        num_prompts_per_group=30,
+        system_prompt_len=100,
+        question_distribution=Distribution(mean=5.0, std_dev=2.0, min=1, max=15),
+        output_distribution=Distribution(mean=10.0, std_dev=1.0, min=1, max=20),
+        enable_multi_turn_chat=True,
+    )
+    data_config = DataConfig(type=DataGenType.SharedPrefix, shared_prefix=shared_prefix_cfg)
+    gen = SharedPrefixDataGenerator(api_config, data_config, tokenizer)
+
+    by_group: dict[int, list[tuple[str, str]]] = {}
+    for prompt, prefix, gid in zip(gen.prompts, gen.prefix_texts, gen.prompt_groups, strict=True):
+        by_group.setdefault(gid, []).append((prompt, prefix))
+
+    for gid, entries in by_group.items():
+        canonical_prefix = entries[0][1]
+        canonical_prefix_ids = hf(canonical_prefix, add_special_tokens=False).input_ids
+        n_prefix = len(canonical_prefix_ids)
+        assert n_prefix > 0
+
+        first_n = {tuple(hf(prompt, add_special_tokens=False).input_ids[:n_prefix]) for prompt, _ in entries}
+        assert len(first_n) == 1, (
+            f"group {gid}: prefix tokenization differs across {len(entries)} prompts; "
+            f"got {len(first_n)} distinct token-prefix sequences"
+        )

--- a/tests/required/datagen/test_datagen_utils.py
+++ b/tests/required/datagen/test_datagen_utils.py
@@ -1,7 +1,6 @@
-import numpy as np
 import pytest
 from typing import Any, List
-from inference_perf.datagen.datagen_utils import converge_to_exact_length_text, generate_random_exact_length_text
+from inference_perf.datagen.datagen_utils import converge_to_exact_length_text
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
@@ -40,39 +39,16 @@ def test_generate_exact_length_text_success() -> None:
             current_tokens.append(40)
         return current_tokens
 
-    result = converge_to_exact_length_text(
+    result, ids = converge_to_exact_length_text(
         tokenizer=tokenizer,
         target_len=target_len,
-        prefix_text="",
         initial_tokens=initial_tokens,
         adjust_tokens_fn=adjust_tokens,
     )
 
     assert tokenizer.count_tokens(result) == target_len
     assert result == "10 20 30 40 40"  # initial 3 + 2 added
-
-
-def test_generate_exact_length_text_with_prefix() -> None:
-    tokenizer = DummyCustomTokenizer()
-    target_len = 6
-    prefix_text = "p1 p2"  # len 2
-    initial_tokens = [10, 20]  # len 2
-
-    def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
-        if current_len < target_len:
-            current_tokens.append(30)
-        return current_tokens
-
-    result = converge_to_exact_length_text(
-        tokenizer=tokenizer,
-        target_len=target_len,
-        prefix_text=prefix_text,
-        initial_tokens=initial_tokens,
-        adjust_tokens_fn=adjust_tokens,
-    )
-
-    assert tokenizer.count_tokens(result) == target_len
-    assert result == "p1 p2 10 20 30 30"  # prefix(2) + initial(2) + added(2) = 6
+    assert ids == [10, 20, 30, 40, 40]
 
 
 def test_generate_exact_length_text_failure() -> None:
@@ -88,7 +64,6 @@ def test_generate_exact_length_text_failure() -> None:
         converge_to_exact_length_text(
             tokenizer=tokenizer,
             target_len=target_len,
-            prefix_text="",
             initial_tokens=initial_tokens,
             adjust_tokens_fn=adjust_tokens,
         )
@@ -96,43 +71,11 @@ def test_generate_exact_length_text_failure() -> None:
 
 def test_generate_exact_length_text_zero_len() -> None:
     tokenizer = DummyCustomTokenizer()
-    result = converge_to_exact_length_text(
+    result, ids = converge_to_exact_length_text(
         tokenizer=tokenizer,
         target_len=0,
-        prefix_text="",
         initial_tokens=[10],
         adjust_tokens_fn=lambda c, _, __: c,
     )
     assert result == ""
-
-
-def test_generate_exact_length_text_prefix_already_too_long() -> None:
-    tokenizer = DummyCustomTokenizer()
-    prefix_text = "p1 p2 p3"  # len 3
-    with pytest.raises(
-        AssertionError, match=r"target_len \(2\) must be > prefix_len \(3\)\. This helper generates suffix tokens"
-    ):
-        converge_to_exact_length_text(
-            tokenizer=tokenizer,
-            target_len=2,
-            prefix_text=prefix_text,
-            initial_tokens=[10],
-            adjust_tokens_fn=lambda c, _, __: c,
-        )
-
-
-def test_generate_random_exact_length_text_prefix_already_too_long() -> None:
-    tokenizer = DummyCustomTokenizer()
-    rng = np.random.default_rng(0)
-    valid_token_ids = np.array([10, 20, 30, 40], dtype=np.int64)
-    prefix_text = "p1 p2 p3"  # len 3
-    with pytest.raises(
-        AssertionError, match=r"target_len \(2\) must be > prefix_len \(3\)\. This helper generates suffix tokens"
-    ):
-        generate_random_exact_length_text(
-            rng=rng,
-            valid_token_ids=valid_token_ids,
-            tokenizer=tokenizer,
-            target_len=2,
-            prefix_text=prefix_text,
-        )
+    assert ids == []


### PR DESCRIPTION
## Summary

Fixes #490 and a related prefix-cache stability hazard. Both share one root cause: prompts were composed by string concatenation (`prefix_text + " " + suffix_text`) and then re-tokenized, so the prefix/suffix boundary did not tokenize as `len(prefix_ids) + len(suffix_ids)`.

**Symptom 1 (loud, #490)**: `shared_prefix` raised `ValueError: Could not generate a prompt of exactly N tokens after 20 attempts (got N+1)` whenever the sampled question length was 1. The convergence target is additive (`sys_prompt_len + question_len`), but the explicit `" "` separator inserted between prefix and suffix tokenizes to its own token that the target never budgeted for, so the composed prompt comes out one token over. (Most BPE/SentencePiece tokens already carry a leading space, so `prefix + " " + " word"` produces a redundant double space that costs an extra token.) At `question_len == 1` the suffix is already at its one-token floor and the loop cannot trim it back to target, so it exhausts its retry budget one token over; `question_len >= 2` converged because the loop could drop a suffix token to absorb the extra. In #490 this was target 1006, got 1007.

**Symptom 2 (quiet)**: even on prompts that converged, the server-side tokenization of the prefix portion could differ across requests in the same group when different suffixes caused the prefix region to re-tokenize differently at the boundary, breaking prefix-cache hits.

## Fix

Compose at the token level instead of concatenating strings: build the prompt as `decode(prefix_ids + suffix_ids)` with no separator string, and draw the first suffix token from the subset of vocab whose decoded form starts with whitespace (BPE word-start / SentencePiece `▁*`). The word-start token supplies exactly one boundary space, and the tokenizer cannot merge it backward into the prefix, so for any prefix and any suffix length:

- `count_tokens(decode(prefix_ids + suffix_ids)) == len(prefix_ids) + len(suffix_ids)`, exact, by construction (fixes #490)
- `encode(decode(prefix_ids + suffix_ids))[:len(prefix_ids)]` is stable across suffix variants (fixes prefix-cache stability)

Both invariants follow from the same one-line property.