### PR TITLE
Add random-interval dispatch (`interval` / `session_interval`) for load stages

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -151,6 +151,10 @@ load:
   interval: 1.0                     # Seconds between request batches
   stages:                           # Load progression stages
     - rate: 1                       # Requests per second (CONSTANT or POISSON LOADS)
+      # interval:                   # OR: random delay in seconds between requests (CONSTANT LOADS,
+      #   type: uniform             #     mutually exclusive with rate — specify exactly one)
+      #   min: 1                    #     each request is sent 1-10s after the previous one
+      #   max: 10
       duration: 30                  # Seconds to maintain this rate (CONSTANT or POISSON LOADS)
       concurrency_level: 3          # Level of concurrency/number of worker threads (CONCURRENT LOADS)
       num_requests: 40              # Number of requests to be processed by concurrency_level worker threads (CONCURRENT LOADS)

--- a/docs/config.md
+++ b/docs/config.md
@@ -413,7 +413,7 @@ OTel trace replay reconstructs the original call graph from trace files, preserv
 2. **Session-Based Execution**: Each trace file represents one *session*. The load generator controls:
    - How many sessions run concurrently (`concurrent_sessions`)
    - How many sessions to process per stage (`num_sessions`)
-   - Optional rate limiting for session starts (`session_rate`)
+   - Optional rate limiting for session starts (`session_rate` or `session_interval`)
 
 3. **Output Substitution**: When a request depends on a predecessor's output, the recorded assistant message is replaced at runtime with the actual generated text, ensuring realistic KV-cache behavior for multi-turn conversations and agent chains.
 
@@ -455,6 +455,10 @@ load:
     - concurrent_sessions: 4                      # Max sessions active simultaneously
       num_sessions: 20                            # Run 20 sessions in this stage
       session_rate: 2.0                           # Optional: start max 2 sessions/sec
+      # session_interval:                         # OR: random delay between session starts
+      #   type: uniform                           #     (mutually exclusive with session_rate)
+      #   min: 1                                  #     each session starts 1-10s after the
+      #   max: 10                                 #     previous one
       timeout: 300                                # Optional: stage timeout in seconds
   num_workers: 4                                  # Worker processes
   worker_max_concurrency: 10                      # Max concurrent requests per worker
@@ -473,6 +477,13 @@ load:
 **`session_rate`** (optional): Rate limit for starting new sessions
 - Omit for no rate limiting
 - Useful for controlled ramp-up scenarios
+
+**`session_interval`** (optional): Random delay in seconds between session starts
+- A [`Distribution`](#data-configuration) sampled once per session dispatch, e.g.
+  `{type: uniform, min: 1, max: 10}` starts each session 1-10 seconds after the previous one
+- Supports `uniform`, `normal`, `lognormal`, `fixed`, and other distribution types
+- Set `min`/`max` explicitly: samples are clamped to `[min, max]`
+- Mutually exclusive with `session_rate` (it is equivalent to a randomized `session_rate`)
 
 **`timeout`** (optional): Wall-clock safety limit
 - If exceeded, in-flight sessions are cancelled and stage exits as FAILED

--- a/docs/otel_trace_replay.md
+++ b/docs/otel_trace_replay.md
@@ -243,7 +243,8 @@ The `load.trace_session_replay` section controls how sessions are executed. Unli
 |-----------|------|----------|-------------|
 | `concurrent_sessions` | integer | Yes | Max sessions running simultaneously. Set to `0` for unlimited (stress mode) |
 | `num_sessions` | integer | No | Total sessions to run in this stage. Omit to run all remaining sessions (entire corpus if single stage) |
-| `session_rate` | float | No | Optional rate limit for starting new sessions (sessions/sec) |
+| `session_rate` | float | No | Optional rate limit for starting new sessions (sessions/sec). Mutually exclusive with `session_interval` |
+| `session_interval` | Distribution | No | Optional random delay in seconds between session starts, sampled per dispatch (e.g. `{type: uniform, min: 1, max: 10}`). Mutually exclusive with `session_rate` |
 
 **Example:**
 

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -19,7 +19,7 @@ from typing import List, Optional, Union
 from inference_perf.config.common import StrictBaseModel
 from pydantic import ConfigDict, Field, model_validator
 
-from inference_perf.config.common import Distribution
+from inference_perf.config.common import Distribution, DistributionType
 from inference_perf.config.datagen.replay import TraceConfig
 
 
@@ -38,9 +38,24 @@ class LoadStage(StrictBaseModel):
 
 
 class StandardLoadStage(LoadStage):
-    """Load stage for CONSTANT and POISSON load types."""
+    """Load stage for CONSTANT and POISSON load types.
 
-    rate: float = Field(..., gt=0, description="Request rate (QPS)")
+    Exactly one of ``rate`` or ``interval`` must be set: ``rate`` dispatches
+    requests at a fixed QPS, ``interval`` draws the delay between consecutive
+    requests from a Distribution (CONSTANT load type only).
+    """
+
+    rate: Optional[float] = Field(None, gt=0, description="Request rate (QPS). Specify exactly one of 'rate' or 'interval'.")
+    interval: Optional[Distribution] = Field(
+        None,
+        description=(
+            "Distribution of the delay in seconds between consecutive requests, "
+            "sampled once per request (e.g. type: uniform, min: 1, max: 10). "
+            "Only supported with the CONSTANT load type. Specify exactly one of "
+            "'rate' or 'interval'. Set min/max explicitly: samples are clamped to "
+            "[min, max] and the Distribution defaults are tuned for token counts."
+        ),
+    )
     duration: int = Field(..., gt=0, description="Duration in seconds")
 
     # These fields should not be set for standard load types
@@ -49,6 +64,15 @@ class StandardLoadStage(LoadStage):
 
     @model_validator(mode="after")
     def validate_standard_fields(self) -> "StandardLoadStage":
+        if (self.rate is None) == (self.interval is None):
+            raise ValueError("Specify exactly one of 'rate' or 'interval' for CONSTANT/POISSON load stages")
+        if self.interval is not None:
+            if self.interval.min < 0:
+                raise ValueError(
+                    f"interval.min ({self.interval.min}) must be >= 0; intervals are delays in seconds between requests."
+                )
+            if self.interval.type == DistributionType.FIXED and self.interval.mean <= 0:
+                raise ValueError(f"interval.mean ({self.interval.mean}) must be > 0 for a fixed interval")
         if self.num_requests is not None:
             raise ValueError("num_requests should not be set for CONSTANT/POISSON load types")
         if self.concurrency_level is not None:
@@ -142,11 +166,14 @@ class TraceSessionReplayLoadStage(LoadStage):
                 "session_interval is equivalent to a randomized session_rate."
             )
 
