### PR TITLE
Emit Prometheus merics for runtime observability

### DIFF
--- a/inference_perf/observability/metrics/__init__.py
+++ b/inference_perf/observability/metrics/__init__.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Runtime observability surfaces for inference-perf.
+"""Metric exposition surfaces (Prometheus, pushgateway, etc.) for inference-perf."""
 
-This package emits structured signals *about* a benchmark run (progress, errors,
-stage state, latency distributions). It is distinct from
-``inference_perf.client.server_metrics``, which *consumes* metrics from the
-model server under test.
-"""
+from .prometheus import PrometheusMetricsServer
+
+__all__ = ["PrometheusMetricsServer"]

--- a/inference_perf/observability/metrics/prometheus.py
+++ b/inference_perf/observability/metrics/prometheus.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal Prometheus exposition surface for inference-perf runtime observability.
+
+Seed of kubernetes-sigs/inference-perf#489. Exposes a single gauge,
+``inference_perf_run_elapsed_seconds``, over an HTTP ``/metrics`` endpoint.
+The full metric set and naming conventions are intentionally out of scope here;
+expect this surface to grow once the conventions are agreed upon.
+"""
+
+from __future__ import annotations
+
+import time
+from threading import Thread
+from typing import Iterator, Optional
+from wsgiref.simple_server import WSGIServer
+
+from prometheus_client import CollectorRegistry, start_http_server
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import Collector
+
+DEFAULT_PORT = 9464
+
+
+class _RunElapsedCollector(Collector):
+    def __init__(self) -> None:
+        self._start_time: Optional[float] = None
+
+    def mark_start(self) -> None:
+        self._start_time = time.monotonic()
+
+    def collect(self) -> Iterator[GaugeMetricFamily]:
+        elapsed = 0.0 if self._start_time is None else time.monotonic() - self._start_time
+        yield GaugeMetricFamily(
+            "inference_perf_run_elapsed_seconds",
+            "Wall-clock seconds elapsed since the metrics server started.",
+            value=elapsed,
+        )
+
+
+class PrometheusMetricsServer:
+    """Serves inference-perf's own metrics over an HTTP ``/metrics`` endpoint.
+
+    Currently emits only ``inference_perf_run_elapsed_seconds``. Use a fresh
+    ``CollectorRegistry`` per instance (not the default global one) so multiple
+    runs in the same process do not collide.
+
+    Pass ``port=0`` to bind to an ephemeral port; the actual port is then
+    available via :attr:`bound_port`.
+    """
+
+    def __init__(self, port: int = DEFAULT_PORT, addr: str = "0.0.0.0") -> None:
+        self.port = port
+        self.addr = addr
+        self.registry = CollectorRegistry()
+        self._elapsed = _RunElapsedCollector()
+        self.registry.register(self._elapsed)
+        self._server: Optional[WSGIServer] = None
+        self._thread: Optional[Thread] = None
+
+    def start(self) -> None:
+        if self._server is not None:
+            raise RuntimeError("PrometheusMetricsServer is already running")
+        self._elapsed.mark_start()
+        self._server, self._thread = start_http_server(
+            port=self.port,
+            addr=self.addr,
+            registry=self.registry,
+        )
+
+    def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.shutdown()
+        self._server = None
+        self._thread = None
+
+    @property
+    def bound_port(self) -> Optional[int]:
+        if self._server is None:
+            return None
+        return self._server.server_address[1]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "analysis", "dev", "lint", "otel", "test", "types"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c5407fbbdc7c29926c17e1f86ddd558820e1b8be86d5b2d7061fed3e288a854e"
+content_hash = "sha256:ad0a9b9b45fa6d53e538dd10a4fe08e539ae6acb7ab9807611aae659b8b49079"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -2338,6 +2338,17 @@ dependencies = [
 files = [
     {file = "pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b"},
     {file = "pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9"},
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+requires_python = ">=3.9"
+summary = "Python client for the Prometheus monitoring system."
+groups = ["default"]
+files = [
+    {file = "prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1"},
+    {file = "prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "rich>=13.0.0",
     "av>=13.0.0",
     "pillow>=10.0.0",
+    "prometheus-client>=0.20.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/tests/required/observability/test_prometheus.py
+++ b/tests/required/observability/test_prometheus.py
@@ -1,0 +1,73 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import urllib.request
+
+import pytest
+
+from inference_perf.observability.metrics import PrometheusMetricsServer
+from inference_perf.observability.metrics.prometheus import DEFAULT_PORT
+
+
+@pytest.fixture
+def server():
+    s = PrometheusMetricsServer(port=0)
+    s.start()
+    yield s
+    s.stop()
+
+
+def _scrape(port: int) -> str:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics", timeout=2) as resp:
+        return resp.read().decode()
+
+
+def _parse_elapsed(body: str) -> float:
+    for line in body.splitlines():
+        if line.startswith("inference_perf_run_elapsed_seconds "):
+            return float(line.split()[1])
+    raise AssertionError(f"inference_perf_run_elapsed_seconds not found in:\n{body}")
+
+
+def test_default_port_constant() -> None:
+    assert DEFAULT_PORT == 9464
+
+
+def test_server_starts_and_exposes_elapsed_gauge(server: PrometheusMetricsServer) -> None:
+    assert server.bound_port is not None
+    body = _scrape(server.bound_port)
+    assert "inference_perf_run_elapsed_seconds" in body
+    assert _parse_elapsed(body) >= 0.0
+
+
+def test_elapsed_gauge_advances_between_scrapes(server: PrometheusMetricsServer) -> None:
+    assert server.bound_port is not None
+    first = _parse_elapsed(_scrape(server.bound_port))
+    time.sleep(0.1)
+    second = _parse_elapsed(_scrape(server.bound_port))
+    assert second > first
+
+
+def test_double_start_raises(server: PrometheusMetricsServer) -> None:
+    with pytest.raises(RuntimeError):
+        server.start()
+
+
+def test_stop_is_idempotent() -> None:
+    s = PrometheusMetricsServer(port=0)
+    s.start()
+    s.stop()
+    s.stop()
+    assert s.bound_port is None

--- a/tests/required/observability/test_prometheus.py
+++ b/tests/required/observability/test_prometheus.py
@@ -14,6 +14,7 @@
 
 import time
 import urllib.request
+from typing import Iterator
 
 import pytest
 
@@ -22,7 +23,7 @@ from inference_perf.observability.metrics.prometheus import DEFAULT_PORT
 
 
 @pytest.fixture
-def server():
+def server() -> Iterator[PrometheusMetricsServer]:
     s = PrometheusMetricsServer(port=0)
     s.start()
     yield s
@@ -31,7 +32,8 @@ def server():
 
 def _scrape(port: int) -> str:
     with urllib.request.urlopen(f"http://127.0.0.1:{port}/metrics", timeout=2) as resp:
-        return resp.read().decode()
+        body: bytes = resp.read()
+    return body.decode()
 
 
 def _parse_elapsed(body: str) -> float:


### PR DESCRIPTION
Partially Adresses: #489

## Summary 

Adds a Prometheus HTTP exposition surface under a new `inference_perf/observability/` package and emits **one** metric:

- `inference_perf_run_elapsed_seconds`, wall-clock seconds since the metrics server started.

No wiring into the run lifecycle, no CLI flag, no pushgateway, no additional metrics. Those are deliberate follow-ups so this PR stays trivially reviewable and so the metric-naming decisions in #489 don't block landing the plumbing.

## Intentionally deferred

- CLI flag / config integration
- Additional metrics (request counts, in-flight, TTFT/ITL histograms, stage state, errors)
- Final metric naming convention and label set
- CLI progress bars reading from the registry (per #489)