### PR TITLE
fix: RNG state synchronization across multiworkers

### DIFF
--- a/inference_perf/datagen/conversation_replay_datagen.py
+++ b/inference_perf/datagen/conversation_replay_datagen.py
@@ -289,9 +289,7 @@ class ConversationReplayDataGenerator(DataGenerator, LazyLoadDataMixin):
                 # BACKWARDS COMPATIBILITY: Stage 0 must use the shared global self.rng
                 # to maintain the exact sequence of calls at startup, ensuring existing
                 # benchmark seeds generate identical conversation blueprints.
-                self._current_shared_prompt = self._generate_random_token_text(
-                    self.cr_config.shared_system_prompt_len
-                )
+                self._current_shared_prompt = self._generate_random_token_text(self.cr_config.shared_system_prompt_len)
             else:
                 # Later stages derive their seed stably from the base seed and stage ID.
                 # This happens dynamically at runtime (post-setup) and uses local isolated RNGs.

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -277,6 +277,10 @@ class Worker(mp.Process):
         # Seed with current time + worker id to ensure unique random sequences per worker
         seed = (self.base_seed + self.id) % 2**32
         np.random.seed(seed)
+        # Also reseed any np.random.Generator on the datagen (e.g. RandomDataGenerator.rng),
+        # since np.random.seed() only affects the legacy module, not Generator instances.
+        if hasattr(self.datagen, "rng") and isinstance(self.datagen.rng, np.random.Generator):
+            self.datagen.rng = np.random.default_rng(seed)
         logger.debug(f"[Worker {self.id}] seeded numpy with {seed} and base seed {self.base_seed}")
 
         # Ignore SIGINT in workers to prevent multiple calls to SIGINT handler

--- a/tests/required/datagen/test_random_datagen.py
+++ b/tests/required/datagen/test_random_datagen.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from inference_perf.apis import CompletionAPIData, LazyLoadInferenceAPIData
 from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
 from inference_perf.datagen.random_datagen import RandomDataGenerator
@@ -53,6 +55,37 @@ def test_random_datagen_yields_string() -> None:
     # Verify prompt is str
     assert isinstance(real_data.prompt, str)
     assert len(real_data.prompt) > 0
+
+
+def test_worker_rng_uniqueness_per_worker() -> None:
+    """Workers must produce different content even when all input lengths are identical (std_dev=0)."""
+    api_config = APIConfig(type=APIType.Completion, streaming=True)
+    data_config = DataConfig(
+        type=DataGenType.Random,
+        input_distribution=Distribution(min=10, max=10, mean=10, std_dev=0.0, total_count=5),
+        output_distribution=Distribution(min=5, max=5, mean=5, std_dev=0.0, total_count=5),
+    )
+    tokenizer = DummyCustomTokenizer()
+
+    # Simulate what Worker.run() does: reseed the datagen's rng with a worker-specific seed.
+    # Worker 0 and Worker 1 use (base_seed + id) % 2**32, so they differ.
+    base_seed = 42
+
+    generator_w0 = RandomDataGenerator(api_config, data_config, tokenizer)
+    generator_w0.rng = np.random.default_rng((base_seed + 0) % 2**32)
+
+    generator_w1 = RandomDataGenerator(api_config, data_config, tokenizer)
+    generator_w1.rng = np.random.default_rng((base_seed + 1) % 2**32)
+
+    lazy = LazyLoadInferenceAPIData(data_index=0)
+    result_w0 = generator_w0.load_lazy_data(lazy)
+    result_w1 = generator_w1.load_lazy_data(lazy)
+
+    assert isinstance(result_w0, CompletionAPIData)
+    assert isinstance(result_w1, CompletionAPIData)
+    assert result_w0.prompt != result_w1.prompt, (
+        "Workers with different seeds must produce different prompts"
+    )
 
 
 def test_random_datagen_excludes_special_tokens() -> None:

--- a/tests/required/datagen/test_random_datagen.py
+++ b/tests/required/datagen/test_random_datagen.py
@@ -83,9 +83,7 @@ def test_worker_rng_uniqueness_per_worker() -> None:
 
     assert isinstance(result_w0, CompletionAPIData)
     assert isinstance(result_w1, CompletionAPIData)
-    assert result_w0.prompt != result_w1.prompt, (
-        "Workers with different seeds must produce different prompts"
-    )
+    assert result_w0.prompt != result_w1.prompt, "Workers with different seeds must produce different prompts"
 
 
 def test_random_datagen_excludes_special_tokens() -> None:

--- a/tests/required/loadgen/test_worker_rng.py
+++ b/tests/required/loadgen/test_worker_rng.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ast
+import multiprocessing as mp
+import sys
+import unittest
+from typing import Any
+
+from inference_perf.client.modelserver.mock_client import MockModelServerClient
+from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType, Distribution, LoadConfig, LoadType, StandardLoadStage
+from inference_perf.datagen.random_datagen import RandomDataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+# Match the start method used in production (main.py) so the tokenizer and
+# datagen objects are inherited rather than pickled into worker processes.
+if sys.platform == "darwin":
+    try:
+        mp.set_start_method("fork", force=True)
+    except RuntimeError:
+        pass
+
+
+class _DummyHFTokenizer:
+    """Minimal HuggingFace-shaped tokenizer backed by space-delimited integers."""
+
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def decode(self, tokens: list[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+
+class _DummyCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return _DummyHFTokenizer()
+
+    def count_tokens(self, text: str) -> int:
+        # Each space-separated integer is one token.
+        return len(text.split()) if text else 0
+
+
+class TestWorkerRNGUniqueness(unittest.IsolatedAsyncioTestCase):
+    """Integration test: multi-worker LoadGenerator must produce unique prompts per request.
+
+    Regression test for the bug where every worker inherited the same
+    np.random.Generator state from the parent process, causing bitwise-duplicate
+    prompts whenever std_dev=0 (all input lengths identical).
+    """
+
+    async def test_multiworker_prompts_unique_with_zero_stdev(self) -> None:
+        """All prompts must be distinct even when std_dev=0 forces identical input lengths."""
+        num_requests = 6
+        num_workers = 2
+
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        data_config = DataConfig(
+            type=DataGenType.Random,
+            input_distribution=Distribution(min=10, max=10, mean=10.0, std_dev=0.0, total_count=num_requests),
+            output_distribution=Distribution(min=5, max=5, mean=5.0, std_dev=0.0, total_count=num_requests),
+        )
+        datagen = RandomDataGenerator(api_config, data_config, _DummyCustomTokenizer())
+
+        collector = MultiprocessRequestMetricCollector()
+        client = MockModelServerClient(collector, api_config, mock_latency=0)
+
+        load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            num_workers=num_workers,
+            worker_max_concurrency=10,
+            stages=[StandardLoadStage(rate=num_requests, duration=1)],
+            base_seed=42,
+        )
+        load_gen = LoadGenerator(datagen, load_config)
+
+        async with collector.start():
+            await load_gen.mp_run(client)
+
+        metrics = collector.get_metrics()
+        self.assertEqual(len(metrics), num_requests, f"Expected {num_requests} completed requests")
+
+        prompts = [ast.literal_eval(m.request_data)["prompt"] for m in metrics]
+        self.assertEqual(
+            len(set(prompts)),
+            num_requests,
+            f"Expected {num_requests} unique prompts across {num_workers} workers, got duplicates:\n"
+            + "\n".join(f"  [{i}] {p!r}" for i, p in enumerate(prompts)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/test_worker_rng.py
+++ b/tests/required/loadgen/test_worker_rng.py
@@ -18,7 +18,16 @@ import unittest
 from typing import Any
 
 from inference_perf.client.modelserver.mock_client import MockModelServerClient
-from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType, Distribution, LoadConfig, LoadType, StandardLoadStage
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    DataConfig,
+    DataGenType,
+    Distribution,
+    LoadConfig,
+    LoadType,
+    StandardLoadStage,
+)
 from inference_perf.datagen.random_datagen import RandomDataGenerator
 from inference_perf.loadgen.load_generator import LoadGenerator
 from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -247,7 +247,9 @@ class TestConversationReplayDataGenerator:
         for stage_idx in range(3):
             LocalUserSession.clear_instances()
             for conv_idx in range(3):
-                gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=conv_idx, preferred_worker_id=conv_idx, stage_id=stage_idx))
+                gen.load_lazy_data(
+                    LazyLoadInferenceAPIData(data_index=conv_idx, preferred_worker_id=conv_idx, stage_id=stage_idx)
+                )
                 current_context = LocalUserSession._instances[f"conv_{conv_idx}"].context
                 assert current_context != last_contexts[conv_idx]
                 last_contexts[conv_idx] = current_context
