### PR TITLE
Add SLOs to workload catalog

### DIFF
--- a/workload-catalog/batch-summarization-rag/config.json
+++ b/workload-catalog/batch-summarization-rag/config.json
@@ -50,7 +50,7 @@
       "ttft_p90_ms": 15000,
       "ttft_p90_ms_justification": "MLPerf Server non-interactive TTFT targets range from 2000 - 6000 ms (see *.Server.ttft_latency fields, ignoring *-interactive.Server.ttft_latency fields at https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). This workload's inputs are large (up to 80,000 tokens) and it runs offline with no user waiting on the first token, so a ceiling of 15s, a few times the largest of those targets, at P90 is comfortably loose.",
       "itl_p95_ms": 150,
-      "itl_p95_ms_justification": "The MLPerf server tier targets 80 - 200 ms per token (see *.Server.tpot_latency fields excluding *-interactive.Server.tpot_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). Because this is an offline batch job, we can be loser in the target.",
+      "itl_p95_ms_justification": "The MLPerf server tier targets 80 - 200 ms per token (see *.Server.tpot_latency fields excluding *-interactive.Server.tpot_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). Because this is an offline batch job, we can be looser in the target.",
       "e2e_p99_ms": 630000,
       "e2e_p99_ms_justification": "A worst-case request is time-to-first-token (15s) plus generation of the maximum 2,000 output tokens at 150 ms each, about 315s of service. Doubling that to allow for time spent waiting behind other jobs on a busy batch server gives the stated value."
     }

--- a/workload-catalog/batch-summarization-rag/config.json
+++ b/workload-catalog/batch-summarization-rag/config.json
@@ -48,8 +48,11 @@
     "prefill_decode_ratio": 30.0,
     "slos": {
       "ttft_p99_ms": 15000,
+      "ttft_p99_ms_justification": "MLPerf v5.0 Server time-to-first-token targets for large models range from 2s (Llama 2 70B) to 6s (Llama 3.1 405B; https://mlcommons.org/2025/04/llm-inference-v5/). This workload's inputs are far larger (up to 80,000 tokens) and it runs offline with no user waiting on the first token, so a ceiling of 15s, a few times the largest of those targets, is comfortably loose.",
       "itl_p99_ms": 100,
-      "e2e_p99_ms": 430000
+      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). Because this is an offline batch job, output is not streamed to a person reading it live, so the tighter interactive target (50ms) is unnecessary.",
+      "e2e_p99_ms": 430000,
+      "e2e_p99_ms_justification": "A worst-case request is time-to-first-token (15s) plus generation of the maximum 2,000 output tokens at 100ms each (200s), about 215s of service. Doubling that to allow for time spent waiting behind other jobs on a busy batch server gives the stated value."
     }
   }
 }

--- a/workload-catalog/batch-summarization-rag/config.json
+++ b/workload-catalog/batch-summarization-rag/config.json
@@ -47,12 +47,12 @@
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading"],
     "prefill_decode_ratio": 30.0,
     "slos": {
-      "ttft_p99_ms": 15000,
-      "ttft_p99_ms_justification": "MLPerf v5.0 Server time-to-first-token targets for large models range from 2s (Llama 2 70B) to 6s (Llama 3.1 405B; https://mlcommons.org/2025/04/llm-inference-v5/). This workload's inputs are far larger (up to 80,000 tokens) and it runs offline with no user waiting on the first token, so a ceiling of 15s, a few times the largest of those targets, is comfortably loose.",
-      "itl_p99_ms": 100,
-      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). Because this is an offline batch job, output is not streamed to a person reading it live, so the tighter interactive target (50ms) is unnecessary.",
-      "e2e_p99_ms": 430000,
-      "e2e_p99_ms_justification": "A worst-case request is time-to-first-token (15s) plus generation of the maximum 2,000 output tokens at 100ms each (200s), about 215s of service. Doubling that to allow for time spent waiting behind other jobs on a busy batch server gives the stated value."
+      "ttft_p90_ms": 15000,
+      "ttft_p90_ms_justification": "MLPerf Server non-interactive TTFT targets range from 2000 - 6000 ms (see *.Server.ttft_latency fields, ignoring *-interactive.Server.ttft_latency fields at https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). This workload's inputs are large (up to 80,000 tokens) and it runs offline with no user waiting on the first token, so a ceiling of 15s, a few times the largest of those targets, at P90 is comfortably loose.",
+      "itl_p95_ms": 150,
+      "itl_p95_ms_justification": "The MLPerf server tier targets 80 - 200 ms per token (see *.Server.tpot_latency fields excluding *-interactive.Server.tpot_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). Because this is an offline batch job, we can be loser in the target.",
+      "e2e_p99_ms": 630000,
+      "e2e_p99_ms_justification": "A worst-case request is time-to-first-token (15s) plus generation of the maximum 2,000 output tokens at 150 ms each, about 315s of service. Doubling that to allow for time spent waiting behind other jobs on a busy batch server gives the stated value."
     }
   }
 }

