### PR TITLE
Add absolute coverage metrics, artifacts, and a Coveralls badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,9 +9,16 @@ on:
       - '**/*.md'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     runs-on: ubuntu-latest
+    # contents: write is only needed to push the badge to the 'badges' branch,
+    # which happens solely on push to main (see the publish step's condition).
+    permissions:
+      contents: write
     strategy:
       matrix:
         python-version: ['3.13']
@@ -53,3 +60,37 @@ jobs:
       - name: Run Validation
         if: steps.changes.outputs.code == 'true'
         run: pdm run check:cov
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-reports
+          path: |
+            coverage.json
+            coverage.xml
+            coverage-endpoint.json
+          if-no-files-found: warn
+      - name: Publish coverage badge to badges branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          cp coverage-endpoint.json /tmp/coverage-endpoint.json
+          # Use an isolated worktree on an orphan 'badges' branch so we never
+          # touch the checked-out source tree. The README points shields.io at
+          # this JSON; shields renders the badge and GitHub camo-proxies it.
+          git fetch origin badges --depth=1 || true
+          if git show-ref --verify --quiet refs/remotes/origin/badges; then
+            git worktree add /tmp/badges origin/badges
+          else
+            git worktree add --orphan -b badges /tmp/badges
+          fi
+          cp /tmp/coverage-endpoint.json /tmp/badges/coverage-endpoint.json
+          cd /tmp/badges
+          git add coverage-endpoint.json
+          if git diff --staged --quiet; then
+            echo "Badge unchanged; nothing to publish."
+          else
+            git commit -m "Update coverage badge"
+            git push origin HEAD:badges
+          fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,10 +15,6 @@ permissions:
 jobs:
   format-check:
     runs-on: ubuntu-latest
-    # contents: write is only needed to push the badge to the 'badges' branch,
-    # which happens solely on push to main (see the publish step's condition).
-    permissions:
-      contents: write
     strategy:
       matrix:
         python-version: ['3.13']
@@ -67,30 +63,17 @@ jobs:
           path: |
             coverage.json
             coverage.xml
-            coverage-endpoint.json
+            coverage.lcov
           if-no-files-found: warn
-      - name: Publish coverage badge to badges branch
+      # Coveralls renders the README coverage badge. It authenticates with the
+      # built-in GITHUB_TOKEN, so this needs no repository secret and no push
+      # access to any branch (the job stays at contents: read). Restricted to
+      # push-on-main so the badge tracks main and forked PRs, whose token is
+      # read-only, never attempt an upload.
+      - name: Send coverage to Coveralls
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          cp coverage-endpoint.json /tmp/coverage-endpoint.json
-          # Use an isolated worktree on an orphan 'badges' branch so we never
-          # touch the checked-out source tree. The README points shields.io at
-          # this JSON; shields renders the badge and GitHub camo-proxies it.
-          git fetch origin badges --depth=1 || true
-          if git show-ref --verify --quiet refs/remotes/origin/badges; then
-            git worktree add /tmp/badges origin/badges
-          else
-            git worktree add --orphan -b badges /tmp/badges
-          fi
-          cp /tmp/coverage-endpoint.json /tmp/badges/coverage-endpoint.json
-          cd /tmp/badges
-          git add coverage-endpoint.json
-          if git diff --staged --quiet; then
-            echo "Badge unchanged; nothing to publish."
-          else
-            git commit -m "Update coverage badge"
-            git push origin HEAD:badges
-          fi
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.lcov
+          format: lcov

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
+coverage_main.json
+coverage-endpoint.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ nosetests.xml
 coverage.xml
 coverage.json
 coverage_main.json
