### PR TITLE
feat: add reasoning output support for OTEL trace replay

### DIFF
--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -238,7 +238,7 @@ class openAIModelServerClientSession(ModelServerClientSession):
                     if stripped_response.startswith("data:"):
                         output_parts = []
                         reasoning_parts = []
-                        last_delta = {}
+                        tool_call_parts = []
                         for line in stripped_response.splitlines():
                             line = line.strip()
                             if not line or not line.startswith("data:"):
@@ -253,18 +253,20 @@ class openAIModelServerClientSession(ModelServerClientSession):
                             choices = chunk.get("choices", [])
                             if not choices:
                                 continue
-                            last_delta = choices[0].get("delta", {})
-                            if last_delta.get("content"):
-                                output_parts.append(last_delta["content"])
-                            if last_delta.get("reasoning_content"):
-                                reasoning_parts.append(last_delta["reasoning_content"])
+                            delta = choices[0].get("delta", {})
+                            if delta.get("content"):
+                                output_parts.append(delta["content"])
+                            if delta.get("reasoning_content"):
+                                reasoning_parts.append(delta["reasoning_content"])
+                            if delta.get("tool_calls"):
+                                tool_call_parts.append(delta)
 
                         if output_parts:
                             otel_response_info["output_text"] = "".join(output_parts)
                         if reasoning_parts:
                             otel_response_info["reasoning_text"] = "".join(reasoning_parts)
-                        if last_delta.get("tool_calls"):
-                            otel_response_info["output_message"] = json.dumps(last_delta)
+                        if tool_call_parts:
+                            otel_response_info["output_message"] = json.dumps(tool_call_parts)
                 elif response and response.status == 200 and response_content:
                     response_json = json.loads(response_content)
                     choices = response_json.get("choices", [])

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -220,74 +220,42 @@ class openAIModelServerClientSession(ModelServerClientSession):
             # Extract input and output following GenAI semantic conventions
             try:
                 # Extract input based on request type
-                messages = getattr(data, "messages", None)
-                if messages is not None:
+                if hasattr(data, "messages"):
                     # Serialize each message, preserving tool_calls when present.
-                    input_messages = [msg.to_dict() for msg in messages]
+                    input_messages = [msg.to_dict() for msg in data.messages]
                     otel_response_info["input_messages"] = json.dumps(input_messages)
 
                     # Record tool definitions so they appear in Jaeger alongside the request.
-                    tool_definitions = getattr(data, "tool_definitions", None)
-                    if tool_definitions:
-                        otel_response_info["tool_definitions"] = json.dumps(tool_definitions)
-                else:
-                    prompt = getattr(data, "prompt", None)
-                    if prompt is not None:
-                        # Text completion - store as prompt string (gen_ai.prompt)
-                        otel_response_info["input_prompt"] = prompt
+                    if hasattr(data, "tool_definitions") and data.tool_definitions:
+                        otel_response_info["tool_definitions"] = json.dumps(data.tool_definitions)
+                elif hasattr(data, "prompt"):
+                    # Text completion - store as prompt string (gen_ai.prompt)
+                    otel_response_info["input_prompt"] = data.prompt
 
                 # Extract output text (gen_ai.output.text)
-                if response and response.status == 200 and response_content:
-                    response_json = None
-                    stripped_response = response_content.strip()
+                if isinstance(inner, StreamedResponseMetrics):
+                    if hasattr(info, "output_text") and info.output_text:
+                        otel_response_info["output_text"] = info.output_text
+                    if hasattr(info, "output_message") and info.output_message:
+                        otel_response_info["output_message"] = json.dumps(info.output_message)
+                elif response and response.status == 200 and response_content:
+                    response_json = json.loads(response_content)
+                    choices = response_json.get("choices", [])
+                    if choices:
+                        if "message" in choices[0]:
+                            msg_out = choices[0].get("message", {})
+                            output_text = msg_out.get("content") or ""
+                            reasoning_content = msg_out.get("reasoning_content")
 
-                    if stripped_response.startswith("data:"):
-                        sse_payloads = []
-                        for line in stripped_response.splitlines():
-                            line = line.strip()
-                            if not line or not line.startswith("data:"):
-                                continue
+                            otel_response_info["output_text"] = output_text
+                            if reasoning_content:
+                                otel_response_info["reasoning_text"] = reasoning_content
 
