### PR TITLE
Refactor and improve max-model-len truncation to be more efficient

### DIFF
--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -119,6 +119,10 @@ class InferenceAPIData(BaseModel):
         """Called after every request completes (real or mock). Override to add post-completion side effects."""
         pass
 
+    async def on_completion_async(self, info: InferenceInfo) -> None:
+        """Asynchronous callback called after request has been processed and connection is closed."""
+        pass
+
     async def process_failure(
         self,
         response: Optional[ClientResponse],

--- a/inference_perf/apis/user_session.py
+++ b/inference_perf/apis/user_session.py
@@ -25,6 +25,18 @@ from inference_perf.config import APIConfig
 logger = logging.getLogger(__name__)
 
 
+def join_conversation_context(system_prompt: str, history: list[str], current_prompt: str = "") -> str:
+    """Assembles a full context string from system prompt, conversation history, and an optional current prompt."""
+    parts = []
+    if system_prompt:
+        parts.append(system_prompt)
+    if history:
+        parts.append(" ".join(history))
+    if current_prompt:
+        parts.append(current_prompt)
+    return " ".join(parts)
+
+
 class LocalUserSession:
     user_session_id: str
     context: str
@@ -84,11 +96,20 @@ class LocalUserSession:
         return self.context
 
     def update_context(self, response: str, response_len: Optional[int] = None) -> None:
+        """
+        Updates the session's conversation history and context with the new turn's content.
+
+        This function extracts the newly added prompt/response from the full response string,
+        appends it to history, updates the cached history token lengths, and applies a sliding
+        window truncation if the total tokens exceed max_model_len. Finally, it releases
+        the session's concurrency lock to allow the next turn of this user to begin.
+        """
         if self.system_prompt and self.tokenizer and self.max_model_len:
             history_context = " ".join(self.history) if self.history else ""
             base_len = len(self.system_prompt)
             if history_context:
                 base_len += len(history_context) + 1
+            # Extract the content added in this turn by discarding previous system prompt & history
             turn_content = response[base_len:].strip()
             if turn_content:
                 self.history.append(turn_content)
@@ -100,19 +121,14 @@ class LocalUserSession:
             system_tokens = self.tokenizer.count_tokens(self.system_prompt)
             total_tokens = system_tokens + sum(self.history_tokens)
 
+            # Drop older turns from history if the aggregated context length exceeds limits
             if total_tokens > self.max_model_len:
                 while self.history and total_tokens > self.max_model_len:
                     self.history.pop(0)
                     popped_len = self.history_tokens.pop(0)
                     total_tokens -= popped_len
 
-            self.context = (
-                self.system_prompt + " " + " ".join(self.history)
-                if self.history and self.system_prompt
-                else " ".join(self.history)
-                if self.history
-                else self.system_prompt
-            )
+            self.context = join_conversation_context(self.system_prompt, self.history)
         else:
             self.context = response
 
@@ -145,6 +161,17 @@ class UserSessionCompletionAPIData(CompletionAPIData):
     async def to_request_body(
         self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
     ) -> RequestBody:
+        """
+        Constructs the API request payload while managing multi-turn chat history.
+
+        This function:
+        1. Acquires the user session concurrency lock to ensure sequential execution of chat rounds.
+        2. Evaluates context limitations using the session's maximum token capacity.
+        3. Performs a lightweight history pruning (sliding window) if context bounds are exceeded.
+        4. In extreme cases (e.g. single prompt exceeds context bounds), performs character-level
+           truncation of the system instruction and prompt to avoid model context failures.
+        5. Combines the active system prompt, history, and active turn prompt into the final request payload.
+        """
         self._session_context = await self.user_session.get_context(self.target_round)
 
         if self.user_session.tokenizer and self.user_session.max_model_len:
@@ -161,82 +188,50 @@ class UserSessionCompletionAPIData(CompletionAPIData):
             current_prompt = self.prompt
 
             system_tokens = self.user_session.tokenizer.count_tokens(system_prompt)
-            
-            if self.prompt_len is not None:
-                current_prompt_tokens = self.prompt_len
-            else:
-                current_prompt_tokens = self.user_session.tokenizer.count_tokens(current_prompt)
+            current_prompt_tokens = (
+                self.prompt_len
+                if self.prompt_len is not None
+                else self.user_session.tokenizer.count_tokens(current_prompt)
+            )
 
             total_len = system_tokens + sum(history_tokens) + current_prompt_tokens
 
+            # Truncation logic: remove messages from history (oldest first) until the context fits
             if total_len > target_len:
-                # Truncation logic: remove messages from history (oldest) until the combined text fits within the target length
-                # This ensures we send the most recent messages to the model while also keeping the system prompt and shared
-                # system prompt + history context as long as possible.
                 while history and total_len > target_len:
                     history.pop(0)
                     popped_len = history_tokens.pop(0)
                     total_len -= popped_len
 
-                # If history is empty and it still exceeds target_len, truncate system/current prompt
-                if total_len > target_len:
-                    system_ids = hf_tokenizer.encode(system_prompt)
-                    current_ids = hf_tokenizer.encode(current_prompt)
+            # If history is fully truncated and still exceeds target_len, truncate system/current prompt
+            if total_len > target_len:
+                system_ids = hf_tokenizer.encode(system_prompt)
+                current_ids = hf_tokenizer.encode(current_prompt)
 
-                    available_for_system = target_len - len(current_ids)
-
-                    if available_for_system > 0:
-                        system_ids = system_ids[:available_for_system]
-                        system_prompt = hf_tokenizer.decode(system_ids, skip_special_tokens=True)
-                    else:
-                        system_prompt = ""
-                        current_ids = current_ids[:target_len]
-                        current_prompt = hf_tokenizer.decode(current_ids, skip_special_tokens=True)
-
-                    combined_text = (
-                        system_prompt + " " + current_prompt
-                        if system_prompt
-                        else current_prompt
-                    )
-
-                    if system_prompt != self.user_session.system_prompt:
-                        self.user_session.system_prompt = system_prompt
-                        self.user_session.history_tokens = []
+                available_for_system = target_len - len(current_ids)
+                if available_for_system > 0:
+                    system_ids = system_ids[:available_for_system]
+                    system_prompt = hf_tokenizer.decode(system_ids, skip_special_tokens=True)
                 else:
-                    def get_text(sys: str, hist: list[str], curr: str) -> str:
-                        parts = []
-                        if sys:
-                            parts.append(sys)
-                        if hist:
-                            parts.append(" ".join(hist))
-                        if curr:
-                            parts.append(curr)
-                        return " ".join(parts)
+                    system_prompt = ""
+                    current_ids = current_ids[:target_len]
+                    current_prompt = hf_tokenizer.decode(current_ids, skip_special_tokens=True)
 
-                    combined_text = get_text(system_prompt, history, current_prompt)
+                if system_prompt != self.user_session.system_prompt:
+                    self.user_session.system_prompt = system_prompt
+                    self.user_session.history_tokens = []
+
+                combined_text = (
+                    system_prompt + " " + current_prompt
+                    if system_prompt
+                    else current_prompt
+                )
             else:
-                def get_text(sys: str, hist: list[str], curr: str) -> str:
-                    parts = []
-                    if sys:
-                        parts.append(sys)
-                    if hist:
-                        parts.append(" ".join(hist))
-                    if curr:
-                        parts.append(curr)
-                    return " ".join(parts)
-
-                combined_text = get_text(system_prompt, history, current_prompt)
+                combined_text = join_conversation_context(system_prompt, history, current_prompt)
 
             self.user_session.history = history
             self.user_session.history_tokens = history_tokens
-            self.user_session.context = (
-                system_prompt + " " + " ".join(history)
-                if history and system_prompt
-                else " ".join(history)
-                if history
-                else system_prompt
-            )
-
+            self.user_session.context = join_conversation_context(system_prompt, history, "")
             self.prompt = combined_text
         else:
             self.prompt = self._session_context + " " + self.prompt

--- a/inference_perf/apis/user_session.py
+++ b/inference_perf/apis/user_session.py
@@ -189,9 +189,7 @@ class UserSessionCompletionAPIData(CompletionAPIData):
 
             system_tokens = self.user_session.tokenizer.count_tokens(system_prompt)
             current_prompt_tokens = (
-                self.prompt_len
-                if self.prompt_len is not None
-                else self.user_session.tokenizer.count_tokens(current_prompt)
+                self.prompt_len if self.prompt_len is not None else self.user_session.tokenizer.count_tokens(current_prompt)
             )
 
             total_len = system_tokens + sum(history_tokens) + current_prompt_tokens
@@ -221,11 +219,7 @@ class UserSessionCompletionAPIData(CompletionAPIData):
                     self.user_session.system_prompt = system_prompt
                     self.user_session.history_tokens = []
 
-                combined_text = (
-                    system_prompt + " " + current_prompt
-                    if system_prompt
-                    else current_prompt
-                )
+                combined_text = system_prompt + " " + current_prompt if system_prompt else current_prompt
             else:
                 combined_text = join_conversation_context(system_prompt, history, current_prompt)
 
@@ -247,9 +241,8 @@ class UserSessionCompletionAPIData(CompletionAPIData):
     ) -> InferenceInfo:
         inference_info = await super().process_response(response, config, tokenizer)
         self.update_inference_info(inference_info)
