### PR TITLE
fix: catch TimeoutError in predecessor wait to prevent session hang

### DIFF
--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -36,6 +36,7 @@ from aiohttp import ClientResponse
 
 from inference_perf.apis import (
     ChatCompletionAPIData,
+    ErrorResponseInfo,
     InferenceInfo,
     LazyLoadInferenceAPIData,
     SessionLifecycleMetric,
@@ -292,6 +293,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 "session_id": session_id,
                 "completion_time": completion_time,
                 "failed": True,
+                "failure_reason": reason,
                 "cancelled_events": cancelled,
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
             }
@@ -316,6 +318,9 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 )
             except EventFailedError:
                 self._fail_and_notify(session_id, "predecessor failed")
+                return
+            except (TimeoutError, Exception) as e:
+                self._fail_and_notify(session_id, f"predecessor wait failed: {type(e).__name__}")
                 return
             logger.debug(f"Event {self.event_id} all predecessors done")
 
@@ -754,6 +759,7 @@ class ReplaySessionState:
     is_active: bool = False
     is_complete: bool = False
     failed: bool = False
+    failure_reason: Optional[str] = None
     cancelled_events: int = 0
     random_string: Optional[str] = None  # Random string for KV-cache invalidation (shared by all events in session)
 
@@ -1037,6 +1043,10 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
         num_events_completed = len(state.completed_events)
         num_events_cancelled = state.cancelled_events if state.failed else 0
 
+        error = None
+        if state.failure_reason:
+            error = ErrorResponseInfo(error_type="SessionReplayError", error_msg=state.failure_reason)
+
         return SessionLifecycleMetric(
             session_id=session_id,
             stage_id=stage_id,
@@ -1047,6 +1057,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             num_events=num_events,
             num_events_completed=num_events_completed,
             num_events_cancelled=num_events_cancelled,
+            error=error,
         )
 
     def activate_session(self, session_id: str) -> None:
@@ -1079,6 +1090,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
 
                     completed_state.is_complete = True
                     completed_state.failed = completion_data.get("failed", False)
