### PR TITLE
fix: preserve partial response body when a streaming request fails

### DIFF
--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -26,6 +26,22 @@ from typing import Any, Callable, List, Optional, Tuple
 from aiohttp import ClientResponse
 
 
+class StreamInterruptedError(Exception):
+    """Raised when an SSE stream fails partway through being read.
+
+    Carries the raw bytes received before the failure (``raw_content``) so
+    callers can still surface what the server actually sent, which is the whole
+    point of per-request error capture. The triggering exception is preserved as
+    ``original`` so callers can report its real type and message rather than this
+    wrapper's.
+    """
+
+    def __init__(self, original: Exception, raw_content: str) -> None:
+        super().__init__(str(original))
+        self.original = original
+        self.raw_content = raw_content
+
+
 async def parse_sse_stream(
     response: ClientResponse, extract_content: Callable[[dict[str, Any]], Optional[str]]
 ) -> Tuple[str, List[float], str, List[str], Optional[dict[str, Any]]]:
@@ -63,30 +79,37 @@ async def parse_sse_stream(
     response_chunks: List[str] = []
     server_usage: Optional[dict[str, Any]] = None
 
-    async for chunk in response.content.iter_any():
-        raw_content += chunk
-        buffer += chunk
-        while b"\n\n" in buffer:
-            message, buffer = buffer.split(b"\n\n", 1)
-            message_time = time.perf_counter()
-            done = False
-            for line in message.split(sep=b"\n"):
-                if line.startswith(b"data:"):
-                    data_str = line.removeprefix(b"data: ").strip()
-                    if data_str == b"[DONE]":
-                        done = True
-                        break
-                    try:
-                        data = json.loads(data_str)
-                        if usage := data.get("usage"):
-                            server_usage = usage
-                        if content := extract_content(data):
-                            output_text += content
-                            chunk_times.append(message_time)
-                            response_chunks.append(data_str.decode("utf-8", errors="ignore"))
-                    except (json.JSONDecodeError, IndexError):
-                        continue
-            if done:
-                break
+    try:
+        async for chunk in response.content.iter_any():
+            raw_content += chunk
+            buffer += chunk
+            while b"\n\n" in buffer:
+                message, buffer = buffer.split(b"\n\n", 1)
+                message_time = time.perf_counter()
+                done = False
+                for line in message.split(sep=b"\n"):
+                    if line.startswith(b"data:"):
+                        data_str = line.removeprefix(b"data: ").strip()
+                        if data_str == b"[DONE]":
+                            done = True
+                            break
+                        try:
+                            data = json.loads(data_str)
+                            if usage := data.get("usage"):
+                                server_usage = usage
+                            if content := extract_content(data):
+                                output_text += content
+                                chunk_times.append(message_time)
+                                response_chunks.append(data_str.decode("utf-8", errors="ignore"))
+                        except (json.JSONDecodeError, IndexError):
+                            continue
+                if done:
+                    break
+    except Exception as e:
+        # The stream broke partway (e.g. a truncated SSE stream, a dropped
+        # connection, or a proxy that 200s then sends an error page). Re-raise
+        # with the bytes received so far attached so the caller can still record
+        # what the server actually sent instead of an empty response body.
+        raise StreamInterruptedError(e, raw_content.decode("utf-8", errors="ignore")) from e
 
     return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -22,6 +22,7 @@ from inference_perf.apis import (
     ErrorResponseInfo,
     StreamedResponseMetrics,
 )
+from inference_perf.apis.streaming_parser import StreamInterruptedError
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.utils import CustomTokenizer
 from .base import ModelServerClient, ModelServerClientSession, PrometheusMetricMetadata
@@ -409,15 +410,25 @@ class openAIModelServerClientSession(ModelServerClientSession):
                         # aiohttp.ClientError handler.
                         if response is not None and response.status == 200 and not info:
                             caught_exception = read_error
+                            # If the stream broke partway, recover the bytes
+                            # received so the per-request report shows what the
+                            # server actually sent, and report the underlying
+                            # exception (e.g. ClientPayloadError) rather than the
+                            # StreamInterruptedError wrapper.
+                            original_error: Exception = read_error
+                            if isinstance(read_error, StreamInterruptedError):
+                                original_error = read_error.original
+                                if read_error.raw_content:
+                                    response_content = read_error.raw_content
                             error = ErrorResponseInfo(
-                                error_msg=str(read_error),
-                                error_type=type(read_error).__name__,
+                                error_msg=str(original_error),
+                                error_type=type(original_error).__name__,
                             )
                             info = await data.process_failure(
                                 response=None,
                                 config=self.client.api_config,
                                 tokenizer=self.client.tokenizer,
-                                exception=read_error,
+                                exception=original_error,
                                 lora_adapter=lora_adapter,
                             )
                         else:

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -14,7 +14,7 @@
 
 from typing import Any, AsyncGenerator, Optional
 from unittest.mock import Mock
-from inference_perf.apis.streaming_parser import parse_sse_stream
+from inference_perf.apis.streaming_parser import parse_sse_stream, StreamInterruptedError
 import pytest
 
 
@@ -98,3 +98,41 @@ async def test_parse_sse_stream_timestamps_only_content_events() -> None:
     assert server_usage == {"prompt_tokens": 5, "completion_tokens": 2}, (
         "usage info from a content-less chunk should still be surfaced separately"
     )
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
+    """A stream that breaks partway (e.g. truncated SSE / dropped connection on a
+    200 response) must raise StreamInterruptedError carrying the bytes received so
+    far. This is what lets the per-request report show what the server actually sent
+    instead of an empty response body, so 200-but-failed requests stay diagnosable."""
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    chunks = [
+        b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": " world"}}]}\n\n',
+    ]
+    boom = ConnectionResetError("Response payload is not completed")
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+        raise boom
+
+    mock_content.iter_any = mock_iter_any
+
+    def extract_content(data: dict[str, Any]) -> Optional[str]:
+        return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
+
+    with pytest.raises(StreamInterruptedError) as exc_info:
+        await parse_sse_stream(mock_response, extract_content)
+
+    err = exc_info.value
+    # The original transport exception is preserved for accurate error_type/error_msg.
+    assert err.original is boom
+    assert isinstance(err.original, ConnectionResetError)
+    # The bytes received before the break are retained, not discarded.
+    assert "Hello" in err.raw_content
+    assert "world" in err.raw_content


### PR DESCRIPTION
Addresses: https://github.com/kubernetes-sigs/inference-perf/issues/531

When a streaming response broke partway through on an HTTP 200 (truncated SSE stream, dropped connection, or a proxy that returns 200 then sends an error page), parse_sse_stream discarded the bytes it had already received. The OpenAI client only assigned response_content after process_response returned, so on a parse failure the per-request report recorded an empty response body, leaving 200-but-failed requests undiagnosable.

parse_sse_stream now re-raises failures as StreamInterruptedError, which carries the raw bytes received so far plus the original exception. The client recovers those bytes into response_content and reports the original exception's type and message (e.g. ClientPayloadError) rather than the wrapper, so the per-request report shows what the server actually sent.

Add a parser test covering a stream that breaks partway.