-        total_turn_tokens = (
-            inference_info.request_metrics.text.input_tokens +
-            (inference_info.response_metrics.output_tokens if inference_info.response_metrics else 0)
+        total_turn_tokens = inference_info.request_metrics.text.input_tokens + (
+            inference_info.response_metrics.output_tokens if inference_info.response_metrics else 0
         )
         self.user_session.update_context(self.prompt + " " + self.model_response, response_len=total_turn_tokens)
         return inference_info

--- a/inference_perf/apis/user_session.py
+++ b/inference_perf/apis/user_session.py
@@ -31,6 +31,7 @@ class LocalUserSession:
     system_prompt: str
     max_model_len: Optional[int]
     history: list[str]
+    history_tokens: list[int]
 
     _instances: dict[str, "LocalUserSession"] = {}
 
@@ -48,6 +49,7 @@ class LocalUserSession:
         self.tokenizer = tokenizer
         self.max_model_len = max_model_len
         self.history = []
+        self.history_tokens = []
         self._current_round = 0
         self._in_flight: Optional[asyncio.Lock] = None
         self._waiting_rounds: Optional[asyncio.Queue[asyncio.Future[bool]]] = None
@@ -81,7 +83,7 @@ class LocalUserSession:
         self._current_round += 1
         return self.context
 
-    def update_context(self, response: str) -> None:
+    def update_context(self, response: str, response_len: Optional[int] = None) -> None:
         if self.system_prompt and self.tokenizer and self.max_model_len:
             history_context = " ".join(self.history) if self.history else ""
             base_len = len(self.system_prompt)
@@ -90,18 +92,19 @@ class LocalUserSession:
             turn_content = response[base_len:].strip()
             if turn_content:
                 self.history.append(turn_content)
+                if response_len is not None:
+                    self.history_tokens.append(response_len)
+                else:
+                    self.history_tokens.append(self.tokenizer.count_tokens(turn_content))
 
-            history_str = " ".join(self.history)
             system_tokens = self.tokenizer.count_tokens(self.system_prompt)
-            history_tokens = self.tokenizer.count_tokens(history_str)
+            total_tokens = system_tokens + sum(self.history_tokens)
 
-            if system_tokens + history_tokens > self.max_model_len:
-                while self.history:
-                    history_str = " ".join(self.history)
-                    history_tokens = self.tokenizer.count_tokens(history_str)
-                    if system_tokens + history_tokens <= self.max_model_len:
-                        break
+            if total_tokens > self.max_model_len:
+                while self.history and total_tokens > self.max_model_len:
                     self.history.pop(0)
+                    popped_len = self.history_tokens.pop(0)
+                    total_tokens -= popped_len
 
             self.context = (
                 self.system_prompt + " " + " ".join(self.history)
@@ -133,6 +136,7 @@ class UserSessionCompletionAPIData(CompletionAPIData):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     user_session_id: str = Field(exclude=True)
     target_round: int
+    prompt_len: Optional[int] = None
 
     @property
     def user_session(self) -> LocalUserSession:
@@ -150,32 +154,32 @@ class UserSessionCompletionAPIData(CompletionAPIData):
 
             system_prompt = self.user_session.system_prompt
             history = list(self.user_session.history)
+            history_tokens = list(self.user_session.history_tokens)
+            if len(history_tokens) != len(history):
+                history_tokens = [self.user_session.tokenizer.count_tokens(h) for h in history]
+                self.user_session.history_tokens = list(history_tokens)
             current_prompt = self.prompt
 
-            def get_text(sys: str, hist: list[str], curr: str) -> str:
-                parts = []
-                if sys:
-                    parts.append(sys)
-                if hist:
-                    parts.append(" ".join(hist))
-                if curr:
-                    parts.append(curr)
-                return " ".join(parts)
+            system_tokens = self.user_session.tokenizer.count_tokens(system_prompt)
+            
+            if self.prompt_len is not None:
+                current_prompt_tokens = self.prompt_len
+            else:
+                current_prompt_tokens = self.user_session.tokenizer.count_tokens(current_prompt)
 
-            combined_text = get_text(system_prompt, history, current_prompt)
-            token_ids = hf_tokenizer.encode(combined_text)
+            total_len = system_tokens + sum(history_tokens) + current_prompt_tokens
 
-            if len(token_ids) > target_len:
+            if total_len > target_len:
                 # Truncation logic: remove messages from history (oldest) until the combined text fits within the target length
                 # This ensures we send the most recent messages to the model while also keeping the system prompt and shared
                 # system prompt + history context as long as possible.
-                while history and len(token_ids) > target_len:
+                while history and total_len > target_len:
                     history.pop(0)
-                    combined_text = get_text(system_prompt, history, current_prompt)
-                    token_ids = hf_tokenizer.encode(combined_text)
+                    popped_len = history_tokens.pop(0)
+                    total_len -= popped_len
 
                 # If history is empty and it still exceeds target_len, truncate system/current prompt
-                if len(token_ids) > target_len:
+                if total_len > target_len:
                     system_ids = hf_tokenizer.encode(system_prompt)
                     current_ids = hf_tokenizer.encode(current_prompt)
 
@@ -189,12 +193,42 @@ class UserSessionCompletionAPIData(CompletionAPIData):
                         current_ids = current_ids[:target_len]
                         current_prompt = hf_tokenizer.decode(current_ids, skip_special_tokens=True)
 
-                    combined_text = get_text(system_prompt, [], current_prompt)
+                    combined_text = (
+                        system_prompt + " " + current_prompt
+                        if system_prompt
+                        else current_prompt
+                    )
 
                     if system_prompt != self.user_session.system_prompt:
                         self.user_session.system_prompt = system_prompt
+                        self.user_session.history_tokens = []
+                else:
+                    def get_text(sys: str, hist: list[str], curr: str) -> str:
+                        parts = []
+                        if sys:
+                            parts.append(sys)
+                        if hist:
+                            parts.append(" ".join(hist))
+                        if curr:
+                            parts.append(curr)
+                        return " ".join(parts)
+
+                    combined_text = get_text(system_prompt, history, current_prompt)
+            else:
+                def get_text(sys: str, hist: list[str], curr: str) -> str:
+                    parts = []
+                    if sys:
+                        parts.append(sys)
+                    if hist:
+                        parts.append(" ".join(hist))
+                    if curr:
+                        parts.append(curr)
+                    return " ".join(parts)
+
+                combined_text = get_text(system_prompt, history, current_prompt)
 
             self.user_session.history = history
+            self.user_session.history_tokens = history_tokens
             self.user_session.context = (
                 system_prompt + " " + " ".join(history)
                 if history and system_prompt
@@ -218,7 +252,11 @@ class UserSessionCompletionAPIData(CompletionAPIData):
     ) -> InferenceInfo:
         inference_info = await super().process_response(response, config, tokenizer)
         self.update_inference_info(inference_info)
-        self.user_session.update_context(self.prompt + " " + self.model_response)
+        total_turn_tokens = (
+            inference_info.request_metrics.text.input_tokens +
+            (inference_info.response_metrics.output_tokens if inference_info.response_metrics else 0)
+        )
+        self.user_session.update_context(self.prompt + " " + self.model_response, response_len=total_turn_tokens)
         return inference_info
 
     async def process_failure(
@@ -232,7 +270,7 @@ class UserSessionCompletionAPIData(CompletionAPIData):
         # no response returned, use context from the last round
         inference_info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=0)))
         self.update_inference_info(inference_info)
