### PR TITLE
[conversation_replay] force min_tokens == max_tokens for deterministic output length

### DIFF
--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -26,6 +26,13 @@ from inference_perf.apis.streaming_parser import parse_sse_stream
 class CompletionAPIData(InferenceAPIData):
     prompt: str
     max_tokens: int = 0
+    # vLLM extension. When set, the server is forced to generate at least
+    # this many tokens before honoring EOS or any stop_token_ids. Critical
+    # for deterministic output length across model families whose
+    # generation_config.eos_token_id lists differ — `ignore_eos` alone only
+    # suppresses the primary EOS, leaving chat-template stop tokens (e.g.
+    # <|im_end|>) to terminate generation early.
+    min_tokens: Optional[int] = None
     model_response: str = ""
 
     def get_api_type(self) -> APIType:
@@ -39,7 +46,7 @@ class CompletionAPIData(InferenceAPIData):
     ) -> RequestBody:
         if self.max_tokens == 0:
             self.max_tokens = max_tokens
-        return {
+        body: RequestBody = {
             "model": effective_model_name,
             "prompt": self.prompt,
             "max_tokens": self.max_tokens,
@@ -47,6 +54,9 @@ class CompletionAPIData(InferenceAPIData):
             "stream": streaming,
             **({"stream_options": {"include_usage": True}} if streaming else {}),
         }
+        if self.min_tokens is not None:
+            body["min_tokens"] = self.min_tokens
+        return body
 
     async def process_response(
         self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: Optional[str] = None

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -235,9 +235,17 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
             logger.debug("Slot %d starting conversation %d", conv_idx, convo_num)
 
         latency = bp.turn_tool_call_latencies[turn_idx] if bp.turn_tool_call_latencies else 0.0
+        # Force min_tokens == max_tokens so every turn emits exactly the
+        # sampled output length, regardless of which stop_token_ids the
+        # model's generation_config defines. Without this, cross-model
+        # throughput comparisons are invalid: chat-template stop tokens
+        # (e.g. Qwen <|im_end|>, Llama <|eot_id|>) terminate generation
+        # early in spite of ignore_eos=True, which only suppresses the
+        # primary EOS.
         return _ConversationReplayAPIData(
             prompt=bp.turn_prompts[turn_idx],
             max_tokens=bp.turn_output_lens[turn_idx],
+            min_tokens=bp.turn_output_lens[turn_idx],
             user_session_id=self.user_sessions[conv_idx].user_session_id,
             target_round=round_num,
             tool_call_latency_sec=latency,

--- a/tests/required/apis/test_completion.py
+++ b/tests/required/apis/test_completion.py
@@ -34,6 +34,23 @@ async def test_completion_api_data() -> None:
 
 
 @pytest.mark.asyncio
+async def test_completion_api_data_omits_min_tokens_when_unset() -> None:
+    """min_tokens defaults to None and is not included in the payload."""
+    data = CompletionAPIData(prompt="Hello")
+    payload = await data.to_request_body("test-model", 100, False, False)
+    assert "min_tokens" not in payload
+
+
+@pytest.mark.asyncio
+async def test_completion_api_data_includes_min_tokens_when_set() -> None:
+    """min_tokens propagates into the request body verbatim."""
+    data = CompletionAPIData(prompt="Hello", max_tokens=256, min_tokens=256)
+    payload = await data.to_request_body("test-model", 100, False, False)
+    assert payload["min_tokens"] == 256
+    assert payload["max_tokens"] == 256
+
+
+@pytest.mark.asyncio
 async def test_chat_completion_api_data_with_tools() -> None:
     tool_defs = [
         {

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -285,6 +285,33 @@ class TestConversationReplayDataGenerator:
             # All within bounds
             assert all(1 <= lat <= 30 for lat in bp.turn_tool_call_latencies)
 
+    def test_min_tokens_equals_max_tokens_for_deterministic_output(self) -> None:
+        """Every emitted per-turn API data has min_tokens == max_tokens == sampled output length.
+
+        Without this invariant, models whose generation_config.eos_token_id
+        is a list (Qwen3, Llama 3, Nemotron) terminate generation early at
+        chat-template stop tokens despite ignore_eos=True, yielding
+        different mean output token counts per model family and
+        invalidating throughput comparisons.
+        """
+        api_config, data_config = _make_config(num_conversations=3, turns_min=4, turns_max=4, turns_mean=4)
+        gen = ConversationReplayDataGenerator(api_config, data_config, _make_mock_tokenizer())
+
+        # Sweep across every (conversation, turn) pair the datagen will dispatch.
+        total_turns = sum(bp.num_turns for bp in gen.blueprints)
+        for data_index in range(total_turns):
+            conv_idx = data_index % len(gen.blueprints)
+            lazy = LazyLoadInferenceAPIData(data_index=data_index, preferred_worker_id=conv_idx)
+            result = gen.load_lazy_data(lazy)
+            assert isinstance(result, _ConversationReplayAPIData)
+            assert result.min_tokens is not None
+            assert result.min_tokens == result.max_tokens
+            # And both equal the per-turn sampled output length.
+            bp = gen.blueprints[conv_idx]
+            round_num = data_index // len(gen.blueprints)
+            turn_idx = round_num % bp.num_turns
+            assert result.max_tokens == bp.turn_output_lens[turn_idx]
+
 
 class TestDistributionExtensions:
     def test_lognormal_distribution(self) -> None:


### PR DESCRIPTION
## Problem

Conversation-replay benchmarks compare model throughput by sampling a fixed output-length distribution per turn (`turn_output_lens`) and assuming each turn emits exactly that many tokens. In practice the sampled length is not honored: different model families terminate at different chat-template stop tokens, so the same workload yields different total output token counts on Qwen vs Llama vs Nemotron. This invalidates `tok/sec` and `convos/hr` comparisons across models — TPOT remains valid, but the per-turn token budget does not.

`ignore_eos=True` does **not** fix this. vLLM's `ignore_eos` only suppresses the single canonical `tokenizer.eos_token_id`; it does **not** suppress the rest of the ids in `generation_config.eos_token_id`. Examples:

- Qwen3: `eos_token_id = [151645, 151643]` — `<|im_end|>`, `<|endoftext|>`
- Llama3: `eos_token_id = [128001, 128008, 128009]`

Once a chat-template stop token fires, generation stops regardless of `ignore_eos`. In live runs we've seen the same workload produce ~585 output tokens on one model and ~280 on another for the same `max_tokens`/`ignore_eos=True` settings, purely because the second model's `<|im_end|>` slipped past the EOS filter.

## Fix

Use vLLM's `min_tokens`, which is checked **before** any stop condition (EOS, `stop_token_ids`, custom stops). Setting `min_tokens == max_tokens` forces deterministic per-turn output length across every model family.

## Changes

- `inference_perf/apis/completion.py` — add `min_tokens: Optional[int] = None` to `CompletionAPIData` and include it in the request body when set. `UserSessionCompletionAPIData.to_request_body` already calls `super().to_request_body()`, so the field is propagated through to conversation_replay automatically.
- `inference_perf/datagen/conversation_replay_datagen.py` — set `min_tokens=bp.turn_output_lens[turn_idx]` parallel to the existing `max_tokens` when constructing each per-turn `_ConversationReplayAPIData`.

## Tests

- `min_tokens` is omitted from the payload when unset (back-compat for the other API surfaces).
- When set, it round-trips through `to_request_body` verbatim alongside `max_tokens`.
- Every per-turn payload produced by `ConversationReplayDataGenerator` has `min_tokens == max_tokens == turn_output_lens[i]` for the entire materialized stream.

Full suite still green: 288/288.

## Design note

`min_tokens` is always set for conversation_replay with no config knob. The point of conversation_replay is reproducibility; making deterministic length opt-in defeats the purpose, and there is no scenario where a user wants the cross-model drift behavior back. Other API types (`CompletionAPIData` used outside conversation_replay) are unaffected because `min_tokens` defaults to `None`.

## Caveats

- vLLM still clamps `max_tokens` when `prompt_tokens + max_tokens > max_model_len`. If the prompt grows that large during a session, vLLM may emit fewer than `min_tokens` tokens and error or truncate. Watch `error_rate` and tune `output_tokens_per_turn` against your `max_model_len`.
- `min_tokens` is a vLLM extension, not OpenAI-spec. Other OpenAI-compatible backends will ignore the field — the existing drift behavior persists there. This PR doesn't change behavior for non-vLLM servers.