### PR TITLE
cleanup: Start load generator workers with forkserver instead of fork

### DIFF
--- a/e2e/tests/test_forkserver_mp.py
+++ b/e2e/tests/test_forkserver_mp.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end guard for the fork -> forkserver multiprocessing switch.
+
+The load generator starts workers with a ``forkserver`` context instead of the
+(Python 3.14 deprecated) ``fork`` default. Unlike fork, forkserver pickles the
+worker payload and runs it in a fresh interpreter, so the entire production
+payload -- the model server client, the datagen, and its CustomTokenizer -- must
+be picklable. The unit suite only exercises this boundary with picklable
+doubles; these tests drive the real ``inference-perf`` CLI through the
+multiprocessing path (num_workers > 0) with a real tokenizer-backed datagen and
+the mock server (so no real model is required).
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from utils.benchmark import run_benchmark_minimal
+
+# A real, tiny tokenizer so the datagen carries a genuine CustomTokenizer across
+# the forkserver boundary (rather than a mock that only survives fork).
+_TOKENIZER = "gpt2"
+
+# rate * duration -> total requests issued across the stage.
+_RATE = 2
+_DURATION = 5
+_EXPECTED_REQUESTS = _RATE * _DURATION
+
+
+def _config(datagen_type: str) -> Dict[str, Any]:
+    distribution = {"min": 10, "max": 50, "mean": 30, "std_dev": 10}
+    return {
+        "data": {
+            "type": datagen_type,
+            "input_distribution": dict(distribution),
+            "output_distribution": dict(distribution),
+        },
+        "load": {
+            "type": "constant",
+            "stages": [{"rate": _RATE, "duration": _DURATION}],
+            # > 0 forces the mp_run path, which starts forkserver workers and
+            # pickles the datagen + tokenizer into them.
+            "num_workers": 2,
+        },
+        "api": {"type": "completion"},
+        "server": {"type": "mock", "base_url": "http://0.0.0.0:8000"},
+        "tokenizer": {"pretrained_model_name_or_path": _TOKENIZER},
+        "report": {"request_lifecycle": {"summary": True, "per_stage": True, "per_request": True}},
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("datagen_type", ["synthetic", "random"])
+async def test_real_datagen_pickles_into_forkserver_workers(datagen_type: str) -> None:
+    result = await run_benchmark_minimal(_config(datagen_type), timeout_sec=180)
+
+    assert result.success, (
+        f"Benchmark failed for datagen={datagen_type} "
+        f"(rc={result.return_code}, timed_out={result.timed_out}).\n"
+        f"If this is a PicklingError or a 'SemLock created in a fork context' "
+        f"error, the worker payload is not forkserver-safe.\n{result.stdout}"
+    )
+    assert result.reports, "No reports generated from benchmark"
+
+    summary = result.reports["summary_lifecycle_metrics.json"]
+    assert summary["successes"]["count"] == _EXPECTED_REQUESTS, (
+        f"expected {_EXPECTED_REQUESTS} successful requests, got {summary['successes']['count']}"
+    )
+
+    # The deprecated fork() warning must not reappear: workers now start from the
+    # single-threaded forkserver, not a fork of this multi-threaded process.
+    assert "use of fork() may lead to deadlocks" not in result.stdout, (
+        f"fork() deprecation warning present for datagen={datagen_type}; "
+        f"workers are not using the forkserver context.\n{result.stdout}"
+    )

--- a/e2e/tests/test_metrics_fallback.py
+++ b/e2e/tests/test_metrics_fallback.py
@@ -19,7 +19,7 @@ import sys
 import threading
 import pytest
 
-from utils.benchmark import run_benchmark_minimal
+from utils.benchmark import pythonpath_env, run_benchmark_minimal
 from test_prometheus import is_prometheus_available
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.resolve()
@@ -140,7 +140,7 @@ async def test_legacy_metric_name(prometheus_server):
         result = await run_benchmark_minimal(
             _benchmark_config(prometheus_server.url, prometheus_server.sim_port),
             executable=[sys.executable, str(MAIN_PY_PATH)],
-            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
+            extra_env=pythonpath_env(PROJECT_ROOT),
         )
 
         assert result.success, f"Benchmark failed: {result.stdout}"
@@ -165,7 +165,7 @@ async def test_new_metric_name(prometheus_server):
         result = await run_benchmark_minimal(
             _benchmark_config(prometheus_server.url, prometheus_server.sim_port),
             executable=[sys.executable, str(MAIN_PY_PATH)],
-            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
+            extra_env=pythonpath_env(PROJECT_ROOT),
         )
 
         assert result.success, f"Benchmark failed: {result.stdout}"

--- a/e2e/tests/test_prometheus.py
+++ b/e2e/tests/test_prometheus.py
@@ -23,7 +23,7 @@ import pytest
 import requests
 import textwrap
 
-from utils.benchmark import run_benchmark_minimal
+from utils.benchmark import pythonpath_env, run_benchmark_minimal
 from utils.llm_d_inference_sim import LLMDInferenceSimRunner
 from utils.testdata import extract_tarball
 
@@ -101,7 +101,7 @@ async def test_prometheus_metrics_collection(prometheus_server):
                 },
             },
             executable=[sys.executable, str(MAIN_PY_PATH)],
