### PR TITLE
[P1] Unit tests: config

### DIFF
--- a/tests/required/config/apis/test_api_config.py
+++ b/tests/required/config/apis/test_api_config.py
@@ -1,0 +1,45 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validity rules for ``inference_perf.config.apis``."""
+
+from inference_perf.config import APIConfig, APIType, ResponseFormat, ResponseFormatType
+
+
+def test_api_config_defaults() -> None:
+    cfg = APIConfig()
+    assert cfg.type == APIType.Completion
+    assert cfg.streaming is False
+    assert cfg.response_format is None
+
+
+def test_response_format_json_schema_is_default() -> None:
+    fmt = ResponseFormat(json_schema={"type": "object"})
+    assert fmt.type == ResponseFormatType.JSON_SCHEMA
+    assert fmt.to_api_format() == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "structured_output",
+            "schema": {"type": "object"},
+        },
+    }
+
+
+def test_response_format_custom_name_in_api_format() -> None:
+    fmt = ResponseFormat(name="my_schema", json_schema={"type": "object"})
+    assert fmt.to_api_format()["json_schema"]["name"] == "my_schema"
+
+
+def test_response_format_json_object() -> None:
+    fmt = ResponseFormat(type=ResponseFormatType.JSON_OBJECT)
+    assert fmt.to_api_format() == {"type": "json_object"}

--- a/tests/required/config/client/test_server_metrics_config.py
+++ b/tests/required/config/client/test_server_metrics_config.py
@@ -1,0 +1,39 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validity rules for ``inference_perf.config.client.server_metrics``."""
+
+import pytest
+
+from inference_perf.config import PrometheusClientConfig
+
+
+def test_url_only_is_valid() -> None:
+    config = PrometheusClientConfig(url="http://localhost:9090")
+    # Pydantic's HttpUrl normalizes by appending a trailing slash.
+    assert str(config.url) == "http://localhost:9090/"
+
+
+def test_google_managed_only_is_valid() -> None:
+    config = PrometheusClientConfig(google_managed=True)
+    assert config.google_managed is True
+
+
+def test_both_url_and_google_managed_is_error() -> None:
+    with pytest.raises(ValueError, match="Exactly one of 'url' or 'google_managed' must be set"):
+        PrometheusClientConfig(url="http://localhost:9090", google_managed=True)
+
+
+def test_neither_url_nor_google_managed_is_error() -> None:
+    with pytest.raises(ValueError, match="Exactly one of 'url' or 'google_managed' must be set"):
+        PrometheusClientConfig(google_managed=False)

