### PR TITLE
is_llm_span: classify by gen_ai.operation.name instead of gen_ai.input.messages presence

### DIFF
--- a/inference_perf/datagen/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/otel_trace_to_replay_graph.py
@@ -463,7 +463,10 @@ def is_llm_span(span: Dict[str, Any], include_errors: bool = False) -> bool:
     """Check if span represents an LLM call."""
     name = span.get("name", "") or ""
     attrs = span.get("attributes") or {}
-    is_llm = name.startswith("chat ") or "gen_ai.input.messages" in attrs
+    # Classify on gen_ai.operation.name (name fallback), not key-presence: a fixed-schema
+    # source can carry an empty gen_ai.input.messages on every span.
+    op = attrs.get("gen_ai.operation.name")
+    is_llm = (op == "chat" or name.startswith("chat ")) and bool(attrs.get("gen_ai.input.messages"))
     if not is_llm:
         return False
     if not include_errors:

--- a/tests/test_otel_trace_to_replay_graph.py
+++ b/tests/test_otel_trace_to_replay_graph.py
@@ -41,6 +41,7 @@ from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_graph,
     build_raw_calls,
     extract_messages,
+    is_llm_span,
     print_graph,
     summarize_graph,
 )
@@ -746,3 +747,29 @@ class TestDeveloperRoleNormalization:
         assert isinstance(msg, ComplexReplayMessage)
         assert msg.message_info["role"] == "system"
         assert normalized_count == 1
+
+
+def test_is_llm_span_uses_operation_name_not_message_key_presence() -> None:
+    """Spans are classified as LLM calls by the OTel ``gen_ai.operation.name``
+    discriminator, not by mere presence of the ``gen_ai.input.messages`` key.
+
+    A fixed-schema source (e.g. a typed columnar export) can carry an empty
+    ``gen_ai.input.messages`` on every span; keying off presence alone would
+    misclassify ``execute_tool`` / ``invoke_agent`` spans as LLM calls.
+    """
+    tool_span = {
+        "name": "execute_tool get_weather",
+        "attributes": {
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.input.messages": None,  # present-but-empty
+        },
+    }
+    chat_span = {
+        "name": "chat gpt-4",
+        "attributes": {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.input.messages": '[{"role": "user", "content": "hi"}]',
+        },
+    }
+    assert is_llm_span(tool_span) is False
+    assert is_llm_span(chat_span) is True


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`is_llm_span` classified a span as an LLM call by the *presence* of the `gen_ai.input.messages` key. The OTel GenAI discriminator for operation type is [`gen_ai.operation.name`](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) (`chat` / `execute_tool` / `invoke_agent` / …), and `gen_ai.input.messages` is a chat-span attribute. A fixed-schema source (e.g. a typed columnar export) can carry an empty `gen_ai.input.messages` on every span, so key-presence misclassifies `execute_tool` / `invoke_agent` spans as LLM calls; they are then skipped at dispatch while their dependents wait, deadlocking the replay (`Stage 0: timeout`, 0 requests dispatched).

This classifies on `gen_ai.operation.name == "chat"` (with a `name` fallback for sources that omit it) and requires message content. Adds a regression test.

#### Which issue(s) this PR fixes:

Fixes #545

#### Special notes for your reviewer:

Repro (also the new regression test):

```python
from inference_perf.datagen.otel_trace_to_replay_graph import is_llm_span

span = {"name": "execute_tool x",
        "attributes": {"gen_ai.operation.name": "execute_tool", "gen_ai.input.messages": None}}
print(is_llm_span(span))   # was True (misclassified); now False
```

Validated locally: `ruff format --check`, `ruff check`, `mypy --strict`, and `pytest tests/test_otel_trace_to_replay_graph.py` (6 passed) all green.

#### Does this PR introduce a user-facing change?

```release-note
Fix an `otel_trace_replay` deadlock where `is_llm_span` misclassified non-chat (`execute_tool`/`invoke_agent`) spans as LLM calls; span classification now uses the `gen_ai.operation.name` discriminator.
```
