### PR TITLE
Validate unary responses against the official OpenAI schema

### DIFF
--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from aiohttp import ClientResponse
+from openai.types.chat import ChatCompletion
 from pydantic import BaseModel, field_validator
 
 from inference_perf.apis import InferenceAPIData, InferenceInfo, UnaryResponseMetrics, StreamedResponseMetrics
@@ -582,16 +583,20 @@ class ChatCompletionAPIData(InferenceAPIData):
                 extra_info={"raw_response": raw_content},
             )
 
-        data = await response.json()
-        server_usage = data.get("usage")
+        # Validate against the official OpenAI schema so malformed bodies
+        # fail loudly instead of silently reporting an empty response.
+        data = ChatCompletion.model_validate(await response.json())
+        server_usage = data.usage.model_dump() if data.usage else None
         prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
-        choices = data.get("choices", [])
-        if len(choices) == 0:
+        if len(data.choices) == 0:
             return InferenceInfo(
                 request_metrics=self._build_request_metrics(prompt_len, 0),
                 lora_adapter=lora_adapter,
             )
-        output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
+        output_text = "".join(choice.message.content or "" for choice in data.choices)
+        # Generated text is a continuation, not a sequence start: counting it
+        # with special tokens would add a BOS the server's completion_tokens
+        # never contains.
         output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
         return InferenceInfo(
             request_metrics=self._build_request_metrics(prompt_len, output_len),

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -16,6 +16,8 @@
 from typing import Any, Dict, Optional
 
 from aiohttp import ClientResponse
+from openai.types import Completion
+
 from inference_perf.apis import InferenceAPIData, InferenceInfo, UnaryResponseMetrics, StreamedResponseMetrics
 from inference_perf.payloads import RequestBody, RequestMetrics, Text
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
@@ -98,16 +100,20 @@ class CompletionAPIData(InferenceAPIData):
                 extra_info={"raw_response": raw_content},
             )
         else:
-            data = await response.json()
-            server_usage = data.get("usage")
+            # Validate against the official OpenAI schema so malformed bodies
+            # fail loudly instead of silently reporting an empty response.
+            data = Completion.model_validate(await response.json())
+            server_usage = data.usage.model_dump() if data.usage else None
             prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
-            choices = data.get("choices", [])
-            if len(choices) == 0:
+            if len(data.choices) == 0:
                 return InferenceInfo(
                     request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
                     lora_adapter=lora_adapter,
                 )