-                            payload = line[len("data:") :].strip()
-                            if not payload or payload == "[DONE]":
-                                continue
-
-                            try:
-                                sse_payloads.append(json.loads(payload))
-                            except json.JSONDecodeError:
-                                continue
-
-                        if sse_payloads:
-                            response_json = sse_payloads[-1]
-                            # Concatenate all content deltas for full output text
-                            full_text = "".join(
-                                p.get("choices", [{}])[0].get("delta", {}).get("content", "") for p in sse_payloads
-                            )
-                            if full_text:
-                                otel_response_info["output_text"] = full_text
-                            # Check last chunk for tool_calls
-                            last_delta = sse_payloads[-1].get("choices", [{}])[0].get("delta", {})
-                            if last_delta.get("tool_calls"):
-                                otel_response_info["output_message"] = json.dumps(last_delta)
-                    else:
-                        response_json = json.loads(response_content)
-
-                    if response_json and not stripped_response.startswith("data:"):
-                        choices = response_json.get("choices", [])
-                        if choices:
-                            choice = choices[0]
-                            if "message" in choice:
-                                # Chat completion response
-                                msg_out = choice.get("message", {})
-                                output_text = msg_out.get("content") or ""
-                                if msg_out.get("tool_calls"):
-                                    otel_response_info["output_message"] = json.dumps(msg_out)
-                                else:
-                                    otel_response_info["output_text"] = output_text
-                            elif "text" in choice:
-                                # Text completion response
-                                output_text = choice.get("text", "")
-                                otel_response_info["output_text"] = output_text
+                            if msg_out.get("tool_calls") or reasoning_content:
+                                otel_response_info["output_message"] = json.dumps(msg_out)
+                        elif "text" in choices[0]:
+                            output_text = choices[0].get("text", "")
+                            otel_response_info["output_text"] = output_text
             except Exception as e:
                 logger.warning(f"Failed to extract messages for OTEL: {e}")
 

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -220,7 +220,7 @@ class openAIModelServerClientSession(ModelServerClientSession):
             # Extract input and output following GenAI semantic conventions
             try:
                 # Extract input based on request type
-                if hasattr(data, "messages"):
+                if hasattr(data, "messages") and data.messages:
                     # Serialize each message, preserving tool_calls when present.
                     input_messages = [msg.to_dict() for msg in data.messages]
                     otel_response_info["input_messages"] = json.dumps(input_messages)
@@ -233,11 +233,38 @@ class openAIModelServerClientSession(ModelServerClientSession):
                     otel_response_info["input_prompt"] = data.prompt
 
                 # Extract output text (gen_ai.output.text)
-                if isinstance(inner, StreamedResponseMetrics):
-                    if hasattr(info, "output_text") and info.output_text:
-                        otel_response_info["output_text"] = info.output_text
-                    if hasattr(info, "output_message") and info.output_message:
-                        otel_response_info["output_message"] = json.dumps(info.output_message)
+                if self.client.api_config.streaming and response_content:
+                    stripped_response = response_content.strip()
+                    if stripped_response.startswith("data:"):
+                        output_parts = []
+                        reasoning_parts = []
+                        last_delta = {}
+                        for line in stripped_response.splitlines():
+                            line = line.strip()
+                            if not line or not line.startswith("data:"):
+                                continue
+                            payload = line[len("data:") :].strip()
+                            if not payload or payload == "[DONE]":
+                                continue
+                            try:
+                                chunk = json.loads(payload)
+                            except json.JSONDecodeError:
+                                continue
+                            choices = chunk.get("choices", [])
+                            if not choices:
+                                continue
+                            last_delta = choices[0].get("delta", {})
+                            if last_delta.get("content"):
+                                output_parts.append(last_delta["content"])
+                            if last_delta.get("reasoning_content"):
+                                reasoning_parts.append(last_delta["reasoning_content"])
+
+                        if output_parts:
+                            otel_response_info["output_text"] = "".join(output_parts)
+                        if reasoning_parts:
+                            otel_response_info["reasoning_text"] = "".join(reasoning_parts)
+                        if last_delta.get("tool_calls"):
+                            otel_response_info["output_message"] = json.dumps(last_delta)
                 elif response and response.status == 200 and response_content:
                     response_json = json.loads(response_content)
                     choices = response_json.get("choices", [])

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -594,10 +594,11 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             return ""
 
         if config.streaming:
-            # Accumulate tool_call chunks alongside text content.
+            # Accumulate tool_call chunks and reasoning_content alongside text content.
             # delta.tool_calls is a list of partial objects; each chunk carries an
             # index that identifies which tool call it belongs to.
             tool_call_chunks: Dict[int, Dict[str, Any]] = {}
+            reasoning_content_chunks: list[str] = []
 
             def _extract_streaming_content(data: Dict[str, Any]) -> Optional[str]:
                 delta = data.get("choices", [{}])[0].get("delta", {})
@@ -616,12 +617,25 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                         tool_call_chunks[idx]["function"]["arguments"] += fn["arguments"]
                     if chunk.get("id"):
                         tool_call_chunks[idx]["id"] = chunk["id"]
+
+                # Accumulate reasoning_content chunks
+                reasoning_chunk = delta.get("reasoning_content")
+                if reasoning_chunk is not None:
+                    reasoning_content_chunks.append(str(reasoning_chunk))
+
                 content = delta.get("content")
                 return str(content) if content is not None else None
 
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+            text_content, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response, extract_content=_extract_streaming_content
             )
+
+            # Combine reasoning_content with output text for the content field
+            reasoning_text = "".join(reasoning_content_chunks) if reasoning_content_chunks else ""
+            if reasoning_text:
+                output_text = reasoning_text + text_content
+            else:
+                output_text = text_content
 
             streaming_output_message: Optional[Dict[str, Any]] = None
             if tool_call_chunks:
@@ -631,6 +645,11 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     streaming_output_message["content"] = output_text
             else:
                 streaming_output_message = {"role": "assistant", "content": output_text}
+
+            # Keep separate reasoning_content and output_content fields
+            if reasoning_text:
+                streaming_output_message["reasoning_content"] = reasoning_text
+                streaming_output_message["output_content"] = text_content
 
             prompt_text = "".join([_get_text(msg.content) for msg in self.messages if msg.content])
             prompt_len = tokenizer.count_tokens(prompt_text)
@@ -664,14 +683,27 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             tool_calls = None
             if choices:
                 msg_dict = choices[0].get("message", {})
-                output_text = msg_dict.get("content", "") or ""
+                text_content = msg_dict.get("content", "") or ""
                 tool_calls = msg_dict.get("tool_calls")
+                reasoning_content = msg_dict.get("reasoning_content")
+
+                # Combine reasoning_content with output text for the content field
+                if reasoning_content:
+                    output_text = reasoning_content + text_content
+                else:
+                    output_text = text_content
+
                 if tool_calls:
                     output_message = {"role": "assistant", "tool_calls": tool_calls}
                     if output_text:
                         output_message["content"] = output_text
                 else:
                     output_message = {"role": "assistant", "content": output_text}
+
+                # Keep separate reasoning_content and output_content fields
+                if reasoning_content:
+                    output_message["reasoning_content"] = reasoning_content
+                    output_message["output_content"] = text_content
             usage = data.get("usage") or {}
             server_completion_tokens = usage.get("completion_tokens")
             if server_completion_tokens is not None:

--- a/tests/test_reasoning_output_support.py
+++ b/tests/test_reasoning_output_support.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for reasoning output support in OTEL trace replay.
+
+Exercises the actual production code in SessionChatCompletionAPIData.process_response
+to verify correct handling of reasoning_content from reasoning models.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncGenerator, Dict, List, Optional, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import ClientResponse
+
+from inference_perf.apis.chat import ChatMessage
+from inference_perf.datagen.replay_graph_session_datagen import (
+    EventOutputRegistry,
+    SessionChatCompletionAPIData,
+    SessionInferenceInfo,
+    WorkerSessionTracker,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tokenizer() -> MagicMock:
+    tok = MagicMock()
+    tok.count_tokens = lambda text: max(1, len((text or "").split()))
+    return tok
+
+
+def _make_config(streaming: bool = False) -> MagicMock:
+    cfg = MagicMock()
+    cfg.streaming = streaming
+    return cfg
+
+
+def _make_non_streaming_response(
+    content: str = "",
+    reasoning_content: Optional[str] = None,
+    tool_calls: Optional[List[Dict[str, Any]]] = None,
+) -> MagicMock:
+    message: Dict[str, Any] = {"role": "assistant", "content": content}
+    if reasoning_content is not None:
+        message["reasoning_content"] = reasoning_content
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    response = MagicMock()
+    response.json = AsyncMock(return_value={"choices": [{"message": message}]})
+    return response
+
+
+class FakeStreamingResponse:
+    """Minimal aiohttp ClientResponse stand-in that yields preset SSE bytes."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        self.status = 200
+        self.headers = {"content-type": "text/event-stream"}
+        self._chunks = chunks
+        self.content = self._make_content()
+
+    def _make_content(self) -> MagicMock:
+        content = MagicMock()
+
+        async def iter_any() -> AsyncGenerator[bytes, None]:
+            for chunk in self._chunks:
+                yield chunk
+
+        content.iter_any = iter_any
+        return content
+
+
+def _build_sse_stream(deltas: List[Dict[str, Any]], completion_tokens: Optional[int] = None) -> bytes:
+    """Build an OpenAI-style SSE byte stream from a list of delta dicts."""
+    parts: List[bytes] = []
+    for delta in deltas:
+        chunk = json.dumps({"choices": [{"delta": delta}]})
+        parts.append(f"data: {chunk}\n\n".encode())
+    if completion_tokens is not None:
+        usage_chunk = json.dumps({"choices": [], "usage": {"completion_tokens": completion_tokens}})
+        parts.append(f"data: {usage_chunk}\n\n".encode())
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+def _make_streaming_response(deltas: List[Dict[str, Any]], completion_tokens: Optional[int] = None) -> ClientResponse:
+    sse_bytes = _build_sse_stream(deltas, completion_tokens)
+    return cast(ClientResponse, FakeStreamingResponse([sse_bytes]))
+
+
+def _make_session_api_data(
+    event_id: str = "session_1:event_0",
+    registry: Optional[EventOutputRegistry] = None,
+    tracker: Optional[WorkerSessionTracker] = None,
+) -> SessionChatCompletionAPIData:
+    if registry is None:
+        registry = EventOutputRegistry()
+    if tracker is None:
+        tracker = WorkerSessionTracker()
+    return SessionChatCompletionAPIData(
+        messages=[ChatMessage(role="user", content="Hello")],
+        max_tokens=500,
+        event_id=event_id,
+        registry=registry,
+        worker_tracker=tracker,
+        completion_queue=None,
+        total_events_in_session=1,
+        predecessor_event_ids=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningNonStreaming:
+    """Test reasoning_content handling via the real non-streaming process_response path."""
+
+    @pytest.mark.asyncio
+    async def test_reasoning_combined_with_content(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        response = _make_non_streaming_response(
+            content="The answer is 42.",
+            reasoning_content="Let me think. ",
+        )
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        assert isinstance(info, SessionInferenceInfo)
+        assert info.output_text == "Let me think. The answer is 42."
+        assert registry.get_output_by_event_id("session_1:event_0") == "Let me think. The answer is 42."
+
+    @pytest.mark.asyncio
+    async def test_no_reasoning_content(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        response = _make_non_streaming_response(content="Hello there!")
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        assert info.output_text == "Hello there!"
+        assert registry.get_output_by_event_id("session_1:event_0") == "Hello there!"
+
+    @pytest.mark.asyncio
+    async def test_empty_reasoning_content(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        response = _make_non_streaming_response(content="Answer", reasoning_content="")
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        # Empty string is falsy, so reasoning should not be prepended
+        assert info.output_text == "Answer"
+
+    @pytest.mark.asyncio
+    async def test_null_reasoning_content(self) -> None:
+        """Explicit None in the response dict should be handled like absent."""
+        response = MagicMock()
+        response.json = AsyncMock(
+            return_value={"choices": [{"message": {"role": "assistant", "content": "Answer", "reasoning_content": None}}]}
+        )
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        assert info.output_text == "Answer"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_with_tool_calls(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        tool_calls = [{"id": "call_1", "type": "function", "function": {"name": "get_data", "arguments": "{}"}}]
+        response = _make_non_streaming_response(
+            content="Here you go.",
+            reasoning_content="Let me check. ",
+            tool_calls=tool_calls,
+        )
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        assert info.output_text == "Let me check. Here you go."
+        msg = info.output_message
+        assert msg is not None
+        assert "tool_calls" in msg
+        assert msg["tool_calls"] == tool_calls
+
+    @pytest.mark.asyncio
+    async def test_reasoning_only_no_content(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        response = _make_non_streaming_response(content="", reasoning_content="Just thinking...")
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        assert info.output_text == "Just thinking..."
+
+
+# ---------------------------------------------------------------------------
+# Streaming tests
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningStreaming:
+    """Test reasoning_content handling via the real streaming process_response path."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_reasoning_chunks_combined(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        deltas = [
+            {"reasoning_content": "Let me "},
+            {"reasoning_content": "think. "},
+            {"content": "Answer: "},
+            {"content": "42"},
+        ]
+        response = _make_streaming_response(deltas, completion_tokens=8)
+
+        info = await api_data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+        assert isinstance(info, SessionInferenceInfo)
+        assert info.output_text == "Let me think. Answer: 42"
+        assert registry.get_output_by_event_id("session_1:event_0") == "Let me think. Answer: 42"
+
+    @pytest.mark.asyncio
+    async def test_streaming_without_reasoning(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        deltas = [
+            {"content": "Hello "},
+            {"content": "there!"},
+        ]
+        response = _make_streaming_response(deltas, completion_tokens=2)
+
+        info = await api_data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+        assert info.output_text == "Hello there!"
+        assert registry.get_output_by_event_id("session_1:event_0") == "Hello there!"
+
+    @pytest.mark.asyncio
+    async def test_streaming_reasoning_only_no_content(self) -> None:
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        deltas = [
+            {"reasoning_content": "Deep thought..."},
+        ]
+        response = _make_streaming_response(deltas, completion_tokens=3)
+
+        info = await api_data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+        assert info.output_text == "Deep thought..."
+
+
+# ---------------------------------------------------------------------------
+# Registry integration tests — verify output_message structure
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningRegistryIntegration:
+    """Test that output_message stored in registry has correct structure."""
+
+    @pytest.mark.asyncio
+    async def test_output_message_has_separate_fields(self) -> None:
+        """Non-streaming: output_message should have reasoning_content and output_content."""
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        response = _make_non_streaming_response(
+            content="The answer.",
+            reasoning_content="Reasoning. ",
+        )
+
+        await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        msg = registry.get_message_by_event_id("session_1:event_0")
+        assert msg is not None
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Reasoning. The answer."
+        assert msg["reasoning_content"] == "Reasoning. "
+        assert msg["output_content"] == "The answer."
+
+    @pytest.mark.asyncio
+    async def test_streaming_output_message_has_separate_fields(self) -> None:
+        """Streaming: output_message should have reasoning_content and output_content."""
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        deltas = [
+            {"reasoning_content": "Think. "},
+            {"content": "Result."},
+        ]
+        response = _make_streaming_response(deltas, completion_tokens=4)
+
+        await api_data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+        msg = registry.get_message_by_event_id("session_1:event_0")
+        assert msg is not None
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Think. Result."
+        assert msg["reasoning_content"] == "Think. "
+        assert msg["output_content"] == "Result."
+
+    @pytest.mark.asyncio
+    async def test_registry_message_without_reasoning_has_no_extra_fields(self) -> None:
+        """Without reasoning_content, output_message should not have extra fields."""
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        response = _make_non_streaming_response(content="Plain answer.")
+
+        await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        msg = registry.get_message_by_event_id("session_1:event_0")
+        assert msg is not None
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Plain answer."
+        assert "reasoning_content" not in msg
+        assert "output_content" not in msg
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Combine reasoning_content with output text in content field
- Store separate reasoning_content and output_content fields
- Support both streaming and non-streaming responses
- Fix streaming: use info.output_text instead of parsing empty response_content
- Consistent behavior across replay and OTEL instrumentation