+                    completed_state.failure_reason = completion_data.get("failure_reason")
                     completed_state.cancelled_events = completion_data.get("cancelled_events", 0)
                     logger.debug(
                         "Session %s marked complete from queue notification (failed=%s)",

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -319,7 +319,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             except EventFailedError:
                 self._fail_and_notify(session_id, "predecessor failed")
                 return
-            except (TimeoutError, Exception) as e:
+            except (TimeoutError, asyncio.TimeoutError) as e:
                 self._fail_and_notify(session_id, f"predecessor wait failed: {type(e).__name__}")
                 return
             logger.debug(f"Event {self.event_id} all predecessors done")

--- a/inference_perf/metrics/session_collector.py
+++ b/inference_perf/metrics/session_collector.py
@@ -86,5 +86,7 @@ class SessionMetricsCollector:
             inp, out = token_by_session.get(sm.session_id, (0, 0))
             sm.total_input_tokens = inp
             sm.total_output_tokens = out
-            sm.error = error_by_session.get(sm.session_id)
+            request_error = error_by_session.get(sm.session_id)
+            if request_error is not None:
+                sm.error = request_error
             sm.success = (sm.num_events_completed == sm.num_events) and (sm.error is None)

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -831,7 +831,9 @@ class ReportGenerator:
             inp, out = token_by_session.get(sm.session_id, (0, 0))
             sm.total_input_tokens = inp
             sm.total_output_tokens = out
-            sm.error = error_by_session.get(sm.session_id)
+            request_error = error_by_session.get(sm.session_id)
+            if request_error is not None:
+                sm.error = request_error
             sm.success = (sm.num_events_completed == sm.num_events) and (sm.error is None)
 
     def generate_session_reports(

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -18,6 +18,12 @@ from inference_perf.apis import LazyLoadInferenceAPIData
 from inference_perf.apis.completion import CompletionAPIData
 from inference_perf.datagen.random_datagen import RandomDataGenerator
 from inference_perf.datagen.base import LazyLoadDataMixin
+from inference_perf.datagen.replay_graph_session_datagen import (
+    ReplayGraphSessionGeneratorBase,
+    ReplaySession,
+    ReplaySessionState,
+)
+from inference_perf.datagen.replay_graph_types import ReplayGraph
 from inference_perf.config import APIConfig, DataConfig, APIType, TraceFormat, TraceConfig, DataGenType
 
 
@@ -85,3 +91,69 @@ class TestTraceReplay:
 
         finally:
             temp_path.unlink()
+
+
+class TestBuildSessionMetricFailureReason:
+    """Tests that failure_reason is surfaced as an error in SessionLifecycleMetric."""
+
+    def _make_generator(self) -> ReplayGraphSessionGeneratorBase:
+        api_config = APIConfig(type=APIType.Chat)
+        data_config = DataConfig(type=DataGenType.Random)
+        return ReplayGraphSessionGeneratorBase(
+            api_config=api_config,
+            config=data_config,
+            tokenizer=None,
+        )
+
+    def _make_graph(self) -> ReplayGraph:
+        return ReplayGraph(
+            events={"evt_1": Mock()},
+            root_event_ids=["evt_1"],
+            source_file="test_trace.json",
+        )
+
+    def test_failure_reason_produces_error(self) -> None:
+        gen = self._make_generator()
+        graph = self._make_graph()
+
+        gen.sessions = [ReplaySession(session_id="s1", source_id="src", session_index=0, graph=graph)]
+        gen.session_graph_state["s1"] = ReplaySessionState(
+            session_id="s1",
+            graph=graph,
+            ready_events=set(),
+            dispatched_events=set(),
+            completed_events=set(),
+            event_completion_times={},
+            failed=True,
+            failure_reason="predecessor wait failed: TimeoutError",
+            cancelled_events=1,
+        )
+
+        metric = gen.build_session_metric(session_id="s1", stage_id=0, start_time=100.0, end_time=110.0)
+
+        assert metric.error is not None
+        assert metric.error.error_type == "SessionReplayError"
+        assert metric.error.error_msg == "predecessor wait failed: TimeoutError"
+        assert metric.num_events_cancelled == 1
+
+    def test_no_failure_reason_no_error(self) -> None:
+        gen = self._make_generator()
+        graph = self._make_graph()
+
+        gen.sessions = [ReplaySession(session_id="s1", source_id="src", session_index=0, graph=graph)]
+        gen.session_graph_state["s1"] = ReplaySessionState(
+            session_id="s1",
+            graph=graph,
+            ready_events=set(),
+            dispatched_events=set(),
+            completed_events={"evt_1"},
+            event_completion_times={"evt_1": 105.0},
+            failed=False,
+            failure_reason=None,
+        )
+
+        metric = gen.build_session_metric(session_id="s1", stage_id=0, start_time=100.0, end_time=110.0)
+
+        assert metric.error is None
+        assert metric.num_events_completed == 1
+        assert metric.num_events_cancelled == 0


### PR DESCRIPTION
In the Otel replay mechanism, when a predecessor event takes longer than the timeout in `require_async`, a `TimeoutError` is raised but nothing catches it. The session gets stuck, it never notifies the completion queue, never frees its pool slot, and the entire run eventually hangs indefinitely.

**What this PR does:**

- Adds an `except (TimeoutError, Exception)` block in `wait_for_predecessors_and_substitute` that calls `_fail_and_notify`, so timed-out sessions fail gracefully instead of hanging forever

- Propagates the failure reason into session reports so it's clear why a session failed. Without this, the error field in the report would be `null` for timed-out sessions (since no HTTP request was ever made, there's no request-level error to report). To fix the null error in the reports:
  - Added a `failure_reason` field to `ReplaySessionState` that gets populated from `_fail_and_notify` through the completion queue
  - Converts that reason into an `ErrorResponseInfo` when building the `SessionLifecycleMetric`
  - Updated the enrichment logic in `session_collector.py` and `reportgen/base.py` to only overwrite `sm.error` when an actual HTTP request error exists, otherwise the session-level error (e.g. "predecessor wait failed: TimeoutError") is preserved

**How I tested:**

- Lowered the timeout to 10s and commented out the fix, confirmed the run hangs indefinitely
- Re-enabled the fix, run completes normally, failed sessions show up in the report with a clear error message
- All checks pass (`pdm check`, `pdm run validate`, `pdm test`, `pdm check:cov`)

Fixes #551