### PR TITLE
Inject session identity header for session replay requests 

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -13,6 +13,7 @@ These command line flags are automatically generated from the internal `Config` 
 | `--api.response_format.type` | Enum (json_schema, json_object) | Matches api.response_format.type in config |
 | `--api.response_format.name` | str | Matches api.response_format.name in config |
 | `--api.response_format.json_schema` | JSON | Matches api.response_format.json_schema in config |
+| `--api.session_id_header_key` | str | Matches api.session_id_header_key in config |
 | `--data.type` | Enum (mock, shareGPT, synthetic, random, shared_prefix, cnn_dailymail, infinity_instruct, billsum_conversations, otel_trace_replay, conversation_replay) | Matches data.type in config |
 | `--data.path` | str | Matches data.path in config |
 | `--data.input_distribution.min` | int | Matches data.input_distribution.min in config |

--- a/examples/otel/configs/simple/hf_dataset_example.yml
+++ b/examples/otel/configs/simple/hf_dataset_example.yml
@@ -5,6 +5,7 @@
 api:
   type: chat
   streaming: false
+  session_id_header_key: "x-session-id"
 
 data:
   type: otel_trace_replay

--- a/examples/otel/configs/simple/two-sessions-sequential.yml
+++ b/examples/otel/configs/simple/two-sessions-sequential.yml
@@ -4,6 +4,7 @@
 api:
   type: chat
   streaming: false
+  session_id_header_key: "x-session-id"
 
 data:
   type: otel_trace_replay

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -326,6 +326,9 @@ class openAIModelServerClientSession(ModelServerClientSession):
         if self.client.api_config.headers:
             headers.update(self.client.api_config.headers)
 
+        if data.session_id and self.client.api_config.session_id_header_key:
+            headers[self.client.api_config.session_id_header_key] = data.session_id
+
         request_data = json.dumps(payload)
 
         # Determine operation name based on API type

--- a/inference_perf/config/apis/config.py
+++ b/inference_perf/config/apis/config.py
@@ -59,3 +59,4 @@ class APIConfig(BaseModel):
     slo_tpot_header: Optional[str] = None
     slo_ttft_header: Optional[str] = None
     response_format: Optional[ResponseFormat] = None
+    session_id_header_key: Optional[str] = None

--- a/tests/required/client/modelserver/test_openai_client.py
+++ b/tests/required/client/modelserver/test_openai_client.py
@@ -165,3 +165,61 @@ async def test_otel_records_output_from_sse_response(mock_client: MagicMock, moc
     call_kwargs = mock_client.otel.record_response_metrics.call_args[1]
     response_info = call_kwargs["response_info"]
     assert response_info["output_text"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_session_id_header_injected_when_both_set(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    mock_data.session_id = "trace0_test_session"
+    mock_client.api_config.session_id_header_key = "x-session-id"
+
+    session = openAIModelServerClientSession(mock_client)
+    session.session = MagicMock()
+
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("force exit"))
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    session.session.post.return_value = mock_post_ctx
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    headers_passed = session.session.post.call_args.kwargs["headers"]
+    assert "x-session-id" in headers_passed
+    assert headers_passed["x-session-id"] == "trace0_test_session"
+
+
+@pytest.mark.asyncio
+async def test_session_id_header_not_injected_when_session_id_is_none(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    mock_data.session_id = None
+    mock_client.api_config.session_id_header_key = "x-session-id"
+
+    session = openAIModelServerClientSession(mock_client)
+    session.session = MagicMock()
+
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("force exit"))
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    session.session.post.return_value = mock_post_ctx
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    headers_passed = session.session.post.call_args.kwargs["headers"]
+    assert "x-session-id" not in headers_passed
+
+
+@pytest.mark.asyncio
+async def test_session_id_header_not_injected_when_header_key_is_none(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    mock_data.session_id = "trace0_test_session"
+    mock_client.api_config.session_id_header_key = None
+
+    session = openAIModelServerClientSession(mock_client)
+    session.session = MagicMock()
+
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("force exit"))
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    session.session.post.return_value = mock_post_ctx
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    headers_passed = session.session.post.call_args.kwargs["headers"]
+    assert "x-session-id" not in headers_passed


### PR DESCRIPTION
- Added configurable session_id_header_key to APIConfig 
- Injected session_id as an HTTP header in openai_client when session_id_header_key is set
- Updated example configs with session_id_header_key under api: section
- Added unit tests verifying header injection and skip behavior

Resolves #492