--- a/workload-catalog/batch-summarization-rag/config.json
+++ b/workload-catalog/batch-summarization-rag/config.json
@@ -45,6 +45,11 @@
   "input_sequence_type_token_ratio": 0.2,
   "metadata": {
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading"],
-    "prefill_decode_ratio": 30.0
+    "prefill_decode_ratio": 30.0,
+    "slos": {
+      "ttft_p99_ms": 15000,
+      "itl_p99_ms": 100,
+      "e2e_p99_ms": 430000
+    }
   }
 }

--- a/workload-catalog/batch-synthetic-data-generation/config.json
+++ b/workload-catalog/batch-synthetic-data-generation/config.json
@@ -45,6 +45,9 @@
   "input_sequence_type_token_ratio": 0.5,
   "metadata": {
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading", "Wide Expert Parallelism", "Fault-tolerant queueing"],
-    "prefill_decode_ratio": 0.125
+    "prefill_decode_ratio": 0.125,
+    "slos": {
+      "e2e_p99_ms": 30000
+    }
   }
 }

--- a/workload-catalog/batch-synthetic-data-generation/config.json
+++ b/workload-catalog/batch-synthetic-data-generation/config.json
@@ -47,8 +47,8 @@
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading", "Wide Expert Parallelism", "Fault-tolerant queueing"],
     "prefill_decode_ratio": 0.125,
     "slos": {
-      "e2e_p99_ms": 1800000,
-      "e2e_p99_ms_justification": "Runaway backstop for an offline job. Worst case is the maximum 8,000 output tokens at 175ms each, the slowest inter-token latency in any MLPerf v5.0 benchmark (Llama 3.1 405B Server; https://mlcommons.org/2025/04/llm-inference-v5/), about 23 min, plus ~30% headroom for queueing and scheduling. Anything beyond 30 min signals a fault rather than normal load."
+      "e2e_p99_ms": 2080000,
+      "e2e_p99_ms_justification": "Runaway backstop for an offline job. Worst case is the maximum 8,000 output tokens at 200 ms each, the slowest inter-token latency in any MLPerf benchmark (https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06), 1600 seconds, plus 30% headroom for queueing and scheduling."
     }
   }
 }

--- a/workload-catalog/batch-synthetic-data-generation/config.json
+++ b/workload-catalog/batch-synthetic-data-generation/config.json
@@ -47,7 +47,8 @@
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading", "Wide Expert Parallelism", "Fault-tolerant queueing"],
     "prefill_decode_ratio": 0.125,
     "slos": {
-      "e2e_p99_ms": 30000
+      "e2e_p99_ms": 1800000,
+      "e2e_p99_ms_justification": "Runaway backstop for an offline job. Worst case is the maximum 8,000 output tokens at 175ms each, the slowest inter-token latency in any MLPerf v5.0 benchmark (Llama 3.1 405B Server; https://mlcommons.org/2025/04/llm-inference-v5/), about 23 min, plus ~30% headroom for queueing and scheduling. Anything beyond 30 min signals a fault rather than normal load."
     }
   }
 }