--- a/tests/required/config/client/test_storage_config.py
+++ b/tests/required/config/client/test_storage_config.py
@@ -1,0 +1,49 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validity rules for ``inference_perf.config.client.filestorage``."""
+
+import pytest
+from pydantic import ValidationError
+
+from inference_perf.config import SimpleStorageServiceConfig
+
+
+def test_defaults() -> None:
+    config = SimpleStorageServiceConfig(bucket_name="my-bucket")
+    assert config.bucket_name == "my-bucket"
+    assert config.endpoint_url is None
+    assert config.region_name is None
+    assert config.addressing_style is None
+
+
+def test_accepts_addressing_overrides() -> None:
+    config = SimpleStorageServiceConfig(
+        bucket_name="my-bucket",
+        endpoint_url="https://s3.example.com",
+        region_name="us-east-1",
+        addressing_style="virtual",
+    )
+    assert config.endpoint_url == "https://s3.example.com"
+    assert config.region_name == "us-east-1"
+    assert config.addressing_style == "virtual"
+
+
+def test_accepts_path_addressing_style() -> None:
+    config = SimpleStorageServiceConfig(bucket_name="my-bucket", addressing_style="path")
+    assert config.addressing_style == "path"
+
+
+def test_rejects_invalid_addressing_style() -> None:
+    with pytest.raises(ValidationError):
+        SimpleStorageServiceConfig(bucket_name="my-bucket", addressing_style="hosted")

--- a/tests/required/config/datagen/test_data_config.py
+++ b/tests/required/config/datagen/test_data_config.py
@@ -1,0 +1,225 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validity rules for the ``DataConfig`` / ``SharedPrefix`` surface.
+
+These exercise the ``data:`` block of the config (``Config.data``).
+"""
+
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from inference_perf.config import (
+    Config,
+    DataGenType,
+    Distribution,
+    DistributionType,
+    VideoProfile,
+    read_config,
+)
+
+
+# --- SharedPrefix aliases / distribution syntax --------------------------
+
+
+def test_shared_prefix_short_names() -> None:
+    config = Config.model_validate(
+        {
+            "data": {
+                "type": DataGenType.SharedPrefix,
+                "shared_prefix": {"num_groups": 5, "num_prompts_per_group": 20},
+            }
+        }
+    )
+    assert config.data.shared_prefix is not None
+    assert config.data.shared_prefix.num_groups == 5
+    assert config.data.shared_prefix.num_prompts_per_group == 20
+
+
+def test_shared_prefix_alias_names() -> None:
+    config = Config.model_validate(
+        {
+            "data": {
+                "type": DataGenType.SharedPrefix,
+                "shared_prefix": {"num_unique_system_prompts": 7, "num_users_per_system_prompt": 15},
+            }
+        }
+    )
+    assert config.data.shared_prefix is not None
+    assert config.data.shared_prefix.num_groups == 7
+    assert config.data.shared_prefix.num_prompts_per_group == 15
+
+
+def test_shared_prefix_serializes_with_aliases() -> None:
+    config = Config.model_validate(
+        {
+            "data": {
+                "type": DataGenType.SharedPrefix,
+                "shared_prefix": {"num_unique_system_prompts": 7, "num_users_per_system_prompt": 15},
+            }
+        }
+    )
+    dumped = config.model_dump(mode="json", by_alias=True)
+    shared_prefix_dump = dumped["data"]["shared_prefix"]
+    assert shared_prefix_dump["num_unique_system_prompts"] == 7
+    assert shared_prefix_dump["num_users_per_system_prompt"] == 15
+
+
+def test_shared_prefix_inline_distribution() -> None:
+    config = Config.model_validate(
+        {
+            "data": {
+                "type": DataGenType.SharedPrefix,
+                "shared_prefix": {
+                    "num_groups": 5,
+                    "question_len": {
+                        "type": "skew_normal",
+                        "mean": 200,
+                        "std_dev": 80,
+                        "skew": 2.5,
+                        "min": 10,
+                        "max": 2000,
+                    },
+                },
+            }
+        }
+    )
+    sp = config.data.shared_prefix
+    assert sp is not None
+    assert isinstance(sp.question_len, Distribution)
+    assert sp.question_len.type == DistributionType.SKEW_NORMAL
+    assert sp.question_len.mean == 200
+    assert sp.question_len.skew == 2.5
+
+
+def test_shared_prefix_fixed_int_unchanged() -> None:
+    config = Config.model_validate(
+        {
+            "data": {
+                "type": DataGenType.SharedPrefix,
+                "shared_prefix": {"question_len": 75},
+            }
+        }
+    )
+    sp = config.data.shared_prefix
+    assert sp is not None
+    assert sp.question_len == 75
+    assert isinstance(sp.question_len, int)
+
+
+def test_shared_prefix_ambiguous_distribution_is_error() -> None:
+    with pytest.raises(Exception, match="Cannot specify both"):
+        Config.model_validate(
+            {
+                "data": {
+                    "type": DataGenType.SharedPrefix,
+                    "shared_prefix": {
+                        "question_len": {
+                            "type": "normal",
+                            "mean": 200,
+                            "min": 10,
+                            "max": 2000,
+                            "std_dev": 50,
+                        },
+                        "question_distribution": {
+                            "min": 10,
+                            "max": 1024,
+                            "mean": 512,
+                            "std_dev": 200,
+                        },
+                    },
+                }
+            }
+        )
+
+
+def test_shared_prefix_legacy_distribution_compat() -> None:
+    config = Config.model_validate(
+        {
+            "data": {
+                "type": DataGenType.SharedPrefix,
+                "shared_prefix": {
+                    "question_len": 50,
+                    "question_distribution": {
+                        "min": 10,
+                        "max": 1024,
+                        "mean": 512,
+                        "std_dev": 200,
+                    },
+                },
+            }
+        }
+    )
+    sp = config.data.shared_prefix
+    assert sp is not None
+    assert sp.question_len == 50
+    assert sp.question_distribution is not None
+    assert sp.question_distribution.mean == 512
+
+
+def test_shared_prefix_seed_field() -> None:
+    config = Config.model_validate(
+        {
+            "data": {
+                "type": DataGenType.SharedPrefix,
+                "shared_prefix": {"seed": 42},
+            }
+        }
+    )
+    assert config.data.shared_prefix is not None
+    assert config.data.shared_prefix.seed == 42
+
+
+# --- multimodal block ----------------------------------------------------
+
+
+def test_multimodal_config_parsing() -> None:
+    config_content = {
+        "data": {
+            "type": "synthetic",
+            "multimodal": {
+                "image": {
+                    "count": {"type": "uniform", "min": 3, "max": 3, "mean": 3},
+                    "insertion_point": 0.5,
+                },
+                "video": {
+                    "count": {"type": "uniform", "min": 1, "max": 1, "mean": 1},
+                    "profiles": {"resolution": "1080p", "frames": 30},
+                },
+            },
+        }
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+        yaml.dump(config_content, tmp)
+        tmp_path = tmp.name
+
+    try:
+        config = read_config(tmp_path)
+        assert config.data.multimodal is not None
+        assert config.data.multimodal.image is not None
+        assert config.data.multimodal.image.insertion_point == 0.5
+        assert config.data.multimodal.image.count is not None
+        assert config.data.multimodal.image.count.mean == 3
+        assert config.data.multimodal.video is not None
+        assert config.data.multimodal.video.count is not None
+        assert config.data.multimodal.video.count.mean == 1
+        assert config.data.multimodal.video.profiles is not None
+        assert isinstance(config.data.multimodal.video.profiles, VideoProfile)
+        assert config.data.multimodal.video.profiles.resolution == "1080p"
+        assert config.data.multimodal.video.profiles.frames == 30
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)