-        if self.session_interval is not None and self.session_interval.min < 0:
-            raise ValueError(
-                f"session_interval.min ({self.session_interval.min}) must be >= 0; "
-                f"intervals are delays in seconds between session starts."
-            )
+        if self.session_interval is not None:
+            if self.session_interval.min < 0:
+                raise ValueError(
+                    f"session_interval.min ({self.session_interval.min}) must be >= 0; "
+                    f"intervals are delays in seconds between session starts."
+                )
+            if self.session_interval.type == DistributionType.FIXED and self.session_interval.mean <= 0:
+                raise ValueError(f"session_interval.mean ({self.session_interval.mean}) must be > 0 for a fixed interval")
 
         # Validate session_rate vs concurrent_sessions
         if self.session_rate is not None and self.concurrent_sessions > 0:
@@ -237,6 +264,11 @@ class LoadConfig(StrictBaseModel):
                 if not isinstance(stage, StandardLoadStage):
                     raise ValueError(
                         f"Stage {i}: {self.type.value.upper()} load type requires StandardLoadStage, got {type(stage).__name__}"
+                    )
+                if stage.interval is not None and self.type != LoadType.CONSTANT:
+                    raise ValueError(
+                        f"Stage {i}: 'interval' is only supported with the CONSTANT load type; "
+                        f"{self.type.value.upper()} defines its own arrival process, use 'rate' instead"
                     )
 
         # Validate multilora traffic split adds up to 1.0 if present

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Union
 from inference_perf.config.common import StrictBaseModel
 from pydantic import ConfigDict, Field, model_validator
 
+from inference_perf.config.common import Distribution
 from inference_perf.config.datagen.replay import TraceConfig
 
 
@@ -83,6 +84,7 @@ class TraceSessionReplayLoadStage(LoadStage):
     Modes:
     1. Simple concurrency control: set concurrent_sessions (and optionally num_sessions)
     2. Rate-based with concurrency: set concurrent_sessions + session_rate (+ num_sessions)