--- a/workload-catalog/code-generation/config.json
+++ b/workload-catalog/code-generation/config.json
@@ -47,10 +47,10 @@
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading"],
     "prefill_decode_ratio": 376.47,
     "slos": {
-      "ttft_p99_ms": 30000,
-      "ttft_p99_ms_justification": "MLPerf v5.0 Server time-to-first-token targets for large models top out at 6s (Llama 3.1 405B; https://mlcommons.org/2025/04/llm-inference-v5/). This workload loads far larger contexts (up to ~990,000 tokens for repository-scale agentic coding), an expected one-time wait that coding tools cover with a progress indicator rather than interactive typing, so 30s is set as a generous ceiling well above the largest benchmark target.",
+      "ttft_p95_ms": 30000,
+      "ttft_p95_ms_justification": "MLPerf server TTFT targets for large models top out at 6000 ms (llama3_1-405b.Server.ttft_latency = 6000 from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). This workload can load very large contexts (up to 990,000 tokens), an expected one-time wait that coding tools cover with a progress indicator rather than interactive typing, so 30s is set as a generous ceiling in addition to only enforcing at P95.",
       "itl_p99_ms": 100,
-      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). Generated code is reviewed in blocks rather than read as streaming prose, so the tighter 50ms chat target is unnecessary."
+      "itl_p99_ms_justification": "The MLPerf server tier targets 80 - 200 ms per token (see *.Server.tpot_latency fields excluding *-interactive.Server.tpot_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). ML Perf uses 99th percentile tail latencies for server scenarios (https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#3-scenarios)."
     }
   }
 }

--- a/workload-catalog/code-generation/config.json
+++ b/workload-catalog/code-generation/config.json
@@ -48,7 +48,9 @@
     "prefill_decode_ratio": 376.47,
     "slos": {
       "ttft_p99_ms": 30000,
-      "itl_p99_ms": 100
+      "ttft_p99_ms_justification": "MLPerf v5.0 Server time-to-first-token targets for large models top out at 6s (Llama 3.1 405B; https://mlcommons.org/2025/04/llm-inference-v5/). This workload loads far larger contexts (up to ~990,000 tokens for repository-scale agentic coding), an expected one-time wait that coding tools cover with a progress indicator rather than interactive typing, so 30s is set as a generous ceiling well above the largest benchmark target.",
+      "itl_p99_ms": 100,
+      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). Generated code is reviewed in blocks rather than read as streaming prose, so the tighter 50ms chat target is unnecessary."
     }
   }
 }

--- a/workload-catalog/code-generation/config.json
+++ b/workload-catalog/code-generation/config.json
@@ -45,7 +45,11 @@
   "input_sequence_type_token_ratio": 0.03,
   "metadata": {
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading"],
-    "prefill_decode_ratio": 376.47
+    "prefill_decode_ratio": 376.47,
+    "slos": {
+      "ttft_p99_ms": 30000,
+      "itl_p99_ms": 100
+    }
   }
 }
 

--- a/workload-catalog/deep-research/config.json
+++ b/workload-catalog/deep-research/config.json
@@ -45,6 +45,10 @@
   "input_sequence_type_token_ratio": 0.08,
   "metadata": {
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading"],
-    "prefill_decode_ratio": 150.0
+    "prefill_decode_ratio": 150.0,
+    "slos": {
+      "ttft_p99_ms": 10000,
+      "itl_p99_ms": 100
+    }
   }
 }

--- a/workload-catalog/deep-research/config.json
+++ b/workload-catalog/deep-research/config.json
@@ -47,10 +47,10 @@
     "suitable_optimizations": ["Prefix aware routing", "KV cache offloading"],
     "prefill_decode_ratio": 150.0,
     "slos": {
-      "ttft_p99_ms": 10000,
-      "ttft_p99_ms_justification": "Set at the 10-second limit for keeping a user's attention while they wait for a response (Nielsen, https://www.nngroup.com/articles/response-times-3-important-limits/). Research queries are large (inputs up to 150,000 tokens), so first-token latency is higher than interactive chat, but a turn that produces nothing within 10s reads as stalled.",
+      "ttft_p90_ms": 10000,
+      "ttft_p90_ms_justification": "Research queries are large (inputs up to 150,000 tokens), so TTFT is higher than interactive chat and set to P90 for some leeway.",
       "itl_p99_ms": 100,
-      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). Most turns in this loop are consumed by the model itself rather than read by a human, so reading speed does not apply."
+      "itl_p99_ms_justification": "The MLPerf server tier targets 80 - 200 ms per token (see *.Server.tpot_latency fields excluding *-interactive.Server.tpot_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). Most turns in this loop are consumed by the model itself rather than read by a human, so reading speed does not apply. ML Perf uses 99th percentile tail latencies for server scenarios (https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#3-scenarios)."
     }
   }
 }