--- a/tests/required/config/loadgen/test_load_config.py
+++ b/tests/required/config/loadgen/test_load_config.py
@@ -1,0 +1,173 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validity rules for ``inference_perf.config.loadgen``.
+
+Covers the per-stage validators (Standard / Concurrent / TraceSessionReplay)
+and the cross-stage ``LoadConfig`` validator that ties stage shape to load
+type and checks the MultiLoRA traffic split.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from inference_perf.config import (
+    ConcurrentLoadStage,
+    LoadConfig,
+    LoadType,
+    MultiLoRAConfig,
+    StandardLoadStage,
+    StageGenType,
+    SweepConfig,
+    TraceSessionReplayLoadStage,
+)
+
+
+# --- StandardLoadStage ---------------------------------------------------
+
+
+def test_standard_load_stage_valid() -> None:
+    stage = StandardLoadStage(rate=10, duration=60)
+    assert stage.rate == 10
+    assert stage.duration == 60
+
+
+def test_standard_load_stage_rejects_num_requests() -> None:
+    with pytest.raises(ValueError, match="num_requests should not be set"):
+        StandardLoadStage(rate=10, duration=60, num_requests=100)
+
+
+def test_standard_load_stage_rejects_concurrency_level() -> None:
+    with pytest.raises(ValueError, match="concurrency_level should not be set"):
+        StandardLoadStage(rate=10, duration=60, concurrency_level=5)
+
+
+def test_standard_load_stage_requires_positive_rate_and_duration() -> None:
+    with pytest.raises(ValidationError):
+        StandardLoadStage(rate=0, duration=60)
+    with pytest.raises(ValidationError):
+        StandardLoadStage(rate=10, duration=0)
+
+
+# --- ConcurrentLoadStage -------------------------------------------------
+
+
+def test_concurrent_load_stage_valid() -> None:
+    stage = ConcurrentLoadStage(num_requests=100, concurrency_level=10)
+    assert stage.num_requests == 100
+    assert stage.concurrency_level == 10
+    # rate/duration are filled at runtime, not by config.
+    assert stage.rate is None
+    assert stage.duration is None
+
+
+def test_concurrent_load_stage_requires_positive_values() -> None:
+    with pytest.raises(ValidationError):
+        ConcurrentLoadStage(num_requests=0, concurrency_level=10)
+    with pytest.raises(ValidationError):
+        ConcurrentLoadStage(num_requests=100, concurrency_level=0)
+
+
+# --- TraceSessionReplayLoadStage ----------------------------------------
+
+
+def test_trace_session_replay_stage_valid() -> None:
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, session_rate=2, num_sessions=10)
+    assert stage.concurrent_sessions == 4
+    assert stage.session_rate == 2
+
+
+def test_trace_session_replay_stage_zero_concurrency_allowed() -> None:
+    # 0 = stress-test mode (all sessions at once); explicitly permitted.
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=0)
+    assert stage.concurrent_sessions == 0
+
+
+def test_trace_session_replay_stage_rate_cannot_exceed_concurrency() -> None:
+    with pytest.raises(ValueError, match="cannot exceed"):
+        TraceSessionReplayLoadStage(concurrent_sessions=2, session_rate=5)
+
+
+def test_trace_session_replay_stage_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        TraceSessionReplayLoadStage(concurrent_sessions=2, bogus_field=1)  # type: ignore[call-arg]
+
+
+# --- LoadConfig cross-stage validation -----------------------------------
+
+
+def test_load_config_defaults_to_constant() -> None:
+    assert LoadConfig().type == LoadType.CONSTANT
+
+
+def test_sweep_with_concurrent_is_error() -> None:
+    with pytest.raises(ValueError, match="Cannot have sweep config with CONCURRENT"):
+        LoadConfig(
+            type=LoadType.CONCURRENT,
+            sweep=SweepConfig(type=StageGenType.GEOM),
+            stages=[ConcurrentLoadStage(num_requests=10, concurrency_level=1)],
+        )
+
+
+def test_sweep_with_trace_session_replay_is_error() -> None:
+    with pytest.raises(ValueError, match="Cannot have sweep config with TRACE_SESSION_REPLAY"):
+        LoadConfig(
+            type=LoadType.TRACE_SESSION_REPLAY,
+            sweep=SweepConfig(type=StageGenType.GEOM),
+            stages=[TraceSessionReplayLoadStage(concurrent_sessions=1)],
+        )
+
+
+def test_concurrent_load_type_requires_concurrent_stage() -> None:
+    with pytest.raises(ValueError, match="CONCURRENT load type requires ConcurrentLoadStage"):
+        LoadConfig(
+            type=LoadType.CONCURRENT,
+            stages=[StandardLoadStage(rate=10, duration=60)],
+        )
+
+
+def test_constant_load_type_requires_standard_stage() -> None:
+    with pytest.raises(ValueError, match="CONSTANT load type requires StandardLoadStage"):
+        LoadConfig(
+            type=LoadType.CONSTANT,
+            stages=[ConcurrentLoadStage(num_requests=10, concurrency_level=1)],
+        )
+
+
+def test_trace_session_replay_load_type_requires_session_stage() -> None:
+    with pytest.raises(ValueError, match="TRACE_SESSION_REPLAY load type requires TraceSessionReplayLoadStage"):
+        LoadConfig(
+            type=LoadType.TRACE_SESSION_REPLAY,
+            stages=[StandardLoadStage(rate=10, duration=60)],
+        )
+
+
+def test_multilora_traffic_split_must_sum_to_one() -> None:
+    with pytest.raises(ValueError, match=r"MultiLoRA traffic split.*does not add up to 1.0"):
+        LoadConfig(
+            lora_traffic_split=[
+                MultiLoRAConfig(name="a", split=0.5),
+                MultiLoRAConfig(name="b", split=0.4),
+            ]
+        )
+
+
+def test_multilora_traffic_split_summing_to_one_is_ok() -> None:
+    cfg = LoadConfig(
+        lora_traffic_split=[
+            MultiLoRAConfig(name="a", split=0.5),
+            MultiLoRAConfig(name="b", split=0.5),
+        ]
+    )
+    assert cfg.lora_traffic_split is not None
+    assert len(cfg.lora_traffic_split) == 2