+    3. Random-interval dispatch: set concurrent_sessions + session_interval (+ num_sessions)
     """
 
     # Session concurrency control (REQUIRED)
@@ -101,6 +103,16 @@ class TraceSessionReplayLoadStage(LoadStage):
         None,
         gt=0,
         description="Sessions to start per second (optional, omit for no rate limit)",
+    )
+    session_interval: Optional[Distribution] = Field(
+        None,
+        description=(
+            "Distribution of the delay in seconds between session starts, sampled "
+            "once per dispatch (e.g. type: uniform, min: 1, max: 10 starts each "
+            "session 1-10s after the previous one). Mutually exclusive with "
+            "session_rate. Set min/max explicitly: samples are clamped to "
+            "[min, max] and the Distribution defaults are tuned for token counts."
+        ),
     )
     num_sessions: Optional[int] = Field(
         None,
@@ -124,6 +136,18 @@ class TraceSessionReplayLoadStage(LoadStage):
 
     @model_validator(mode="after")
     def validate_trace_session_fields(self) -> "TraceSessionReplayLoadStage":
+        if self.session_rate is not None and self.session_interval is not None:
+            raise ValueError(
+                "Specify either 'session_rate' or 'session_interval', not both. "
+                "session_interval is equivalent to a randomized session_rate."
+            )
+
+        if self.session_interval is not None and self.session_interval.min < 0:
+            raise ValueError(
+                f"session_interval.min ({self.session_interval.min}) must be >= 0; "
+                f"intervals are delays in seconds between session starts."
+            )
+
         # Validate session_rate vs concurrent_sessions
         if self.session_rate is not None and self.concurrent_sessions > 0:
             if self.session_rate > self.concurrent_sessions:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -17,7 +17,7 @@ from inference_perf.datagen.base import BaseGenerator
 from inference_perf.utils.trace_reader import AzurePublicDatasetReader
 from inference_perf.utils.numeric.distribution import sample_floats_from_distribution
 from inference_perf.utils.request_queue import RequestQueue
-from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
+from .load_timer import LoadTimer, ConstantLoadTimer, IntervalLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
 from inference_perf.datagen import DataGenerator, SessionGenerator, LazyLoadDataMixin
 from inference_perf.apis import InferenceAPIData
 from inference_perf.apis.user_session import LocalUserSession
@@ -26,6 +26,7 @@ from inference_perf.client.modelserver.otel_instrumentation import get_otel_inst
 from inference_perf.circuit_breaker import get_circuit_breaker
 from inference_perf.metrics import SessionMetricsCollector
 from inference_perf.config import (
+    Distribution,
     LoadConfig,
     LoadType,
     StageGenType,
@@ -367,13 +368,25 @@ class LoadGenerator:
             return str(np.random.choice(self.lora_adapters, p=self.lora_weights))
         return None
 
-    def get_timer(self, rate: float, duration: float) -> LoadTimer:
-        if self.load_type == LoadType.POISSON:
-            return PoissonLoadTimer(rate=rate, duration=duration)
-        elif self.load_type == LoadType.TRACE_REPLAY:
+    def get_timer(
+        self,
+        rate: Optional[float],
+        duration: float,
+        interval: Optional[Distribution] = None,
+        stage_id: int = 0,
+    ) -> LoadTimer:
+        if interval is not None:
+            return IntervalLoadTimer(
+                interval=interval, duration=duration, rng=np.random.default_rng((self.base_seed + stage_id) % 2**32)
+            )
+        if self.load_type == LoadType.TRACE_REPLAY:
             if self.trace is None:
                 raise ValueError("Trace configuration is required for trace replay load generator")
             return TraceReplayLoadTimer(trace_reader=self.trace_reader, trace_file=Path(self.trace.file))
+        if rate is None:
+            raise ValueError(f"{self.load_type.value} load type requires a stage rate")
+        if self.load_type == LoadType.POISSON:
+            return PoissonLoadTimer(rate=rate, duration=duration)
         # For concurrent and constant load types (rate is adjusted in main.py for concurrent load type)
         return ConstantLoadTimer(rate=rate, duration=duration)
 
@@ -746,7 +759,7 @@ class LoadGenerator:
     async def run_stage(
         self,
         stage_id: int,
-        rate: float,
+        rate: Optional[float],
         duration: int,
         request_queue: RequestQueue[RequestQueueData],
         active_requests_counter: "Synchronized[int]",
@@ -756,6 +769,7 @@ class LoadGenerator:
         timeout: Optional[float] = None,
         concurrency_level: Optional[int] = None,
         progress_ctx: Optional[Progress] = None,
+        interval: Optional[Distribution] = None,
     ) -> None:
         logger.info("Stage %d - run started", stage_id)
 
@@ -765,7 +779,7 @@ class LoadGenerator:
         request_phase.set()
         with finished_requests_counter.get_lock():
             finished_requests_counter.value = 0
-        timer = self.get_timer(rate, duration)
+        timer = self.get_timer(rate, duration, interval=interval, stage_id=stage_id)
 
         # Allow generation a second to begin populating the queue so the workers
         # don't miss the initial scheuled request times
@@ -774,7 +788,11 @@ class LoadGenerator:
 
         if isinstance(self.datagen, DataGenerator) and self.datagen.trace is not None:
             num_requests = self.datagen.get_request_count()
+        elif isinstance(timer, IntervalLoadTimer):
+            num_requests = timer.num_requests
         else:
+            if rate is None:
+                raise ValueError("run_stage requires either a rate or an interval")
             num_requests = int(rate * duration)
 
         stage_status = StageStatus.RUNNING
@@ -849,7 +867,7 @@ class LoadGenerator:
 
         self.stage_runtime_info[stage_id] = StageRuntimeInfo(
             stage_id=stage_id,
-            rate=rate,
+            rate=rate if rate is not None else 0.0,
             start_time=start_time_epoch,
             end_time=time.time(),
             status=stage_status,
@@ -1075,6 +1093,7 @@ class LoadGenerator:
                         cancel_signal,
                         concurrency_level=concurrency_level,
                         progress_ctx=progress,
+                        interval=stage.interval,
                     )
                 else:
                     raise Exception(f"Stage {stage_id} has the wrong load type")
@@ -1114,14 +1133,19 @@ class LoadGenerator:
                 if not isinstance(stage, StandardLoadStage):
                     raise TypeError(f"Non-multiprocessing run() only supports StandardLoadStage, got {type(stage)}")
 
-                timer = self.get_timer(stage.rate, stage.duration)
+                timer = self.get_timer(stage.rate, stage.duration, interval=stage.interval, stage_id=stage_id)
                 start_time_epoch = time.time()
                 start_time = time.perf_counter()
                 end_time = start_time + stage.duration
                 stage_status = StageStatus.RUNNING
                 logger.info("Stage %d - run started", stage_id)
 
-                num_requests = int(stage.rate * stage.duration)
+                if isinstance(timer, IntervalLoadTimer):
+                    num_requests = timer.num_requests
+                elif stage.rate is not None:
+                    num_requests = int(stage.rate * stage.duration)
+                else:
+                    raise ValueError("Stage requires either a rate or an interval")
                 stage_task = progress.add_task(description=f"Stage {stage_id} Progress", total=num_requests)
 
                 if not isinstance(self.datagen, DataGenerator):
@@ -1166,7 +1190,7 @@ class LoadGenerator:
                     logger.info("Stage %d - run failed", stage_id)
                 self.stage_runtime_info[stage_id] = StageRuntimeInfo(
                     stage_id=stage_id,
-                    rate=stage.rate,
+                    rate=stage.rate if stage.rate is not None else 0.0,
                     start_time=start_time_epoch,
                     end_time=time.time(),
                     status=stage_status,

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from inference_perf.client.server_metrics.base import StageRuntimeInfo, StageStatus
 from inference_perf.datagen.base import BaseGenerator
 from inference_perf.utils.trace_reader import AzurePublicDatasetReader
+from inference_perf.utils.numeric.distribution import sample_floats_from_distribution
 from inference_perf.utils.request_queue import RequestQueue
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
 from inference_perf.datagen import DataGenerator, SessionGenerator, LazyLoadDataMixin
@@ -431,6 +432,10 @@ class LoadGenerator:
         # Session pool management
         concurrent_sessions = stage.concurrent_sessions
         session_rate = stage.session_rate
+        session_interval_dist = stage.session_interval
+        interval_rng = (
+            np.random.default_rng((self.base_seed + stage_id) % 2**32) if session_interval_dist is not None else None
+        )
         timeout = stage.timeout
 
         # Compute this stage's session slice from the cursor
@@ -447,7 +452,7 @@ class LoadGenerator:
 
         logger.info(
             f"Session pool: concurrent_sessions={concurrent_sessions}, "
-            f"session_rate={session_rate}, timeout={timeout}, "
+            f"session_rate={session_rate}, session_interval={session_interval_dist}, timeout={timeout}, "
             f"num_sessions={effective_num_sessions} (corpus offset {stage_start_cursor}), "
             f"total_sessions={total_sessions}"
         )
@@ -496,7 +501,7 @@ class LoadGenerator:
                 return False
 
             # Check rate limit
-            if session_rate is not None:
+            if session_rate is not None or session_interval_dist is not None:
                 now = time.perf_counter()
                 if now < next_dispatch_time:
                     return False
@@ -569,7 +574,10 @@ class LoadGenerator:
             # Update timing for rate limiting
             now = time.perf_counter()
             last_dispatch_time = now
-            if session_rate is not None:
+            if session_interval_dist is not None and interval_rng is not None:
+                session_interval = float(sample_floats_from_distribution(session_interval_dist, 1, rng=interval_rng)[0])
+                next_dispatch_time = max(next_dispatch_time + session_interval, now)
+            elif session_rate is not None:
                 session_interval = 1.0 / session_rate
                 next_dispatch_time = max(next_dispatch_time + session_interval, now)
 

--- a/inference_perf/loadgen/load_timer.py
+++ b/inference_perf/loadgen/load_timer.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 import time
 from abc import ABC, abstractmethod
-from typing import Generator, Optional, Tuple
+from typing import TYPE_CHECKING, Generator, List, Optional, Tuple
 import numpy as np
+from inference_perf.utils.numeric.distribution import sample_floats_from_distribution
 from inference_perf.utils.trace_reader import TraceReader
 from pathlib import Path
+
+if TYPE_CHECKING:
+    from inference_perf.config import Distribution
 
 
 class LoadTimer(ABC):
@@ -63,6 +67,43 @@ class ConstantLoadTimer(LoadTimer):
         for interval in normalized_intervals:
             next_time += interval
             yield next_time
+
+
+class IntervalLoadTimer(LoadTimer):
+    """
+    A load generator that separates consecutive requests by gaps sampled
+    from a Distribution (e.g. uniform 1-10 seconds).
+
+    The schedule is precomputed so the number of requests that fit in the
+    stage duration is known up front via num_requests.
+    """
+
+    def __init__(self, interval: "Distribution", duration: float, rng: Optional[np.random.Generator] = None) -> None:
+        self._rand = rng if rng is not None else np.random.default_rng()
+        offsets: List[float] = []
+        elapsed = 0.0
+        while elapsed <= duration:
+            gaps = sample_floats_from_distribution(interval, 256, rng=self._rand)
+            if np.sum(gaps) <= 0:
+                raise ValueError(f"interval distribution produced non-positive gaps: {interval}")
+            for gap in gaps:
+                elapsed += float(gap)
+                if elapsed > duration:
+                    break
+                offsets.append(elapsed)
+            else:
+                continue
+            break
+        self._offsets = offsets
+
+    @property
+    def num_requests(self) -> int:
+        return len(self._offsets)
+
+    def start_timer(self, initial: Optional[float] = None) -> Generator[float, None, None]:
+        start_time = time.monotonic() if initial is None else initial
+        for offset in self._offsets:
+            yield start_time + offset
 
 
 class PoissonLoadTimer(LoadTimer):

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -72,6 +72,7 @@ from inference_perf.circuit_breaker import init_circuit_breakers
 from inference_perf.reportgen import ReportGenerator
 from inference_perf.utils import CustomTokenizer, ReportFile, add_global_args, add_pydantic_args, unflatten_dict
 from inference_perf.utils.cli_summary import print_summary_table
+from inference_perf.utils.numeric.distribution import estimate_max_requests_for_interval
 from inference_perf.observability.logging import setup_logging
 import asyncio
 import time
@@ -310,7 +311,12 @@ def main_cli() -> None:
                 max_requests = 0
                 for stage in config.load.stages:
                     if isinstance(stage, StandardLoadStage):
-                        max_requests = max(max_requests, int(stage.rate * stage.duration))
+                        if stage.rate is not None:
+                            max_requests = max(max_requests, int(stage.rate * stage.duration))
+                        elif stage.interval is not None:
+                            max_requests = max(
+                                max_requests, estimate_max_requests_for_interval(stage.interval, stage.duration)
+                            )
                     elif isinstance(stage, ConcurrentLoadStage):
                         max_requests = max(max_requests, stage.num_requests)
                 total_count = max_requests + 1

--- a/inference_perf/utils/numeric/distribution/__init__.py
+++ b/inference_perf/utils/numeric/distribution/__init__.py
@@ -11,6 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .utils import generate_distribution, sample_from_distribution
+from .utils import generate_distribution, sample_floats_from_distribution, sample_from_distribution
 
-__all__ = ["generate_distribution", "sample_from_distribution"]
+__all__ = ["generate_distribution", "sample_floats_from_distribution", "sample_from_distribution"]

--- a/inference_perf/utils/numeric/distribution/__init__.py
+++ b/inference_perf/utils/numeric/distribution/__init__.py
@@ -11,6 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .utils import generate_distribution, sample_floats_from_distribution, sample_from_distribution
+from .utils import (
+    estimate_max_requests_for_interval,
+    generate_distribution,
+    sample_floats_from_distribution,
+    sample_from_distribution,
+)
 
-__all__ = ["generate_distribution", "sample_floats_from_distribution", "sample_from_distribution"]
+__all__ = [
+    "estimate_max_requests_for_interval",
+    "generate_distribution",
+    "sample_floats_from_distribution",
+    "sample_from_distribution",
+]

--- a/inference_perf/utils/numeric/distribution/utils.py
+++ b/inference_perf/utils/numeric/distribution/utils.py
@@ -109,6 +109,45 @@ def _sample_skew_normal(rng: np.random.Generator, mean: float, std_dev: float, s
     return mean + std_dev * z
 
 
+def _sample_continuous(
+    config: "Distribution",
+    count: int,
+    rng: np.random.Generator,
+) -> NDArray[np.float64]:
+    """Sample unclipped continuous values for the non-uniform, non-fixed distribution types."""
+    from inference_perf.config import DistributionType
+
+    if config.type == DistributionType.NORMAL:
+        samples = rng.normal(loc=config.mean, scale=config.std_dev, size=count)
+
+    elif config.type == DistributionType.SKEW_NORMAL:
+        samples = _sample_skew_normal(rng, config.mean, config.std_dev, config.skew, count)
+
+    elif config.type == DistributionType.LOGNORMAL:
+        # Moment-match: convert desired mean/std_dev to underlying normal mu/sigma.
+        if config.mean <= 0:
+            raise ValueError("Lognormal distribution requires mean > 0.")
+        m = config.mean
+        s = config.std_dev
+        if s <= 0:
+            # Degenerate case: constant value
+            samples = np.full(count, m, dtype=np.float64)
+        else:
+            sigma_sq = log(1.0 + (s / m) ** 2)
+            mu = log(m) - sigma_sq / 2.0
+            sigma = sqrt(sigma_sq)
+            samples = rng.lognormal(mean=mu, sigma=sigma, size=count)
+
+    elif config.type == DistributionType.POISSON:
+        lam = config.mean if config.mean > 0 else 1.0
+        samples = rng.poisson(lam=lam, size=count).astype(np.float64)
+
+    else:
+        raise ValueError(f"Unsupported distribution type: {config.type}")
+
+    return cast(NDArray[np.float64], np.asarray(samples, dtype=np.float64))
+
+
 def sample_from_distribution(
     config: "Distribution",
     count: int,
@@ -141,39 +180,54 @@ def sample_from_distribution(
     if config.type == DistributionType.FIXED:
         return cast(NDArray[np.int_], np.full(count, int(config.mean), dtype=int))
 
-    if config.type == DistributionType.NORMAL:
-        samples = rng.normal(loc=config.mean, scale=config.std_dev, size=count)
-
-    elif config.type == DistributionType.SKEW_NORMAL:
-        samples = _sample_skew_normal(rng, config.mean, config.std_dev, config.skew, count)
-
-    elif config.type == DistributionType.LOGNORMAL:
-        # Moment-match: convert desired mean/std_dev to underlying normal mu/sigma.
-        if config.mean <= 0:
-            raise ValueError("Lognormal distribution requires mean > 0.")
-        m = config.mean
-        s = config.std_dev
-        if s <= 0:
-            # Degenerate case: constant value
-            samples = np.full(count, m, dtype=np.float64)
-        else:
-            sigma_sq = log(1.0 + (s / m) ** 2)
-            mu = log(m) - sigma_sq / 2.0
-            sigma = sqrt(sigma_sq)
-            samples = rng.lognormal(mean=mu, sigma=sigma, size=count)
-
-    elif config.type == DistributionType.UNIFORM:
+    if config.type == DistributionType.UNIFORM:
+        # max + 1 so that, after rounding, min and max get the same weight as interior values
         samples = rng.uniform(low=config.min, high=config.max + 1, size=count)
-
-    elif config.type == DistributionType.POISSON:
-        lam = config.mean if config.mean > 0 else 1.0
-        samples = rng.poisson(lam=lam, size=count).astype(np.float64)
-
     else:
-        raise ValueError(f"Unsupported distribution type: {config.type}")
+        samples = _sample_continuous(config, count, rng)
 
     # Clip to bounds and round to integers
     clipped = np.clip(samples, config.min, config.max)
     result = np.round(clipped).astype(int)
     result = np.clip(result, config.min, config.max)
     return cast(NDArray[np.int_], result)
+
+
+def sample_floats_from_distribution(
+    config: "Distribution",
+    count: int,
+    rng: Optional[np.random.Generator] = None,
+) -> NDArray[np.float64]:
+    """Sample float values from a Distribution config without integer rounding.
+
+    Counterpart to sample_from_distribution for continuous quantities such as
+    time intervals in seconds, where rounding to integers would lose precision.
+
+    Args:
+        config: A Distribution specifying the distribution type and parameters.
+        count: Number of samples to generate.
+        rng: Optional numpy Generator for deterministic seeding. If None, creates a default one.
+
+    Returns:
+        A numpy array of floats clamped to [config.min, config.max]
+        (FIXED returns config.mean unclamped, matching sample_from_distribution).
+    """
+    from inference_perf.config import DistributionType
+
+    if count <= 0:
+        raise ValueError("Count must be a positive integer.")
+    if config.min > config.max:
+        raise ValueError(f"min ({config.min}) cannot be greater than max ({config.max}).")
+
+    if rng is None:
+        rng = np.random.default_rng()
+
+    if config.type == DistributionType.FIXED:
+        return cast(NDArray[np.float64], np.full(count, float(config.mean), dtype=np.float64))
+
+    if config.type == DistributionType.UNIFORM:
+        samples = rng.uniform(low=config.min, high=config.max, size=count)
+    else:
+        samples = _sample_continuous(config, count, rng)
+
+    return cast(NDArray[np.float64], np.clip(samples, config.min, config.max).astype(np.float64))

--- a/inference_perf/utils/numeric/distribution/utils.py
+++ b/inference_perf/utils/numeric/distribution/utils.py
@@ -193,6 +193,28 @@ def sample_from_distribution(
     return cast(NDArray[np.int_], result)
 
 
+def estimate_max_requests_for_interval(interval: "Distribution", duration: float) -> int:
+    """Upper-bound estimate of how many requests fit in `duration` seconds when
+    inter-request gaps are drawn from `interval`.
+
+    Uses the smallest possible gap (the distribution's lower clamp, or the mean
+    for FIXED). Falls back to half the expected gap when the lower bound is zero.
+    """
+    from inference_perf.config import DistributionType
+
+    if interval.type == DistributionType.FIXED:
+        smallest_gap = float(interval.mean)
+    else:
+        smallest_gap = float(interval.min)
+    if smallest_gap <= 0:
+        if interval.type == DistributionType.UNIFORM:
+            expected_gap = (interval.min + interval.max) / 2.0
+        else:
+            expected_gap = min(max(interval.mean, float(interval.min)), float(interval.max))
+        smallest_gap = max(expected_gap / 2.0, 1e-3)
+    return int(duration / smallest_gap)
+
+
 def sample_floats_from_distribution(
     config: "Distribution",
     count: int,

--- a/tests/required/loadgen/test_load_timer.py
+++ b/tests/required/loadgen/test_load_timer.py
@@ -1,0 +1,62 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import pytest
+
+from inference_perf.config import Distribution, DistributionType
+from inference_perf.loadgen.load_timer import IntervalLoadTimer
+
+
+class TestIntervalLoadTimer:
+    def test_fixed_interval_schedule(self) -> None:
+        interval = Distribution(type=DistributionType.FIXED, mean=2.0, min=0, max=10)
+        timer = IntervalLoadTimer(interval=interval, duration=10.0)
+        # Gaps of exactly 2s fit requests at t=2,4,6,8,10
+        assert timer.num_requests == 5
+        times = list(timer.start_timer(initial=0.0))
+        assert times == [2.0, 4.0, 6.0, 8.0, 10.0]
+
+    def test_uniform_gaps_within_bounds(self) -> None:
+        interval = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        timer = IntervalLoadTimer(interval=interval, duration=600.0, rng=np.random.default_rng(42))
+        times = list(timer.start_timer(initial=0.0))
+        assert len(times) == timer.num_requests
+        assert len(times) > 0
+        gaps = np.diff([0.0] + times)
+        assert gaps.min() >= 1.0
+        assert gaps.max() <= 10.0
+        assert times[-1] <= 600.0
+
+    def test_deterministic_with_seeded_rng(self) -> None:
+        interval = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        timer1 = IntervalLoadTimer(interval=interval, duration=120.0, rng=np.random.default_rng(7))
+        timer2 = IntervalLoadTimer(interval=interval, duration=120.0, rng=np.random.default_rng(7))
+        assert list(timer1.start_timer(initial=0.0)) == list(timer2.start_timer(initial=0.0))
+
+    def test_initial_offsets_schedule(self) -> None:
+        interval = Distribution(type=DistributionType.FIXED, mean=1.0, min=0, max=10)
+        timer = IntervalLoadTimer(interval=interval, duration=3.0)
+        times = list(timer.start_timer(initial=100.0))
+        assert times == [101.0, 102.0, 103.0]
+
+    def test_gap_larger_than_duration_yields_nothing(self) -> None:
+        interval = Distribution(type=DistributionType.FIXED, mean=30.0, min=0, max=60)
+        timer = IntervalLoadTimer(interval=interval, duration=10.0)
+        assert timer.num_requests == 0
+        assert list(timer.start_timer(initial=0.0)) == []
+
+    def test_zero_gaps_raise(self) -> None:
+        interval = Distribution(type=DistributionType.FIXED, mean=0.0, min=0, max=10)
+        with pytest.raises(ValueError, match="non-positive gaps"):
+            IntervalLoadTimer(interval=interval, duration=10.0)

--- a/tests/required/utils/numeric/distribution/test_utils.py
+++ b/tests/required/utils/numeric/distribution/test_utils.py
@@ -15,7 +15,11 @@ import numpy as np
 import pytest
 
 from inference_perf.config import Distribution, DistributionType
-from inference_perf.utils.numeric.distribution import generate_distribution, sample_from_distribution
+from inference_perf.utils.numeric.distribution import (
+    generate_distribution,
+    sample_floats_from_distribution,
+    sample_from_distribution,
+)
 
 
 class TestSampleFromDistribution:
@@ -121,6 +125,45 @@ class TestSampleFromDistribution:
         # Pydantic validator catches this at construction time
         with pytest.raises(Exception, match="min.*max"):
             Distribution(type=DistributionType.NORMAL, mean=50.0, min=100, max=10, std_dev=10.0)
+
+
+class TestSampleFloatsFromDistribution:
+    def test_uniform_within_bounds_and_continuous(self) -> None:
+        config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        result = sample_floats_from_distribution(config, 1000, rng=np.random.default_rng(42))
+        assert len(result) == 1000
+        assert result.min() >= 1.0
+        assert result.max() <= 10.0
+        # Values are continuous, not rounded to integers
+        assert np.any(result != np.round(result))
+
+    def test_fixed_returns_fractional_mean(self) -> None:
+        config = Distribution(type=DistributionType.FIXED, mean=0.5, min=0, max=1)
+        result = sample_floats_from_distribution(config, 100)
+        assert np.all(result == 0.5)
+
+    def test_normal_within_bounds(self) -> None:
+        config = Distribution(type=DistributionType.NORMAL, mean=5.0, min=1, max=10, std_dev=2.0)
+        result = sample_floats_from_distribution(config, 1000, rng=np.random.default_rng(42))
+        assert result.min() >= 1.0
+        assert result.max() <= 10.0
+
+    def test_lognormal_within_bounds(self) -> None:
+        config = Distribution(type=DistributionType.LOGNORMAL, mean=5.0, min=1, max=60, std_dev=3.0)
+        result = sample_floats_from_distribution(config, 1000, rng=np.random.default_rng(42))
+        assert result.min() >= 1.0
+        assert result.max() <= 60.0
+
+    def test_deterministic_seeding(self) -> None:
+        config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        result1 = sample_floats_from_distribution(config, 100, rng=np.random.default_rng(7))
+        result2 = sample_floats_from_distribution(config, 100, rng=np.random.default_rng(7))
+        np.testing.assert_array_equal(result1, result2)
+
+    def test_invalid_count_zero(self) -> None:
+        config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        with pytest.raises(ValueError, match="positive"):
+            sample_floats_from_distribution(config, 0)
 
 
 class TestLegacyGenerateDistribution:

--- a/tests/required/utils/numeric/distribution/test_utils.py
+++ b/tests/required/utils/numeric/distribution/test_utils.py
@@ -16,6 +16,7 @@ import pytest
 
 from inference_perf.config import Distribution, DistributionType
 from inference_perf.utils.numeric.distribution import (
+    estimate_max_requests_for_interval,
     generate_distribution,
     sample_floats_from_distribution,
     sample_from_distribution,
@@ -164,6 +165,30 @@ class TestSampleFloatsFromDistribution:
         config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
         with pytest.raises(ValueError, match="positive"):
             sample_floats_from_distribution(config, 0)
+
+    def test_unsupported_type_raises(self) -> None:
+        # Both samplers share the unsupported-type guard in _sample_continuous
+        config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        config.type = "bogus"  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="Unsupported distribution type"):
+            sample_floats_from_distribution(config, 10)
+        with pytest.raises(ValueError, match="Unsupported distribution type"):
+            sample_from_distribution(config, 10)
+
+
+class TestEstimateMaxRequestsForInterval:
+    def test_uniform_uses_min_gap(self) -> None:
+        config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        assert estimate_max_requests_for_interval(config, 60.0) == 60
+
+    def test_fixed_uses_mean(self) -> None:
+        config = Distribution(type=DistributionType.FIXED, mean=2.0, min=0, max=10)
+        assert estimate_max_requests_for_interval(config, 60.0) == 30
+
+    def test_zero_min_falls_back_to_expected_gap(self) -> None:
+        config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=0, max=10)
+        # Expected gap is 5s; fallback halves it for headroom -> 60 / 2.5 = 24
+        assert estimate_max_requests_for_interval(config, 60.0) == 24
 
 
 class TestLegacyGenerateDistribution:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,6 +182,42 @@ def test_standard_load_stage_validation() -> None:
         StandardLoadStage(rate=10, duration=60, concurrency_level=5)
 
 
+def test_standard_load_stage_interval_validation() -> None:
+    interval = Distribution(type=DistributionType.UNIFORM, min=1, max=10)
+
+    # interval alone is valid
+    stage = StandardLoadStage(interval=interval, duration=60)
+    assert stage.interval is not None
+    assert stage.rate is None
+
+    # exactly one of rate/interval: neither set
+    with pytest.raises(ValueError, match="exactly one of 'rate' or 'interval'"):
+        StandardLoadStage(duration=60)
+
+    # exactly one of rate/interval: both set
+    with pytest.raises(ValueError, match="exactly one of 'rate' or 'interval'"):
+        StandardLoadStage(rate=10, interval=interval, duration=60)
+
+    # negative interval bound rejected
+    with pytest.raises(ValueError, match="must be >= 0"):
+        StandardLoadStage(interval=Distribution(type=DistributionType.UNIFORM, min=-1, max=10), duration=60)
+
+    # fixed interval requires a positive mean
+    with pytest.raises(ValueError, match="must be > 0 for a fixed interval"):
+        StandardLoadStage(interval=Distribution(type=DistributionType.FIXED, mean=0.0, min=0, max=10), duration=60)
+
+
+def test_load_config_interval_requires_constant_type() -> None:
+    interval = Distribution(type=DistributionType.UNIFORM, min=1, max=10)
+
+    # CONSTANT with interval is valid
+    LoadConfig(type=LoadType.CONSTANT, stages=[StandardLoadStage(interval=interval, duration=60)])
+
+    # POISSON with interval is rejected
+    with pytest.raises(ValueError, match="only supported with the CONSTANT load type"):
+        LoadConfig(type=LoadType.POISSON, stages=[StandardLoadStage(interval=interval, duration=60)])
+
+
 def test_concurrent_load_stage() -> None:
     # Just verify we can create it and it hits the validator returning self
     stage = ConcurrentLoadStage(num_requests=100, concurrency_level=10)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,6 +189,56 @@ def test_concurrent_load_stage() -> None:
     assert stage.concurrency_level == 10
 
 
+def test_trace_session_replay_session_interval_validation() -> None:
+    from inference_perf.config import TraceSessionReplayLoadStage
+
+    # session_interval alone is valid
+    stage = TraceSessionReplayLoadStage(
+        concurrent_sessions=5,
+        session_interval=Distribution(type=DistributionType.UNIFORM, min=1, max=10),
+    )
+    assert stage.session_interval is not None
+    assert stage.session_rate is None
+
+    # session_rate and session_interval are mutually exclusive
+    with pytest.raises(ValueError, match="either 'session_rate' or 'session_interval'"):
+        TraceSessionReplayLoadStage(
+            concurrent_sessions=5,
+            session_rate=1.0,
+            session_interval=Distribution(type=DistributionType.UNIFORM, min=1, max=10),
+        )
+
+    # negative interval bound rejected
+    with pytest.raises(ValueError, match="must be >= 0"):
+        TraceSessionReplayLoadStage(
+            concurrent_sessions=5,
+            session_interval=Distribution(type=DistributionType.UNIFORM, min=-1, max=10),
+        )
+
+
+def test_trace_session_replay_session_interval_from_dict() -> None:
+    from inference_perf.config import TraceSessionReplayLoadStage
+
+    # Parse the way users write it in YAML
+    cfg = LoadConfig.model_validate(
+        {
+            "type": "trace_session_replay",
+            "stages": [
+                {
+                    "concurrent_sessions": 4,
+                    "session_interval": {"type": "uniform", "min": 1, "max": 10},
+                }
+            ],
+        }
+    )
+    stage = cfg.stages[0]
+    assert isinstance(stage, TraceSessionReplayLoadStage)
+    assert stage.session_interval is not None
+    assert stage.session_interval.type == DistributionType.UNIFORM
+    assert stage.session_interval.min == 1
+    assert stage.session_interval.max == 10
+
+
 def test_load_config_validation() -> None:
     import pytest
     from inference_perf.config import SweepConfig, StageGenType


### PR DESCRIPTION
Addresses: #465

## Summary

Adds random delays between dispatches, drawn from the existing `Distribution` config type, in two places:

**1. `session_interval` on `trace_session_replay` stages** — random delay between session starts (the original ask in #465):

```yaml
load:
  type: trace_session_replay
  stages:
    - concurrent_sessions: 4
      session_interval:
        type: uniform
        min: 1
        max: 10   # each session starts 1-10s after the previous one
```

**2. `interval` on standard (CONSTANT) stages** — random delay between consecutive requests, as a sibling of `rate`:

```yaml
load:
  type: constant
  stages:
    - interval:
        type: uniform
        min: 1
        max: 10   # each request is sent 1-10s after the previous one
      duration: 60
```

Reusing `Distribution` means `fixed`, `normal`, and `lognormal` intervals come for free.

## Validation

- Standard stages: exactly one of `rate` or `interval` must be set; `interval` is rejected for POISSON (it defines its own arrival process) and TRACE_REPLAY
- Session stages: `session_rate` and `session_interval` are mutually exclusive (omit both for unthrottled dispatch, the existing default)
- Interval distributions require non-negative bounds, and `fixed` intervals require a positive mean (an all-zero gap schedule would never terminate)

## Implementation notes

- New `sample_floats_from_distribution` in `utils/distribution.py`; the shared distribution math is factored into `_sample_continuous` so the existing integer sampler's behavior (including the unsupported-type `ValueError`, now pinned by a test) is unchanged
- Standard stages use a new `IntervalLoadTimer` that precomputes its schedule, so `num_requests` is known up front like `rate * duration`; session stages sample the next gap at dispatch time
- RNGs are seeded from `base_seed + stage_id`, so runs are reproducible
- Synthetic datagen sizing in `main.py` uses an upper-bound estimate (`estimate_max_requests_for_interval`) in place of `rate * duration`
- Docs updated in `docs/config.md` and `docs/otel_trace_replay.md`
