### PR TITLE
Log synthetic datagen materialization progress

### DIFF
--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 import base64
+import logging
+import os
+import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -37,6 +40,52 @@ from inference_perf.payloads import (
     Videos,
 )
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+logger = logging.getLogger(__name__)
+
+# Heartbeat for multimodal byte materialization. Image / video / audio bytes
+# are rendered lazily in workers during to_request_body, and on large runs the
+# cumulative cost is the dominant pre-server-call latency. The heartbeat
+# surfaces a per-worker cumulative count so the run does not look hung.
+_MULTIMODAL_PROGRESS_LOG_INTERVAL_SEC = 10.0
+_multimodal_materialized_requests: int = 0
+_multimodal_materialized_images: int = 0
+_multimodal_materialized_videos: int = 0
+_multimodal_materialized_audios: int = 0
+_multimodal_materialized_video_frames: int = 0
+_last_multimodal_progress_log_time: Optional[float] = None
+
+
+def _log_multimodal_progress(images: int, videos: int, audios: int, video_frames: int) -> None:
+    """Update per-process counters and emit a heartbeat at most every interval."""
+    global _multimodal_materialized_requests
+    global _multimodal_materialized_images
+    global _multimodal_materialized_videos
+    global _multimodal_materialized_audios
+    global _multimodal_materialized_video_frames
+    global _last_multimodal_progress_log_time
+
+    _multimodal_materialized_requests += 1
+    _multimodal_materialized_images += images
+    _multimodal_materialized_videos += videos
+    _multimodal_materialized_audios += audios
+    _multimodal_materialized_video_frames += video_frames
+
+    now = time.monotonic()
+    if (
+        _last_multimodal_progress_log_time is None
+        or (now - _last_multimodal_progress_log_time) >= _MULTIMODAL_PROGRESS_LOG_INTERVAL_SEC
+    ):
+        logger.info(
+            "Multimodal datagen progress: materialized %d requests (images=%d, videos=%d, video_frames=%d, audios=%d) (worker pid=%d)",
+            _multimodal_materialized_requests,
+            _multimodal_materialized_images,
+            _multimodal_materialized_videos,
+            _multimodal_materialized_video_frames,
+            _multimodal_materialized_audios,
+            os.getpid(),
+        )
+        _last_multimodal_progress_log_time = now
 
 
 # Fields allowed by the OpenAI/vLLM JSON Schema validator for tool parameters.
@@ -353,6 +402,13 @@ class ChatCompletionAPIData(InferenceAPIData):
         self.realized_images = Images(count=len(all_images), instances=all_images) if all_images else None
         self.realized_videos = Videos(count=len(all_videos), instances=all_videos) if all_videos else None
         self.realized_audios = Audios(count=len(all_audios), instances=all_audios) if all_audios else None
+
+        _log_multimodal_progress(
+            images=len(all_images),
+            videos=len(all_videos),
+            audios=len(all_audios),
+            video_frames=sum(v.frames for v in all_videos),
+        )
 
         return combined
 

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -132,12 +132,7 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
         self._materialized_count += 1
         now = time.monotonic()
         if self._last_progress_log_time is None or (now - self._last_progress_log_time) >= _PROGRESS_LOG_INTERVAL_SEC:
-            # Use warning() so the heartbeat surfaces in worker processes even
-            # when the worker interpreter has no logging config inherited from
-            # the parent (the default forkserver / spawn start method on
-            # Python 3.14 does not propagate basicConfig). Python's lastResort
-            # handler prints WARNING+ to stderr with no setup required.
-            logger.warning(
+            logger.info(
                 "Synthetic datagen progress: materialized %d prompts (worker pid=%d)",
                 self._materialized_count,
                 os.getpid(),

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
+import time
 from typing import Generator, List, Optional
 
 from inference_perf.apis import CompletionAPIData, InferenceAPIData, LazyLoadInferenceAPIData
@@ -22,6 +24,12 @@ from .base import DataGenerator, LazyLoadDataMixin
 from .datagen_utils import converge_to_exact_length_text
 
 logger = logging.getLogger(__name__)
+
+# Heartbeat interval for synthetic datagen progress logs. Synthetic prompt
+# materialization happens lazily in worker processes; on large runs with slow
+# tokenizers this can take tens of minutes with no other observable signal,
+# making the run look hung from outside.
+_PROGRESS_LOG_INTERVAL_SEC = 10.0
 
 
 class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
@@ -50,6 +58,13 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
         )
         base_prompt = "Pick as many lines as you can from these poem lines:\n"
         self.token_ids: list[int] = self.tokenizer.get_tokenizer().encode(base_prompt + self.get_sonnet_data())
+
+        # Per-process counters for the progress heartbeat emitted from
+        # load_lazy_data. Each worker process tracks its own count and
+        # log timestamp; aggregating across workers is not worth the
+        # plumbing for a tactical visibility fix.
+        self._materialized_count: int = 0
+        self._last_progress_log_time: Optional[float] = None
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion]
@@ -105,12 +120,27 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.api_config.type == APIType.Completion:
             length = self.input_lengths[n]
             prompt_text = self._generate_exact_length_text(length)
+            self._log_progress()
             return CompletionAPIData(
                 prompt=prompt_text,
                 max_tokens=self.output_lengths[n],
             )
         else:
             raise Exception("Unsupported API type")
+
+    def _log_progress(self) -> None:
+        self._materialized_count += 1
+        now = time.monotonic()
+        if (
+            self._last_progress_log_time is None
+            or (now - self._last_progress_log_time) >= _PROGRESS_LOG_INTERVAL_SEC
+        ):
+            logger.info(
+                "Synthetic datagen progress: materialized %d prompts (worker pid=%d)",
+                self._materialized_count,
+                os.getpid(),
+            )
+            self._last_progress_log_time = now
 
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         if self.tokenizer is None:

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -131,11 +131,13 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
     def _log_progress(self) -> None:
         self._materialized_count += 1
         now = time.monotonic()
-        if (
-            self._last_progress_log_time is None
-            or (now - self._last_progress_log_time) >= _PROGRESS_LOG_INTERVAL_SEC
-        ):
-            logger.info(
+        if self._last_progress_log_time is None or (now - self._last_progress_log_time) >= _PROGRESS_LOG_INTERVAL_SEC:
+            # Use warning() so the heartbeat surfaces in worker processes even
+            # when the worker interpreter has no logging config inherited from
+            # the parent (the default forkserver / spawn start method on
+            # Python 3.14 does not propagate basicConfig). Python's lastResort
+            # handler prints WARNING+ to stderr with no setup required.
+            logger.warning(
                 "Synthetic datagen progress: materialized %d prompts (worker pid=%d)",
                 self._materialized_count,
                 os.getpid(),

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -120,6 +120,11 @@ class Worker(mp.Process):
         self.skip = False
         self.base_seed = base_seed
         self.stage_barrier = stage_barrier
+        # Snapshot the parent's effective root log level so the worker
+        # interpreter (which under forkserver/spawn does not inherit the
+        # parent's basicConfig) can configure its own handler to surface
+        # logs at the same level the user asked for.
+        self._log_level = logging.getLogger().getEffectiveLevel()
 
     async def loop(self) -> None:
         # The self.shared_max_concurrency is initialized to self.max_concurrency
@@ -260,6 +265,15 @@ class Worker(mp.Process):
         logger.debug(f"[Worker {self.id}] stopped")
 
     def run(self) -> None:
+        # forkserver/spawn workers start from a fresh interpreter without the
+        # parent's logging.basicConfig, so logger.info() calls are silently
+        # dropped by the lastResort handler (WARNING+). Install a minimal
+        # handler at the parent-configured level so worker-side logs surface.
+        logging.basicConfig(
+            level=self._log_level,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        )
+
         # Seed with current time + worker id to ensure unique random sequences per worker
         seed = (self.base_seed + self.id) % 2**32
         np.random.seed(seed)

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -11,12 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import MagicMock
+import logging
+from typing import Any, Iterator
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from inference_perf.apis import chat as chat_module
 from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
 from inference_perf.config import APIType
+from inference_perf.payloads.multimodal_spec import (
+    AudioInstanceSpec,
+    ImageInstanceSpec,
+    MultimodalSpec,
+    VideoInstanceSpec,
+)
 
 
 @pytest.mark.asyncio
@@ -55,3 +64,68 @@ def test_count_prompt_tokens_without_prefix_text_unchanged() -> None:
 
     data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="five tokens in this prompt")])
     assert data._count_prompt_tokens(tokenizer) == 5