-        self.user_session.update_context(self._session_context)
+        self.user_session.update_context(self._session_context, response_len=None)
         return inference_info
 
 

--- a/inference_perf/client/modelserver/mock_client.py
+++ b/inference_perf/client/modelserver/mock_client.py
@@ -25,6 +25,7 @@ from inference_perf.apis import (
 from inference_perf.payloads import RequestMetrics, Text
 from .base import ModelServerClient, ModelServerPrometheusMetric, PrometheusMetricMetadata
 import asyncio
+import inspect
 import time
 import logging
 
@@ -60,18 +61,18 @@ class MockModelServerClient(ModelServerClient):
 
                 info = InferenceInfo(
                     request_metrics=RequestMetrics(text=Text(input_tokens=0)),
+                    response_metrics=UnaryResponseMetrics(output_tokens=0),
                     lora_adapter=lora_adapter,
                 )
                 data.on_completion(info)
+                res = data.on_completion_async(info)
+                if inspect.isawaitable(res):
+                    await res
                 self.metrics_collector.record_metric(
                     RequestLifecycleMetric(
                         stage_id=stage_id,
                         request_data=str(await data.to_request_body(effective_model_name, 3, False, False)),
-                        info=InferenceInfo(
-                            request_metrics=RequestMetrics(text=Text(input_tokens=0)),
-                            response_metrics=UnaryResponseMetrics(output_tokens=0),
-                            lora_adapter=lora_adapter,
-                        ),
+                        info=info,
                         error=None,
                         start_time=start,
                         end_time=time.perf_counter(),

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -34,6 +34,7 @@ import time
 import logging
 import requests
 import ssl
+import inspect
 
 
 logger = logging.getLogger(__name__)
@@ -466,7 +467,6 @@ class openAIModelServerClientSession(ModelServerClientSession):
 
         # Post-completion hook executed after connection is closed
         res = data.on_completion_async(metric.info)
-        import inspect
         if inspect.isawaitable(res):
             await res
 

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -464,5 +464,11 @@ class openAIModelServerClientSession(ModelServerClientSession):
         # Record the metric
         self.client.metrics_collector.record_metric(metric)
 
+        # Post-completion hook executed after connection is closed
+        res = data.on_completion_async(metric.info)
+        import inspect
+        if inspect.isawaitable(res):
+            await res
+
     async def close(self) -> None:
         await self.session.close()

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -87,22 +87,31 @@ class _ConversationReplayAPIData(UserSessionCompletionAPIData):
         tokenizer: CustomTokenizer,
         lora_adapter: Optional[str] = None,
     ) -> InferenceInfo:
-        # Run the base completion response handler (sets self.model_response,
-        # records timing metrics) WITHOUT yet releasing the session lock.
-        # We call CompletionAPIData directly to skip UserSessionCompletionAPIData's
-        # update_context call so we can inject the sleep in between.
+        # Run the base completion response handler to populate raw metrics
+        # WITHOUT releasing the session lock or sleeping.
         inference_info = await CompletionAPIData.process_response(self, response, config, tokenizer, lora_adapter)
         self.update_inference_info(inference_info)
+        return inference_info
+
+    async def on_completion_async(self, info: InferenceInfo) -> None:
+        # Only execute session context update and sleep on success (where response_metrics are populated)
+        if not info or not info.response_metrics:
+            return
 
         # Simulate tool execution latency while holding the session lock.
-        # The next turn of this conversation cannot start until the sleep
-        # completes; other conversations' turns run freely during the wait.
+        # This is now executed safely after the HTTP connection is closed.
         if self.tool_call_latency_sec > 0:
             await asyncio.sleep(self.tool_call_latency_sec)
 
         # Release the session lock by updating context (allows next turn).
-        self.user_session.update_context(self.prompt + " " + self.model_response)
-        return inference_info
+        total_turn_tokens = (
+            info.request_metrics.text.input_tokens +
+            info.response_metrics.output_tokens
+        )
+        self.user_session.update_context(
+            self.prompt + " " + self.model_response,
+            response_len=total_turn_tokens
+        )
 
     async def process_failure(
         self,
@@ -112,10 +121,10 @@ class _ConversationReplayAPIData(UserSessionCompletionAPIData):
         exception: Exception,
         lora_adapter: Optional[str] = None,
     ) -> Optional[InferenceInfo]:
-        # On failure, release the lock without sleeping (no tool was called).
+        # On failure, release the lock immediately (no tool was called).
         inference_info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=0)))
         self.update_inference_info(inference_info)
