### PR TITLE
fix: _record_otel_metrics() correctly parse SSE streaming responses

### DIFF
--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -190,6 +190,9 @@ class openAIModelServerClientSession(ModelServerClientSession):
         end_time: float,
     ) -> None:
         """Record OTEL metrics for the request."""
+        if not self.client.otel.enabled or span is None:
+            return
+
         if info:
             inner = info.response_metrics
             otel_response_info: Dict[str, Any] = {
@@ -217,37 +220,74 @@ class openAIModelServerClientSession(ModelServerClientSession):
             # Extract input and output following GenAI semantic conventions
             try:
                 # Extract input based on request type
-                if hasattr(data, "messages"):
+                messages = getattr(data, "messages", None)
+                if messages is not None:
                     # Serialize each message, preserving tool_calls when present.
-                    input_messages = [msg.to_dict() for msg in data.messages]
+                    input_messages = [msg.to_dict() for msg in messages]
                     otel_response_info["input_messages"] = json.dumps(input_messages)
 
                     # Record tool definitions so they appear in Jaeger alongside the request.
-                    if hasattr(data, "tool_definitions") and data.tool_definitions:
-                        otel_response_info["tool_definitions"] = json.dumps(data.tool_definitions)
-                elif hasattr(data, "prompt"):
-                    # Text completion - store as prompt string (gen_ai.prompt)
-                    otel_response_info["input_prompt"] = data.prompt
+                    tool_definitions = getattr(data, "tool_definitions", None)
+                    if tool_definitions:
+                        otel_response_info["tool_definitions"] = json.dumps(tool_definitions)
+                else:
+                    prompt = getattr(data, "prompt", None)
+                    if prompt is not None:
+                        # Text completion - store as prompt string (gen_ai.prompt)
+                        otel_response_info["input_prompt"] = prompt
 
                 # Extract output text (gen_ai.output.text)
                 if response and response.status == 200 and response_content:
-                    response_json = json.loads(response_content)
-                    choices = response_json.get("choices", [])
-                    if choices:
-                        if "message" in choices[0]:
-                            # Chat completion response
-                            msg_out = choices[0].get("message", {})
-                            output_text = msg_out.get("content") or ""
-                            if msg_out.get("tool_calls"):
-                                # Store the full message under a dedicated key so
-                                # gen_ai.output.text stays as plain text only.
-                                otel_response_info["output_message"] = json.dumps(msg_out)
-                            else:
+                    response_json = None
+                    stripped_response = response_content.strip()
+
+                    if stripped_response.startswith("data:"):
+                        sse_payloads = []
+                        for line in stripped_response.splitlines():
+                            line = line.strip()
+                            if not line or not line.startswith("data:"):
+                                continue
+
+                            payload = line[len("data:") :].strip()
+                            if not payload or payload == "[DONE]":
+                                continue
+
+                            try:
+                                sse_payloads.append(json.loads(payload))
+                            except json.JSONDecodeError:
+                                continue
+
+                        if sse_payloads:
+                            response_json = sse_payloads[-1]
+                            # Concatenate all content deltas for full output text
+                            full_text = "".join(
+                                p.get("choices", [{}])[0].get("delta", {}).get("content", "") for p in sse_payloads
+                            )
+                            if full_text:
+                                otel_response_info["output_text"] = full_text
+                            # Check last chunk for tool_calls
+                            last_delta = sse_payloads[-1].get("choices", [{}])[0].get("delta", {})
+                            if last_delta.get("tool_calls"):
+                                otel_response_info["output_message"] = json.dumps(last_delta)
+                    else:
+                        response_json = json.loads(response_content)
+
+                    if response_json and not stripped_response.startswith("data:"):
+                        choices = response_json.get("choices", [])
+                        if choices:
+                            choice = choices[0]
+                            if "message" in choice:
+                                # Chat completion response
+                                msg_out = choice.get("message", {})
+                                output_text = msg_out.get("content") or ""
+                                if msg_out.get("tool_calls"):
+                                    otel_response_info["output_message"] = json.dumps(msg_out)
+                                else:
+                                    otel_response_info["output_text"] = output_text
+                            elif "text" in choice:
+                                # Text completion response
+                                output_text = choice.get("text", "")
                                 otel_response_info["output_text"] = output_text
-                        elif "text" in choices[0]:
-                            # Text completion response
-                            output_text = choices[0].get("text", "")
-                            otel_response_info["output_text"] = output_text
             except Exception as e:
                 logger.warning(f"Failed to extract messages for OTEL: {e}")
 

--- a/tests/required/client/modelserver/test_openai_client.py
+++ b/tests/required/client/modelserver/test_openai_client.py
@@ -102,3 +102,66 @@ async def test_process_request_general_exception(mock_client: MagicMock, mock_da
     metric = mock_client.metrics_collector.record_metric.call_args[0][0]
     assert isinstance(metric.error, ErrorResponseInfo)
     assert metric.error.error_type == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_otel_records_output_from_sse_response(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    """OTEL metrics should correctly parse SSE streaming response content."""
+    from contextlib import contextmanager
+    from inference_perf.config import APIType
+
+    mock_client.api_config.streaming = True
+    mock_client.api_config.type = APIType.Chat
+    mock_client.api_config.response_format = None
+    mock_client.api_key = None
+    mock_client.model_name = "test-model"
+    mock_client.max_completion_tokens = 30
+    mock_client.ignore_eos = True
+
+    # Enable OTEL with a mock span
+    mock_span = MagicMock()
+    mock_client.otel.enabled = True
+
+    @contextmanager
+    def fake_trace(**kwargs):  # type: ignore[no-untyped-def]
+        yield mock_span
+
+    mock_client.otel.trace_llm_request = fake_trace
+
+    # Real SSE response content from vLLM (last chunk has both content and finish_reason)
+    sse_content = (
+        'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1779111798,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}\n\n'
+        'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1779111798,"model":"test-model","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}]}\n\n'
+        'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1779111798,"model":"test-model","choices":[{"index":0,"delta":{"content":" world"},"logprobs":null,"finish_reason":"length"}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+
+    mock_data.session_id = None
+    mock_data.otel_context = None
+    mock_data.messages = None
+    mock_data.prompt = None
+    mock_data.process_response = AsyncMock(
+        return_value=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+            extra_info={"raw_response": sse_content},
+        )
+    )
+
+    # Mock the HTTP response
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    session = openAIModelServerClientSession(mock_client)
+    session.session = MagicMock()
+    session.session.post.return_value = mock_post_ctx
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    # Verify OTEL recorded the full concatenated output from all SSE chunks
+    mock_client.otel.record_response_metrics.assert_called_once()
+    call_kwargs = mock_client.otel.record_response_metrics.call_args[1]
+    response_info = call_kwargs["response_info"]
+    assert response_info["output_text"] == "Hello world"


### PR DESCRIPTION
Previously `_record_otel_metrics()` assumed response_content was always a single JSON object, causing json.loads to fail on SSE streaming responses. This fix detects SSE format, parses all chunks, and concatenates content deltas into the full output text following GenAI semantic conventions. Also adds an early-return guard when [OTel tracing](https://github.com/kubernetes-sigs/inference-perf/blob/main/docs/otel_instrumentation.md) is disabled or span is none, to avoid unnecessary parsing and processing when no telemetry will be recorded.