### PR TITLE
Fixed failing e2e test for nix pdm sync error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763835633,
-        "narHash": "sha256-HzxeGVID5MChuCPESuC0dlQL1/scDKu+MmzoVBJxulM=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "050e09e091117c3d7328c7b2b7b577492c43c134",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
     flake-parts.url = "github:hercules-ci/flake-parts";
 
     pyproject-nix.url = "github:pyproject-nix/pyproject.nix";


### PR DESCRIPTION
Fixed #514

FYI: https://github.com/NixOS/nixpkgs/pull/512735

Track a stable channel rather than an unstable one: fewer "HEAD is broken" regressions.
25.11 has the fetchCargoVendor User-Agent fix (needed so crates.io doesn't 403 libtokenizers' crate downloads)