-        self.user_session.update_context(self._session_context)
+        self.user_session.update_context(self._session_context, response_len=None)
         return inference_info
 
 
@@ -127,6 +136,7 @@ class ConversationBlueprint:
     num_turns: int
     system_prompt: str
     turn_prompts: List[str] = field(default_factory=list)
+    turn_input_lens: List[int] = field(default_factory=list)
     turn_output_lens: List[int] = field(default_factory=list)
     turn_tool_call_latencies: List[float] = field(default_factory=list)
 
@@ -237,6 +247,7 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
         latency = bp.turn_tool_call_latencies[turn_idx] if bp.turn_tool_call_latencies else 0.0
         return _ConversationReplayAPIData(
             prompt=bp.turn_prompts[turn_idx],
+            prompt_len=bp.turn_input_lens[turn_idx],
             max_tokens=bp.turn_output_lens[turn_idx],
             user_session_id=self.user_sessions[conv_idx].user_session_id,
             target_round=round_num,
@@ -357,6 +368,7 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
                 num_turns=num_turns,
                 system_prompt=system_prompt,
                 turn_prompts=turn_prompts,
+                turn_input_lens=turn_input_lens,
                 turn_output_lens=turn_output_lens_list,
                 turn_tool_call_latencies=turn_tool_latencies,
             )