--- a/workload-catalog/deep-research/config.json
+++ b/workload-catalog/deep-research/config.json
@@ -48,7 +48,9 @@
     "prefill_decode_ratio": 150.0,
     "slos": {
       "ttft_p99_ms": 10000,
-      "itl_p99_ms": 100
+      "ttft_p99_ms_justification": "Set at the 10-second limit for keeping a user's attention while they wait for a response (Nielsen, https://www.nngroup.com/articles/response-times-3-important-limits/). Research queries are large (inputs up to 150,000 tokens), so first-token latency is higher than interactive chat, but a turn that produces nothing within 10s reads as stalled.",
+      "itl_p99_ms": 100,
+      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). Most turns in this loop are consumed by the model itself rather than read by a human, so reading speed does not apply."
     }
   }
 }

--- a/workload-catalog/interactive-chat/config.json
+++ b/workload-catalog/interactive-chat/config.json
@@ -47,10 +47,10 @@
     "suitable_optimizations": ["Prefix aware routing", "P/D disaggregation"],
     "prefill_decode_ratio": 13.3,
     "slos": {
-      "ttft_p99_ms": 500,
-      "ttft_p99_ms_justification": "Taken from the MLPerf v5.0 Interactive target for Llama 3.1 8B (500ms p99 time-to-first-token; https://github.com/mlcommons/inference/blob/master/loadgen/mlperf.conf), and kept under the 1-second limit for a user's train of thought to stay uninterrupted (Nielsen, https://www.nngroup.com/articles/response-times-3-important-limits/).",
+      "ttft_p99_ms": 1000,
+      "ttft_p99_ms_justification": "Keep 99% of requests within the 1-second limit for a user's train of thought to stay uninterrupted (Nielsen, https://www.nngroup.com/articles/response-times-3-important-limits/). The *-interactive.Server.ttft_latency values from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf (last updated 2026-02-06) range from 450 - 4500 ms, so 1 second is the right order of magnitude. ML Perf uses 99th percentile tail latencies for interactive scenarios (https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#3-scenarios).",
       "itl_p99_ms": 50,
-      "itl_p99_ms_justification": "Interactive chat streams output to a human reader, so the per-token rate only needs to outpace reading. MLPerf v5.0 defines an Interactive tier at 30-40ms per token (https://mlcommons.org/2025/04/llm-inference-v5/); 50ms is set just above that, about twice as fast as the ~100ms per token that already exceeds typical reading speed (Databricks, https://www.databricks.com/blog/llm-inference-performance-engineering-best-practices)."
+      "itl_p99_ms_justification": "Interactive chat streams output to a human reader, so the per-token rate should outpace reading. The MLPerf interactive tier targets 15 - 80 ms per token (see *-interactive.Server.tpot_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). ML Perf uses 99th percentile tail latencies for interactive scenarios (https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#3-scenarios). Databricks states 100 ms/token translates to ~450 wpm, faster than a typical reader (https://www.databricks.com/blog/llm-inference-performance-engineering-best-practices). Set P99 to 50 ms to keep the system very responsive and allow it to keep up with a reader skimming the text."
     }
   }
 }

--- a/workload-catalog/interactive-chat/config.json
+++ b/workload-catalog/interactive-chat/config.json
@@ -45,6 +45,10 @@
   "input_sequence_type_token_ratio": 0.35,
   "metadata": {
     "suitable_optimizations": ["Prefix aware routing", "P/D disaggregation"],
-    "prefill_decode_ratio": 13.3
+    "prefill_decode_ratio": 13.3,
+    "slos": {
+      "ttft_p99_ms": 500,
+      "itl_p99_ms": 50
+    }
   }
 }

--- a/workload-catalog/interactive-chat/config.json
+++ b/workload-catalog/interactive-chat/config.json
@@ -48,7 +48,9 @@
     "prefill_decode_ratio": 13.3,
     "slos": {
       "ttft_p99_ms": 500,
-      "itl_p99_ms": 50
+      "ttft_p99_ms_justification": "Taken from the MLPerf v5.0 Interactive target for Llama 3.1 8B (500ms p99 time-to-first-token; https://github.com/mlcommons/inference/blob/master/loadgen/mlperf.conf), and kept under the 1-second limit for a user's train of thought to stay uninterrupted (Nielsen, https://www.nngroup.com/articles/response-times-3-important-limits/).",
+      "itl_p99_ms": 50,
+      "itl_p99_ms_justification": "Interactive chat streams output to a human reader, so the per-token rate only needs to outpace reading. MLPerf v5.0 defines an Interactive tier at 30-40ms per token (https://mlcommons.org/2025/04/llm-inference-v5/); 50ms is set just above that, about twice as fast as the ~100ms per token that already exceeds typical reading speed (Databricks, https://www.databricks.com/blog/llm-inference-performance-engineering-best-practices)."
     }
   }
 }

