### PR TITLE
Skip code coverage check on markdown-only changes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - main
       - 'feature/**'
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   format-check:


### PR DESCRIPTION
Fixes #556 — the coverage CI job ran (and failed) on PRs that only touched .md files. Add paths-ignore for **/*.md on both push and pull_request triggers so the job is skipped entirely when no code files changed.