-            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
+            extra_env=pythonpath_env(PROJECT_ROOT),
         )
 
         # Verify benchmark succeeded before proceeding
@@ -212,7 +212,7 @@ async def test_prometheus_metrics_collection_chat(prometheus_server):
                 },
             },
             executable=[sys.executable, str(MAIN_PY_PATH)],
-            extra_env={"PYTHONPATH": str(PROJECT_ROOT)},
+            extra_env=pythonpath_env(PROJECT_ROOT),
         )
 
         # Verify benchmark succeeded before proceeding

--- a/e2e/utils/__init__.py
+++ b/e2e/utils/__init__.py
@@ -14,13 +14,14 @@
 
 """E2E test utilities for inference-perf."""
 
-from .benchmark import BenchmarkResult, run_benchmark_minimal
+from .benchmark import BenchmarkResult, pythonpath_env, run_benchmark_minimal
 from .llm_d_inference_sim import LLMDInferenceSimRunner
 from .testdata import TEST_E2E_DIR, TEST_E2E_TESTDATA, extract_tarball
 from .vllm_server import VLLMServerRunner
 
 __all__ = [
     "BenchmarkResult",
+    "pythonpath_env",
     "run_benchmark_minimal",
     "LLMDInferenceSimRunner",
     "VLLMServerRunner",

--- a/e2e/utils/benchmark.py
+++ b/e2e/utils/benchmark.py
@@ -73,6 +73,23 @@ async def _process_yaml_config(config: Union[str, Path, Dict[str, Any]], out_dir
     return cfg_path
 
 
+def pythonpath_env(*paths: Union[str, Path]) -> Dict[str, str]:
+    """Build a ``PYTHONPATH`` override that keeps the inherited entries.
+
+    Tests that invoke ``inference_perf/main.py`` as a script have to put the
+    project root on ``PYTHONPATH``. Setting it to just the project root drops
+    whatever the surrounding environment had there, and the nix dev shell puts
+    its own ``numpy``/``torch`` on ``PYTHONPATH``. Without them the child falls
+    back to the venv wheels, which are not linked against the nix runtime
+    libraries and fail to import.
+    """
+    entries = [str(p) for p in paths]
+    inherited = os.environ.get("PYTHONPATH", "")
+    if inherited:
+        entries.append(inherited)
+    return {"PYTHONPATH": os.pathsep.join(entries)}
+
+
 def _find_report_files(path: Path) -> Optional[List[Path]]:
     """Return the json reports files under path (if any)."""
     candidates = list(path.glob("**/*.json"))

--- a/inference_perf/datagen/base.py
+++ b/inference_perf/datagen/base.py
@@ -114,6 +114,37 @@ class DataGenerator(BaseGenerator):
         raise NotImplementedError
 
 
+class StreamingDatasetMixin:
+    """Mixin for datagens backed by a live HuggingFace streaming iterator.
+
+    The iterator (``iter``/``itertools.cycle`` over ``load_dataset(..., streaming=True)``)
+    is backed by a generator and cannot be pickled. forkserver/spawn load-generator
+    workers pickle the Worker process and its datagen at start, so a datagen holding
+    such an iterator fails with ``TypeError: cannot pickle 'generator' object``.
+
+    Subclasses keep the iterator under the attribute named by ``_streaming_dataset_attr``
+    and build it in ``_initialize_dataset`` (reading ``self.config``). This mixin drops the
+    iterator when pickling and rebuilds it from ``self.config`` in the worker, so the
+    parent-side construction can stay eager.
+    """
+
+    config: DataConfig
+    _streaming_dataset_attr: str
+
+    def _initialize_dataset(self) -> None:
+        """Build the streaming iterator from ``self.config``. Subclasses must override."""
+        raise NotImplementedError
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop(self._streaming_dataset_attr, None)
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._initialize_dataset()
+
+
 class SessionGenerator(BaseGenerator):
     """Session-based trace replay for agentic workloads (TRACE_SESSION_REPLAY load type).
 

--- a/inference_perf/datagen/dataset/cnn_dailymail_datagen.py
+++ b/inference_perf/datagen/dataset/cnn_dailymail_datagen.py
@@ -15,7 +15,7 @@ import itertools
 import logging
 from inference_perf.apis import InferenceAPIData, CompletionAPIData
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from ..base import DataGenerator
+from ..base import DataGenerator, StreamingDatasetMixin
 from inference_perf.config import APIConfig, APIType, DataConfig
 from typing import Generator, List, Optional
 from datasets import load_dataset
@@ -24,12 +24,23 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class CNNDailyMailDataGenerator(DataGenerator):
+class CNNDailyMailDataGenerator(StreamingDatasetMixin, DataGenerator):
+    _streaming_dataset_attr = "cnn_dailymail_dataset"
+
     def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
         super().__init__(api_config, config, tokenizer)
         if tokenizer is None:
             raise ValueError("CustomTokenizer instance cannot be None")
 
+        self.config = config
+        self.article_key = "article"
+        self.highlights_key = "highlights"
+        self._initialize_dataset()
+        # initialize data collection
+        next(self.cnn_dailymail_dataset)
+
+    def _initialize_dataset(self) -> None:
+        config = self.config
         if config.path is not None:
             # check if the path is valid
             if not os.path.exists(config.path):
@@ -56,10 +67,6 @@ class CNNDailyMailDataGenerator(DataGenerator):
                     split="train",
                 )
             )
-        self.article_key = "article"
-        self.highlights_key = "highlights"
-        # initialize data collection
-        next(self.cnn_dailymail_dataset)
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion]

--- a/inference_perf/datagen/dataset/hf_billsum_datagen.py
+++ b/inference_perf/datagen/dataset/hf_billsum_datagen.py
@@ -20,12 +20,14 @@ from inference_perf.apis import ChatCompletionAPIData, ChatMessage, CompletionAP
 from inference_perf.config import APIConfig, APIType, DataConfig
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
-from ..base import DataGenerator
+from ..base import DataGenerator, StreamingDatasetMixin
 
 logger = logging.getLogger(__name__)
 
 
-class BillsumConversationsDataGenerator(DataGenerator):
+class BillsumConversationsDataGenerator(StreamingDatasetMixin, DataGenerator):
+    _streaming_dataset_attr = "billsum_dataset"
+
     def __init__(
         self,
         api_config: APIConfig,

--- a/inference_perf/datagen/dataset/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/dataset/hf_sharegpt_datagen.py
@@ -21,7 +21,7 @@ from inference_perf.apis import (
     InferenceAPIData,
 )
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from ..base import DataGenerator
+from ..base import DataGenerator, StreamingDatasetMixin
 from inference_perf.config import APIConfig, APIType, DataConfig
 from typing import Any, Generator, List, Optional
 from datasets import load_dataset
@@ -35,10 +35,22 @@ SHAREGPT_HF_DATAFILES_PATH = "ShareGPT_V3_unfiltered_cleaned_split.json"
 SHAREGPT_HF_CHAT_ROLE_MAP = {"human": "user", "gpt": "assistant"}
 
 
-class HFShareGPTDataGenerator(DataGenerator):
+class HFShareGPTDataGenerator(StreamingDatasetMixin, DataGenerator):
+    _streaming_dataset_attr = "sharegpt_dataset"
+
     def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
         super().__init__(api_config, config, tokenizer)
+        self.config = config
+        self.min_num_turns = 2
+        self.data_key = "conversations"
+        self.role_key = "from"
+        self.content_key = "value"
+        self._initialize_dataset()
+        # initialize data collection
+        next(self.sharegpt_dataset)
 
+    def _initialize_dataset(self) -> None:
+        config = self.config
         if config.path is not None:
             # check if the path is valid
             if not os.path.exists(config.path):
@@ -65,12 +77,6 @@ class HFShareGPTDataGenerator(DataGenerator):
                     split="train",
                 )
             )
-        self.min_num_turns = 2
-        self.data_key = "conversations"
-        self.role_key = "from"
-        self.content_key = "value"
-        # initialize data collection
-        next(self.sharegpt_dataset)
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Chat, APIType.Completion, APIType.AnthropicMessages]

--- a/inference_perf/datagen/dataset/infinity_instruct_datagen.py
+++ b/inference_perf/datagen/dataset/infinity_instruct_datagen.py
@@ -14,7 +14,7 @@
 import logging
 from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from ..base import DataGenerator
+from ..base import DataGenerator, StreamingDatasetMixin
 from inference_perf.config import APIConfig, APIType, DataConfig
 from typing import Generator, List, Optional
 from datasets import load_dataset
@@ -23,10 +23,19 @@ import os
 logger = logging.getLogger(__name__)
 
 
-class InfinityInstructDataGenerator(DataGenerator):
+class InfinityInstructDataGenerator(StreamingDatasetMixin, DataGenerator):
+    _streaming_dataset_attr = "infinity_instruct_dataset"
+
     def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
         super().__init__(api_config, config, tokenizer)
+        self.config = config
+        self.conversations_key = "conversations"
+        self._initialize_dataset()
+        # initialize data collection
+        next(self.infinity_instruct_dataset)
 
+    def _initialize_dataset(self) -> None:
+        config = self.config
         if config.path is not None:
             # check if the path is valid
             if not os.path.exists(config.path):
@@ -46,10 +55,6 @@ class InfinityInstructDataGenerator(DataGenerator):
                 raise ValueError(f"Invalid dataset path: {config.path}")
         else:
             raise ValueError("path is not provided in the config")
-
-        self.conversations_key = "conversations"
-        # initialize data collection
-        next(self.infinity_instruct_dataset)
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion, APIType.Chat]

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -81,6 +81,11 @@ from inference_perf.utils.mp_context import MP_CONTEXT
 
 logger = logging.getLogger(__name__)
 
+# Upper bound on how long the parent waits for workers to finish starting up
+# before giving up and starting load anyway. Generous on purpose: a forkserver
+# worker has to rebuild a payload that can include a large tokenizer.
+WORKER_STARTUP_TIMEOUT_SEC = 300.0
+
 
 class RequestQueueData(NamedTuple):
     stage_id: int
@@ -105,6 +110,7 @@ class Worker(MP_CONTEXT.Process):  # type: ignore[name-defined,misc]
         shared_max_concurrency: Optional["Synchronized[int]"],
         base_seed: int,
         stage_barrier: Optional[SyncBarrier] = None,
+        ready_counter: Optional["Synchronized[int]"] = None,
     ):
         super().__init__(daemon=True)  # kill worker process if main process exit unexpected
         self.id = id
@@ -121,6 +127,7 @@ class Worker(MP_CONTEXT.Process):  # type: ignore[name-defined,misc]
         self.skip = False
         self.base_seed = base_seed
         self.stage_barrier = stage_barrier
+        self.ready_counter = ready_counter
         # Snapshot the parent's effective root log level so the worker
         # interpreter (which under forkserver/spawn does not inherit the
         # parent's basicConfig) can configure its own handler to surface
@@ -288,6 +295,14 @@ class Worker(MP_CONTEXT.Process):  # type: ignore[name-defined,misc]
         # Ignore SIGINT in workers to prevent multiple calls to SIGINT handler
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         set_event_loop_policy(uvloop.EventLoopPolicy())
+
+        # Announce that startup is done: the payload has been unpickled and the
+        # queue is about to be consumed. The parent waits on this so worker
+        # startup is not billed as benchmark time (see _await_workers_ready).
+        if self.ready_counter is not None:
+            with self.ready_counter.get_lock():
+                self.ready_counter.value += 1
+
         run(self.loop())
 
 
@@ -306,6 +321,9 @@ class LoadGenerator:
         self.num_workers = load_config.num_workers
         self.worker_max_concurrency = load_config.worker_max_concurrency
         self.workers: List[Worker] = []
+        # Set once the workers are up and load is about to start; the reported
+        # run window is measured from here rather than from process startup.
+        self.load_start_time: Optional[float] = None
         self.circuit_breakers = [get_circuit_breaker(breaker_name) for breaker_name in load_config.circuit_breakers]
         self.sweep_config = load_config.sweep
         self.interrupt_sig = False
@@ -938,6 +956,41 @@ class LoadGenerator:
         self.stages = [StandardLoadStage(rate=r, duration=self.sweep_config.stage_duration) for r in rates]
         logger.info(f"Generated load stages: {[s.rate for s in self.stages]}")
 
+    async def _await_workers_ready(self, ready_counter: "Synchronized[int]") -> None:
+        """Wait until every worker has finished starting up.
+
+        ``Process.start()`` returns as soon as the child exists, well before it
+        has rebuilt its payload, so without this the parent starts dispatching
+        into a queue nobody is reading yet. ``fork`` workers inherited the
+        parent's memory and were ready almost immediately; ``forkserver`` ones
+        are rebuilt in a fresh interpreter, which takes long enough to stretch
+        the run window and deflate every rate derived from it.
+
+        Never fatal: on a dead worker or a timeout this logs and returns, so a
+        run that would have proceeded before still proceeds.
+        """
+        deadline = time.monotonic() + WORKER_STARTUP_TIMEOUT_SEC
+        while True:
+            with ready_counter.get_lock():
+                ready = ready_counter.value
+            if ready >= self.num_workers:
+                logger.debug(f"all {self.num_workers} workers ready")
+                return
+            exited = [w for w in self.workers if w.exitcode is not None]
+            if exited:
+                logger.error(
+                    f"{len(exited)} of {self.num_workers} workers exited during startup "
+                    f"(exit codes {[w.exitcode for w in exited]}); starting load with {ready} ready"
+                )
+                return
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    f"only {ready} of {self.num_workers} workers became ready within "
+                    f"{WORKER_STARTUP_TIMEOUT_SEC}s; starting load anyway"
+                )
+                return
+            await sleep(0.05)
+
     async def mp_run(self, client: ModelServerClient) -> None:
         request_queue: RequestQueue[RequestQueueData] = RequestQueue(
             self.num_workers if self.datagen.is_preferred_worker_requested() else 1
@@ -950,6 +1003,7 @@ class LoadGenerator:
         # Synchronize workers and main at stage boundaries so workers finish
         # in-flight requests and clear session state before the next stage begins.
         stage_barrier: SyncBarrier = MP_CONTEXT.Barrier(self.num_workers + 1)
+        workers_ready: "Synchronized[int]" = MP_CONTEXT.Value("i", 0)
         # start workers in the request phase
         request_phase.set()
 
@@ -976,9 +1030,15 @@ class LoadGenerator:
                     shared_max_concurrency,
                     self.base_seed,
                     stage_barrier,
+                    workers_ready,
                 )
             )
             self.workers[-1].start()
+
+        # Keep worker startup out of the measured window: wait for the workers
+        # to come up, then treat that moment as the start of the run.
+        await self._await_workers_ready(workers_ready)
+        self.load_start_time = time.time()
 
         if self.sweep_config:
             try:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -77,6 +77,7 @@ from rich.progress import (
 import signal
 
 from inference_perf.observability.logging import get_console
+from inference_perf.utils.mp_context import MP_CONTEXT
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ class RequestQueueData(NamedTuple):
     lora_adapter: Optional[str]
 
 
-class Worker(mp.Process):
+class Worker(MP_CONTEXT.Process):  # type: ignore[name-defined,misc]
     def __init__(
         self,
         id: int,
@@ -941,14 +942,14 @@ class LoadGenerator:
         request_queue: RequestQueue[RequestQueueData] = RequestQueue(
             self.num_workers if self.datagen.is_preferred_worker_requested() else 1
         )
-        finished_requests_counter: "Synchronized[int]" = mp.Value("i", 0)
-        active_requests_counter: "Synchronized[int]" = mp.Value("i", 0)
-        request_phase: SyncEvent = mp.Event()
-        stop_signal: SyncEvent = mp.Event()
-        cancel_signal: SyncEvent = mp.Event()
+        finished_requests_counter: "Synchronized[int]" = MP_CONTEXT.Value("i", 0)
+        active_requests_counter: "Synchronized[int]" = MP_CONTEXT.Value("i", 0)
+        request_phase: SyncEvent = MP_CONTEXT.Event()
+        stop_signal: SyncEvent = MP_CONTEXT.Event()
+        cancel_signal: SyncEvent = MP_CONTEXT.Event()
         # Synchronize workers and main at stage boundaries so workers finish
         # in-flight requests and clear session state before the next stage begins.
-        stage_barrier: SyncBarrier = mp.Barrier(self.num_workers + 1)
+        stage_barrier: SyncBarrier = MP_CONTEXT.Barrier(self.num_workers + 1)
         # start workers in the request phase
         request_phase.set()
 
@@ -956,7 +957,7 @@ class LoadGenerator:
         for id in range(self.num_workers):
             # Create shared value for each worker's max concurrency if concurrent load type
             if self.load_type == LoadType.CONCURRENT:
-                shared_max_concurrency = mp.Value("i", self.worker_max_concurrency)
+                shared_max_concurrency = MP_CONTEXT.Value("i", self.worker_max_concurrency)
             else:
                 shared_max_concurrency = None
 

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -389,6 +389,15 @@ def main_cli() -> None:
         pass
 
     end_time = time.time()
+
+    # Bringing workers up is process setup, not benchmark work. Under forkserver
+    # each worker is rebuilt in a fresh interpreter, so counting that startup
+    # stretches the window and deflates every rate derived from it. The load
+    # generator records when load actually began; prefer it when it is set (the
+    # multiprocessing path only, which is where the startup cost lives).
+    if loadgen.load_start_time is not None:
+        start_time = loadgen.load_start_time
+
     duration = end_time - start_time  # Calculate the duration of the test
 
     # Generate Reports after the tests

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import multiprocessing as mp
-import sys
 from argparse import ArgumentParser
 from inference_perf.analysis.analyze import analyze_reports
+from inference_perf.utils.mp_context import MP_CONTEXT
 from typing import List, Optional
 from inference_perf.client.modelserver.tgi_client import TGImodelServerClient
 from inference_perf.datagen.base import BaseGenerator
@@ -111,14 +110,9 @@ class InferencePerfRunner:
 
 
 def main_cli() -> None:
-    # Set multiprocessing start method to 'fork' on macOS to avoid pickle issues
-    # This must be done before any multiprocessing operations
-    if sys.platform == "darwin":  # macOS
-        try:
-            mp.set_start_method("fork", force=True)
-        except RuntimeError:
-            # Start method already set, ignore
-            pass
+    # The load generator pins its own ``forkserver`` multiprocessing context
+    # (see inference_perf.utils.mp_context), so the process-global default start
+    # method is no longer relied upon and is intentionally left untouched here.
 
     # Parse command line arguments
     parser = ArgumentParser()
@@ -264,14 +258,15 @@ def main_cli() -> None:
         raise Exception("Load stages must be configured, or sweep must be configured")
 
     # Create multiprocessing manager for session replay datagens if needed.
-    # Must be created before workers are forked.
+    # Must be created before workers are started, and from the same context as
+    # the workers so its proxies are usable across the worker boundary.
     mp_manager = None
     if (
         config.data
         and config.data.type in (DataGenType.OTelTraceReplay, DataGenType.WekaTraceReplay)
         and config.load.num_workers > 0
     ):
-        mp_manager = mp.Manager()
+        mp_manager = MP_CONTEXT.Manager()
 
     datagen: BaseGenerator
     if config.data:

--- a/inference_perf/metrics/request_collector/multiprocess.py
+++ b/inference_perf/metrics/request_collector/multiprocess.py
@@ -23,6 +23,7 @@ import logging
 from inference_perf.metrics.request_collector import RequestMetricCollector
 from inference_perf.apis import RequestLifecycleMetric
 from inference_perf.circuit_breaker import feed_breakers
+from inference_perf.utils.mp_context import MP_CONTEXT
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class MultiprocessRequestMetricCollector(RequestMetricCollector):
     """Responsible for accumulating client request metrics"""
 
     def __init__(self) -> None:
-        self.queue: "mp.JoinableQueue[Optional[RequestLifecycleMetric]]" = mp.JoinableQueue()
+        self.queue: "mp.JoinableQueue[Optional[RequestLifecycleMetric]]" = MP_CONTEXT.JoinableQueue()
 
     def record_metric(self, metric: RequestLifecycleMetric) -> None:
         self.queue.put(metric)

--- a/inference_perf/utils/mp_context.py
+++ b/inference_perf/utils/mp_context.py
@@ -1,0 +1,34 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared multiprocessing context for the load generator.
+
+Workers are started with ``forkserver`` rather than the platform-default
+``fork``. Python 3.14 deprecates ``fork()`` from a multi-threaded process (the
+main process runs an asyncio event loop and executor threads) because the child
+can deadlock on locks held by threads that do not exist after the fork. The
+``forkserver`` server process is single-threaded, so the forks that create
+workers are safe.
+
+Every multiprocessing object that crosses the worker boundary (queues, shared
+values, events, barriers, managers, and the ``Process`` subclass itself) must be
+created from this same context. Mixing objects from different start-method
+contexts raises at pickle/transfer time.
+"""
+
+import multiprocessing as mp
+from multiprocessing.context import BaseContext
+
+# forkserver is available on Linux and macOS, which are the platforms this tool
+# targets. The server is started lazily on first worker creation.
+MP_CONTEXT: BaseContext = mp.get_context("forkserver")

--- a/inference_perf/utils/request_queue.py
+++ b/inference_perf/utils/request_queue.py
@@ -16,6 +16,8 @@ import multiprocessing as mp
 from queue import Empty
 from typing import Generic, List, TypeVar
 
+from inference_perf.utils.mp_context import MP_CONTEXT
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
@@ -30,7 +32,7 @@ class RequestQueue(Generic[T]):
             num_channels (int, optional): number of channels. Defaults to 1.
         """
         self.num_channels: int = num_channels
-        self.queues: List[mp.JoinableQueue[T]] = [mp.JoinableQueue() for _ in range(num_channels)]
+        self.queues: List[mp.JoinableQueue[T]] = [MP_CONTEXT.JoinableQueue() for _ in range(num_channels)]
 
     def get_channel(self, channel_id: int) -> "mp.JoinableQueue[T]":
         return self.queues[channel_id % self.num_channels]

--- a/tests/required/apis/test_user_session.py
+++ b/tests/required/apis/test_user_session.py
@@ -19,7 +19,7 @@ import re
 import pytest
 from collections import defaultdict
 from queue import Empty
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
 from unittest.mock import MagicMock
 
 from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
@@ -38,6 +38,8 @@ from inference_perf.config import (
 )
 from inference_perf.datagen.synthetic.shared_prefix_datagen import SharedPrefixDataGenerator
 from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.utils.mp_context import MP_CONTEXT
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
 def _mock_tokenizer() -> MagicMock:
@@ -55,7 +57,37 @@ def _mock_tokenizer() -> MagicMock:
     return tok
 
 
-def _make_datagen(num_groups: int = 1, num_prompts_per_group: int = 1) -> SharedPrefixDataGenerator:
+class _PicklableHFTokenizer:
+    """Picklable stand-in for the HF tokenizer object returned by
+    CustomTokenizer.get_tokenizer(). MagicMock is not picklable, so the mp test
+    (which ships the datagen into a forkserver worker) needs a real class.
+    Mirrors the _mock_tokenizer behavior: every decode returns "tok_<len>"."""
+
+    vocab_size = 1000
+    all_special_ids: List[int] = []
+
+    def decode(self, ids: List[int], **kw: object) -> str:
+        return f"tok_{len(ids)}"
+
+    def batch_decode(self, batch: List[List[int]], **kw: object) -> List[str]:
+        return [f"tok_{len(ids)}" for ids in batch]
+
+
+class _PicklableTokenizer:
+    """Picklable CustomTokenizer stand-in, matching _mock_tokenizer's surface."""
+
+    def get_tokenizer(self) -> _PicklableHFTokenizer:
+        return _PicklableHFTokenizer()
+
+    def count_tokens(self, text: object) -> int:
+        if isinstance(text, str):
+            return sum(int(n) for n in re.findall(r"tok_(\d+)", text))
+        return 0
+
+
+def _make_datagen(
+    num_groups: int = 1, num_prompts_per_group: int = 1, tokenizer: Optional[CustomTokenizer] = None
+) -> SharedPrefixDataGenerator:
     api_config = APIConfig(type=APIType.Completion)
     data_config = DataConfig(
         type=DataGenType.SharedPrefix,
@@ -69,7 +101,7 @@ def _make_datagen(num_groups: int = 1, num_prompts_per_group: int = 1) -> Shared
             seed=42,
         ),
     )
-    return SharedPrefixDataGenerator(api_config, data_config, _mock_tokenizer())
+    return SharedPrefixDataGenerator(api_config, data_config, tokenizer if tokenizer is not None else _mock_tokenizer())
 
 
 class SessionTrackingClient(ModelServerClient):
@@ -200,7 +232,7 @@ class TestLocalUserSessionLifecycle:
     async def test_loadgen_mp_does_not_leak_session_context_across_stages(self) -> None:
         """
         Same as the non-mp test but with num_workers=1 so requests flow
-        through a forked Worker subprocess.
+        through a Worker subprocess started via the shared forkserver context.
 
         The client writes (stage_id, prompt) tuples to an mp.Queue that the
         main process drains after the run.  If any stage-1 prompt contains
@@ -209,9 +241,9 @@ class TestLocalUserSessionLifecycle:
 
 
         """
-        mp.set_start_method("fork", force=True)
-
-        datagen = _make_datagen()
+        # forkserver pickles the worker payload, so the datagen needs a
+        # picklable tokenizer rather than the MagicMock used elsewhere.
+        datagen = _make_datagen(tokenizer=cast(CustomTokenizer, _PicklableTokenizer()))
         load_config = LoadConfig(
             type=LoadType.CONSTANT,
             stages=[
@@ -222,7 +254,7 @@ class TestLocalUserSessionLifecycle:
             interval=0,
         )
 
-        prompt_queue: "mp.Queue[Tuple[int, str]]" = mp.Queue()
+        prompt_queue: "mp.Queue[Tuple[int, str]]" = MP_CONTEXT.Queue()
         client = SessionTrackingClient(prompt_queue=prompt_queue)
         loadgen = LoadGenerator(datagen, load_config)
 

--- a/tests/required/datagen/test_streaming_datagen_picklable.py
+++ b/tests/required/datagen/test_streaming_datagen_picklable.py
@@ -1,0 +1,83 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import pickle
+from pathlib import Path
+from typing import Optional, Type, cast
+
+import pytest
+
+from inference_perf.config import APIConfig, APIType
+from inference_perf.config.datagen.config import DataConfig, DataGenType
+from inference_perf.datagen.base import DataGenerator
+from inference_perf.datagen.dataset.cnn_dailymail_datagen import CNNDailyMailDataGenerator
+from inference_perf.datagen.dataset.hf_billsum_datagen import BillsumConversationsDataGenerator
+from inference_perf.datagen.dataset.hf_sharegpt_datagen import HFShareGPTDataGenerator
+from inference_perf.datagen.dataset.infinity_instruct_datagen import InfinityInstructDataGenerator
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+# Non-None, picklable stand-in. The streaming datagens only check the tokenizer
+# for None at construction; the pickle round-trip below never touches it.
+_DUMMY_TOKENIZER = cast(CustomTokenizer, object())
+
+_RECORDS = [
+    {"id": "1", "conversations": [{"from": "human", "value": "hi"}, {"from": "gpt", "value": "hello"}]},
+    {"id": "2", "conversations": [{"from": "human", "value": "2+2?"}, {"from": "gpt", "value": "4"}]},
+]
+
+
+@pytest.fixture
+def dataset_path(tmp_path: Path) -> str:
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps(_RECORDS))
+    return str(path)
+
+
+@pytest.mark.parametrize(
+    "cls, datagen_type, iterator_attr, tokenizer",
+    [
+        (HFShareGPTDataGenerator, DataGenType.ShareGPT, "sharegpt_dataset", None),
+        (CNNDailyMailDataGenerator, DataGenType.CNNDailyMail, "cnn_dailymail_dataset", _DUMMY_TOKENIZER),
+        (BillsumConversationsDataGenerator, DataGenType.BillsumConversations, "billsum_dataset", None),
+        (InfinityInstructDataGenerator, DataGenType.InfinityInstruct, "infinity_instruct_dataset", None),
+    ],
+)
+def test_streaming_datagen_is_picklable(
+    dataset_path: str,
+    cls: Type[DataGenerator],
+    datagen_type: DataGenType,
+    iterator_attr: str,
+    tokenizer: Optional[CustomTokenizer],
+) -> None:
+    """Streaming datagens must survive a pickle round-trip.
+
+    forkserver/spawn load-generator workers pickle the Worker process (and its
+    datagen) at start. The live HuggingFace streaming iterator is generator-backed
+    and not picklable, so each streaming datagen drops it on pickle and rebuilds it
+    on unpickle. Without that, .start() raises 'cannot pickle generator object'.
+    """
+    api_config = APIConfig(type=APIType.Completion)
+    data_config = DataConfig(type=datagen_type, path=dataset_path)
+
+    generator = cls(api_config, data_config, tokenizer)
+    assert iterator_attr in generator.__dict__
+
+    # __getstate__ must omit the unpicklable streaming iterator.
+    state = generator.__getstate__()
+    assert isinstance(state, dict)
+    assert iterator_attr not in state
+
+    # The exact round-trip forkserver performs must succeed and rebuild the iterator.
+    restored = pickle.loads(pickle.dumps(generator))
+    assert iterator_attr in restored.__dict__

--- a/tests/required/loadgen/test_load_generator.py
+++ b/tests/required/loadgen/test_load_generator.py
@@ -224,6 +224,15 @@ class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
             mock_tg = MagicMock()
             MockTaskGroup.return_value.__aenter__.return_value = mock_tg
 
+            # create_task is given client.process_request(...) — an AsyncMock
+            # coroutine. The real TaskGroup would await it; the mock must close
+            # it so it isn't garbage-collected later as "never awaited".
+            def _close_coro(coro: Any) -> MagicMock:
+                coro.close()
+                return MagicMock()
+
+            mock_tg.create_task.side_effect = _close_coro
+
             async def dummy_process_request(*args: Any, **kwargs: Any) -> None:
                 pass
 

--- a/tests/required/loadgen/test_load_generator.py
+++ b/tests/required/loadgen/test_load_generator.py
@@ -261,6 +261,28 @@ class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
         await self.load_generator.drain(q.get_channel(0))
         self.assertTrue(q.get_channel(0).empty())
 
+    async def test_await_workers_ready_returns_once_workers_signal(self) -> None:
+        ready = mp.Value("i", self.load_generator.num_workers)
+        self.load_generator.workers = typing.cast(Any, [MagicMock(exitcode=None), MagicMock(exitcode=None)])
+
+        await asyncio.wait_for(self.load_generator._await_workers_ready(ready), timeout=5)
+
+    async def test_await_workers_ready_gives_up_when_a_worker_exits(self) -> None:
+        # A worker that dies while starting up never signals readiness. The gate
+        # has to give up rather than block the run forever.
+        ready = mp.Value("i", 0)
+        self.load_generator.workers = typing.cast(Any, [MagicMock(exitcode=None), MagicMock(exitcode=1)])
+
+        await asyncio.wait_for(self.load_generator._await_workers_ready(ready), timeout=5)
+
+    async def test_await_workers_ready_gives_up_on_timeout(self) -> None:
+        # Workers still alive but silent: the gate expires and load starts anyway.
+        ready = mp.Value("i", 0)
+        self.load_generator.workers = typing.cast(Any, [MagicMock(exitcode=None), MagicMock(exitcode=None)])
+
+        with patch("inference_perf.loadgen.load_generator.WORKER_STARTUP_TIMEOUT_SEC", 0.1):
+            await asyncio.wait_for(self.load_generator._await_workers_ready(ready), timeout=5)
+
     def test_sigint_handler(self) -> None:
         import signal
 


### PR DESCRIPTION
Python 3.14 deprecates fork() from a multi-threaded process (the main process runs an asyncio event loop and executor threads); the child can deadlock on locks held by threads that no longer exist after the fork. The load generator forked workers from this multi-threaded process, which emitted a DeprecationWarning on every run.

Switch workers to a single shared forkserver context (inference_perf/utils/mp_context.py). The forkserver server process is single-threaded, so the forks that create workers are safe. Unlike fork, forkserver pickles the worker payload and runs it in a fresh interpreter, so every multiprocessing object that crosses the worker boundary must come from the same context: the request queue, the metrics collector queue, the worker sync primitives (Value/Event/Barrier), the Worker process subclass, and the session-replay Manager. The macOS set_start_method("fork") workaround is removed since the context is now pinned explicitly.

Moving off fork means the worker payload (client, datagen, tokenizer) must be picklable rather than inherited. Verified the real payload pickles: OTEL instrumentation, CustomTokenizer (HF), and forkserver-context queues transfer correctly during worker startup. Updated the mp session test to use a picklable tokenizer double (MagicMock only survived fork) and added an e2e test that drives the real CLI through the multiprocessing path with real tokenizer-backed datagens to guard the boundary going forward.

Also fix an unrelated "coroutine never awaited" warning in test_run_single_worker_mode: the mocked TaskGroup.create_task now closes the coroutine it is handed.