--- a/workload-catalog/reasoning/config.json
+++ b/workload-catalog/reasoning/config.json
@@ -48,7 +48,9 @@
     "prefill_decode_ratio": 0.125,
     "slos": {
       "ttft_p99_ms": 2000,
-      "itl_p99_ms": 100
+      "ttft_p99_ms_justification": "Taken from the MLPerf v5.0 Server time-to-first-token target (2s; https://mlcommons.org/2025/04/llm-inference-v5/). Inputs here are small (up to 5,000 tokens), so prefill is quick and this target is easily met; the cost of a reasoning request is in its long generation, not first-token latency.",
+      "itl_p99_ms": 100,
+      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). The thinking phase is not shown to the user, so the per-token rate is not bound by reading speed."
     }
   }
 }

--- a/workload-catalog/reasoning/config.json
+++ b/workload-catalog/reasoning/config.json
@@ -45,6 +45,10 @@
   "input_sequence_type_token_ratio": 0.5,
   "metadata": {
     "suitable_optimizations": ["P/D disaggregation"],
-    "prefill_decode_ratio": 0.125
+    "prefill_decode_ratio": 0.125,
+    "slos": {
+      "ttft_p99_ms": 2000,
+      "itl_p99_ms": 100
+    }
   }
 }

--- a/workload-catalog/reasoning/config.json
+++ b/workload-catalog/reasoning/config.json
@@ -48,9 +48,9 @@
     "prefill_decode_ratio": 0.125,
     "slos": {
       "ttft_p99_ms": 2000,
-      "ttft_p99_ms_justification": "Taken from the MLPerf v5.0 Server time-to-first-token target (2s; https://mlcommons.org/2025/04/llm-inference-v5/). Inputs here are small (up to 5,000 tokens), so prefill is quick and this target is easily met; the cost of a reasoning request is in its long generation, not first-token latency.",
+      "ttft_p99_ms_justification": "MLPerf server TTFT targets range from 2000 - 6000 ms (see *.Server.ttft_latency fields excluding *-interactive.Server.ttft_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). Inputs here are small (up to 5,000 tokens), so prefill is quick and this target is easily met; the cost of a reasoning request is in its long generation, not first-token latency, so pick short end of range. ML Perf uses 99th percentile tail latencies for server scenarios (https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#3-scenarios).",
       "itl_p99_ms": 100,
-      "itl_p99_ms_justification": "Taken from the MLPerf v5.0 Server inter-token latency target for Llama 3.1 8B (100ms; https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc). The thinking phase is not shown to the user, so the per-token rate is not bound by reading speed."
+      "itl_p99_ms_justification": "The MLPerf server tier targets 80 - 200 ms per token (see *.Server.tpot_latency fields excluding *-interactive.Server.tpot_latency fields from https://github.com/mlcommons/inference/blob/7a7db59c1183d6482da22fc363c49ad083b79b3e/loadgen/mlperf.conf, last updated 2026-02-06). ML Perf uses 99th percentile tail latencies for server scenarios (https://github.com/mlcommons/inference_policies/blob/master/inference_rules.adoc#3-scenarios). The thinking phase is not shown to a user, so ITL is not bound by reading speed."
     }
   }
 }


### PR DESCRIPTION
This PR adds example SLOs to the metadata section of `config.json` for each of the workloads in the workload catalog. Each SLO includes justification behind it, with some justifications stronger than others.

Having SLOs tied to each of these workloads will be very useful as a starting point for picking SLOs, as well as a fixed comparison for measuring goodput. When multiple SLO targets are given, the assumption is these will be ANDed together (must meet all to achieve goodput).

I'm open to adjusting/adding/removing any of these SLOs, but I wanted to get an initial stake in the ground we can iterate off of. I'm also open to renaming or moving any of these new fields.