### PR TITLE
Make reasoning YAML output dist consistent with config.json and README

### DIFF
--- a/workload-catalog/reasoning/inference-perf.yaml
+++ b/workload-catalog/reasoning/inference-perf.yaml
@@ -35,7 +35,7 @@ data:
       mean: 1000
       std_dev: 800
     output_tokens_per_turn:
-      type: lognormal
+      type: exponential
       min: 500
       max: 32000
       mean: 8000


### PR DESCRIPTION
The output distribution for the reasoning `inference-perf.yaml` is `lognormal`, but the `config.json` and `README.md` both state it as `exponential`.

I'm not sure which is correct, but with two against one I took a bet on changing `inference-perf.yaml` to be consistent with the other two.