--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -104,14 +104,8 @@ class _ConversationReplayAPIData(UserSessionCompletionAPIData):
             await asyncio.sleep(self.tool_call_latency_sec)
 
         # Release the session lock by updating context (allows next turn).
-        total_turn_tokens = (
-            info.request_metrics.text.input_tokens +
-            info.response_metrics.output_tokens
-        )
-        self.user_session.update_context(
-            self.prompt + " " + self.model_response,
-            response_len=total_turn_tokens
-        )
+        total_turn_tokens = info.request_metrics.text.input_tokens + info.response_metrics.output_tokens
+        self.user_session.update_context(self.prompt + " " + self.model_response, response_len=total_turn_tokens)
 
     async def process_failure(
         self,

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -95,9 +95,7 @@ async def test_multimodal_heartbeat_fires_on_interval(caplog: Any) -> None:
 
     # Drive monotonic forward by the configured interval on every call so each
     # to_request_body crosses the heartbeat boundary.
-    fake_time: Iterator[float] = iter(
-        (i * chat_module._MULTIMODAL_PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100))
-    )
+    fake_time: Iterator[float] = iter((i * chat_module._MULTIMODAL_PROGRESS_LOG_INTERVAL_SEC for i in range(1, 100)))
 
     caplog.set_level(logging.INFO, logger=chat_module.__name__)
     with patch("inference_perf.apis.chat.time.monotonic", side_effect=lambda: next(fake_time)):

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -357,3 +357,51 @@ class TestSlidingWindowTruncation:
         session.update_context(session.context + " Turn4")
         assert session.history == ["Turn2", "Turn3", "Turn4"]
         assert session.context == "System Instruction Turn2 Turn3 Turn4"