--- a/tests/required/config/reportgen/test_report_config.py
+++ b/tests/required/config/reportgen/test_report_config.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validity rules for ``inference_perf.config.reportgen``."""
+
+import os
+import tempfile
+
+import yaml
+
+from inference_perf.config import read_config
+
+
+def test_goodput_constraints_parsing() -> None:
+    config_content = {
+        "report": {
+            "goodput": {
+                "constraints": {
+                    "ttft": 0.5,
+                    "tpot": 0.1,
+                },
+            }
+        }
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+        yaml.dump(config_content, tmp)
+        tmp_path = tmp.name
+
+    try:
+        config = read_config(tmp_path)
+        assert config.report.goodput is not None
+        assert config.report.goodput.constraints["ttft"] == 0.5
+        assert config.report.goodput.constraints["tpot"] == 0.1
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)

--- a/tests/required/config/test_common_distribution.py
+++ b/tests/required/config/test_common_distribution.py
@@ -1,0 +1,61 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validity rules for ``inference_perf.config.common.Distribution``."""
+
+import math
+
+import pytest
+
+from inference_perf.config import Distribution, DistributionType
+
+
+def test_defaults() -> None:
+    d = Distribution()
+    assert d.type == DistributionType.NORMAL
+    assert d.min == 10
+    assert d.max == 1024
+    assert d.mean == 512
+    assert d.std_dev == 200
+    assert d.variance is None
+    assert d.skew == 0.0
+
+
+def test_variance_conversion_to_std_dev() -> None:
+    d = Distribution(type=DistributionType.NORMAL, mean=100.0, variance=6400.0, std_dev=0.0)
+    assert math.isclose(d.std_dev, 80.0, abs_tol=1e-6)
+
+
+def test_both_variance_and_std_dev_is_error() -> None:
+    with pytest.raises(ValueError, match="Specify either"):
+        Distribution(type=DistributionType.NORMAL, mean=100.0, std_dev=10.0, variance=100.0)
+
+
+def test_negative_variance_is_error() -> None:
+    with pytest.raises(ValueError, match="Variance cannot be negative"):
+        Distribution(mean=100.0, std_dev=0.0, variance=-1.0)
+
+
+def test_negative_std_dev_is_error() -> None:
+    with pytest.raises(ValueError, match="std_dev cannot be negative"):
+        Distribution(mean=100.0, std_dev=-1.0)
+
+
+def test_min_greater_than_max_is_error() -> None:
+    with pytest.raises(ValueError, match=r"min \(2000\) cannot be greater than max \(10\)"):
+        Distribution(min=2000, max=10)
+
+
+def test_min_equal_to_max_is_allowed() -> None:
+    d = Distribution(min=5, max=5)
+    assert d.min == d.max == 5