-            output_text = choices[0].get("text", "")
+            output_text = data.choices[0].text
+            # Generated text is a continuation, not a sequence start: counting it
+            # with special tokens would add a BOS the server's completion_tokens
+            # never contains.
             output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             self.model_response = output_text
             return InferenceInfo(

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "analysis", "dev", "lint", "otel", "test", "types"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:e3933d2724dfc873315aabb0ed8d439041fcb9a28a15675d15a5b86f37bbe6cd"
+content_hash = "sha256:195e03d58365d359c0e85cbccecf3cccd6dc3d1675c78ed1eb786ea15af5ea45"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -886,6 +886,17 @@ files = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+requires_python = ">=3.6"
+summary = "Distro - an OS platform information API"
+groups = ["default"]
+files = [
+    {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
+    {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 requires_python = ">=3.8"
@@ -1306,6 +1317,22 @@ files = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+requires_python = ">=3.10"
+summary = "A minimal low-level HTTP client."
+groups = ["default"]
+marker = "sys_platform != \"emscripten\""
+dependencies = [
+    "h11>=0.16",
+    "truststore>=0.10",
+]
+files = [
+    {file = "httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb"},
+    {file = "httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648"},
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 requires_python = ">=3.8"
@@ -1320,6 +1347,37 @@ dependencies = [
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+requires_python = ">=3.10"
+summary = "The next generation HTTP client."
+groups = ["default"]
+dependencies = [
+    "anyio>=4.10; sys_platform != \"emscripten\"",
+    "httpcore2==2.12.0; sys_platform != \"emscripten\"",
+    "httpx2-jsfetch; sys_platform == \"emscripten\" and python_version >= \"3.12\"",
+    "idna>=3.18",
+    "truststore>=0.10; sys_platform != \"emscripten\"",
+    "typing-extensions>=4.5.0; python_version < \"3.13\"",
+]
+files = [
+    {file = "httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36"},
+    {file = "httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf"},
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+requires_python = ">=3.12"
+summary = "httpx2 transports for Emscripten/Pyodide, backed by the JavaScript fetch API."
+groups = ["default"]
+marker = "sys_platform == \"emscripten\" and python_version >= \"3.12\""
+files = [
+    {file = "httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32"},
+    {file = "httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60"},
 ]
 
 [[package]]
@@ -1483,6 +1541,72 @@ dependencies = [
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+requires_python = ">=3.9"
+summary = "Fast iterable JSON parser."
+groups = ["default"]
+files = [
+    {file = "jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a"},
+    {file = "jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9"},
+    {file = "jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730"},
+    {file = "jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f"},
+    {file = "jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274"},
+    {file = "jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7"},
+    {file = "jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195"},
+    {file = "jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053"},
+    {file = "jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb"},
+    {file = "jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84"},
+    {file = "jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e"},
+    {file = "jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd"},
+    {file = "jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee"},
+    {file = "jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29"},
+    {file = "jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a"},
+    {file = "jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00"},
+    {file = "jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe"},
+    {file = "jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106"},
+    {file = "jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8"},
+    {file = "jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585"},
+    {file = "jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af"},
+    {file = "jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077"},
+    {file = "jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734"},
+    {file = "jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db"},
+    {file = "jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce"},
+    {file = "jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c"},
 ]
 
 [[package]]
@@ -2091,6 +2215,27 @@ files = [
     {file = "numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa"},
     {file = "numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865"},
     {file = "numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c"},
+]
+
+[[package]]
+name = "openai"
+version = "3.2.0"
+requires_python = ">=3.10"
+summary = "The official Python library for the openai API"
+groups = ["default"]
+dependencies = [
+    "anyio<5,>=4.10.0",
+    "distro<2,>=1.7.0",
+    "httpx2<3,>=2.7.0",
+    "jiter<1,>=0.10.0",
+    "pydantic<3,>=1.9.0",
+    "sniffio",
+    "tqdm>4",
+    "typing-extensions<5,>=4.14",
+]
+files = [
+    {file = "openai-3.2.0-py3-none-any.whl", hash = "sha256:e97a64a2df665460fbb1f23adbe3e4b717f6ac04b5740552889ad1d8dd9025c2"},
+    {file = "openai-3.2.0.tar.gz", hash = "sha256:1d26bd6f49738f6848bcce370794ee03acc0561d468070df010b44178da8e797"},
 ]
 
 [[package]]
@@ -3277,6 +3422,17 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+requires_python = ">=3.7"
+summary = "Sniff out which async library your code is running under"
+groups = ["default"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 summary = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -3442,6 +3598,18 @@ dependencies = [
 files = [
     {file = "transformers-5.13.0-py3-none-any.whl", hash = "sha256:8adbc1d20bd5463cd6876b2eb7cb31971e1065788e7dc6bc12bab597a7c504b7"},
     {file = "transformers-5.13.0.tar.gz", hash = "sha256:940c1428e42a4238f9ccf0cd41e63c590701aa63c19fd2ce3d7d602222d68495"},
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+requires_python = ">=3.10"
+summary = "Verify certificates using native system trust stores"
+groups = ["default"]
+marker = "sys_platform != \"emscripten\""
+files = [
+    {file = "truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981"},
+    {file = "truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "av>=13.0.0",
     "pillow>=10.0.0",
     "prometheus-client>=0.20.0",
+    "openai>=1.0.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -136,8 +136,12 @@ async def test_process_response_non_streaming_uses_server_prompt_tokens() -> Non
     response = MagicMock()
     response.json = AsyncMock(
         return_value={
-            "choices": [{"message": {"content": "hello there"}}],
-            "usage": {"prompt_tokens": 42, "completion_tokens": 2},
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "hello there"}}],
+            "usage": {"prompt_tokens": 42, "completion_tokens": 2, "total_tokens": 44},
         }
     )
 
@@ -145,7 +149,11 @@ async def test_process_response_non_streaming_uses_server_prompt_tokens() -> Non
 
     assert info.request_metrics.text.input_tokens == 42
     assert isinstance(info.response_metrics, UnaryResponseMetrics)
-    assert info.response_metrics.server_usage == {"prompt_tokens": 42, "completion_tokens": 2}
+    # Usage is normalized through the OpenAI schema, which carries optional
+    # detail fields, so assert the counts rather than exact dict equality.
+    assert info.response_metrics.server_usage is not None
+    assert info.response_metrics.server_usage["prompt_tokens"] == 42
+    assert info.response_metrics.server_usage["completion_tokens"] == 2
 
 
 @pytest.mark.asyncio
@@ -155,7 +163,15 @@ async def test_process_response_non_streaming_falls_back_without_server_usage() 
     tokenizer = _make_tokenizer()
 
     response = MagicMock()
-    response.json = AsyncMock(return_value={"choices": [{"message": {"content": "hi"}}]})
+    response.json = AsyncMock(
+        return_value={
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}],
+        }
+    )
 
     info = await data.process_response(response, _make_config(streaming=False), tokenizer)
 

--- a/tests/required/apis/test_completion.py
+++ b/tests/required/apis/test_completion.py
@@ -165,8 +165,12 @@ async def test_process_response_non_streaming_uses_server_prompt_tokens() -> Non
     response = MagicMock()
     response.json = AsyncMock(
         return_value={
-            "choices": [{"text": "hello there"}],
-            "usage": {"prompt_tokens": 42, "completion_tokens": 2},
+            "id": "cmpl-1",
+            "object": "text_completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [{"index": 0, "finish_reason": "stop", "text": "hello there"}],
+            "usage": {"prompt_tokens": 42, "completion_tokens": 2, "total_tokens": 44},
         }
     )
 
@@ -174,7 +178,11 @@ async def test_process_response_non_streaming_uses_server_prompt_tokens() -> Non
 
     assert info.request_metrics.text.input_tokens == 42
     assert isinstance(info.response_metrics, UnaryResponseMetrics)
-    assert info.response_metrics.server_usage == {"prompt_tokens": 42, "completion_tokens": 2}
+    # Usage is normalized through the OpenAI schema, which carries optional
+    # detail fields, so assert the counts rather than exact dict equality.
+    assert info.response_metrics.server_usage is not None
+    assert info.response_metrics.server_usage["prompt_tokens"] == 42
+    assert info.response_metrics.server_usage["completion_tokens"] == 2
 
 
 @pytest.mark.asyncio
@@ -184,7 +192,15 @@ async def test_process_response_non_streaming_falls_back_without_server_usage() 
     tokenizer = _make_tokenizer()
 
     response = MagicMock()
-    response.json = AsyncMock(return_value={"choices": [{"text": "hi"}]})
+    response.json = AsyncMock(
+        return_value={
+            "id": "cmpl-1",
+            "object": "text_completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [{"index": 0, "finish_reason": "stop", "text": "hi"}],
+        }
+    )
 
     info = await data.process_response(response, _make_config(streaming=False), tokenizer)
 
@@ -198,7 +214,16 @@ async def test_process_response_non_streaming_no_choices_uses_server_prompt_toke
     tokenizer = _make_tokenizer()
 
     response = MagicMock()
-    response.json = AsyncMock(return_value={"choices": [], "usage": {"prompt_tokens": 7}})
+    response.json = AsyncMock(
+        return_value={
+            "id": "cmpl-1",
+            "object": "text_completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [],
+            "usage": {"prompt_tokens": 7, "completion_tokens": 0, "total_tokens": 7},
+        }
+    )
 
     info = await data.process_response(response, _make_config(streaming=False), tokenizer)
 

--- a/tests/required/loadgen/test_multi_turn_hang.py
+++ b/tests/required/loadgen/test_multi_turn_hang.py
@@ -78,7 +78,15 @@ class TestMultiTurnHang(unittest.IsolatedAsyncioTestCase):
         # Simulate successful response processing for request 0
         mock_response = MagicMock()
         mock_json_fut: asyncio.Future[Any] = asyncio.Future()
-        mock_json_fut.set_result({"choices": [{"text": "bot response"}]})
+        mock_json_fut.set_result(
+            {
+                "id": "cmpl-1",
+                "object": "text_completion",
+                "created": 0,
+                "model": "test-model",
+                "choices": [{"index": 0, "finish_reason": "stop", "text": "bot response"}],
+            }
+        )
         mock_response.json = MagicMock(return_value=mock_json_fut)
 
         await data_0.process_response(mock_response, api_config, datagen.tokenizer)

--- a/tests/test_output_len_special_tokens.py
+++ b/tests/test_output_len_special_tokens.py
@@ -117,7 +117,13 @@ async def test_chat_streaming_output_len_excludes_special_tokens() -> None:
 
 @pytest.mark.asyncio
 async def test_chat_unary_output_len_excludes_special_tokens() -> None:
-    payload = {"choices": [{"message": {"content": "aa bb cc"}}]}
+    payload: Dict[str, Any] = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "test-model",
+        "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "aa bb cc"}}],
+    }
     response = FakeUnaryResponse(payload)
     tokenizer = _bos_tokenizer()
     config = APIConfig(type=APIType.Chat, streaming=False)
@@ -149,7 +155,13 @@ async def test_completion_streaming_output_len_excludes_special_tokens() -> None
 
 @pytest.mark.asyncio
 async def test_completion_unary_output_len_excludes_special_tokens() -> None:
-    payload = {"choices": [{"text": "aa bb cc"}]}
+    payload: Dict[str, Any] = {
+        "id": "cmpl-1",
+        "object": "text_completion",
+        "created": 0,
+        "model": "test-model",
+        "choices": [{"index": 0, "finish_reason": "stop", "text": "aa bb cc"}],
+    }
     response = FakeUnaryResponse(payload)
     tokenizer = _bos_tokenizer()
     config = APIConfig(type=APIType.Completion, streaming=False)

--- a/tests/test_streaming_response_order.py
+++ b/tests/test_streaming_response_order.py
@@ -78,7 +78,15 @@ async def test_non_streaming_reads_body() -> None:
 
     response = MagicMock()
     response.status = 200
-    response.json = AsyncMock(return_value={"choices": [{"message": {"content": "Hello world"}}]})
+    response.json = AsyncMock(
+        return_value={
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "Hello world"}}],
+        }
+    )
 
     tokenizer = MagicMock()
     tokenizer.count_tokens = MagicMock(return_value=2)


### PR DESCRIPTION
partially addresses: https://github.com/kubernetes-sigs/inference-perf/issues/531

## Summary

Non-streaming response parsing in `ChatCompletionAPIData` and `CompletionAPIData` previously dug through untyped dicts with `.get()` chains. A malformed 200 body (proxy error page, truncated JSON, schema drift) silently produced an empty response and zero output tokens, skewing benchmark results without any visible error.

This change parses unary bodies with the `openai` package's `ChatCompletion` and `Completion` pydantic models instead:

- Malformed bodies now raise a `ValidationError`, which the client records as a request failure, so bad responses are loud instead of silently zeroed. Same diagnosability motivation as #531, applied to the unary path.
- Response access is fully typed under `mypy --strict` (`choice.message.content` instead of nested `.get()` with `Any`).

## What this does not touch

- The streaming path and SSE parser are unchanged, so per-chunk TTFT/ITL timing is unaffected and there is no per-chunk validation overhead.
- Request building is unchanged. vLLM extensions like `ignore_eos` and `video_url` content blocks still go out as raw dicts.
- No SDK client or HTTP machinery from the `openai` package is used, only its response types. The openai response models use `extra="allow"`, so server-specific extra fields (e.g. vLLM's `kv_transfer_params`) pass through validation.

## Dependency note

This adds `openai>=1.0.0` as a runtime dependency for its types only. If taking the dependency is unpalatable, the fallback is two small local pydantic models with the same shape; happy to switch if reviewers prefer.

Test fixtures that mocked minimal response bodies were updated to be schema-complete.