+
+
+def _reset_multimodal_progress_state() -> None:
+    """Zero the module-level multimodal heartbeat counters between tests."""
+    chat_module._multimodal_materialized_requests = 0
+    chat_module._multimodal_materialized_images = 0
+    chat_module._multimodal_materialized_videos = 0
+    chat_module._multimodal_materialized_audios = 0
+    chat_module._multimodal_materialized_video_frames = 0
+    chat_module._last_multimodal_progress_log_time = None
+
+
+def _make_multimodal_request(images: int = 1, audios: int = 0, videos: int = 0) -> ChatCompletionAPIData:
+    spec = MultimodalSpec(
+        images=[ImageInstanceSpec(width=8, height=8, insertion_point=0.0) for _ in range(images)],
+        videos=[VideoInstanceSpec(width=8, height=8, frames=2, insertion_point=0.0) for _ in range(videos)],
+        audios=[AudioInstanceSpec(duration=0.1, insertion_point=0.0) for _ in range(audios)],
+    )
+    return ChatCompletionAPIData(
+        messages=[ChatMessage(role="user", content="hi")],
+        multimodal_spec=spec,
+    )
+
+
+@pytest.mark.asyncio
+async def test_multimodal_heartbeat_fires_on_interval(caplog: Any) -> None:
+    """Each materialized multimodal request advances counters; a heartbeat fires once per interval."""
+    _reset_multimodal_progress_state()
+
+    # Drive monotonic forward by the configured interval on every call so each
+    # to_request_body crosses the heartbeat boundary.
+    fake_time: Iterator[float] = iter(
+        (i * chat_module._MULTIMODAL_PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100))
+    )
+
+    caplog.set_level(logging.INFO, logger=chat_module.__name__)
+    with patch("inference_perf.apis.chat.time.monotonic", side_effect=lambda: next(fake_time)):
+        for _ in range(3):
+            await _make_multimodal_request(images=2, audios=1).to_request_body("m", 10, False, False)
+
+    progress = [r.message for r in caplog.records if "Multimodal datagen progress" in r.message]
+    assert len(progress) == 3
+    assert "materialized 3 requests" in progress[-1]
+    assert "images=6" in progress[-1]
+    assert "audios=3" in progress[-1]
+
+
+@pytest.mark.asyncio
+async def test_multimodal_heartbeat_skips_within_interval() -> None:
+    """Sub-interval materializations advance counters but only log once."""
+    _reset_multimodal_progress_state()
+
+    base_time = 1_000_000.0
+    fake_time = iter([base_time, base_time + 0.1, base_time + 0.2, base_time + 0.3])
+
+    with (
+        patch.object(chat_module, "logger") as mock_logger,
+        patch("inference_perf.apis.chat.time.monotonic", side_effect=lambda: next(fake_time)),
+    ):
+        for _ in range(4):
+            await _make_multimodal_request(images=1).to_request_body("m", 10, False, False)
+
+    assert mock_logger.info.call_count == 1
+    assert chat_module._multimodal_materialized_requests == 4
+    assert chat_module._multimodal_materialized_images == 4

--- a/tests/required/datagen/test_synthetic_datagen.py
+++ b/tests/required/datagen/test_synthetic_datagen.py
@@ -71,7 +71,7 @@ def test_synthetic_datagen_logs_progress_on_interval(caplog: Any) -> None:
     # so every call crosses the heartbeat boundary.
     fake_time: Iterator[float] = iter((i * synthetic_datagen._PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100)))
 