--- a/tests/required/config/test_config_loading.py
+++ b/tests/required/config/test_config_loading.py
@@ -1,0 +1,165 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Top-level Config assembly: read_config, deep_merge, and cross-field validators.
+
+Per-surface schema rules live in the sibling modules that mirror the
+``inference_perf.config`` package (``loadgen/``, ``datagen/``, ``client/``,
+etc.). This file covers only the glue: loading YAML into a ``Config``,
+merging overrides, timestamp substitution, and the whole-config validators
+defined on ``Config`` itself.
+"""
+
+import os
+import tempfile
+
+import pytest
+import yaml
+
+from inference_perf.config import (
+    APIType,
+    Config,
+    DataGenType,
+    LoadType,
+    MetricsClientType,
+    deep_merge,
+    read_config,
+)
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+def test_read_config() -> None:
+    config = read_config(os.path.join(REPO_ROOT, "config.yml"))
+
+    assert isinstance(config, Config)
+    assert config.api.type == APIType.Completion
+    assert config.data.type == DataGenType.ShareGPT
+    assert config.load.type == LoadType.CONSTANT
+    if config.metrics:
+        assert config.metrics.type == MetricsClientType.PROMETHEUS
+    assert config.report.request_lifecycle.summary is True
+
+
+def test_read_config_empty_yaml_uses_defaults() -> None:
+    """An empty config file is valid; the resulting Config is all defaults."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+        tmp.write("")
+        tmp_path = tmp.name
+    try:
+        config = read_config(tmp_path)
+        assert config == Config()
+    finally:
+        os.remove(tmp_path)
+
+
+def test_read_config_no_file_returns_defaults() -> None:
+    assert read_config() == Config()
+
+
+def test_deep_merge() -> None:
+    base = {
+        "api": APIType.Chat,
+        "data": {"type": DataGenType.ShareGPT},
+        "load": {"type": LoadType.CONSTANT},
+        "metrics": {"type": MetricsClientType.PROMETHEUS},
+    }
+    override = {
+        "data": {"type": DataGenType.Mock},
+        "load": {"type": LoadType.POISSON},
+    }
+    merged = deep_merge(base, override)
+
+    assert merged["api"] == APIType.Chat
+    assert merged["data"]["type"] == DataGenType.Mock
+    assert merged["load"]["type"] == LoadType.POISSON
+    assert merged["metrics"]["type"] == MetricsClientType.PROMETHEUS
+
+
+def test_deep_merge_does_not_mutate_inputs() -> None:
+    base = {"data": {"type": "mock", "path": "keep"}}
+    override = {"data": {"type": "synthetic"}}
+
+    merged = deep_merge(base, override)
+
+    assert merged["data"] == {"type": "synthetic", "path": "keep"}
+    # Originals untouched.
+    assert base == {"data": {"type": "mock", "path": "keep"}}
+    assert override == {"data": {"type": "synthetic"}}
+
+
+def test_read_config_cli_overrides_win() -> None:
+    config_content = {"data": {"type": "shareGPT"}}
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+        yaml.dump(config_content, tmp)
+        tmp_path = tmp.name
+    try:
+        config = read_config(tmp_path, cli_overrides={"data": {"type": "mock"}})
+        assert config.data.type == DataGenType.Mock
+    finally:
+        os.remove(tmp_path)
+
+
+def test_read_config_timestamp_substitution() -> None:
+    # Create a minimalistic config with {timestamp} in the storage path
+    config_content = {
+        "storage": {
+            "local_storage": {"path": "reports-{timestamp}"},
+            "google_cloud_storage": {"bucket_name": "my-bucket", "path": "gcs-reports-{timestamp}"},
+            "simple_storage_service": {"bucket_name": "my-bucket", "path": "s3-reports-{timestamp}"},
+        }
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+        yaml.dump(config_content, tmp)
+        tmp_path = tmp.name
+
+    try:
+        config = read_config(tmp_path)
+        # Verify substitution happened
+        assert config.storage is not None
+        assert "{timestamp}" not in config.storage.local_storage.path
+        assert config.storage.local_storage.path.startswith("reports-")
+
+        assert config.storage.google_cloud_storage is not None
+        assert "{timestamp}" not in config.storage.google_cloud_storage.path
+        assert config.storage.google_cloud_storage.path.startswith("gcs-reports-")
+
+        assert config.storage.simple_storage_service is not None
+        assert "{timestamp}" not in config.storage.simple_storage_service.path
+        assert config.storage.simple_storage_service.path.startswith("s3-reports-")
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def test_otel_trace_replay_requires_trace_session_replay_load() -> None:
+    """Config-level validator: otel_trace_replay data demands session-replay load."""
+    with pytest.raises(ValueError, match="requires load.type 'trace_session_replay'"):
+        Config.model_validate(
+            {
+                "data": {"type": "otel_trace_replay"},
+                "load": {"type": "constant"},
+            }
+        )
+
+
+def test_otel_trace_replay_with_session_replay_load_ok() -> None:
+    config = Config.model_validate(
+        {
+            "data": {"type": "otel_trace_replay"},
+            "load": {"type": "trace_session_replay"},
+        }
+    )
+    assert config.data.type == DataGenType.OTelTraceReplay
+    assert config.load.type == LoadType.TRACE_SESSION_REPLAY


### PR DESCRIPTION
## Summary

Adds unit tests for the config package introduced in #505 (the config-file split).

56 tests covering:

- Top-level config read and deep-merge behavior (`test_config.py`)
- Common distributions (`test_common_distribution.py`)
- Per-package validation: `apis`, `loadgen`, `client` (storage and server_metrics), the datagen `data` block, and `reportgen`
