### PR TITLE
otel_trace_replay: add bad_tool_call_handling=use_recorded for malformed tool_call args (#535)

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -128,6 +128,7 @@ These command line flags are automatically generated from the internal `Config` 
 | `--data.otel_trace_replay.default_max_tokens` | int | Default max_tokens if not specified in trace |
 | `--data.otel_trace_replay.override_tool_call_max_tokens` | boolean | Override tool call max_tokens to 4096 instead of using trace recorded length |
 | `--data.otel_trace_replay.inject_random_session_id` | boolean | Inject random string into unique segments to invalidate KV-cache between sessions |
+| `--data.otel_trace_replay.bad_tool_call_handling` | Enum (none, use_recorded) | Mitigation for tool_calls whose function.arguments is not valid JSON. `none` (default): no mitigation. `use_recorded`: substitute the recorded assistant message at the affected slot. See docs/otel_trace_replay.md |
 | `--data.otel_trace_replay.duplicate_sessions_target` | int | Target number of sessions to reach by duplicating existing sessions. If None, no duplication occurs. |
 | `--data.otel_trace_replay.max_wait_ms` | int | Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace. |
 | `--data.otel_trace_replay.include_errors` | boolean | Include spans with error status |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -128,7 +128,6 @@ These command line flags are automatically generated from the internal `Config` 
 | `--data.otel_trace_replay.default_max_tokens` | int | Default max_tokens if not specified in trace |
 | `--data.otel_trace_replay.override_tool_call_max_tokens` | boolean | Override tool call max_tokens to 4096 instead of using trace recorded length |
 | `--data.otel_trace_replay.inject_random_session_id` | boolean | Inject random string into unique segments to invalidate KV-cache between sessions |
-| `--data.otel_trace_replay.bad_tool_call_handling` | Enum (none, use_recorded) | Mitigation for tool_calls whose function.arguments is not valid JSON. `none` (default): no mitigation. `use_recorded`: substitute the recorded assistant message at the affected slot. See docs/otel_trace_replay.md |
 | `--data.otel_trace_replay.duplicate_sessions_target` | int | Target number of sessions to reach by duplicating existing sessions. If None, no duplication occurs. |
 | `--data.otel_trace_replay.max_wait_ms` | int | Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace. |
 | `--data.otel_trace_replay.include_errors` | boolean | Include spans with error status |
@@ -144,6 +143,7 @@ Example: "lambda x: x['benchmark'] == 'gsm8k'" or "lambda x: 'spans' in x and le
 Security: Filter expressions use eval() and should only contain trusted input. |
 | `--data.otel_trace_replay.attribute_to_header_map` | JSON | Map OTel span attributes to HTTP headers |
 | `--data.otel_trace_replay.attribute_to_label_map` | JSON | Map OTel span attributes to metrics reporting labels |
+| `--data.otel_trace_replay.bad_tool_call_handling` | Enum (none, use_recorded) | How to handle tool_calls whose function.arguments is not valid JSON. none (default): no mitigation, bytes propagate and vLLM may return HTTP 400 on the next turn. use_recorded: discard the live response and substitute the recorded assistant message at the affected slot; the recorded tool_call_id flows into the recorded role:tool successor unchanged. |
 | `--data.weka_trace_replay.use_static_model` | boolean | Use a single static model for all requests |
 | `--data.weka_trace_replay.static_model_name` | str | Static model name (required if use_static_model=True) |
 | `--data.weka_trace_replay.model_mapping` | JSON | Map recorded model names to target models |

--- a/docs/config.md
+++ b/docs/config.md
@@ -440,6 +440,9 @@ data:
     include_errors: false                         # Skip spans with error status, that is, status != 0 (default)
     skip_invalid_files: true                      # Skip unparseable trace files during replay
 
+    # Tool-call mitigation (client-side, default disabled)
+    bad_tool_call_handling: none                  # none|use_recorded — see docs/otel_trace_replay.md#bad-tool-call-handling
+
 load:
   type: trace_session_replay                      # Required for otel_trace_replay
   stages:

--- a/docs/otel_trace_replay.md
+++ b/docs/otel_trace_replay.md
@@ -103,6 +103,7 @@ The `data.otel_trace_replay` section controls what traces to replay and how to p
 | `include_errors` | boolean | No (default: `true`) | Include spans marked as errors in the trace. Set to `false` to exclude error spans entirely |
 | `skip_invalid_files` | boolean | No (default: `true`) | Skip unparseable trace files instead of failing |
 | `filter` | string | No | Lambda expression applied to each trace record before replay. Evaluated via `eval()` — use only with trusted inputs. Example: `"lambda x: x['benchmark'] == 'gsm8k'"`. Applies uniformly across all three trace sources |
+| `bad_tool_call_handling` | enum | No (default: `none`) | How to handle tool_calls whose `function.arguments` is not valid JSON. `none`: no mitigation (upstream behavior). `use_recorded`: substitute the recorded assistant message at the affected slot. See [Bad tool-call handling](#bad-tool-call-handling) |
 
 **Examples:**
 
@@ -148,6 +149,42 @@ data:
 
 > **Note:** The `hf_dataset_path` option automatically downloads the dataset from HuggingFace Hub and caches it locally (typically in `~/.cache/huggingface/datasets`). Subsequent runs will use the cached version. All JSON files in the dataset directory tree will be loaded as trace files.
 
+### Bad tool-call handling
+
+Some server-side tool-call parsers emit malformed JSON in
+`tool_calls[i].function.arguments` — for example vLLM's `qwen3_xml` parser
+leaks closing XML markers (`</parameter></function>`) into the JSON string
+value at decode time. The model server still returns 200 on the response,
+but on the *next* turn the chat template's `json.loads(arguments)` raises
+and the server returns HTTP 400. Replaying the bad bytes verbatim therefore
+halts the session.
+
+The `bad_tool_call_handling` knob on `otel_trace_replay` selects a
+client-side mitigation:
+
+| Value | Behavior |
+|---|---|
+| `none` (default) | No mitigation. Bytes propagate; the server may HTTP-400 on the next turn. Use for benchmarking the upstream parser bug or for strict trace fidelity. |
+| `use_recorded` | When the live model returns malformed `arguments`, discard the live response and substitute the recorded assistant message at this slot. The recorded `tool_call_id` flows naturally into the recorded `role:tool` successor that follows. The next-turn request is structurally identical to a healthy replay (same message count, same roles, valid JSON in arguments, matching `tool_call_id` pairs). |
+
+The mitigation lives entirely in the substitution path — the response path
+stores raw bytes from the model exactly as upstream main does.
+
+If `use_recorded` detects malformed `tool_calls` AND the recorded fallback
+is also malformed (the trace was captured from a buggy parser too), the
+current event is hard-failed; `EventFailedError` cascades to events that
+await this one's output, while parallel DAG branches continue.
+
+When at least one substitution fires, the session's completion record gains
+two extra keys for telemetry:
+
+- `recorded_substitution_event_ids` — sorted list of predecessor event_ids
+  whose live tool_call response was replaced
+- `n_recorded_substitutions` — `len(recorded_substitution_event_ids)`
+
+These keys are gated behind `len(...) > 0`, so a default-config run
+produces an identical wire format to upstream main.
+
 ### Scaling a Small Corpus
 
 For stress testing with a corpus smaller than your target session count, set
@@ -160,12 +197,23 @@ do not share KV-cache state.
 data:
   type: otel_trace_replay
   otel_trace_replay:
+    trace_directory: "production_traces/"
+    use_static_model: true
+    static_model_name: "qwen3-2b"
+    bad_tool_call_handling: use_recorded
+```
+
+```yaml
+data:
+  type: otel_trace_replay
+  otel_trace_replay:
     trace_directory: "small_corpus/"
     duplicate_sessions_target: 500   # inflate any size up to 500 sessions
 ```
 
 If you also want non-duplicate sessions to be KV-cache-isolated from each
 other, set `inject_random_session_id: true`.
+
 
 ### Load Configuration: `trace_session_replay`
 

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -84,6 +84,13 @@ class SessionLifecycleMetric(BaseModel):
     num_events: int
     num_events_completed: int
     num_events_cancelled: Optional[int] = None
+    # Per-session count of events whose live tool_call response was
+    # detected malformed and replaced with the recorded assistant
+    # message at substitution time. None when bad_tool_call_handling
+    # is `none` (the upstream-default). Zero when handling is enabled
+    # but no malformed tool_calls were observed.
+    n_recorded_substitutions: Optional[int] = None
+    recorded_substitution_event_ids: Optional[List[str]] = None
     success: Optional[bool] = None
     error: Optional[ErrorResponseInfo] = None
     total_input_tokens: Optional[int] = None

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -23,6 +23,42 @@ class TraceFormat(Enum):
     AZURE_PUBLIC_DATASET = "AzurePublicDataset"
 
 
+class BadToolCallHandling(str, Enum):
+    """How to handle a tool-call response whose `function.arguments` is not
+    valid JSON.
+
+    Some server-side tool-call parsers (e.g. vLLM's `qwen3_xml`) leak parser
+    markers into the `arguments` JSON string at decode time. vLLM still
+    returns 200 on the response, but on the *next* turn the chat template's
+    `json.loads(arguments)` raises and vLLM returns HTTP 400. Replaying the
+    bad bytes verbatim therefore halts the session.
+
+    none
+        Default. No mitigation. Bytes propagate; vLLM may HTTP-400 on the
+        next turn. Use for benchmarking the upstream bug or for strict
+        trace fidelity.
+
+    use_recorded
+        When the live model returns malformed `arguments` for a tool_call,
+        discard the live response and substitute the recorded assistant
+        message at this slot. The recorded `tool_call_id` flows naturally
+        into the recorded role:tool successor that follows. The next-turn
+        request is structurally identical to a healthy replay: same
+        message count, same roles, valid JSON in arguments, matching
+        tool_call_id pairs. The next-turn live model never sees its own
+        malformed output.
+
+        If the recorded message ALSO has malformed tool_calls (the trace
+        was captured from a buggy parser too), the current event is
+        hard-failed via _fail_and_notify(); EventFailedError cascades to
+        downstream events that await this one's output. Parallel DAG
+        branches continue.
+    """
+
+    NONE = "none"
+    USE_RECORDED = "use_recorded"
+
+
 class TraceConfig(BaseModel):
     file: str
     format: TraceFormat = TraceFormat.AZURE_PUBLIC_DATASET
@@ -135,6 +171,23 @@ class OTelTraceReplayConfig(SessionReplayConfig):
     attribute_to_header_map: Optional[Dict[str, str]] = Field(None, description="Map OTel span attributes to HTTP headers")
     attribute_to_label_map: Optional[Dict[str, str]] = Field(
         None, description="Map OTel span attributes to metrics reporting labels"
+    )
+
+    # Client-side mitigation for server-side tool-call parser bugs (e.g.
+    # vLLM's `qwen3_xml` leaking closing XML markers into the JSON `arguments`
+    # string at decode time). The default `none` preserves upstream behavior
+    # (the bug reproduces). `use_recorded` substitutes the recorded
+    # assistant message at the affected slot. See BadToolCallHandling.
+    bad_tool_call_handling: BadToolCallHandling = Field(
+        BadToolCallHandling.NONE,
+        description=(
+            "How to handle tool_calls whose function.arguments is not valid "
+            "JSON. none (default): no mitigation, bytes propagate and vLLM "
+            "may return HTTP 400 on the next turn. use_recorded: discard "
+            "the live response and substitute the recorded assistant "
+            "message at the affected slot; the recorded tool_call_id flows "
+            "into the recorded role:tool successor unchanged."
+        ),
     )
 
     @model_validator(mode="after")

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -292,6 +292,10 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     # `none` (default) is byte-identical to upstream main; `use_recorded`
     # substitutes the recorded assistant message at the affected slot.
     bad_tool_call_handling: BadToolCallHandling = BadToolCallHandling.NONE
+    # Set by _build_messages_with_substitution when it calls record_failure
+    # early (e.g. recorded fallback also malformed). Lets the caller pass the
+    # right reason string to _fail_and_notify instead of a generic fallback.
+    _substitution_failure_reason: Optional[str] = None
 
     async def to_request_body(
         self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
@@ -413,7 +417,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             # early when substitution is not possible (e.g. tool call expected but
             # live model returned plain text). Detect that and skip the request.
             if self.registry.is_event_failed(self.event_id):
-                self._fail_and_notify(session_id, "substitution failed (tool call expected but plain text returned)")
+                reason = self._substitution_failure_reason or "Unknown"
+                self._fail_and_notify(session_id, reason)
                 return
             self.messages = [
                 ChatMessage(
@@ -500,12 +505,11 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                                     f"but the recorded fallback is also malformed "
                                     f"(errors={[e for (_, _, e) in bad_recorded]}). Failing event."
                                 )
-                                session_id = self._extract_session_id()
-                                self._fail_and_notify(
-                                    session_id,
-                                    f"recorded fallback for {seg.source_event_id} is also malformed",
+                                self._substitution_failure_reason = (
+                                    f"recorded fallback for {seg.source_event_id} is also malformed"
                                 )
-                                return result  # partial; caller checks skip_request
+                                self.registry.record_failure(self.event_id)
+                                return result  # partial; caller checks is_event_failed
                             # Tag the predecessor event_id for telemetry. Set
                             # semantics dedupe across DAG fan-out.
                             session_id = self._extract_session_id()
@@ -550,6 +554,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                                     f"returned plain text. Marking event as failed to prevent downstream "
                                     f"requests with dangling tool_call_id references."
                                 )
+                                self._substitution_failure_reason = (
+                                    "substitution failed (tool call expected but plain text returned)")
                                 self.registry.record_failure(self.event_id)
                                 return result  # partial result; caller should check skip_request
                             for msg in seg_msgs:

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -94,6 +94,8 @@ def _detect_bad_tool_calls(
         except json.JSONDecodeError as e:
             bad.append((i, fn.get("name", "?"), str(e)))
     return bad
+
+
 # --- end bad_tool_call_handling --------------------------------------------
 
 
@@ -477,8 +479,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                         # request would 400 on the chat template's json.loads.
                         bad_live = (
                             _detect_bad_tool_calls(live_tool_calls)
-                            if (self.bad_tool_call_handling == BadToolCallHandling.USE_RECORDED
-                                and live_tool_calls)
+                            if (self.bad_tool_call_handling == BadToolCallHandling.USE_RECORDED and live_tool_calls)
                             else []
                         )
                         if bad_live:
@@ -514,13 +515,9 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                             # semantics dedupe across DAG fan-out.
                             session_id = self._extract_session_id()
                             pred_event_id = (
-                                seg.source_event_id.split(":", 1)[1]
-                                if ":" in seg.source_event_id
-                                else seg.source_event_id
+                                seg.source_event_id.split(":", 1)[1] if ":" in seg.source_event_id else seg.source_event_id
                             )
-                            self.worker_tracker.record_recorded_substitution(
-                                session_id, pred_event_id
-                            )
+                            self.worker_tracker.record_recorded_substitution(session_id, pred_event_id)
                             result.append(recorded_message)
                             logger.warning(
                                 f"Event {self.event_id}: substituted RECORDED message for "
@@ -555,7 +552,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                                     f"requests with dangling tool_call_id references."
                                 )
                                 self._substitution_failure_reason = (
-                                    "substitution failed (tool call expected but plain text returned)")
+                                    "substitution failed (tool call expected but plain text returned)"
+                                )
                                 self.registry.record_failure(self.event_id)
                                 return result  # partial result; caller should check skip_request
                             for msg in seg_msgs:
@@ -1389,7 +1387,9 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             override_tool_call_max_tokens=self.replay_config.override_tool_call_max_tokens if self.replay_config else False,
             # Mitigation knob: read once per event from replay_config. Default
             # NONE keeps the wire format byte-identical to upstream main.
-            bad_tool_call_handling=getattr(self.replay_config, "bad_tool_call_handling", BadToolCallHandling.NONE) if self.replay_config else BadToolCallHandling.NONE,
+            bad_tool_call_handling=getattr(self.replay_config, "bad_tool_call_handling", BadToolCallHandling.NONE)
+            if self.replay_config
+            else BadToolCallHandling.NONE,
         )
 
     def cleanup_session(self, session_id: str) -> None:

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -47,11 +47,54 @@ from inference_perf.apis.chat import ChatMessage
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.apis.streaming_parser import parse_sse_stream
 from inference_perf.config import APIConfig, APIType, DataConfig, SessionReplayConfig
+from inference_perf.config.datagen.replay import BadToolCallHandling
 from inference_perf.datagen.base import LazyLoadDataMixin, SessionGenerator
 from inference_perf.datagen.replay_graph_types import InputSegment, ReplayGraph
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 logger = logging.getLogger(__name__)
+
+# --- bad_tool_call_handling ------------------------------------------------
+# Server-side tool-call parsers can emit malformed JSON in
+# tool_calls[i].function.arguments — for example vLLM's `qwen3_xml` parser
+# leaks closing XML markers (`</parameter></function>`) into the JSON string
+# value at decode time. vLLM still returns 200 on the response, but on the
+# *next* turn the chat template's `json.loads(arguments)` raises and vLLM
+# returns HTTP 400. Replaying the bad bytes verbatim therefore halts the
+# session.
+#
+# This mitigation lives ENTIRELY in the substitution path
+# (`_build_messages_with_substitution`). The response path is byte-identical
+# to upstream main: it stores the raw tool_calls in the registry exactly as
+# the model emitted them. At substitution time, when a downstream event
+# pulls a predecessor's stored message, we run `_detect_bad_tool_calls` on
+# its `tool_calls` and, if `bad_tool_call_handling=use_recorded`, substitute
+# the recorded assistant message at this slot.
+#
+# Gated per-event by the `bad_tool_call_handling` field on the OTel replay
+# config. When the value is `none` (the default), the inline detection is
+# short-circuited and behavior is identical to upstream main.
+
+
+def _detect_bad_tool_calls(
+    tool_calls: Optional[List[Dict[str, Any]]],
+) -> List[Tuple[int, str, str]]:
+    """Return [(index, function_name, json_error)] for tool_calls whose
+    `arguments` field is a string that fails json.loads(). Empty list = ok."""
+    bad: List[Tuple[int, str, str]] = []
+    if not tool_calls:
+        return bad
+    for i, tc in enumerate(tool_calls):
+        fn = tc.get("function") or {}
+        args = fn.get("arguments", "")
+        if not isinstance(args, str):
+            continue
+        try:
+            json.loads(args)
+        except json.JSONDecodeError as e:
+            bad.append((i, fn.get("name", "?"), str(e)))
+    return bad
+# --- end bad_tool_call_handling --------------------------------------------
 
 
 class EventFailedError(Exception):
@@ -89,6 +132,13 @@ class WorkerSessionTracker:
     def __init__(self) -> None:
         self._event_completions: Dict[str, Dict[str, float]] = {}
         self._failed_sessions: Set[str] = set()
+        # Per-session set of predecessor event_ids whose live tool_call
+        # response was detected malformed at substitution time and replaced
+        # with the recorded assistant message. Empty when
+        # bad_tool_call_handling is `none`. Stored as a set so a
+        # predecessor with multiple downstream consumers (DAG fan-out) is
+        # counted once, not once per consumer.
+        self._recorded_substitution_event_ids: Dict[str, Set[str]] = {}
 
     def record_event_completed(self, session_id: str, event_id: str, completion_time: float) -> None:
         if session_id not in self._event_completions:
@@ -112,6 +162,15 @@ class WorkerSessionTracker:
 
     def get_session_completion_times(self, session_id: str) -> Dict[str, float]:
         return self._event_completions.get(session_id, {}).copy()
+
+    def record_recorded_substitution(self, session_id: str, event_id: str) -> None:
+        """Tag a predecessor event_id whose live tool_call response was
+        replaced with the recorded message. Idempotent."""
+        self._recorded_substitution_event_ids.setdefault(session_id, set()).add(event_id)
+
+    def get_session_recorded_substitution_event_ids(self, session_id: str) -> List[str]:
+        # Sorted for deterministic test/log output.
+        return sorted(self._recorded_substitution_event_ids.get(session_id, set()))
 
 
 class EventOutputRegistry:
@@ -229,6 +288,10 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     inject_random_session_id: bool = False
     session_random_string: Optional[str] = None
     override_tool_call_max_tokens: bool = False
+    # Mitigation for tool-call responses with malformed JSON in `arguments`.
+    # `none` (default) is byte-identical to upstream main; `use_recorded`
+    # substitutes the recorded assistant message at the affected slot.
+    bad_tool_call_handling: BadToolCallHandling = BadToolCallHandling.NONE
 
     async def to_request_body(
         self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
@@ -403,14 +466,72 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     actual_message = self.registry.get_message_by_event_id(seg.source_event_id)
                     if actual_message:
                         live_tool_calls = actual_message.get("tool_calls")
-                        if live_tool_calls:
-                            # Record the position of this assistant message so the post-pass
-                            # can rewrite tool_call_id in the role:tool messages that follow.
-                            pending_id_rewrites.append((len(result), live_tool_calls))
-                        result.append(actual_message)
-                        logger.debug(
-                            f"Event {self.event_id}: substituted output segment with structured message from {seg.source_event_id}"
+                        # Inline detection: if the live model produced tool_calls
+                        # AND bad_tool_call_handling is enabled, check each
+                        # `arguments` for valid JSON. Any failure means the next
+                        # request would 400 on the chat template's json.loads.
+                        bad_live = (
+                            _detect_bad_tool_calls(live_tool_calls)
+                            if (self.bad_tool_call_handling == BadToolCallHandling.USE_RECORDED
+                                and live_tool_calls)
+                            else []
                         )
+                        if bad_live:
+                            # Substitute the recorded assistant message at this slot.
+                            # The recorded message is `seg_msgs[0]` (output segments
+                            # cover exactly one message — the assistant turn). Its
+                            # `tool_call_id` flows naturally into the role:tool
+                            # successors that follow in `original_messages`, so no
+                            # entry is appended to pending_id_rewrites for this
+                            # position. The wire body for the demoted slot is
+                            # structurally identical to a healthy replay.
+                            recorded_message = seg_msgs[0]
+                            recorded_tool_calls = recorded_message.get("tool_calls") or []
+                            # Defensive: if the recorded trace ALSO has malformed
+                            # tool_calls at this slot, we have no clean fallback.
+                            # Hard-fail the event; EventFailedError will cascade
+                            # to downstream events that await this one. Parallel
+                            # DAG branches continue.
+                            bad_recorded = _detect_bad_tool_calls(recorded_tool_calls)
+                            if bad_recorded:
+                                logger.error(
+                                    f"Event {self.event_id}: bad_tool_call_handling=use_recorded "
+                                    f"detected malformed live tool_calls from {seg.source_event_id}, "
+                                    f"but the recorded fallback is also malformed "
+                                    f"(errors={[e for (_, _, e) in bad_recorded]}). Failing event."
+                                )
+                                session_id = self._extract_session_id()
+                                self._fail_and_notify(
+                                    session_id,
+                                    f"recorded fallback for {seg.source_event_id} is also malformed",
+                                )
+                                return result  # partial; caller checks skip_request
+                            # Tag the predecessor event_id for telemetry. Set
+                            # semantics dedupe across DAG fan-out.
+                            session_id = self._extract_session_id()
+                            pred_event_id = (
+                                seg.source_event_id.split(":", 1)[1]
+                                if ":" in seg.source_event_id
+                                else seg.source_event_id
+                            )
+                            self.worker_tracker.record_recorded_substitution(
+                                session_id, pred_event_id
+                            )
+                            result.append(recorded_message)
+                            logger.warning(
+                                f"Event {self.event_id}: substituted RECORDED message for "
+                                f"{seg.source_event_id} (live had {len(bad_live)} malformed "
+                                f"tool_call(s); recorded structurally clean)"
+                            )
+                        else:
+                            if live_tool_calls:
+                                # Record the position of this assistant message so the post-pass
+                                # can rewrite tool_call_id in the role:tool messages that follow.
+                                pending_id_rewrites.append((len(result), live_tool_calls))
+                            result.append(actual_message)
+                            logger.debug(
+                                f"Event {self.event_id}: substituted output segment with structured message from {seg.source_event_id}"
+                            )
                     else:
                         actual_output = self.registry.get_output_by_event_id(seg.source_event_id)
                         logger.debug(
@@ -568,6 +689,14 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 "failed": self.worker_tracker.is_session_failed(session_id),
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
             }
+            # Telemetry: only emit recorded-substitution keys when at least
+            # one substitution fired in this session, so upstream-default runs
+            # (handling=none, or handling set but no malformed tool_calls
+            # observed) produce an identical wire format.
+            recorded_subst_ids = self.worker_tracker.get_session_recorded_substitution_event_ids(session_id)
+            if recorded_subst_ids:
+                completion_data["recorded_substitution_event_ids"] = recorded_subst_ids
+                completion_data["n_recorded_substitutions"] = len(recorded_subst_ids)
 
             if self.completion_queue is not None:
                 try:
@@ -795,6 +924,12 @@ class ReplaySessionState:
     failed: bool = False
     failure_reason: Optional[str] = None
     cancelled_events: int = 0
+    # Populated from completion_data when the worker finishes the
+    # session. None means the worker did not push the keys (i.e.
+    # bad_tool_call_handling=none); empty list means handling was
+    # enabled but no substitutions fired.
+    n_recorded_substitutions: Optional[int] = None
+    recorded_substitution_event_ids: Optional[List[str]] = None
     random_string: Optional[str] = None  # Random string for KV-cache invalidation (shared by all events in session)
 
 
@@ -1092,6 +1227,8 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             num_events_completed=num_events_completed,
             num_events_cancelled=num_events_cancelled,
             error=error,
+            n_recorded_substitutions=state.n_recorded_substitutions,
+            recorded_substitution_event_ids=state.recorded_substitution_event_ids,
         )
 
     def activate_session(self, session_id: str) -> None:
@@ -1126,6 +1263,16 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                     completed_state.failed = completion_data.get("failed", False)
                     completed_state.failure_reason = completion_data.get("failure_reason")
                     completed_state.cancelled_events = completion_data.get("cancelled_events", 0)
+                    # Bad tool-call handling telemetry. The two keys are
+                    # gated worker-side behind `len(...) > 0`, so their
+                    # absence here is meaningful (no substitution path
+                    # exercised) and we propagate that absence to the
+                    # session metric as None.
+                    if "n_recorded_substitutions" in completion_data:
+                        completed_state.n_recorded_substitutions = completion_data["n_recorded_substitutions"]
+                        completed_state.recorded_substitution_event_ids = completion_data.get(
+                            "recorded_substitution_event_ids", []
+                        )
                     logger.debug(
                         "Session %s marked complete from queue notification (failed=%s)",
                         completed_session_id,
@@ -1234,6 +1381,9 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             inject_random_session_id=self.replay_config.inject_random_session_id if self.replay_config else False,
             session_random_string=state.random_string if state else None,
             override_tool_call_max_tokens=self.replay_config.override_tool_call_max_tokens if self.replay_config else False,
+            # Mitigation knob: read once per event from replay_config. Default
+            # NONE keeps the wire format byte-identical to upstream main.
+            bad_tool_call_handling=getattr(self.replay_config, "bad_tool_call_handling", BadToolCallHandling.NONE) if self.replay_config else BadToolCallHandling.NONE,
         )
 
     def cleanup_session(self, session_id: str) -> None:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -775,6 +775,16 @@ class ReportGenerator:
         total_events = sum(m.num_events for m in metrics)
         total_events_completed = sum(m.num_events_completed for m in metrics)
         total_events_cancelled = sum(m.num_events_cancelled for m in metrics if m.num_events_cancelled is not None)
+        # Bad tool-call handling: sum across sessions where the worker
+        # exercised the substitution path. Sessions with handling=none
+        # contribute None and are skipped, so a default-config run
+        # surfaces 0 sessions and a `null` total in the report.
+        sessions_with_recorded_substitution = sum(
+            1 for m in metrics if m.n_recorded_substitutions is not None and m.n_recorded_substitutions > 0
+        )
+        total_recorded_substitutions = sum(
+            m.n_recorded_substitutions for m in metrics if m.n_recorded_substitutions is not None
+        )
 
         sessions_per_second = 0.0
         if num_sessions > 0:
@@ -789,6 +799,8 @@ class ReportGenerator:
             "total_events": total_events,
             "total_events_completed": total_events_completed,
             "total_events_cancelled": total_events_cancelled,
+            "sessions_with_recorded_substitution": sessions_with_recorded_substitution,
+            "total_recorded_substitutions": total_recorded_substitutions,
             "sessions_per_second": sessions_per_second,
             "session_duration_sec": summarize([m.duration_sec for m in metrics], percentiles),
             "num_events": summarize([float(m.num_events) for m in metrics], percentiles),

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -315,6 +315,7 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
     session_summary_table.add_column("Total Events", justify="right")
     session_summary_table.add_column("Events Completed", justify="right")
     session_summary_table.add_column("Events Cancelled", justify="right")
+    session_summary_table.add_column("Bad Tool Calls Substitutions", justify="right")
 
     # Table 2: Session Duration & Events
     session_duration_table = Table(
@@ -351,6 +352,7 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
         total_events_completed = contents.get("total_events_completed", 0)
         total_events_cancelled = contents.get("total_events_cancelled", 0)
         sessions_per_second = contents.get("sessions_per_second", 0.0)
+        total_recorded_substitutions = contents.get("total_recorded_substitutions", 0)
 
         # Color code succeeded/failed sessions
         succeeded_str = f"[green]{num_sessions_succeeded}[/]"
@@ -363,6 +365,11 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
         error_color = "red" if session_error_rate > 0.05 else ("yellow" if session_error_rate > 0 else "green")
         error_str = f"[{error_color}]{session_error_pct:.1f}%[/]"
 
+        substitution_str = (
+            f"[yellow]{total_recorded_substitutions}[/]" if total_recorded_substitutions > 0
+            else str(total_recorded_substitutions)
+        )
+
         # Populate Table 1
         session_summary_table.add_row(
             str(stage_id),
@@ -374,6 +381,7 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
             str(total_events),
             str(total_events_completed),
             str(total_events_cancelled),
+            substitution_str,
         )
 
         # Extract session duration metrics

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -366,7 +366,8 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
         error_str = f"[{error_color}]{session_error_pct:.1f}%[/]"
 
         substitution_str = (
-            f"[yellow]{total_recorded_substitutions}[/]" if total_recorded_substitutions > 0
+            f"[yellow]{total_recorded_substitutions}[/]"
+            if total_recorded_substitutions > 0
             else str(total_recorded_substitutions)
         )
 

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -1535,11 +1535,11 @@ MALFORMED_ARGS_CASES = [
 VALID_ARGS = '{"location": "Paris"}'
 
 
-def _make_tool_call(args: str, call_id: str = "call_0", name: str = "get_weather") -> dict:
+def _make_tool_call(args: str, call_id: str = "call_0", name: str = "get_weather") -> dict[str, Any]:
     return {"id": call_id, "type": "function", "function": {"name": name, "arguments": args}}
 
 
-def _make_assistant_message_with_tool_call(args: str, call_id: str = "call_0") -> dict:
+def _make_assistant_message_with_tool_call(args: str, call_id: str = "call_0") -> dict[str, Any]:
     return {"role": "assistant", "content": None, "tool_calls": [_make_tool_call(args, call_id)]}
 
 
@@ -1614,9 +1614,7 @@ class TestBadToolCallHandling:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("case_id,malformed_args,desc", MALFORMED_ARGS_CASES)
-    async def test_malformed_live_tool_call_substitutes_recorded(
-        self, case_id: str, malformed_args: str, desc: str
-    ) -> None:
+    async def test_malformed_live_tool_call_substitutes_recorded(self, case_id: str, malformed_args: str, desc: str) -> None:
         """Malformed live tool_call arguments are replaced with the recorded assistant message."""
         print(f"\n[{case_id}] {desc}")
         registry = EventOutputRegistry()
@@ -1642,9 +1640,7 @@ class TestBadToolCallHandling:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("case_id,malformed_args,desc", MALFORMED_ARGS_CASES)
-    async def test_malformed_live_and_recorded_hard_fails(
-        self, case_id: str, malformed_args: str, desc: str
-    ) -> None:
+    async def test_malformed_live_and_recorded_hard_fails(self, case_id: str, malformed_args: str, desc: str) -> None:
         """When both the live response and the recorded fallback are malformed, the event hard-fails exactly once."""
         print(f"\n[{case_id}] {desc}")
         registry = EventOutputRegistry()
@@ -1668,18 +1664,14 @@ class TestBadToolCallHandling:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("case_id,malformed_args,desc", MALFORMED_ARGS_CASES)
-    async def test_handling_none_does_not_substitute(
-        self, case_id: str, malformed_args: str, desc: str
-    ) -> None:
+    async def test_handling_none_does_not_substitute(self, case_id: str, malformed_args: str, desc: str) -> None:
         """With bad_tool_call_handling=none, malformed args pass through unchanged (upstream behavior)."""
         print(f"\n[{case_id}] {desc}")
         registry = EventOutputRegistry()
         tracker = WorkerSessionTracker()
         self._register_live_message(registry, "session_0:event_0", malformed_args)
 
-        api_data = _make_api_data_with_tool_call_output(
-            registry, tracker, VALID_ARGS, handling=BadToolCallHandling.NONE
-        )
+        api_data = _make_api_data_with_tool_call_output(registry, tracker, VALID_ARGS, handling=BadToolCallHandling.NONE)
         await api_data.wait_for_predecessors_and_substitute()
 
         # event_1 must not be skipped — handling=none never intervenes regardless of arg validity

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -773,6 +773,7 @@ class TestEndToEndSimpleChain:
         mock_otel_config = MagicMock()
         mock_otel_config.attribute_to_header_map = {}
         mock_otel_config.attribute_to_label_map = {}
+        mock_otel_config.bad_tool_call_handling = BadToolCallHandling.NONE
         gen.otel_config = mock_otel_config
         gen.replay_config = mock_otel_config
         gen.session_graph_state = {session_id: MagicMock(graph=graph, random_string=None)}
@@ -1572,6 +1573,7 @@ def _make_api_data_with_tool_call_output(
         predecessor_event_ids=["session_0:event_0"],
         input_segments=segments,
         original_messages=original_messages,
+        override_tool_call_max_tokens=False,
         bad_tool_call_handling=handling,
     )
 

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -57,6 +57,7 @@ from inference_perf.datagen.replay_graph_session_datagen import (
     SessionInferenceInfo,
     WorkerSessionTracker,
 )
+from inference_perf.config.datagen.replay import BadToolCallHandling
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_graph,
@@ -1506,3 +1507,187 @@ class TestBuildReplayScheduleRandomSessionID:
 
         # 3 sessions x 2 events each = 6 total events
         assert len(gen.all_events) == 6
+
+
+# ---------------------------------------------------------------------------
+# bad_tool_call_handling tests
+# ---------------------------------------------------------------------------
+
+# Registry of known server-side tool-call parser bugs that produce malformed
+# `function.arguments` strings. Add new entries here when a new bug pattern
+# is discovered — the parameterized tests below will automatically cover them.
+#
+# Each entry: (id, malformed_args_string, human_readable_description)
+MALFORMED_ARGS_CASES = [
+    (
+        "xml_parser_leak",
+        "</parameter></function>",
+        "vLLM tool parser can leak closing XML markers into the arguments string, thus making it an invalid json",
+    ),
+    (
+        "truncated_mid_string",
+        '{"command": "',
+        "Truncation race in non-streaming concurrent path — arguments string ends mid-JSON",
+    ),
+]
+
+VALID_ARGS = '{"location": "Paris"}'
+
+
+def _make_tool_call(args: str, call_id: str = "call_0", name: str = "get_weather") -> dict:
+    return {"id": call_id, "type": "function", "function": {"name": name, "arguments": args}}
+
+
+def _make_assistant_message_with_tool_call(args: str, call_id: str = "call_0") -> dict:
+    return {"role": "assistant", "content": None, "tool_calls": [_make_tool_call(args, call_id)]}
+
+
+def _make_api_data_with_tool_call_output(
+    registry: EventOutputRegistry,
+    tracker: WorkerSessionTracker,
+    recorded_args: str,
+    handling: BadToolCallHandling = BadToolCallHandling.USE_RECORDED,
+) -> SessionChatCompletionAPIData:
+    """Two-event chain: event_0 produces a tool_call; event_1 reads it via an output segment."""
+    recorded_assistant = _make_assistant_message_with_tool_call(recorded_args)
+    original_messages = [
+        {"role": "user", "content": "What is the weather?"},
+        recorded_assistant,  # slot that will be substituted
+    ]
+    segments = [
+        InputSegment(type="unique", message_count=1, token_count=5),
+        InputSegment(type="output", message_count=1, token_count=10, source_event_id="session_0:event_0"),
+    ]
+    return SessionChatCompletionAPIData(
+        messages=[
+            ChatMessage(role="user", content="What is the weather?"),
+            ChatMessage(role="assistant", content=None, tool_calls=[_make_tool_call(recorded_args)]),
+        ],
+        max_tokens=50,
+        event_id="session_0:event_1",
+        registry=registry,
+        worker_tracker=tracker,
+        completion_queue=None,
+        total_events_in_session=2,
+        predecessor_event_ids=["session_0:event_0"],
+        input_segments=segments,
+        original_messages=original_messages,
+        bad_tool_call_handling=handling,
+    )
+
+
+class TestBadToolCallHandling:
+    """End-to-end tests for bad_tool_call_handling via wait_for_predecessors_and_substitute.
+
+    Parameterized over MALFORMED_ARGS_CASES so every known parser-bug pattern is
+    covered automatically. To add a new pattern, append an entry to that registry.
+    """
+
+    def _register_live_message(self, registry: EventOutputRegistry, event_id: str, args: str) -> None:
+        """Seed the registry with a live assistant tool_call response."""
+        live_message = _make_assistant_message_with_tool_call(args, call_id="live_call_0")
+        registry.record(event_id, "", [], output_message=live_message)
+
+    @pytest.mark.asyncio
+    async def test_clean_live_tool_call_passes_through(self) -> None:
+        """With use_recorded, a valid live tool_call is used as-is (no substitution)."""
+        registry = EventOutputRegistry()
+        tracker = WorkerSessionTracker()
+        self._register_live_message(registry, "session_0:event_0", VALID_ARGS)
+
+        api_data = _make_api_data_with_tool_call_output(registry, tracker, VALID_ARGS)
+        await api_data.wait_for_predecessors_and_substitute()
+
+        # event_1 must not be skipped — valid live args should proceed normally
+        assert not api_data.skip_request
+        # event_1 must not be marked failed in the registry
+        assert not registry.is_event_failed("session_0:event_1")
+        # The live message (valid args) was used directly, not replaced
+        assert api_data.messages[1].tool_calls is not None
+        assert api_data.messages[1].tool_calls[0]["function"]["arguments"] == VALID_ARGS
+        # No substitution fired, so telemetry must be empty
+        assert tracker.get_session_recorded_substitution_event_ids("session_0") == []
+        # No failure reason set
+        assert api_data._substitution_failure_reason is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("case_id,malformed_args,desc", MALFORMED_ARGS_CASES)
+    async def test_malformed_live_tool_call_substitutes_recorded(
+        self, case_id: str, malformed_args: str, desc: str
+    ) -> None:
+        """Malformed live tool_call arguments are replaced with the recorded assistant message."""
+        print(f"\n[{case_id}] {desc}")
+        registry = EventOutputRegistry()
+        tracker = WorkerSessionTracker()
+        # Live response has malformed args; recorded slot (in original_messages) has valid args.
+        self._register_live_message(registry, "session_0:event_0", malformed_args)
+
+        api_data = _make_api_data_with_tool_call_output(registry, tracker, VALID_ARGS)
+        await api_data.wait_for_predecessors_and_substitute()
+
+        # event_1 must not be skipped — recorded fallback was clean so replay can continue
+        assert not api_data.skip_request, f"[{case_id}] should not skip when recorded fallback is clean"
+        # event_1 must not be marked failed in the registry
+        assert not registry.is_event_failed("session_0:event_1")
+        # The recorded message (valid args) was substituted in place of the malformed live one
+        assert api_data.messages[1].tool_calls is not None
+        assert api_data.messages[1].tool_calls[0]["function"]["arguments"] == VALID_ARGS
+        # Telemetry must record event_0 as the predecessor whose live response was replaced
+        subs = tracker.get_session_recorded_substitution_event_ids("session_0")
+        assert "event_0" in subs, f"[{case_id}] substitution telemetry must name the predecessor"
+        # No failure reason set — substitution succeeded cleanly
+        assert api_data._substitution_failure_reason is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("case_id,malformed_args,desc", MALFORMED_ARGS_CASES)
+    async def test_malformed_live_and_recorded_hard_fails(
+        self, case_id: str, malformed_args: str, desc: str
+    ) -> None:
+        """When both the live response and the recorded fallback are malformed, the event hard-fails exactly once."""
+        print(f"\n[{case_id}] {desc}")
+        registry = EventOutputRegistry()
+        tracker = WorkerSessionTracker()
+        # Both live and recorded have the same malformed args — no clean fallback.
+        self._register_live_message(registry, "session_0:event_0", malformed_args)
+
+        api_data = _make_api_data_with_tool_call_output(registry, tracker, malformed_args)
+        await api_data.wait_for_predecessors_and_substitute()
+
+        # event_1 must be skipped — no clean message to send to the model
+        assert api_data.skip_request, f"[{case_id}] must skip when both live and recorded are malformed"
+        # The registry must mark event_1 as failed so downstream events in the DAG cascade-fail
+        assert registry.is_event_failed("session_0:event_1")
+        # No telemetry recorded — the substitution never completed successfully
+        assert tracker.get_session_recorded_substitution_event_ids("session_0") == []
+        # The failure reason must name the recorded fallback specifically, not the generic plain-text message,
+        # so the log is actionable (tells the operator the trace itself was captured from a buggy parser)
+        assert api_data._substitution_failure_reason is not None
+        assert "recorded fallback" in api_data._substitution_failure_reason
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("case_id,malformed_args,desc", MALFORMED_ARGS_CASES)
+    async def test_handling_none_does_not_substitute(
+        self, case_id: str, malformed_args: str, desc: str
+    ) -> None:
+        """With bad_tool_call_handling=none, malformed args pass through unchanged (upstream behavior)."""
+        print(f"\n[{case_id}] {desc}")
+        registry = EventOutputRegistry()
+        tracker = WorkerSessionTracker()
+        self._register_live_message(registry, "session_0:event_0", malformed_args)
+
+        api_data = _make_api_data_with_tool_call_output(
+            registry, tracker, VALID_ARGS, handling=BadToolCallHandling.NONE
+        )
+        await api_data.wait_for_predecessors_and_substitute()
+
+        # event_1 must not be skipped — handling=none never intervenes regardless of arg validity
+        assert not api_data.skip_request, f"[{case_id}] handling=none must never skip"
+        # event_1 must not be marked failed in the registry
+        assert not registry.is_event_failed("session_0:event_1")
+        # The live malformed args passed through byte-for-byte; no recorded fallback was consulted
+        assert api_data.messages[1].tool_calls is not None
+        assert api_data.messages[1].tool_calls[0]["function"]["arguments"] == malformed_args
+        # No substitution fired, so telemetry must be empty
+        assert tracker.get_session_recorded_substitution_event_ids("session_0") == []
+        # No failure reason set
+        assert api_data._substitution_failure_reason is None


### PR DESCRIPTION
When a model server's tool-call parser emits malformed JSON in tool_calls[i].function.arguments — e.g. vLLM's `qwen3_xml` parser leaks closing XML markers (`</parameter></function>`) into the JSON string at decode time — vLLM still returns 200 on the response. But on the *next* turn, replaying that response verbatim in messages[] makes the chat template's `json.loads(arguments)` raise JSONDecodeError, and vLLM returns HTTP 400. The session can no longer make progress.

This patch introduces a new knob called `bad_tool_call_handling` with two values.

Default is `none` — behavior is byte-identical to upstream main, the bug reproduces. `use_recorded` enables detection at substitution time and replaces the live (malformed) assistant response with the predecessor's recorded assistant message at the affected slot.

 * `none` (default)  No mitigation. Bytes propagate; vLLM may HTTP-400 on the next turn. Use for benchmarking the upstream bug or for strict trace fidelity.

 * `use_recorded`: When the live model returns malformed `arguments`, discard the live response and substitute the
                recorded assistant message at this slot. The recorded `tool_call_id` flows naturally into the recorded `role:tool` successor that follows. The next-turn request is structurally identical to a healthy replay: same message count, same roles, valid JSON in arguments, matching tool_call_id pairs. The next-turn live model never sees its own malformed output.

Fixes: https://github.com/kubernetes-sigs/inference-perf/issues/535 