-    caplog.set_level(logging.WARNING, logger=synthetic_datagen.__name__)
+    caplog.set_level(logging.INFO, logger=synthetic_datagen.__name__)
     with patch.object(synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)):
         for i in range(3):
             generator.load_lazy_data(LazyLoadInferenceAPIData(data_index=i))
@@ -103,4 +103,4 @@ def test_synthetic_datagen_skips_progress_log_within_interval() -> None:
 
     # First call sets the baseline timestamp and logs; subsequent sub-interval
     # calls should be silent.
-    assert mock_logger.warning.call_count == 1
+    assert mock_logger.info.call_count == 1

--- a/tests/required/datagen/test_synthetic_datagen.py
+++ b/tests/required/datagen/test_synthetic_datagen.py
@@ -72,7 +72,7 @@ def test_synthetic_datagen_logs_progress_on_interval(caplog: Any) -> None:
     fake_time: Iterator[float] = iter((i * synthetic_datagen._PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100)))
 
     caplog.set_level(logging.INFO, logger=synthetic_datagen.__name__)
-    with patch.object(synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)):
+    with patch("inference_perf.datagen.synthetic_datagen.time.monotonic", side_effect=lambda: next(fake_time)):
         for i in range(3):
             generator.load_lazy_data(LazyLoadInferenceAPIData(data_index=i))
 
@@ -96,7 +96,7 @@ def test_synthetic_datagen_skips_progress_log_within_interval() -> None:
 
     with (
         patch.object(synthetic_datagen, "logger") as mock_logger,
-        patch.object(synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)),
+        patch("inference_perf.datagen.synthetic_datagen.time.monotonic", side_effect=lambda: next(fake_time)),
     ):
         for i in range(4):
             generator.load_lazy_data(LazyLoadInferenceAPIData(data_index=i))

--- a/tests/required/datagen/test_synthetic_datagen.py
+++ b/tests/required/datagen/test_synthetic_datagen.py
@@ -69,11 +69,9 @@ def test_synthetic_datagen_logs_progress_on_interval(caplog: Any) -> None:
 
     # Drive time forward by the configured interval on every materialization
     # so every call crosses the heartbeat boundary.
-    fake_time: Iterator[float] = iter(
-        (i * synthetic_datagen._PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100))
-    )
+    fake_time: Iterator[float] = iter((i * synthetic_datagen._PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100)))
 
-    caplog.set_level(logging.INFO, logger=synthetic_datagen.__name__)
+    caplog.set_level(logging.WARNING, logger=synthetic_datagen.__name__)
     with patch.object(synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)):
         for i in range(3):
             generator.load_lazy_data(LazyLoadInferenceAPIData(data_index=i))
@@ -96,12 +94,13 @@ def test_synthetic_datagen_skips_progress_log_within_interval() -> None:
     base_time = 1_000_000.0
     fake_time = iter([base_time, base_time + 0.1, base_time + 0.2, base_time + 0.3])
 
-    with patch.object(synthetic_datagen, "logger") as mock_logger, patch.object(
-        synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)
+    with (
+        patch.object(synthetic_datagen, "logger") as mock_logger,
+        patch.object(synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)),
     ):
         for i in range(4):
             generator.load_lazy_data(LazyLoadInferenceAPIData(data_index=i))
 
     # First call sets the baseline timestamp and logs; subsequent sub-interval
     # calls should be silent.
-    assert mock_logger.info.call_count == 1
+    assert mock_logger.warning.call_count == 1

--- a/tests/required/datagen/test_synthetic_datagen.py
+++ b/tests/required/datagen/test_synthetic_datagen.py
@@ -1,8 +1,12 @@
+import logging
+from typing import Any, Iterator
+from unittest.mock import patch
+
 from inference_perf.apis import CompletionAPIData, LazyLoadInferenceAPIData
 from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.datagen import synthetic_datagen
 from inference_perf.datagen.synthetic_datagen import SyntheticDataGenerator
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from typing import Any
 
 
 class DummyTokenizer:
@@ -51,3 +55,53 @@ def test_synthetic_datagen_yields_string() -> None:
 
     assert isinstance(real_data.prompt, str)
     assert len(real_data.prompt) > 0
+
+
+def test_synthetic_datagen_logs_progress_on_interval(caplog: Any) -> None:
+    """Materializing prompts should emit a heartbeat log line at the configured interval."""
+    api_config = APIConfig(type=APIType.Completion)
+    data_config = DataConfig(
+        type=DataGenType.Synthetic,
+        input_distribution=Distribution(min=10, max=20, mean=15, std_dev=2, total_count=20),
+        output_distribution=Distribution(min=5, max=10, mean=7, std_dev=1, total_count=20),
+    )
+    generator = SyntheticDataGenerator(api_config, data_config, DummyCustomTokenizer())
+
+    # Drive time forward by the configured interval on every materialization
+    # so every call crosses the heartbeat boundary.
+    fake_time: Iterator[float] = iter(
+        (i * synthetic_datagen._PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100))
+    )
+
+    caplog.set_level(logging.INFO, logger=synthetic_datagen.__name__)
+    with patch.object(synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)):
+        for i in range(3):
+            generator.load_lazy_data(LazyLoadInferenceAPIData(data_index=i))
+
+    progress_messages = [r.message for r in caplog.records if "Synthetic datagen progress" in r.message]
+    assert len(progress_messages) == 3
+    assert "materialized 3 prompts" in progress_messages[-1]
+
+
+def test_synthetic_datagen_skips_progress_log_within_interval() -> None:
+    """Sub-interval materializations should only log once."""
+    api_config = APIConfig(type=APIType.Completion)
+    data_config = DataConfig(
+        type=DataGenType.Synthetic,
+        input_distribution=Distribution(min=10, max=20, mean=15, std_dev=2, total_count=20),
+        output_distribution=Distribution(min=5, max=10, mean=7, std_dev=1, total_count=20),
+    )
+    generator = SyntheticDataGenerator(api_config, data_config, DummyCustomTokenizer())
+
+    base_time = 1_000_000.0
+    fake_time = iter([base_time, base_time + 0.1, base_time + 0.2, base_time + 0.3])
+
+    with patch.object(synthetic_datagen, "logger") as mock_logger, patch.object(
+        synthetic_datagen.time, "monotonic", side_effect=lambda: next(fake_time)
+    ):
+        for i in range(4):
+            generator.load_lazy_data(LazyLoadInferenceAPIData(data_index=i))
+
+    # First call sets the baseline timestamp and logs; subsequent sub-interval
+    # calls should be silent.
+    assert mock_logger.info.call_count == 1


### PR DESCRIPTION
Addresses: #488 

SyntheticDataGenerator materializes prompts lazily inside worker processes. On large runs with slow tokenizers there is no other signal of forward progress between the run start and the first response, making the benchmark look hung. Emit a per-worker INFO heartbeat from load_lazy_data at most every 10s so logs show prompts are still being produced.


Logs snippet:
```
2026-05-19 17:22:47,282 - inference_perf.loadgen.load_generator - INFO - Stage 0 - run started
2026-05-19 17:22:49,313 - inference_perf.apis.chat - INFO - Multimodal datagen progress: materialized 1 requests (images=3, videos=0, video_frames=0, audios=0) (worker pid=409863)
2026-05-19 17:22:59,368 - inference_perf.apis.chat - INFO - Multimodal datagen progress: materialized 11 requests (images=33, videos=0, video_frames=0, audios=0) (worker pid=409863)
2026-05-19 17:23:09,413 - inference_perf.apis.chat - INFO - Multimodal datagen progress: materialized 21 requests (images=63, videos=0, video_frames=0, audios=0) (worker pid=409863)
2026-05-19 17:23:19,471 - inference_perf.apis.chat - INFO - Multimodal datagen progress: materialized 31 requests (images=93, videos=0, video_frames=0, audios=0) (worker pid=409863)
2026-05-19 17:23:29,339 - inference_perf.loadgen.load_generator - INFO - Stage 0 - run completed
```