-coverage-endpoint.json
+coverage.lcov
 *.cover
 *.py,cover
 .hypothesis/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI Release](https://img.shields.io/pypi/v/inference-perf.svg?label=PyPI%20Release)](https://pypi.python.org/pypi/inference-perf)
 [![Container Image](https://img.shields.io/badge/Container-latest-blue)](https://quay.io/inference-perf/inference-perf)
 [![Tests](https://img.shields.io/github/actions/workflow/status/kubernetes-sigs/inference-perf/unit_test.yml?branch=main&label=Tests)](https://github.com/kubernetes-sigs/inference-perf/actions/workflows/unit_test.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kubernetes-sigs/inference-perf/badges/coverage-endpoint.json)](https://github.com/kubernetes-sigs/inference-perf/actions/workflows/coverage.yml)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
 
 # Inference Perf

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI Release](https://img.shields.io/pypi/v/inference-perf.svg?label=PyPI%20Release)](https://pypi.python.org/pypi/inference-perf)
 [![Container Image](https://img.shields.io/badge/Container-latest-blue)](https://quay.io/inference-perf/inference-perf)
 [![Tests](https://img.shields.io/github/actions/workflow/status/kubernetes-sigs/inference-perf/unit_test.yml?branch=main&label=Tests)](https://github.com/kubernetes-sigs/inference-perf/actions/workflows/unit_test.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kubernetes-sigs/inference-perf/badges/coverage-endpoint.json)](https://github.com/kubernetes-sigs/inference-perf/actions/workflows/coverage.yml)
+[![Coverage Status](https://coveralls.io/repos/github/kubernetes-sigs/inference-perf/badge.svg?branch=main)](https://coveralls.io/github/kubernetes-sigs/inference-perf?branch=main)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.10314/status.svg)](https://doi.org/10.21105/joss.10314)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI Release](https://img.shields.io/pypi/v/inference-perf.svg?label=PyPI%20Release)](https://pypi.python.org/pypi/inference-perf)
 [![Container Image](https://img.shields.io/badge/Container-latest-blue)](https://quay.io/inference-perf/inference-perf)
 [![Tests](https://img.shields.io/github/actions/workflow/status/kubernetes-sigs/inference-perf/unit_test.yml?branch=main&label=Tests)](https://github.com/kubernetes-sigs/inference-perf/actions/workflows/unit_test.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/kubernetes-sigs/inference-perf/badges/coverage-endpoint.json)](https://github.com/kubernetes-sigs/inference-perf/actions/workflows/coverage.yml)
 [![Join Slack](https://img.shields.io/badge/Join_Slack-blue?logo=slack)](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.10314/status.svg)](https://doi.org/10.21105/joss.10314)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,18 @@ ignore_missing_imports = true
 [tool.coverage.run]
 source = ["inference_perf"]
 omit = ["tests/*", "**/__init__.py", "scripts/*", "scripts/**/*"]
+# Trace subprocesses (e.g. the multiprocessing request-collector Workers in
+# inference_perf/loadgen/load_generator.py) which are otherwise reported as
+# uncovered even when tests exercise them. parallel=true writes per-process
+# data files that pytest-cov combines; sigterm=true flushes data when a
+# daemon worker is terminated.
+concurrency = ["multiprocessing"]
+parallel = true
+sigterm = true
 
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+
+[tool.coverage.xml]
+output = "coverage.xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,18 @@ ignore_errors = true
 [tool.coverage.run]
 source = ["inference_perf"]
 omit = ["tests/*", "**/__init__.py", "scripts/*", "scripts/**/*"]
+# Trace subprocesses (e.g. the multiprocessing request-collector Workers in
+# inference_perf/loadgen/load_generator.py) which are otherwise reported as
+# uncovered even when tests exercise them. parallel=true writes per-process
+# data files that pytest-cov combines; sigterm=true flushes data when a
+# daemon worker is terminated.
+concurrency = ["multiprocessing"]
+parallel = true
+sigterm = true
 
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+
+[tool.coverage.xml]
+output = "coverage.xml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,12 +208,14 @@ source = ["inference_perf"]
 omit = ["tests/*", "**/__init__.py", "scripts/*", "scripts/**/*"]
 # Trace subprocesses (e.g. the multiprocessing request-collector Workers in
 # inference_perf/loadgen/load_generator.py) which are otherwise reported as
-# uncovered even when tests exercise them. parallel=true writes per-process
-# data files that pytest-cov combines; sigterm=true flushes data when a
-# daemon worker is terminated.
+# uncovered even when tests exercise them. pytest-cov owns data-file handling
+# here (it already passes data_suffix=True and combines the per-process files),
+# so parallel=true is not set. sigterm=true is deliberately not set either: it
+# installs a SIGTERM handler in every Worker, which makes Process.terminate()
+# asynchronous and lets the load generator fall through to SIGKILL, hanging
+# harness.shutdown() in Condition.notify. Data from a worker killed at the
+# force deadline is lost after SIGKILL regardless.
 concurrency = ["multiprocessing"]
-parallel = true
-sigterm = true
 
 [tool.coverage.report]
 show_missing = true

--- a/scripts/check_coverage_regression.py
+++ b/scripts/check_coverage_regression.py
@@ -22,6 +22,18 @@ import argparse
 # Ensure PDM doesn't reuse the current virtualenv when we are trying to use another one (e.g. for baseline)
 os.environ["PDM_IGNORE_ACTIVE_VENV"] = "1"
 
+# Absolute repo-wide coverage floor. Set just below the current total so the
+# build fails if coverage regresses meaningfully in absolute terms, independent
+# of the delta-vs-main ratchet. Raise this as coverage improves.
+MIN_TOTAL_COVERAGE = 63.0
+
+# Coverage config (pyproject.toml) used for both the current and baseline runs.
+# Exporting COVERAGE_PROCESS_START lets coverage start measuring inside the
+# multiprocessing Workers (see [tool.coverage.run] concurrency=multiprocessing),
+# so subprocess code reports real numbers instead of reading as uncovered.
+COVERAGE_CONFIG = Path("pyproject.toml").absolute()
+os.environ["COVERAGE_PROCESS_START"] = str(COVERAGE_CONFIG)
+
 
 def get_coverage_data(report_path):
     if not Path(report_path).exists():
@@ -101,11 +113,46 @@ def generate_baseline(output_path: Path):
 
 
 def generate_current(output_path: Path):
-    """Generates coverage for the current branch/environment."""
+    """Generates coverage for the current branch/environment.
+
+    Also emits coverage.xml (Cobertura) as a CI artifact. Uses the same
+    --cov-config as the baseline run so multiprocessing-aware settings apply
+    consistently and the two reports are comparable.
+    """
     print("--- Generating current coverage ---")
-    cmd = f"pdm run pytest --cov=inference_perf --cov-report=json:{output_path.absolute()} tests/"
+    cmd = (
+        f"pdm run pytest --cov=inference_perf --cov-config={COVERAGE_CONFIG} "
+        f"--cov-report=json:{output_path.absolute()} --cov-report=xml:coverage.xml tests/"
+    )
     run_command(cmd)
-    print(f"✅ Current report generated: {output_path.name}")
+    print(f"✅ Current report generated: {output_path.name} (+ coverage.xml)")
+
+
+def _badge_color(coverage: float) -> str:
+    """Maps a coverage percentage to a shields.io badge color."""
+    for threshold, color in ((90, "brightgreen"), (80, "green"), (70, "yellowgreen"), (60, "yellow"), (50, "orange")):
+        if coverage >= threshold:
+            return color
+    return "red"
+
+
+def write_badge_endpoint(coverage: float, output_path: Path = Path("coverage-endpoint.json")):
+    """Writes a shields.io endpoint-badge JSON describing total coverage.
+
+    The README references this file on the 'badges' branch via
+    https://img.shields.io/endpoint?url=...coverage-endpoint.json so that
+    shields.io renders the badge (proxied by GitHub's camo) rather than linking a
+    raw SVG directly, which renders inconsistently.
+    """
+    payload = {
+        "schemaVersion": 1,
+        "label": "coverage",
+        "message": f"{coverage:.2f}%",
+        "color": _badge_color(coverage),
+    }
+    with open(output_path, "w") as f:
+        json.dump(payload, f)
+    print(f"✅ Badge endpoint written: {output_path.name} ({payload['message']}, {payload['color']})")
 
 
 def print_detailed_report(current_data, baseline_data):
@@ -186,20 +233,41 @@ def main():
     current_val = current_data["totals"]["percent_covered"]
     baseline_val = baseline_data["totals"]["percent_covered"]
 
+    # Emit the badge endpoint JSON for the current coverage (published to the
+    # 'badges' branch by CI). Written regardless of pass/fail so the badge always
+    # reflects the latest measured number.
+    write_badge_endpoint(current_val)
+
     if args.detailed:
         print_detailed_report(current_data, baseline_data)
 
     print("\n--- Coverage Summary ---")
-    print(f"Main Branch:    {baseline_val:.2f}%")
-    print(f"Current Branch: {current_val:.2f}%")
+    print(f"Absolute coverage: {current_val:.2f}% (floor: {MIN_TOTAL_COVERAGE:.2f}%)")
+    print(f"Main Branch:       {baseline_val:.2f}%")
+    print(f"Current Branch:    {current_val:.2f}%")
 
-    # Use a small epsilon (0.01) to handle floating point precision issues
+    failures = []
+
+    # Check 1: absolute repo-wide floor.
+    if current_val < (MIN_TOTAL_COVERAGE - 0.01):
+        failures.append(f"Absolute coverage {current_val:.2f}% is below the floor of {MIN_TOTAL_COVERAGE:.2f}%")
+    else:
+        print(f"✅ Absolute: {current_val:.2f}% meets the {MIN_TOTAL_COVERAGE:.2f}% floor.")
+
+    # Check 2: delta-vs-main ratchet. Use a small epsilon (0.01) for float precision.
     if current_val < (baseline_val - 0.01):
         diff = baseline_val - current_val
-        print(f"❌ FAIL: Total coverage decreased by {diff:.2f}%")
+        failures.append(f"Total coverage decreased by {diff:.2f}% vs main ({baseline_val:.2f}%)")
+    else:
+        print("✅ Delta: coverage is maintained or improved vs main.")
+
+    if failures:
+        print("\n❌ FAIL:")
+        for f in failures:
+            print(f"  - {f}")
         sys.exit(1)
 
-    print("✅ PASS: Coverage is maintained or improved.")
+    print("\n✅ PASS: absolute floor and delta-vs-main both satisfied.")
 
 
 if __name__ == "__main__":

--- a/scripts/check_coverage_regression.py
+++ b/scripts/check_coverage_regression.py
@@ -115,44 +115,19 @@ def generate_baseline(output_path: Path):
 def generate_current(output_path: Path):
     """Generates coverage for the current branch/environment.
 
-    Also emits coverage.xml (Cobertura) as a CI artifact. Uses the same
+    Also emits coverage.xml (Cobertura) as a CI artifact and coverage.lcov,
+    which CI uploads to Coveralls to render the README badge. Uses the same
     --cov-config as the baseline run so multiprocessing-aware settings apply
     consistently and the two reports are comparable.
     """
     print("--- Generating current coverage ---")
     cmd = (
         f"pdm run pytest --cov=inference_perf --cov-config={COVERAGE_CONFIG} "
-        f"--cov-report=json:{output_path.absolute()} --cov-report=xml:coverage.xml tests/"
+        f"--cov-report=json:{output_path.absolute()} --cov-report=xml:coverage.xml "
+        f"--cov-report=lcov:coverage.lcov tests/"
     )
     run_command(cmd)
-    print(f"✅ Current report generated: {output_path.name} (+ coverage.xml)")
-
-
-def _badge_color(coverage: float) -> str:
-    """Maps a coverage percentage to a shields.io badge color."""
-    for threshold, color in ((90, "brightgreen"), (80, "green"), (70, "yellowgreen"), (60, "yellow"), (50, "orange")):
-        if coverage >= threshold:
-            return color
-    return "red"
-
-
-def write_badge_endpoint(coverage: float, output_path: Path = Path("coverage-endpoint.json")):
-    """Writes a shields.io endpoint-badge JSON describing total coverage.
-
-    The README references this file on the 'badges' branch via
-    https://img.shields.io/endpoint?url=...coverage-endpoint.json so that
-    shields.io renders the badge (proxied by GitHub's camo) rather than linking a
-    raw SVG directly, which renders inconsistently.
-    """
-    payload = {
-        "schemaVersion": 1,
-        "label": "coverage",
-        "message": f"{coverage:.2f}%",
-        "color": _badge_color(coverage),
-    }
-    with open(output_path, "w") as f:
-        json.dump(payload, f)
-    print(f"✅ Badge endpoint written: {output_path.name} ({payload['message']}, {payload['color']})")
+    print(f"✅ Current report generated: {output_path.name} (+ coverage.xml, coverage.lcov)")
 
 
 def print_detailed_report(current_data, baseline_data):
@@ -232,11 +207,6 @@ def main():
 
     current_val = current_data["totals"]["percent_covered"]
     baseline_val = baseline_data["totals"]["percent_covered"]
-
-    # Emit the badge endpoint JSON for the current coverage (published to the
-    # 'badges' branch by CI). Written regardless of pass/fail so the badge always
-    # reflects the latest measured number.
-    write_badge_endpoint(current_val)
 
     if args.detailed:
         print_detailed_report(current_data, baseline_data)

--- a/scripts/check_coverage_regression.py
+++ b/scripts/check_coverage_regression.py
@@ -25,7 +25,7 @@ os.environ["PDM_IGNORE_ACTIVE_VENV"] = "1"
 # Absolute repo-wide coverage floor. Set just below the current total so the
 # build fails if coverage regresses meaningfully in absolute terms, independent
 # of the delta-vs-main ratchet. Raise this as coverage improves.
-MIN_TOTAL_COVERAGE = 63.0
+MIN_TOTAL_COVERAGE = 77.0
 
 # Coverage config (pyproject.toml) used for both the current and baseline runs.
 # Exporting COVERAGE_PROCESS_START lets coverage start measuring inside the


### PR DESCRIPTION
Addresses: https://github.com/kubernetes-sigs/inference-perf/issues/518

## Summary

Augments the coverage gate (`scripts/check_coverage_regression.py`) beyond the delta-vs-main ratchet:

- Enable multiprocessing-aware coverage so subprocess code (the `Worker` request collector in `inference_perf/loadgen/load_generator.py`) reports real numbers instead of reading as uncovered.
- Print absolute total coverage and enforce a repo-wide floor (`MIN_TOTAL_COVERAGE`) alongside the existing delta ratchet. Both hard-fail.
- Emit `coverage.json`, `coverage.xml` and `coverage.lcov`, and publish them as CI artifacts.
- Upload `coverage.lcov` to Coveralls on push to main. The README badge renders from there.

## What multiprocessing collection buys

Measured over the full suite with only the `concurrency` setting varied, everything else held constant:

| | without | with | delta |
|---|---|---|---|
| `inference_perf/loadgen/load_generator.py` | 45.65% | 59.78% | +14.13 |
| `inference_perf/loadgen/` package | 47.66% | 60.81% | +13.15 |
| repo total | 76.12% | 77.17% | +1.05 |

That code was always exercised by the suite. It just was not being recorded.

## Badge publishing

An earlier revision of this PR pushed a shields.io endpoint JSON to a `badges` branch. That does not work in this org: Prow's branchprotector protects every branch in `kubernetes-sigs` except a few reserved prefixes, so `badges` would be protected shortly after creation and every later push rejected for a missing `EasyCLA` status, leaving Code Coverage red on main from then on. Unblocking it would have needed a companion kubernetes/test-infra change.

Coveralls needs none of that. It authenticates with the built-in `GITHUB_TOKEN`, so there is no repository secret, no org-level app install, and no push access to any branch. The job stays at `contents: read`, and there is no branch left for concurrent pushes to race on. `kubernetes-sigs/lws` already publishes its coverage badge this way.

Coveralls creates the repo on its side on first upload, so the badge stays blank until the first push-to-main run after this merges.

## Notes

`sigterm = true` is deliberately not set in `[tool.coverage.run]`. It installs a SIGTERM handler in every load-generator `Worker`, which makes `Process.terminate()` asynchronous, lets the load generator fall through to SIGKILL, and hangs `harness.shutdown()` in `Condition.notify`. Coverage data from a worker killed at the force deadline is lost after SIGKILL regardless. `parallel = true` is likewise unset: pytest-cov owns data-file handling and already passes `data_suffix=True`.

`MIN_TOTAL_COVERAGE` is raised from 63% to 77%. It was set just below the total when this PR was opened in June; main has since risen to 77.46%, so 63% had stopped gating anything.