+
+
+class TestOnCompletionAsyncAndTokenCaching:
+    def test_on_completion_async_caches_tokens(self) -> None:
+        from inference_perf.apis.user_session import LocalUserSession
+        from inference_perf.apis import InferenceInfo, UnaryResponseMetrics
+        from inference_perf.payloads import RequestMetrics, Text
+
+        mock_tokenizer = _make_mock_tokenizer()
+
+        system_prompt = "System Instruction"  # 20 tokens
+        session = LocalUserSession(
+            user_session_id="test_async_session",
+            context=system_prompt,
+            system_prompt=system_prompt,
+            tokenizer=mock_tokenizer,
+            max_model_len=1000,
+        )
+        LocalUserSession._instances["test_async_session"] = session
+
+        api_config, data_config = _make_config(num_conversations=1)
+        gen = ConversationReplayDataGenerator(api_config, data_config, mock_tokenizer)
+        gen.user_sessions = [session]
+
+        # Retrieve data object
+        lazy = LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0)
+        data = gen.load_lazy_data(lazy)
+
+        # Simulate request processing
+        data.model_response = "Assistant response"
+        info = InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=20)),
+            response_metrics=UnaryResponseMetrics(output_tokens=15),
+            lora_adapter=None,
+        )
+
+        # Before calling callback, history_tokens is empty
+        assert len(session.history_tokens) == 0
+
+        # Simulate execution of request preparation and async callback
+        import asyncio
+        asyncio.run(data.to_request_body("some_model", 10, False, False))
+        asyncio.run(data.on_completion_async(info))
+
+        # history_tokens should now have the total turn tokens (20 + 15 = 35)
+        assert session.history_tokens == [35]
+        assert len(session.history) == 1
+

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -398,10 +398,10 @@ class TestOnCompletionAsyncAndTokenCaching:
 
         # Simulate execution of request preparation and async callback
         import asyncio
+
         asyncio.run(data.to_request_body("some_model", 10, False, False))
         asyncio.run(data.on_completion_async(info))
 
         # history_tokens should now have the total turn tokens (20 + 15 = 35)
         assert session.history_tokens == [35]
         assert len(session.history) == 1
-


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/inference-perf/issues/511

By
- Avoiding tokenization where possible and truncates the array of token IDs based on length
- Refactoring to remove duplication and adding comments to explain some of the more complex logic