@@ -385,7 +387,7 @@ class TestConversationReplayDataGenerator:
 
         context_conv0_s1 = LocalUserSession._instances["conv_0"].context
         context_conv1_s1 = LocalUserSession._instances["conv_1"].context
-        
+
         # Verify they are still identical in Stage 1
         assert context_conv0_s1 == context_conv1_s1
         # Verify Stage 1 prompt is different from Stage 0 prompt
@@ -394,6 +396,7 @@ class TestConversationReplayDataGenerator:
     def test_unique_system_prompt_within_stage_after_clear(self) -> None:
         """Verify that different conversations with dynamic_system_prompt_len get unique system prompts after stage clear."""
         api_config, data_config = _make_config(num_conversations=2)
+
         def make_deterministic_mock_tok() -> MagicMock:
             mock_tok = MagicMock()
             hf_tok = MagicMock()
@@ -424,7 +427,7 @@ class TestConversationReplayDataGenerator:
 
         # 1. The system prompts in Stage 1 should still be different from each other
         assert context_conv0_s1 != context_conv1_s1
-        
+
         # 2. Stage 1 prompts should also be different from their Stage 0 versions (new stage prefix)
         assert context_conv0_s1 != context_conv0_s0
         assert context_conv1_s1 != context_conv1_s0
@@ -458,6 +461,8 @@ class TestConversationReplayDataGenerator:
 
         # Decode should have been called exactly once for the shared prompt across both slot re-primes.
         assert decode_count == 1
+
+
 class TestDistributionExtensions:
     def test_lognormal_distribution(self) -> None:
         rng = np.random.default_rng(42)


### PR DESCRIPTION
**Fix duplicate prompts in multi-worker random data generation**                                                                                                                 
When num_workers > 0, each Worker process inherited the same np.random.Generator state from the parent. Worker.run() called np.random.seed() to diverge workers, but that only seeds the legacy np.random.* module — it has no effect on np.random.Generator instances (used by RandomDataGenerator.rng). Every worker therefore generated identical token sequences, producing bitwise-duplicate request prompts. With std_dev=0.0 (all input lengths identical), every request across all workers was an exact duplicate.  

fixes #509 
                                                                                                                                                                               
**Fix**: After seeding legacy numpy in Worker.run(), also reseed self.datagen.rng if it is a np.random.Generator, using the same worker-specific seed (base_seed + worker_id) % 2**32.
                                                                                                                                                                               
**Tests added**:    
  - test_worker_rng_uniqueness_per_worker (unit): simulates two workers by reseeding the datagen's rng directly and asserts their outputs differ for the same data_index under std_dev=0.0.                                                                                                                                                                 
  - test_multiworker_prompts_unique_with_zero_stdev (integration): runs a real LoadGenerator with num_workers=2 against a MockModelServerClient, collects all recorded request bodies, and asserts all prompts are distinct.

NOTE: AI was used in creating this PR and its commits