### PR TITLE
Support multi-tenant headers and OTel mapping

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -139,6 +139,8 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--data.otel_trace_replay.filter` | str | Lambda expression to filter trace records. Applied uniformly to all data sources.
 Example: "lambda x: x['benchmark'] == 'gsm8k'" or "lambda x: 'spans' in x and len(x['spans']) > 5"
 Security: Filter expressions use eval() and should only contain trusted input. |
+| `--data.otel_trace_replay.attribute_to_header_map` | JSON | Map OTel span attributes to HTTP headers |
+| `--data.otel_trace_replay.attribute_to_label_map` | JSON | Map OTel span attributes to metrics reporting labels |
 | `--data.conversation_replay.seed` | int | Random seed for deterministic generation |
 | `--data.conversation_replay.num_conversations` | int | Number of conversation blueprints to generate |
 | `--data.conversation_replay.shared_system_prompt_len` | int | Fixed shared system prompt length in tokens |

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -41,6 +41,7 @@ class InferenceInfo(BaseModel):
     response_metrics: Optional[SerializeAsAny[ResponseMetrics]] = None
     extra_info: dict[str, Any] = {}
     lora_adapter: Optional[str] = None
+    labels: dict[str, str] = {}
 
     # DEPRECATED: mirror of request_metrics.text.input_tokens kept at the top
     # level for back-compat with parsers of pre-multimodal
@@ -95,6 +96,8 @@ class InferenceAPIData(BaseModel):
     session_id: Optional[str] = None  # set by loadgen for session-based workloads
     otel_context: Optional[dict[str, str]] = None  # OTEL trace context for distributed tracing
     stage_id: int = 0  # stage id
+    headers: Optional[dict[str, str]] = None
+    labels: dict[str, str] = {}
 
     @abstractmethod
     def get_api_type(self) -> APIType:

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -152,6 +152,15 @@ class openAIModelServerClient(ModelServerClient):
         except Exception as e:
             logger.error(f"Got exception retrieving supported models {e}")
             return []
+
+
+def _update_headers_case_insensitive(target: dict[str, str], source: dict[str, str]) -> None:
+    for k, v in source.items():
+        k_lower = k.lower()
+        matching_keys = [exist_k for exist_k in target.keys() if exist_k.lower() == k_lower]
+        for mk in matching_keys:
+            del target[mk]
+        target[k] = v
 
 
 class openAIModelServerClientSession(ModelServerClientSession):
@@ -321,7 +330,10 @@ class openAIModelServerClientSession(ModelServerClientSession):
             headers["Authorization"] = f"Bearer {self.client.api_key}"
 
         if self.client.api_config.headers:
-            headers.update(self.client.api_config.headers)
+            _update_headers_case_insensitive(headers, self.client.api_config.headers)
+
+        if data.headers:
+            _update_headers_case_insensitive(headers, data.headers)
 
         if data.session_id and self.client.api_config.session_id_header_key:
             headers[self.client.api_config.session_id_header_key] = data.session_id
@@ -461,12 +473,17 @@ class openAIModelServerClientSession(ModelServerClientSession):
                 lora_adapter=lora_adapter,
             )
 
+        if not info:
+            info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=0)))
+        if data.labels:
+            info.labels = data.labels
+
         metric = RequestLifecycleMetric(
             stage_id=stage_id,
             session_id=data.session_id if isinstance(data.session_id, str) else None,
             request_data=request_data,
             response_data=response_content,
-            info=info if info else InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=0))),
+            info=info,
             error=error,
             start_time=start,
             end_time=end_time,
@@ -487,19 +504,34 @@ class openAIModelServerClientSession(ModelServerClientSession):
             default_tpot_header = f"x-slo-tpot-{slo_unit}"
             ttft_header = getattr(self.client.api_config, "slo_ttft_header", None) or default_ttft_header
             tpot_header = getattr(self.client.api_config, "slo_tpot_header", None) or default_tpot_header
+
+            combined_headers = {}
             if self.client.api_config.headers:
-                ttft_threshold = self.client.api_config.headers.get(ttft_header)
-                tpot_threshold = self.client.api_config.headers.get(tpot_header)
+                for k, v in self.client.api_config.headers.items():
+                    combined_headers[k.lower()] = v
+            if data.headers:
+                for k, v in data.headers.items():
+                    combined_headers[k.lower()] = v
+
+            if combined_headers:
+                ttft_threshold = combined_headers.get(ttft_header.lower())
+                tpot_threshold = combined_headers.get(tpot_header.lower())
 
                 unit = slo_unit.lower()
                 unit_to_s = {"s": 1.0, "ms": 0.001, "us": 0.000001}
                 factor = unit_to_s.get(unit, 1.0)
 
-                if ttft_threshold is not None:
-                    metric.ttft_slo_sec = float(ttft_threshold) * factor
+                if ttft_threshold is not None and ttft_threshold != "default":
+                    try:
+                        metric.ttft_slo_sec = float(ttft_threshold) * factor
+                    except ValueError:
+                        logger.warning(f"Invalid TTFT SLO value: {ttft_threshold}")
 
-                if tpot_threshold is not None:
-                    metric.tpot_slo_sec = float(tpot_threshold) * factor
+                if tpot_threshold is not None and tpot_threshold != "default":
+                    try:
+                        metric.tpot_slo_sec = float(tpot_threshold) * factor
+                    except ValueError:
+                        logger.warning(f"Invalid TPOT SLO value: {tpot_threshold}")
 
         # Record the metric
         self.client.metrics_collector.record_metric(metric)

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -128,6 +128,10 @@ class OTelTraceReplayConfig(SessionReplayConfig):
             "Security: Filter expressions use eval() and should only contain trusted input."
         ),
     )
+    attribute_to_header_map: Optional[Dict[str, str]] = Field(None, description="Map OTel span attributes to HTTP headers")
+    attribute_to_label_map: Optional[Dict[str, str]] = Field(
+        None, description="Map OTel span attributes to metrics reporting labels"
+    )
 
     @model_validator(mode="after")
     def validate_trace_sources(self) -> "OTelTraceReplayConfig":

--- a/inference_perf/datagen/otel_trace_replay_datagen.py
+++ b/inference_perf/datagen/otel_trace_replay_datagen.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -68,12 +68,14 @@ from inference_perf.config import APIConfig, DataConfig
 from inference_perf.datagen.replay_graph_session_datagen import (
     ReplaySession,
     ReplayGraphSessionGeneratorBase,
+    SessionChatCompletionAPIData,
 )
 from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_raw_calls,
     build_graph,
 )
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from inference_perf.apis import LazyLoadInferenceAPIData
 
 logger = logging.getLogger(__name__)
 
@@ -382,7 +384,15 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
             _validate_dataset_schema(dataset, self.otel_config.trace_directory)
 
         elif self.otel_config.trace_files:
+            # Multiple files mode
+            for path in self.otel_config.trace_files:
+                if "*" not in path and "?" not in path:
+                    if not Path(path).is_file():
+                        raise ValueError(f"Trace file does not exist: {path}")
+
             trace_files = resolve_trace_files(self.otel_config.trace_files)
+            if not trace_files:
+                raise ValueError(f"No trace files resolved from {self.otel_config.trace_files}")
 
             for trace_file in trace_files:
                 if not trace_file.exists():
@@ -489,3 +499,45 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
             session_index=trace_index,
             graph=graph,
         )
+
+    def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> SessionChatCompletionAPIData:
+        api_data = super().load_lazy_data(data)
+
+        n = data.data_index
+        event = self.all_events[n]
+        session_id = event.event_id.split(":")[0] if ":" in event.event_id else event.event_id
+        raw_event_id = event.event_id.split(":", 1)[1] if ":" in event.event_id else event.event_id
+        state = self.session_graph_state.get(session_id)
+        gc = state.graph.events[raw_event_id].call if state and raw_event_id in state.graph.events else None
+
+        if gc:
+            # Ensure we have a dict to query, even if the span had no extra attributes
+            attributes = gc.attributes or {}
+            headers = {}
+            labels = {}
+
+            if self.otel_config.attribute_to_header_map:
+                for attr_key, header_name in self.otel_config.attribute_to_header_map.items():
+                    val = attributes.get(attr_key)
+                    if val is None:
+                        val = "default"
+                    headers[header_name] = str(val)
+
+            if self.otel_config.attribute_to_label_map:
+                for attr_key, label_name in self.otel_config.attribute_to_label_map.items():
+                    val = attributes.get(attr_key)
+                    if val is None:
+                        val = "default"
+                    labels[label_name] = str(val)
+
+            if headers:
+                if api_data.headers is None:
+                    api_data.headers = {}
+                api_data.headers.update(headers)
+
+            if labels:
+                if api_data.labels is None:
+                    api_data.labels = {}
+                api_data.labels.update(labels)
+
+        return api_data

--- a/inference_perf/datagen/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/otel_trace_to_replay_graph.py
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -53,7 +53,7 @@ import argparse
 import json
 import logging
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
@@ -320,6 +320,7 @@ class RawCall:
     temperature: Optional[float]
     max_tokens_recorded: Optional[int]
     tool_definitions: Optional[List[Dict[str, Any]]] = None
+    extra_attributes: Dict[str, Any] = field(default_factory=dict)
 
 
 def filter_duplicate_spans(spans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -405,6 +406,18 @@ def build_raw_calls(spans: List[Dict[str, Any]], include_errors: bool = False) -
                 logger.warning(f"Span {s.get('span_id')}: failed to parse gen_ai.tool.definitions as JSON, ignoring")
         elif isinstance(tool_definitions_raw, list):
             tool_definitions = tool_definitions_raw
+
+        # Filter out known large standard GenAI attributes
+        excluded_keys = {
+            "gen_ai.input.messages",
+            "gen_ai.output.messages",
+            "gen_ai.tool.definitions",
+            "gen_ai.output.text",
+            "gen_ai.completion",
+            "gen_ai.output",
+        }
+        extra_attrs = {k: v for k, v in attrs.items() if k not in excluded_keys}
+
         calls.append(
             RawCall(
                 call_id=s.get("span_id") or "",
@@ -419,6 +432,7 @@ def build_raw_calls(spans: List[Dict[str, Any]], include_errors: bool = False) -
                 temperature=attrs.get("gen_ai.request.temperature"),
                 max_tokens_recorded=attrs.get("gen_ai.request.max_tokens"),
                 tool_definitions=tool_definitions,
+                extra_attributes=extra_attrs,
             )
         )
     return calls
@@ -426,6 +440,7 @@ def build_raw_calls(spans: List[Dict[str, Any]], include_errors: bool = False) -
 
 # ---------------------------------------------------------------------------
 # Causal dependency detection (message-level)
+# ---------------------------------------------------------------------------
 
 
 class DEPENDENCY_TYPE(Enum):
@@ -1068,6 +1083,7 @@ def build_graph(
             tool_definitions=rc.tool_definitions,
             expected_output_is_tool_call=effective_is_tool_call,
             expected_output_tool_names=expected_output_tool_names or None,
+            attributes=rc.extra_attributes or None,
         )
 
         # Compute wait_ms: gap between when the last predecessor ends and this call starts
@@ -1130,6 +1146,8 @@ def graph_call_to_dict(gc: GraphCall) -> Dict[str, Any]:
         d["expected_output_is_tool_call"] = gc.expected_output_is_tool_call
     if gc.expected_output_tool_names is not None:
         d["expected_output_tool_names"] = gc.expected_output_tool_names
+    if gc.attributes is not None:
+        d["attributes"] = gc.attributes
     return d
 
 

--- a/inference_perf/datagen/replay_graph_types.py
+++ b/inference_perf/datagen/replay_graph_types.py
@@ -89,6 +89,7 @@ class GraphCall:
     # specific function when there is exactly one tool call; with multiple calls
     # we fall back to "required" since vLLM only accepts one name at a time.
     expected_output_tool_names: Optional[List[str]] = None
+    attributes: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/tests/test_multitenant_loadgen.py
+++ b/tests/test_multitenant_loadgen.py
@@ -1,0 +1,447 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import http.server
+import threading
+import socket
+import sys
+import logging
+from pathlib import Path
+from typing import Any, ClassVar, Dict, Generator, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure project root is on path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from inference_perf.apis import (
+    LazyLoadInferenceAPIData,
+    RequestLifecycleMetric,
+    InferenceInfo,
+    StreamedResponseMetrics,
+)
+from inference_perf.config import APIConfig, APIType, DataConfig, OTelTraceReplayConfig
+from inference_perf.datagen.otel_trace_replay_datagen import OTelTraceReplayDataGenerator
+from inference_perf.client.modelserver.openai_client import openAIModelServerClient, openAIModelServerClientSession
+from inference_perf.payloads import RequestMetrics, Text
+
+# Bypassed Hub Connection globally
+import inference_perf.client.modelserver.openai_client
+
+inference_perf.client.modelserver.openai_client.CustomTokenizer = MagicMock()  # type: ignore[attr-defined]
+
+
+class ConcreteOpenAIClient(openAIModelServerClient):
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion]
+
+    def get_prometheus_metric_metadata(self) -> Any:
+        return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Mock HTTP Server Fixture
+# ---------------------------------------------------------------------------
+
+
+class MockHandler(http.server.BaseHTTPRequestHandler):
+    received_headers: ClassVar[Dict[str, str]] = {}
+    received_body: ClassVar[bytes | None] = None
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length)
+        MockHandler.received_body = body
+
+        # Capture headers case-sensitively
+        MockHandler.received_headers = {k: v for k, v in self.headers.items()}
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+
+        # Return a mock OpenAI-like response
+        response = {
+            "choices": [{"message": {"role": "assistant", "content": "Mock response content"}}],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 5},
+        }
+        self.wfile.write(json.dumps(response).encode("utf-8"))
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass  # Suppress logging
+
+
+@pytest.fixture
+def mock_server() -> Generator[str, None, None]:
+    # Find a free port
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    server = http.server.HTTPServer(("127.0.0.1", port), MockHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    yield f"http://127.0.0.1:{port}"
+
+    server.shutdown()
+    server.server_close()
+    thread.join()
+    MockHandler.received_headers = {}
+    MockHandler.received_body = None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiTenantLoadGen:
+    def test_otel_attributes_extraction_and_mapping(self, tmp_path: Path) -> None:
+        """Verify OTel span attributes extract and map to headers/labels correctly."""
+        # 1. Create mock spans
+        spans = [
+            {
+                "span_id": "span_1",
+                "trace_id": "trace_1",
+                "start_time": "2026-06-01T00:00:00Z",
+                "end_time": "2026-06-01T00:00:01Z",
+                "name": "chat completions",
+                "attributes": {
+                    "gen_ai.input.messages": json.dumps([{"role": "user", "content": "hello"}]),
+                    "gen_ai.output.text": "hi",
+                    "gen_ai.request.model": "test-model",
+                    "otel.genai.tenant_id": "tenant-123",
+                    "otel.genai.token": "secret-token",
+                    # This one is NOT mapped, should stay in extra_attributes but not map to header/label
+                    "custom.attribute": "keep-me",
+                    "otel.genai.nil_attr": None,  # Test None value fallback
+                },
+            }
+        ]
+
+        # Write mock trace to a temp file
+        trace_file = tmp_path / "mock_trace.json"
+        trace_file.write_text(json.dumps({"spans": spans}), encoding="utf-8")
+
+        # 2. Configure generator with mapping
+        api_config = APIConfig(type=APIType.Chat, streaming=False)
+        otel_config = OTelTraceReplayConfig(
+            trace_files=[str(trace_file)],
+            attribute_to_header_map={
+                "otel.genai.token": "x-tenant-token",
+                "otel.genai.nil_attr": "x-nil-header",  # Should map to 'default'
+                "missing.attr": "x-missing-header",  # Test missing attribute fallback
+            },
+            attribute_to_label_map={
+                "otel.genai.tenant_id": "tenant_id",
+                "otel.genai.nil_attr": "nil_label",  # Should map to 'default'
+                "missing.attr": "missing_label",  # Test missing attribute fallback
+            },
+        )
+
+        data_config = DataConfig(type="otel_trace_replay", otel_trace_replay=otel_config)
+
+        # Initialize generator (this will load the trace file and build graph)
+        gen = OTelTraceReplayDataGenerator(api_config=api_config, config=data_config, tokenizer=None, num_workers=1)
+
+        # 3. Load lazy data and assert mappings
+        lazy_data = LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0)
+        api_data = gen.load_lazy_data(lazy_data)
+
+        # Assert headers mapped correctly
+        assert api_data.headers is not None
+        assert api_data.headers.get("x-tenant-token") == "secret-token"
+        assert api_data.headers.get("x-nil-header") == "default"  # None value fallback
+        assert api_data.headers.get("x-missing-header") == "default"  # Missing key fallback
+
+        # Assert labels mapped correctly
+        assert api_data.labels is not None
+        assert api_data.labels.get("tenant_id") == "tenant-123"
+        assert api_data.labels.get("nil_label") == "default"  # None value fallback
+        assert api_data.labels.get("missing_label") == "default"  # Missing key fallback
+
+    def test_otel_attributes_extraction_and_mapping_missing_attributes(self, tmp_path: Path) -> None:
+        """Verify OTel span attributes mapping still injects defaults when span has no extra attributes."""
+        # 1. Create mock spans with ONLY excluded standard attributes
+        spans = [
+            {
+                "span_id": "span_1",
+                "trace_id": "trace_1",
+                "start_time": "2026-06-01T00:00:00Z",
+                "end_time": "2026-06-01T00:00:01Z",
+                "name": "chat completions",
+                "attributes": {
+                    "gen_ai.input.messages": json.dumps([{"role": "user", "content": "hello"}]),
+                    "gen_ai.output.text": "hi",
+                    "gen_ai.request.model": "test-model",
+                },
+            }
+        ]
+
+        # Write mock trace to a temp file
+        trace_file = tmp_path / "mock_trace_missing_attrs.json"
+        trace_file.write_text(json.dumps({"spans": spans}), encoding="utf-8")
+
+        # 2. Configure generator with mapping
+        api_config = APIConfig(type=APIType.Chat, streaming=False)
+        otel_config = OTelTraceReplayConfig(
+            trace_files=[str(trace_file)],
+            attribute_to_header_map={
+                "missing.attr": "x-missing-header",
+            },
+            attribute_to_label_map={
+                "missing.attr": "missing_label",
+            },
+        )
+
+        data_config = DataConfig(type="otel_trace_replay", otel_trace_replay=otel_config)
+
+        # Initialize generator
+        gen = OTelTraceReplayDataGenerator(api_config=api_config, config=data_config, tokenizer=None, num_workers=1)
+
+        # 3. Load lazy data and assert mappings still receive defaults
+        lazy_data = LazyLoadInferenceAPIData(data_index=0, preferred_worker_id=0)
+        api_data = gen.load_lazy_data(lazy_data)
+
+        # Assert headers mapped to default
+        assert api_data.headers is not None
+        assert api_data.headers.get("x-missing-header") == "default"
+
+        # Assert labels mapped to default
+        assert api_data.labels is not None
+        assert api_data.labels.get("missing_label") == "default"
+
+    @pytest.mark.asyncio
+    async def test_client_slo_resolution(self) -> None:
+        """Verify that client combined SLO resolution logic resolves thresholds correctly."""
+        # Setup mock client and session
+        metrics_collector = MagicMock()
+        api_config = APIConfig(
+            type=APIType.Chat,
+            streaming=True,
+            headers={"x-slo-ttft-ms": "100", "x-slo-tpot-ms": "20"},  # Global SLOs
+        )
+        client = ConcreteOpenAIClient(
+            metrics_collector=metrics_collector,
+            api_config=api_config,
+            uri="http://mock",
+            model_name="test-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+        session = openAIModelServerClientSession(client)
+
+        # Mock response and info to trigger SLO parsing block
+        response_metrics = StreamedResponseMetrics(
+            output_tokens=2, output_token_times=[1.0, 1.1], response_chunks=["a", "b"], chunk_times=[1.0, 1.1]
+        )
+        info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=5)), response_metrics=response_metrics)
+
+        # Mock data.process_response to return our info
+        data = MagicMock()
+        data.headers = {"x-slo-ttft-ms": "50"}  # Request-specific override (TTFT only)
+        data.labels = {}
+        data.session_id = "sess-1"
+        data.get_route.return_value = "/v1/chat/completions"
+        data.to_request_body = AsyncMock(return_value={})
+        data.process_response = AsyncMock(return_value=info)
+        data.process_failure = AsyncMock(return_value=info)
+
+        # Mock aiohttp post
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+
+        mock_post = MagicMock()
+        mock_post.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_post.__aexit__ = AsyncMock(return_value=None)
+        # Run process_request with mocked post
+        with patch.object(session.session, "post", return_value=mock_post):
+            await session.process_request(data, stage_id=1, scheduled_time=0.0)
+
+        # Verify recorded metric
+        assert metrics_collector.record_metric.called
+        metric = metrics_collector.record_metric.call_args[0][0]
+        assert isinstance(metric, RequestLifecycleMetric)
+
+        # SLOs should be resolved:
+        # Global TTFT (100ms) overridden by Request-specific TTFT (50ms) -> 0.05s
+        # Global TPOT (20ms) kept because request didn't override it -> 0.02s
+        assert metric.ttft_slo_sec == 0.05
+        assert metric.tpot_slo_sec == 0.02
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_mock_server_headers_transmission(self, mock_server: str) -> None:
+        """Verify that mapped headers are physically transmitted on the wire."""
+        metrics_collector = MagicMock()
+        api_config = APIConfig(type=APIType.Chat, streaming=False)
+        client = ConcreteOpenAIClient(
+            metrics_collector=metrics_collector,
+            api_config=api_config,
+            uri=mock_server,  # Point to our mock server
+            model_name="test-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+        session = openAIModelServerClientSession(client)
+
+        # Create request data with custom headers
+        data = MagicMock()
+        data.headers = {"x-llm-d-inference-fairness-id": "tenant-fairness-456", "x-custom-auth": "token-789"}
+        data.labels = {}
+        data.session_id = "sess-1"
+        data.get_route.return_value = "/v1/chat/completions"
+        # We need to return a valid body dict for json.dumps
+        data.to_request_body = AsyncMock(return_value={"model": "test-model", "messages": []})
+
+        # Mock process_response to avoid tokenizer dependencies in this wire test
+        info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=5)), response_metrics=None)
+        data.process_response = AsyncMock(return_value=info)
+
+        # Run process_request
+        await session.process_request(data, stage_id=1, scheduled_time=0.0)
+
+        # Assert headers were received by the server
+        headers = MockHandler.received_headers
+        assert headers is not None
+
+        # Case-insensitive check
+        headers_lower = {k.lower(): v for k, v in headers.items()}
+        assert headers_lower.get("x-llm-d-inference-fairness-id") == "tenant-fairness-456"
+        assert headers_lower.get("x-custom-auth") == "token-789"
+        assert headers_lower.get("content-type") == "application/json"
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_client_slo_resolution_malformed_values(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Verify that client handles malformed SLO thresholds gracefully by logging warning and keeping None."""
+        # Setup mock client and session
+        metrics_collector = MagicMock()
+        api_config = APIConfig(
+            type=APIType.Chat,
+            streaming=True,
+            headers={"x-slo-ttft-ms": "not-a-float", "x-slo-tpot-ms": "also-not-a-float"},  # Global malformed SLOs
+        )
+        client = ConcreteOpenAIClient(
+            metrics_collector=metrics_collector,
+            api_config=api_config,
+            uri="http://mock",
+            model_name="test-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+        session = openAIModelServerClientSession(client)
+
+        # Mock response and info to trigger SLO parsing block
+        response_metrics = StreamedResponseMetrics(
+            output_tokens=2, output_token_times=[1.0, 1.1], response_chunks=["a", "b"], chunk_times=[1.0, 1.1]
+        )
+        info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=5)), response_metrics=response_metrics)
+
+        # Mock data
+        data = MagicMock()
+        data.headers = {"x-slo-ttft-ms": "bad-request-value"}  # Request-specific override (also malformed)
+        data.labels = {}
+        data.session_id = "sess-1"
+        data.get_route.return_value = "/v1/chat/completions"
+        data.to_request_body = AsyncMock(return_value={})
+        data.process_response = AsyncMock(return_value=info)
+        data.process_failure = AsyncMock(return_value=info)
+
+        # Mock aiohttp post
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+
+        mock_post = MagicMock()
+        mock_post.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_post.__aexit__ = AsyncMock(return_value=None)
+        # Run process_request while capturing warnings and mocking post
+        with caplog.at_level(logging.WARNING), patch.object(session.session, "post", return_value=mock_post):
+            await session.process_request(data, stage_id=1, scheduled_time=0.0)
+
+        # Verify recorded metric
+        assert metrics_collector.record_metric.called
+        metric = metrics_collector.record_metric.call_args[0][0]
+        assert isinstance(metric, RequestLifecycleMetric)
+
+        # SLOs should be None
+        assert metric.ttft_slo_sec is None
+        assert metric.tpot_slo_sec is None
+
+        # Assert warnings were logged
+        warnings = [record.message for record in caplog.records if record.levelname == "WARNING"]
+        assert any("Invalid TTFT SLO value: bad-request-value" in w for w in warnings)
+        assert any("Invalid TPOT SLO value: also-not-a-float" in w for w in warnings)
+
+        await session.close()
+
+    @pytest.mark.asyncio
+    async def test_mock_server_headers_transmission_casing_overwrite(self, mock_server: str) -> None:
+        """Verify that request headers overwrite global headers case-insensitively on the wire without duplicates."""
+        metrics_collector = MagicMock()
+        # Configure global headers with mixed casing
+        api_config = APIConfig(type=APIType.Chat, streaming=False, headers={"X-LLM-D-Inference-Fairness-ID": "global-val"})
+        client = ConcreteOpenAIClient(
+            metrics_collector=metrics_collector,
+            api_config=api_config,
+            uri=mock_server,
+            model_name="test-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+        session = openAIModelServerClientSession(client)
+
+        # Configure request headers with different casing
+        data = MagicMock()
+        data.headers = {"x-llm-d-inference-fairness-id": "request-override"}
+        data.labels = {}
+        data.session_id = "sess-1"
+        data.get_route.return_value = "/v1/chat/completions"
+        data.to_request_body = AsyncMock(return_value={"model": "test-model", "messages": []})
+
+        info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=5)), response_metrics=None)
+        data.process_response = AsyncMock(return_value=info)
+
+        # Run process_request
+        await session.process_request(data, stage_id=1, scheduled_time=0.0)
+
+        # Assert headers received
+        headers = MockHandler.received_headers
+        assert headers is not None
+
+        # Count how many times the fairness-id header appears (case-insensitively)
+        fairness_keys = [k for k in headers.keys() if k.lower() == "x-llm-d-inference-fairness-id"]
+
+        # We expect exactly one matching key
+        assert len(fairness_keys) == 1, f"Expected exactly one fairness-id header, but got: {fairness_keys}"
+
+        # We expect the value to be the request-specific override
+        target_key = fairness_keys[0]
+        assert headers[target_key] == "request-override"
+
+        # The key itself should have the casing of the request-specific header
+        assert target_key == "x-llm-d-inference-fairness-id"
+
+        await session.close()

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -769,7 +769,11 @@ class TestEndToEndSimpleChain:
         gen.worker_tracker = tracker
         gen.session_completion_queue = queue
         gen.api_config = make_api_config()
-        gen.replay_config = None  # Add missing replay_config attribute
+        mock_otel_config = MagicMock()
+        mock_otel_config.attribute_to_header_map = {}
+        mock_otel_config.attribute_to_label_map = {}
+        gen.otel_config = mock_otel_config
+        gen.replay_config = mock_otel_config
         gen.session_graph_state = {session_id: MagicMock(graph=graph, random_string=None)}
 
         from inference_perf.apis import LazyLoadInferenceAPIData


### PR DESCRIPTION
Part of #524 (1 of 3)

## Why

Currently, the load generator does not support propagating request-specific headers or metric labels extracted from trace spans. This prevents users from validating multi-tenant routing and quality-of-service features (like those in the `llm-d-router` Flow Control layer), which rely on dynamic headers (e.g., tenant identity, priority class) under shared, saturated loads.

This change introduces the core data structures and client logic to extract custom attributes from OTel traces, map them case-insensitively, and forward them as HTTP headers on wire calls while propagating labels to telemetry metrics.

## How

* **Core Data APIs (`inference_perf/apis/base.py`)**:
  * Extended `InferenceInfo` and `InferenceAPIData` to store request-specific headers (`headers: Optional[dict[str, str]]`) and metric reporting labels (`labels: dict[str, str]`).
* **OpenAI Client Session (`inference_perf/client/modelserver/openai_client.py`)**:
  * Implemented case-insensitive header merging via `_update_headers_case_insensitive` to merge client API configurations and request-specific headers, preventing duplicate wire transmissions.
  * Propagated `data.labels` into `InferenceInfo` for trace-level label reporting.
  * Redesigned client-side SLO resolution to merge global configurations with request-specific headers case-insensitively. This allows per-request threshold overrides via headers (e.g., TTFT and TPOT limits) with resilient parsing logic that handles unit factors (s/ms/us), logs warning messages for malformed inputs, and falls back gracefully to global defaults.
* **OTel Mapping & Parsing**:
  * `inference_perf/config.py`: Exposed `attribute_to_header_map` and `attribute_to_label_map` options in `OTelTraceReplayConfig` to allow arbitrary user mappings.
  * `inference_perf/datagen/replay_graph_types.py` & `otel_trace_to_replay_graph.py`: Modified span extraction to capture extra attributes into `attributes` on `GraphCall`, while filtering out heavy fields (e.g., messages, completions, prompts) to keep memory footprint low.
  * `inference_perf/datagen/otel_trace_replay_datagen.py`: Extended `OTelTraceReplayDataGenerator.load_lazy_data` to dynamically resolve mapped OTel attributes to request headers and metrics labels, with a robust case-insensitive fallback to `"default"` for missing or null attributes (consistently applied even when spans have no extra attributes).

## Changed Files

* `inference_perf/apis/base.py`
* `inference_perf/client/modelserver/openai_client.py`
* `inference_perf/config.py`
* `inference_perf/datagen/otel_trace_replay_datagen.py`
* `inference_perf/datagen/otel_trace_to_replay_graph.py`
* `inference_perf/datagen/replay_graph_types.py`
* `tests/test_otel_replay_datagen.py`
* `tests/test_multitenant_loadgen.py`

## Verification

* **Automated Tests Added**: A new test suite `tests/test_multitenant_loadgen.py` was added, verifying:
  * `test_otel_attributes_extraction_and_mapping`: Asserts correct span attribute extraction, mapping, and fallback defaults under the OTel data generator.
  * `test_otel_attributes_extraction_and_mapping_missing_attributes`: Asserts that OTel mapping still consistently injects `"default"` fallbacks even when a span has no extra attributes (preventing a truthiness trap on `gc.attributes`).
  * `test_client_slo_resolution`: Asserts SLO resolution, unit factor conversion (seconds, milliseconds, microseconds), and custom header priority.
  * `test_mock_server_headers_transmission`: Runs a background local HTTP server to verify headers are physically transmitted on the wire.
  * `test_client_slo_resolution_malformed_values`: Asserts malformed SLO values are safely ignored, warning log messages are emitted, and standard defaults are preserved.
  * `test_mock_server_headers_transmission_casing_overwrite`: Asserts that per-request headers overwrite global configurations case-insensitively without creating duplicate HTTP headers.

* **Regression Fixes**:
  * Fixed `test_output_substitution_end_to_end` in `tests/test_otel_replay_datagen.py` by properly mocking the newly required `otel_config` and `replay_config` attributes.