### PR TITLE
Add per_request_fields to control raw fields in per-request lifecycle report

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -241,6 +241,10 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--report.request_lifecycle.summary` | boolean | Matches report.request_lifecycle.summary in config |
 | `--report.request_lifecycle.per_stage` | boolean | Matches report.request_lifecycle.per_stage in config |
 | `--report.request_lifecycle.per_request` | boolean | Matches report.request_lifecycle.per_request in config |
+| `--report.request_lifecycle.per_request_fields.request` | boolean | Matches report.request_lifecycle.per_request_fields.request in config |
+| `--report.request_lifecycle.per_request_fields.response` | boolean | Matches report.request_lifecycle.per_request_fields.response in config |
+| `--report.request_lifecycle.per_request_fields.info` | boolean | Matches report.request_lifecycle.per_request_fields.info in config |
+| `--report.request_lifecycle.per_request_fields.response_chunks` | boolean | Matches report.request_lifecycle.per_request_fields.response_chunks in config |
 | `--report.request_lifecycle.per_adapter` | boolean | Matches report.request_lifecycle.per_adapter in config |
 | `--report.request_lifecycle.per_adapter_stage` | boolean | Matches report.request_lifecycle.per_adapter_stage in config |
 | `--report.request_lifecycle.percentiles` | JSON | Matches report.request_lifecycle.percentiles in config |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -245,6 +245,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--report.request_lifecycle.per_request_fields.response` | boolean | Matches report.request_lifecycle.per_request_fields.response in config |
 | `--report.request_lifecycle.per_request_fields.info` | boolean | Matches report.request_lifecycle.per_request_fields.info in config |
 | `--report.request_lifecycle.per_request_fields.response_chunks` | boolean | Matches report.request_lifecycle.per_request_fields.response_chunks in config |
+| `--report.request_lifecycle.per_request_fields.computed_metrics` | boolean | Matches report.request_lifecycle.per_request_fields.computed_metrics in config |
 | `--report.request_lifecycle.per_adapter` | boolean | Matches report.request_lifecycle.per_adapter in config |
 | `--report.request_lifecycle.per_adapter_stage` | boolean | Matches report.request_lifecycle.per_adapter_stage in config |
 | `--report.request_lifecycle.percentiles` | JSON | Matches report.request_lifecycle.percentiles in config |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -82,7 +82,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--data.shared_prefix.multimodal.video.count.skew` | float | Skewness of the distribution. Only used when type is 'skew_normal'. |
 | `--data.shared_prefix.multimodal.video.insertion_point` | string | Placement of media within the text prompt. Float in range [0.0, 1.0] (0=start, 1=end), or a Distribution to sample from. |
 | `--data.shared_prefix.multimodal.video.profiles` | JSON | Video profile or list of weighted video profiles for generated videos. |
-| `--data.shared_prefix.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` Ã— ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
+| `--data.shared_prefix.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` ¡¿ ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
 | `--data.shared_prefix.multimodal.audio.count.min` | int | Smallest value the distribution can produce; samples below are clamped. |
 | `--data.shared_prefix.multimodal.audio.count.max` | int | Largest value the distribution can produce; samples above are clamped. |
 | `--data.shared_prefix.multimodal.audio.count.mean` | float | Mean of the distribution. |
@@ -114,7 +114,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--data.multimodal.video.count.skew` | float | Skewness of the distribution. Only used when type is 'skew_normal'. |
 | `--data.multimodal.video.insertion_point` | string | Placement of media within the text prompt. Float in range [0.0, 1.0] (0=start, 1=end), or a Distribution to sample from. |
 | `--data.multimodal.video.profiles` | JSON | Video profile or list of weighted video profiles for generated videos. |
-| `--data.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` Ã— ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
+| `--data.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` ¡¿ ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
 | `--data.multimodal.audio.count.min` | int | Smallest value the distribution can produce; samples below are clamped. |
 | `--data.multimodal.audio.count.max` | int | Largest value the distribution can produce; samples above are clamped. |
 | `--data.multimodal.audio.count.mean` | float | Mean of the distribution. |
@@ -359,6 +359,11 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--report.request_lifecycle.summary` | boolean | Generate a summary report across the whole run. |
 | `--report.request_lifecycle.per_stage` | boolean | Generate a report for each load stage. |
 | `--report.request_lifecycle.per_request` | boolean | Generate a report with per-request details. |
+| `--report.request_lifecycle.per_request_fields.request` | boolean | Include the raw request payload in per-request report entries. |
+| `--report.request_lifecycle.per_request_fields.response` | boolean | Include the raw response payload in per-request report entries. |
+| `--report.request_lifecycle.per_request_fields.info` | boolean | Include response metadata in per-request report entries. |
+| `--report.request_lifecycle.per_request_fields.response_chunks` | boolean | Include streamed response chunks in per-request metadata. |
+| `--report.request_lifecycle.per_request_fields.computed_metrics` | boolean | Include computed per-request latency and token metrics in report entries. |
 | `--report.request_lifecycle.per_adapter` | boolean | Generate a report for each LoRA adapter. |
 | `--report.request_lifecycle.per_adapter_stage` | boolean | Generate a report for each LoRA adapter within each load stage. |
 | `--report.request_lifecycle.percentiles` | JSON | Percentiles reported for each metric. |
@@ -392,66 +397,3 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--tokenizer.trust_remote_code` | boolean | Allow the tokenizer to execute code from its repository when loading. |
 | `--tokenizer.token` | str | HuggingFace access token used to download the tokenizer. |
 | `--circuit_breakers` | JSON | Circuit breakers that stop the run when observed metrics cross configured thresholds. |
-| `--load.type` | Enum (constant, poisson, trace_replay, concurrent, trace_session_replay) | Matches load.type in config |
-| `--load.interval` | float | Matches load.interval in config |
-| `--load.stages` | JSON | Matches load.stages in config |
-| `--load.sweep.type` | Enum (geometric, linear) | Matches load.sweep.type in config |
-| `--load.sweep.num_requests` | int | Matches load.sweep.num_requests in config |
-| `--load.sweep.timeout` | float | Matches load.sweep.timeout in config |
-| `--load.sweep.num_stages` | int | Matches load.sweep.num_stages in config |
-| `--load.sweep.stage_duration` | int | Matches load.sweep.stage_duration in config |
-| `--load.sweep.saturation_percentile` | float | Matches load.sweep.saturation_percentile in config |
-| `--load.num_workers` | int | Matches load.num_workers in config |
-| `--load.worker_max_concurrency` | int | Matches load.worker_max_concurrency in config |
-| `--load.worker_max_tcp_connections` | int | Matches load.worker_max_tcp_connections in config |
-| `--load.trace.file` | str | Matches load.trace.file in config |
-| `--load.trace.format` | Enum (AzurePublicDataset) | Matches load.trace.format in config |
-| `--load.circuit_breakers` | JSON | Matches load.circuit_breakers in config |
-| `--load.request_timeout` | float | Matches load.request_timeout in config |
-| `--load.lora_traffic_split` | JSON | Matches load.lora_traffic_split in config |
-| `--load.base_seed` | int | Matches load.base_seed in config |
-| `--metrics.type` | Enum (prometheus, default) | Matches metrics.type in config |
-| `--metrics.prometheus.scrape_interval` | int | Matches metrics.prometheus.scrape_interval in config |
-| `--metrics.prometheus.url` | string | Matches metrics.prometheus.url in config |
-| `--metrics.prometheus.filters` | JSON | Matches metrics.prometheus.filters in config |
-| `--metrics.prometheus.google_managed` | boolean | Matches metrics.prometheus.google_managed in config |
-| `--report.request_lifecycle.summary` | boolean | Matches report.request_lifecycle.summary in config |
-| `--report.request_lifecycle.per_stage` | boolean | Matches report.request_lifecycle.per_stage in config |
-| `--report.request_lifecycle.per_request` | boolean | Matches report.request_lifecycle.per_request in config |
-| `--report.request_lifecycle.per_request_fields.request` | boolean | Matches report.request_lifecycle.per_request_fields.request in config |
-| `--report.request_lifecycle.per_request_fields.response` | boolean | Matches report.request_lifecycle.per_request_fields.response in config |
-| `--report.request_lifecycle.per_request_fields.info` | boolean | Matches report.request_lifecycle.per_request_fields.info in config |
-| `--report.request_lifecycle.per_request_fields.response_chunks` | boolean | Matches report.request_lifecycle.per_request_fields.response_chunks in config |
-| `--report.request_lifecycle.per_request_fields.computed_metrics` | boolean | Matches report.request_lifecycle.per_request_fields.computed_metrics in config |
-| `--report.request_lifecycle.per_adapter` | boolean | Matches report.request_lifecycle.per_adapter in config |
-| `--report.request_lifecycle.per_adapter_stage` | boolean | Matches report.request_lifecycle.per_adapter_stage in config |
-| `--report.request_lifecycle.percentiles` | JSON | Matches report.request_lifecycle.percentiles in config |
-| `--report.request_lifecycle.use_server_output_tokens` | boolean | Matches report.request_lifecycle.use_server_output_tokens in config |
-| `--report.prometheus.summary` | boolean | Matches report.prometheus.summary in config |
-| `--report.prometheus.per_stage` | boolean | Matches report.prometheus.per_stage in config |
-| `--report.session_lifecycle.summary` | boolean | Matches report.session_lifecycle.summary in config |
-| `--report.session_lifecycle.per_stage` | boolean | Matches report.session_lifecycle.per_stage in config |
-| `--report.session_lifecycle.per_session` | boolean | Matches report.session_lifecycle.per_session in config |
-| `--report.goodput.constraints` | JSON | Matches report.goodput.constraints in config |
-| `--storage.local_storage.path` | str | Matches storage.local_storage.path in config |
-| `--storage.local_storage.report_file_prefix` | str | Matches storage.local_storage.report_file_prefix in config |
-| `--storage.google_cloud_storage.path` | str | Matches storage.google_cloud_storage.path in config |
-| `--storage.google_cloud_storage.report_file_prefix` | str | Matches storage.google_cloud_storage.report_file_prefix in config |
-| `--storage.google_cloud_storage.bucket_name` | str | Matches storage.google_cloud_storage.bucket_name in config |
-| `--storage.simple_storage_service.path` | str | Matches storage.simple_storage_service.path in config |
-| `--storage.simple_storage_service.report_file_prefix` | str | Matches storage.simple_storage_service.report_file_prefix in config |
-| `--storage.simple_storage_service.bucket_name` | str | Matches storage.simple_storage_service.bucket_name in config |
-| `--storage.simple_storage_service.endpoint_url` | str | Matches storage.simple_storage_service.endpoint_url in config |
-| `--storage.simple_storage_service.region_name` | str | Matches storage.simple_storage_service.region_name in config |
-| `--storage.simple_storage_service.addressing_style` | string | Matches storage.simple_storage_service.addressing_style in config |
-| `--server.type` | Enum (vllm, sglang, tgi, mock) | Matches server.type in config |
-| `--server.model_name` | str | Matches server.model_name in config |
-| `--server.base_url` | str | Matches server.base_url in config |
-| `--server.ignore_eos` | boolean | Matches server.ignore_eos in config |
-| `--server.api_key` | str | Matches server.api_key in config |
-| `--server.cert_path` | str | Matches server.cert_path in config |
-| `--server.key_path` | str | Matches server.key_path in config |
-| `--tokenizer.pretrained_model_name_or_path` | str | Matches tokenizer.pretrained_model_name_or_path in config |
-| `--tokenizer.trust_remote_code` | boolean | Matches tokenizer.trust_remote_code in config |
-| `--tokenizer.token` | str | Matches tokenizer.token in config |
-| `--circuit_breakers` | JSON | Matches circuit_breakers in config |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -392,3 +392,65 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--tokenizer.trust_remote_code` | boolean | Allow the tokenizer to execute code from its repository when loading. |
 | `--tokenizer.token` | str | HuggingFace access token used to download the tokenizer. |
 | `--circuit_breakers` | JSON | Circuit breakers that stop the run when observed metrics cross configured thresholds. |
+| `--load.type` | Enum (constant, poisson, trace_replay, concurrent, trace_session_replay) | Matches load.type in config |
+| `--load.interval` | float | Matches load.interval in config |
+| `--load.stages` | JSON | Matches load.stages in config |
+| `--load.sweep.type` | Enum (geometric, linear) | Matches load.sweep.type in config |
+| `--load.sweep.num_requests` | int | Matches load.sweep.num_requests in config |
+| `--load.sweep.timeout` | float | Matches load.sweep.timeout in config |
+| `--load.sweep.num_stages` | int | Matches load.sweep.num_stages in config |
+| `--load.sweep.stage_duration` | int | Matches load.sweep.stage_duration in config |
+| `--load.sweep.saturation_percentile` | float | Matches load.sweep.saturation_percentile in config |
+| `--load.num_workers` | int | Matches load.num_workers in config |
+| `--load.worker_max_concurrency` | int | Matches load.worker_max_concurrency in config |
+| `--load.worker_max_tcp_connections` | int | Matches load.worker_max_tcp_connections in config |
+| `--load.trace.file` | str | Matches load.trace.file in config |
+| `--load.trace.format` | Enum (AzurePublicDataset) | Matches load.trace.format in config |
+| `--load.circuit_breakers` | JSON | Matches load.circuit_breakers in config |
+| `--load.request_timeout` | float | Matches load.request_timeout in config |
+| `--load.lora_traffic_split` | JSON | Matches load.lora_traffic_split in config |
+| `--load.base_seed` | int | Matches load.base_seed in config |
+| `--metrics.type` | Enum (prometheus, default) | Matches metrics.type in config |
+| `--metrics.prometheus.scrape_interval` | int | Matches metrics.prometheus.scrape_interval in config |
+| `--metrics.prometheus.url` | string | Matches metrics.prometheus.url in config |
+| `--metrics.prometheus.filters` | JSON | Matches metrics.prometheus.filters in config |
+| `--metrics.prometheus.google_managed` | boolean | Matches metrics.prometheus.google_managed in config |
+| `--report.request_lifecycle.summary` | boolean | Matches report.request_lifecycle.summary in config |
+| `--report.request_lifecycle.per_stage` | boolean | Matches report.request_lifecycle.per_stage in config |
+| `--report.request_lifecycle.per_request` | boolean | Matches report.request_lifecycle.per_request in config |
+| `--report.request_lifecycle.per_request_fields.request` | boolean | Matches report.request_lifecycle.per_request_fields.request in config |
+| `--report.request_lifecycle.per_request_fields.response` | boolean | Matches report.request_lifecycle.per_request_fields.response in config |
+| `--report.request_lifecycle.per_request_fields.info` | boolean | Matches report.request_lifecycle.per_request_fields.info in config |
+| `--report.request_lifecycle.per_request_fields.response_chunks` | boolean | Matches report.request_lifecycle.per_request_fields.response_chunks in config |
+| `--report.request_lifecycle.per_adapter` | boolean | Matches report.request_lifecycle.per_adapter in config |
+| `--report.request_lifecycle.per_adapter_stage` | boolean | Matches report.request_lifecycle.per_adapter_stage in config |
+| `--report.request_lifecycle.percentiles` | JSON | Matches report.request_lifecycle.percentiles in config |
+| `--report.request_lifecycle.use_server_output_tokens` | boolean | Matches report.request_lifecycle.use_server_output_tokens in config |
+| `--report.prometheus.summary` | boolean | Matches report.prometheus.summary in config |
+| `--report.prometheus.per_stage` | boolean | Matches report.prometheus.per_stage in config |
+| `--report.session_lifecycle.summary` | boolean | Matches report.session_lifecycle.summary in config |
+| `--report.session_lifecycle.per_stage` | boolean | Matches report.session_lifecycle.per_stage in config |
+| `--report.session_lifecycle.per_session` | boolean | Matches report.session_lifecycle.per_session in config |
+| `--report.goodput.constraints` | JSON | Matches report.goodput.constraints in config |
+| `--storage.local_storage.path` | str | Matches storage.local_storage.path in config |
+| `--storage.local_storage.report_file_prefix` | str | Matches storage.local_storage.report_file_prefix in config |
+| `--storage.google_cloud_storage.path` | str | Matches storage.google_cloud_storage.path in config |
+| `--storage.google_cloud_storage.report_file_prefix` | str | Matches storage.google_cloud_storage.report_file_prefix in config |
+| `--storage.google_cloud_storage.bucket_name` | str | Matches storage.google_cloud_storage.bucket_name in config |
+| `--storage.simple_storage_service.path` | str | Matches storage.simple_storage_service.path in config |
+| `--storage.simple_storage_service.report_file_prefix` | str | Matches storage.simple_storage_service.report_file_prefix in config |
+| `--storage.simple_storage_service.bucket_name` | str | Matches storage.simple_storage_service.bucket_name in config |
+| `--storage.simple_storage_service.endpoint_url` | str | Matches storage.simple_storage_service.endpoint_url in config |
+| `--storage.simple_storage_service.region_name` | str | Matches storage.simple_storage_service.region_name in config |
+| `--storage.simple_storage_service.addressing_style` | string | Matches storage.simple_storage_service.addressing_style in config |
+| `--server.type` | Enum (vllm, sglang, tgi, mock) | Matches server.type in config |
+| `--server.model_name` | str | Matches server.model_name in config |
+| `--server.base_url` | str | Matches server.base_url in config |
+| `--server.ignore_eos` | boolean | Matches server.ignore_eos in config |
+| `--server.api_key` | str | Matches server.api_key in config |
+| `--server.cert_path` | str | Matches server.cert_path in config |
+| `--server.key_path` | str | Matches server.key_path in config |
+| `--tokenizer.pretrained_model_name_or_path` | str | Matches tokenizer.pretrained_model_name_or_path in config |
+| `--tokenizer.trust_remote_code` | boolean | Matches tokenizer.trust_remote_code in config |
+| `--tokenizer.token` | str | Matches tokenizer.token in config |
+| `--circuit_breakers` | JSON | Matches circuit_breakers in config |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -422,6 +422,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--report.request_lifecycle.per_request_fields.response` | boolean | Matches report.request_lifecycle.per_request_fields.response in config |
 | `--report.request_lifecycle.per_request_fields.info` | boolean | Matches report.request_lifecycle.per_request_fields.info in config |
 | `--report.request_lifecycle.per_request_fields.response_chunks` | boolean | Matches report.request_lifecycle.per_request_fields.response_chunks in config |
+| `--report.request_lifecycle.per_request_fields.computed_metrics` | boolean | Matches report.request_lifecycle.per_request_fields.computed_metrics in config |
 | `--report.request_lifecycle.per_adapter` | boolean | Matches report.request_lifecycle.per_adapter in config |
 | `--report.request_lifecycle.per_adapter_stage` | boolean | Matches report.request_lifecycle.per_adapter_stage in config |
 | `--report.request_lifecycle.percentiles` | JSON | Matches report.request_lifecycle.percentiles in config |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -82,7 +82,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--data.shared_prefix.multimodal.video.count.skew` | float | Skewness of the distribution. Only used when type is 'skew_normal'. |
 | `--data.shared_prefix.multimodal.video.insertion_point` | string | Placement of media within the text prompt. Float in range [0.0, 1.0] (0=start, 1=end), or a Distribution to sample from. |
 | `--data.shared_prefix.multimodal.video.profiles` | JSON | Video profile or list of weighted video profiles for generated videos. |
-| `--data.shared_prefix.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` ¡¿ ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
+| `--data.shared_prefix.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` Ã— ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
 | `--data.shared_prefix.multimodal.audio.count.min` | int | Smallest value the distribution can produce; samples below are clamped. |
 | `--data.shared_prefix.multimodal.audio.count.max` | int | Largest value the distribution can produce; samples above are clamped. |
 | `--data.shared_prefix.multimodal.audio.count.mean` | float | Mean of the distribution. |
@@ -114,7 +114,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--data.multimodal.video.count.skew` | float | Skewness of the distribution. Only used when type is 'skew_normal'. |
 | `--data.multimodal.video.insertion_point` | string | Placement of media within the text prompt. Float in range [0.0, 1.0] (0=start, 1=end), or a Distribution to sample from. |
 | `--data.multimodal.video.profiles` | JSON | Video profile or list of weighted video profiles for generated videos. |
-| `--data.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` ¡¿ ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
+| `--data.multimodal.video.representation` | Enum (mp4, png_frames, jpeg_frames) | Wire-format strategy. ``mp4`` sends one ``video_url`` block carrying an MP4 blob (measures full pipeline including server-side decode). ``png_frames`` and ``jpeg_frames`` send ``frames`` Ã— ``image_url`` blocks at one insertion point in the named encoding (no decode dependency, useful for prefix-cache benchmarks and servers that don't accept ``video_url``). |
 | `--data.multimodal.audio.count.min` | int | Smallest value the distribution can produce; samples below are clamped. |
 | `--data.multimodal.audio.count.max` | int | Largest value the distribution can produce; samples above are clamped. |
 | `--data.multimodal.audio.count.mean` | float | Mean of the distribution. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -244,6 +244,11 @@ report:
     summary: true             # Generate high-level summary
     per_stage: true           # Include breakdown by load stage
     per_request: false        # Enable detailed per-request logs (verbose)
+    per_request_fields:       # Control fields included in per_request_lifecycle_metrics.json
+      request: true           # Include raw request payloads
+      response: true          # Include raw response payloads
+      info: true              # Include structured request/response metadata
+      response_chunks: true   # Include raw streaming chunks inside info.response_metrics
     per_adapter: false        # Generate metrics grouped by LoRA adapter
     per_adapter_stage: false  # Generate metrics grouped by adapter and stage
     percentiles: [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9] # List of percentiles to calculate
@@ -252,6 +257,24 @@ report:
     summary: true             # Include Prometheus metrics summary
     per_stage: false          # Disable Prometheus stage breakdown
 ```
+
+For smaller per-request reports that preserve structured timing data such as
+`output_token_times`, disable raw request/response payloads and streaming chunks
+while keeping `info` enabled:
+
+```yaml
+report:
+  request_lifecycle:
+    per_request: true
+    per_request_fields:
+      request: false
+      response: false
+      info: true
+      response_chunks: false
+```
+
+Setting `info: false` removes the entire `info` block, including
+`response_chunks`; in that case `response_chunks` has no effect.
 
 ### Storage
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -249,6 +249,7 @@ report:
       response: true          # Include raw response payloads
       info: true              # Include structured request/response metadata
       response_chunks: true   # Include raw streaming chunks inside info.response_metrics
+      computed_metrics: false # Include computed per-request latency metrics (TTFT/TPOT/ITL/...)
     per_adapter: false        # Generate metrics grouped by LoRA adapter
     per_adapter_stage: false  # Generate metrics grouped by adapter and stage
     percentiles: [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9] # List of percentiles to calculate
@@ -258,9 +259,9 @@ report:
     per_stage: false          # Disable Prometheus stage breakdown
 ```
 
-For smaller per-request reports that preserve structured timing data such as
-`output_token_times`, disable raw request/response payloads and streaming chunks
-while keeping `info` enabled:
+For metrics-only per-request reports, disable the raw fields and enable
+`computed_metrics` instead — this removes the multi-GB raw payloads while
+keeping full per-request latency analysis:
 
 ```yaml
 report:
@@ -269,12 +270,23 @@ report:
     per_request_fields:
       request: false
       response: false
-      info: true
+      info: false
       response_chunks: false
+      computed_metrics: true
 ```
 
 Setting `info: false` removes the entire `info` block, including
 `response_chunks`; in that case `response_chunks` has no effect.
+
+`computed_metrics` (off by default) adds a `computed_metrics` block to each
+successful entry with `request_latency`, `normalized_time_per_output_token`,
+`time_to_first_token`, `time_per_output_token`, `inter_token_latency` (mean),
+`inter_token_latencies` (per-token deltas), `input_tokens`, `output_tokens`,
+and the request's `ttft_slo_sec`/`tpot_slo_sec` SLOs — the same values (and
+the same tokenizer-based correction from raw streaming chunks) used to compute
+the `summary_lifecycle_metrics.json` / `stage_*_lifecycle_metrics.json`
+aggregates. Non-streamed or non-streamable requests report `null` for
+`time_to_first_token`, `time_per_output_token`, and `inter_token_latency`.
 
 ### Storage
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -249,6 +249,7 @@ report:
       response: true          # Include raw response payloads
       info: true              # Include structured request/response metadata
       response_chunks: true   # Include raw streaming chunks inside info.response_metrics
+      computed_metrics: false # Include computed per-request latency metrics (TTFT/TPOT/ITL/...)
     per_adapter: false        # Generate metrics grouped by LoRA adapter
     per_adapter_stage: false  # Generate metrics grouped by adapter and stage
     percentiles: [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9] # List of percentiles to calculate
@@ -260,9 +261,9 @@ report:
     per_stage: false          # Disable Prometheus stage breakdown
 ```
 
-For smaller per-request reports that preserve structured timing data such as
-`output_token_times`, disable raw request/response payloads and streaming chunks
-while keeping `info` enabled:
+For metrics-only per-request reports, disable the raw fields and enable
+`computed_metrics` instead — this removes the multi-GB raw payloads while
+keeping full per-request latency analysis:
 
 ```yaml
 report:
@@ -271,12 +272,23 @@ report:
     per_request_fields:
       request: false
       response: false
-      info: true
+      info: false
       response_chunks: false
+      computed_metrics: true
 ```
 
 Setting `info: false` removes the entire `info` block, including
 `response_chunks`; in that case `response_chunks` has no effect.
+
+`computed_metrics` (off by default) adds a `computed_metrics` block to each
+successful entry with `request_latency`, `normalized_time_per_output_token`,
+`time_to_first_token`, `time_per_output_token`, `inter_token_latency` (mean),
+`inter_token_latencies` (per-token deltas), `input_tokens`, `output_tokens`,
+and the request's `ttft_slo_sec`/`tpot_slo_sec` SLOs — the same values (and
+the same tokenizer-based correction from raw streaming chunks) used to compute
+the `summary_lifecycle_metrics.json` / `stage_*_lifecycle_metrics.json`
+aggregates. Non-streamed or non-streamable requests report `null` for
+`time_to_first_token`, `time_per_output_token`, and `inter_token_latency`.
 
 ### Storage
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -244,6 +244,11 @@ report:
     summary: true             # Generate high-level summary
     per_stage: true           # Include breakdown by load stage
     per_request: false        # Enable detailed per-request logs (verbose)
+    per_request_fields:       # Control fields included in per_request_lifecycle_metrics.json
+      request: true           # Include raw request payloads
+      response: true          # Include raw response payloads
+      info: true              # Include structured request/response metadata
+      response_chunks: true   # Include raw streaming chunks inside info.response_metrics
     per_adapter: false        # Generate metrics grouped by LoRA adapter
     per_adapter_stage: false  # Generate metrics grouped by adapter and stage
     percentiles: [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9] # List of percentiles to calculate
@@ -254,6 +259,24 @@ report:
     summary: true             # Include Prometheus metrics summary
     per_stage: false          # Disable Prometheus stage breakdown
 ```
+
+For smaller per-request reports that preserve structured timing data such as
+`output_token_times`, disable raw request/response payloads and streaming chunks
+while keeping `info` enabled:
+
+```yaml
+report:
+  request_lifecycle:
+    per_request: true
+    per_request_fields:
+      request: false
+      response: false
+      info: true
+      response_chunks: false
+```
+
+Setting `info: false` removes the entire `info` block, including
+`response_chunks`; in that case `response_chunks` has no effect.
 
 ### Storage
 

--- a/inference_perf/config/__init__.py
+++ b/inference_perf/config/__init__.py
@@ -70,6 +70,7 @@ from inference_perf.config.metrics import (
 )
 from inference_perf.config.reportgen import (
     GoodputConfig,
+    PerRequestFieldsConfig,
     PrometheusMetricsReportConfig,
     ReportConfig,
     RequestLifecycleMetricsReportConfig,
@@ -103,6 +104,7 @@ __all__ = [
     "ModelServerType",
     "MultiLoRAConfig",
     "OTelTraceReplayConfig",
+    "PerRequestFieldsConfig",
     "PrometheusClientConfig",
     "PrometheusMetricsReportConfig",
     "ReportConfig",

--- a/inference_perf/config/__init__.py
+++ b/inference_perf/config/__init__.py
@@ -78,6 +78,7 @@ from inference_perf.config.metrics import (
 )
 from inference_perf.config.reportgen import (
     GoodputConfig,
+    PerRequestFieldsConfig,
     PrometheusMetricsReportConfig,
     ReportConfig,
     RequestLifecycleMetricsReportConfig,
@@ -113,6 +114,7 @@ __all__ = [
     "ModelServerType",
     "MultiLoRAConfig",
     "OTelTraceReplayConfig",
+    "PerRequestFieldsConfig",
     "PrometheusClientConfig",
     "PrometheusMetricsReportConfig",
     "ReportConfig",

--- a/inference_perf/config/config.py
+++ b/inference_perf/config/config.py
@@ -62,9 +62,7 @@ class Config(StrictBaseModel):
     @model_validator(mode="after")
     def synthetic_agentic_not_yet_available(self) -> "Config":
         if self.data.type == DataGenType.SyntheticAgentic:
-            raise ValueError(
-                "synthetic_agentic is not yet available and will be enabled in a future release."
-            )
+            raise ValueError("synthetic_agentic is not yet available and will be enabled in a future release.")
         return self
 
     @model_validator(mode="after")

--- a/inference_perf/config/reportgen/__init__.py
+++ b/inference_perf/config/reportgen/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from inference_perf.config.reportgen.config import (
     GoodputConfig,
+    PerRequestFieldsConfig,
     PrometheusMetricsReportConfig,
     ReportConfig,
     RequestLifecycleMetricsReportConfig,
@@ -21,6 +22,7 @@ from inference_perf.config.reportgen.config import (
 
 __all__ = [
     "GoodputConfig",
+    "PerRequestFieldsConfig",
     "PrometheusMetricsReportConfig",
     "ReportConfig",
     "RequestLifecycleMetricsReportConfig",

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -13,13 +13,21 @@
 # limitations under the License.
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class PerRequestFieldsConfig(BaseModel):
+    request: bool = True
+    response: bool = True
+    info: bool = True
+    response_chunks: bool = True
 
 
 class RequestLifecycleMetricsReportConfig(BaseModel):
     summary: Optional[bool] = True
     per_stage: Optional[bool] = True
     per_request: Optional[bool] = False
+    per_request_fields: PerRequestFieldsConfig = Field(default_factory=PerRequestFieldsConfig)
     per_adapter: Optional[bool] = True
     per_adapter_stage: Optional[bool] = False
     percentiles: List[float] = [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9]

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -21,6 +21,7 @@ class PerRequestFieldsConfig(BaseModel):
     response: bool = True
     info: bool = True
     response_chunks: bool = True
+    computed_metrics: bool = False
 
 
 class RequestLifecycleMetricsReportConfig(BaseModel):

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -18,18 +18,22 @@ from pydantic import Field
 
 
 class PerRequestFieldsConfig(StrictBaseModel):
-    request: bool = True
-    response: bool = True
-    info: bool = True
-    response_chunks: bool = True
-    computed_metrics: bool = False
+    request: bool = Field(default=True, description="Include the raw request payload in per-request report entries.")
+    response: bool = Field(default=True, description="Include the raw response payload in per-request report entries.")
+    info: bool = Field(default=True, description="Include response metadata in per-request report entries.")
+    response_chunks: bool = Field(default=True, description="Include streamed response chunks in per-request metadata.")
+    computed_metrics: bool = Field(
+        default=False, description="Include computed per-request latency and token metrics in report entries."
+    )
 
 
 class RequestLifecycleMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = Field(default=True, description="Generate a summary report across the whole run.")
     per_stage: Optional[bool] = Field(default=True, description="Generate a report for each load stage.")
     per_request: Optional[bool] = Field(default=False, description="Generate a report with per-request details.")
-    per_request_fields: PerRequestFieldsConfig = Field(default_factory=PerRequestFieldsConfig)
+    per_request_fields: PerRequestFieldsConfig = Field(
+        default_factory=PerRequestFieldsConfig, description="Select raw and computed fields included in per-request entries."
+    )
     per_adapter: Optional[bool] = Field(default=True, description="Generate a report for each LoRA adapter.")
     per_adapter_stage: Optional[bool] = Field(
         default=False, description="Generate a report for each LoRA adapter within each load stage."
@@ -46,6 +50,8 @@ class RequestLifecycleMetricsReportConfig(StrictBaseModel):
         description="Cap on the number of distinct example error messages retained per error label in the failure "
         "report, and per substitution entry.",
     )
+
+
 class PrometheusMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = Field(default=True, description="Generate a summary report across the whole run.")
     per_stage: Optional[bool] = Field(default=False, description="Generate a report for each load stage.")

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -22,6 +22,7 @@ class PerRequestFieldsConfig(StrictBaseModel):
     response: bool = True
     info: bool = True
     response_chunks: bool = True
+    computed_metrics: bool = False
 
 
 class RequestLifecycleMetricsReportConfig(StrictBaseModel):

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -17,10 +17,18 @@ from inference_perf.config.common import StrictBaseModel
 from pydantic import Field
 
 
+class PerRequestFieldsConfig(StrictBaseModel):
+    request: bool = True
+    response: bool = True
+    info: bool = True
+    response_chunks: bool = True
+
+
 class RequestLifecycleMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = Field(default=True, description="Generate a summary report across the whole run.")
     per_stage: Optional[bool] = Field(default=True, description="Generate a report for each load stage.")
     per_request: Optional[bool] = Field(default=False, description="Generate a report with per-request details.")
+    per_request_fields: PerRequestFieldsConfig = Field(default_factory=PerRequestFieldsConfig)
     per_adapter: Optional[bool] = Field(default=True, description="Generate a report for each LoRA adapter.")
     per_adapter_stage: Optional[bool] = Field(
         default=False, description="Generate a report for each LoRA adapter within each load stage."
@@ -37,8 +45,6 @@ class RequestLifecycleMetricsReportConfig(StrictBaseModel):
         description="Cap on the number of distinct example error messages retained per error label in the failure "
         "report, and per substitution entry.",
     )
-
-
 class PrometheusMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = Field(default=True, description="Generate a summary report across the whole run.")
     per_stage: Optional[bool] = Field(default=False, description="Generate a report for each load stage.")

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -686,7 +686,7 @@ def summarize_requests(
 def build_per_request_lifecycle_entry(
     metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig
 ) -> dict[str, Any]:
-    entry = {
+    entry: dict[str, Any] = {
         "start_time": metric.start_time,
         "end_time": metric.end_time,
         "error": metric.error.model_dump() if metric.error else None,

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -683,9 +683,7 @@ def summarize_requests(
     )
 
 
-def build_per_request_lifecycle_entry(
-    metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig
-) -> dict[str, Any]:
+def build_per_request_lifecycle_entry(metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig) -> dict[str, Any]:
     entry: dict[str, Any] = {
         "start_time": metric.start_time,
         "end_time": metric.end_time,

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -426,6 +426,107 @@ def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummar
     )
 
 
+def correct_streamed_response_metrics(m: RequestLifecycleMetric, tokenizer: Optional[CustomTokenizer]) -> bool:
+    """Re-derive output_token_times for a streamed response from its raw chunks.
+
+    Mutates m.info.response_metrics in place so that the summary, per-stage, and
+    per-request reports all see the same tokenizer-corrected token timings.
+    Returns True if the tokenizer-derived token count doesn't match the
+    server-reported completion_tokens.
+    """
+    if not (
+        isinstance(m.info.response_metrics, StreamedResponseMetrics) and m.info.response_metrics.response_chunks and tokenizer
+    ):
+        return False
+
+    output_token_times = []
+    accumulated_tokens = 0
+    parsed_chunks = []
+    expected_output_tokens = (
+        m.info.response_metrics.server_usage.get("completion_tokens") if m.info.response_metrics.server_usage else None
+    )
+
+    for chunk_str, chunk_time in zip(
+        m.info.response_metrics.response_chunks, m.info.response_metrics.chunk_times, strict=True
+    ):
+        try:
+            data = json.loads(chunk_str)
+            if choices := data.get("choices"):
+                delta = choices[0]
+                text = delta.get("text") or delta.get("delta", {}).get("content")
+                if text:
+                    parsed_chunks.append((text, chunk_time))
+        except json.JSONDecodeError:
+            continue
+
+    for text, chunk_time in parsed_chunks:
+        # Count each chunk as a sequence fragment (add_special_tokens=False): re-tokenizing a
+        # chunk with special tokens prepends a BOS per chunk, which inflates the count (~2x at
+        # one token per chunk) and, since these timestamps are the basis for ITL, deflates ITL
+        # by the same factor. See #564.
+        tokens_in_chunk = tokenizer.count_tokens(text, add_special_tokens=False)
+        if tokens_in_chunk > 0:
+            # Assign every token in a chunk the chunk's arrival time to match user-perceived
+            # latency: intra-chunk ITL is 0, inter-chunk ITL absorbs the full gap. TPOT still
+            # reports the smoothed average.
+            for _ in range(tokens_in_chunk):
+                output_token_times.append(chunk_time)
+            accumulated_tokens += tokens_in_chunk
+
+    m.info.response_metrics.output_token_times = output_token_times
+    # Do not overwrite output_tokens with the per-chunk sum. Keep the API layer's whole-message
+    # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
+
+    return expected_output_tokens is not None and accumulated_tokens != expected_output_tokens
+
+
+def compute_request_latency_metrics(m: RequestLifecycleMetric, use_server_output_tokens: bool = False) -> dict[str, Any]:
+    """Compute per-request latency metrics for a single successful request.
+
+    Uses the same formulas as the aggregation loop in summarize_requests() so
+    per-request values stay consistent with the summary/per-stage reports.
+    Assumes correct_streamed_response_metrics() has already been applied.
+    """
+    request_latency = m.end_time - m.start_time
+    response_metrics = m.info.response_metrics
+
+    # NTPOT: (End - Start) / Output Tokens
+    ntpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
+    ntpot = request_latency / ntpot_output_tokens if ntpot_output_tokens > 0 else 0.0
+
+    ttft: Optional[float] = None
+    tpot: Optional[float] = None
+    itl: Optional[float] = None
+    itl_deltas: List[float] = []
+
+    # Check if streamable: Must have more than 1 output token timestamp
+    if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
+        # TTFT: First Token Time - Start Time
+        ttft = response_metrics.output_token_times[0] - m.start_time
+
+        # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
+        duration = response_metrics.output_token_times[-1] - response_metrics.output_token_times[0]
+        tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
+        if tpot_output_tokens > 1:
+            tpot = duration / (tpot_output_tokens - 1)
+
+        itl_deltas = [
+            t2 - t1
+            for t1, t2 in zip(response_metrics.output_token_times, response_metrics.output_token_times[1:], strict=False)
+        ]
+        if itl_deltas:
+            itl = sum(itl_deltas) / len(itl_deltas)
+
+    return {
+        "request_latency": request_latency,
+        "normalized_time_per_output_token": ntpot,
+        "time_to_first_token": ttft,
+        "time_per_output_token": tpot,
+        "inter_token_latency": itl,
+        "inter_token_latency_deltas": itl_deltas,
+    }
+
+
 def summarize_requests(
     metrics: List[RequestLifecycleMetric],
     percentiles: List[float],
@@ -474,93 +575,16 @@ def summarize_requests(
 
     mismatched_requests = 0
     for m in all_successful:
-        request_latency_values.append(m.end_time - m.start_time)
+        if correct_streamed_response_metrics(m, tokenizer):
+            mismatched_requests += 1
 
-        # Process raw chunks if present and tokenizer is available
-        if (
-            isinstance(m.info.response_metrics, StreamedResponseMetrics)
-            and m.info.response_metrics.response_chunks
-            and tokenizer
-        ):
-            output_token_times = []
-            accumulated_tokens = 0
-            parsed_chunks = []
-            expected_output_tokens = (
-                m.info.response_metrics.server_usage.get("completion_tokens") if m.info.response_metrics.server_usage else None
-            )
-
-            for chunk_str, chunk_time in zip(
-                m.info.response_metrics.response_chunks, m.info.response_metrics.chunk_times, strict=True
-            ):
-                try:
-                    data = json.loads(chunk_str)
-                    if choices := data.get("choices"):
-                        delta = choices[0]
-                        text = delta.get("text") or delta.get("delta", {}).get("content")
-                        if text:
-                            parsed_chunks.append((text, chunk_time))
-                except json.JSONDecodeError:
-                    continue
-
-            for text, chunk_time in parsed_chunks:
-                # Count each chunk as a sequence fragment (add_special_tokens=False): re-tokenizing a
-                # chunk with special tokens prepends a BOS per chunk, which inflates the count (~2x at
-                # one token per chunk) and, since these timestamps are the basis for ITL, deflates ITL
-                # by the same factor. See #564.
-                tokens_in_chunk = tokenizer.count_tokens(text, add_special_tokens=False)
-                if tokens_in_chunk > 0:
-                    # Assign every token in a chunk the chunk's arrival time to match user-perceived
-                    # latency: intra-chunk ITL is 0, inter-chunk ITL absorbs the full gap. TPOT still
-                    # reports the smoothed average.
-                    for _ in range(tokens_in_chunk):
-                        output_token_times.append(chunk_time)
-                    accumulated_tokens += tokens_in_chunk
-
-            m.info.response_metrics.output_token_times = output_token_times
-            # Do not overwrite output_tokens with the per-chunk sum. Keep the API layer's whole-message
-            # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
-
-            if expected_output_tokens is not None and accumulated_tokens != expected_output_tokens:
-                mismatched_requests += 1
-
-        # NTPOT: (End - Start) / Output Tokens (Calculated for ALL successful requests)
-        ntpot_output_tokens = effective_output_tokens(m.info.response_metrics, use_server_output_tokens)
-        if ntpot_output_tokens > 0:
-            ntpot_values.append((m.end_time - m.start_time) / ntpot_output_tokens)
-        else:
-            ntpot_values.append(0.0)
-
-        # Check if streamable: Must have more than 1 output token timestamp
-        response_metrics = m.info.response_metrics
-        if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
-            # TTFT: First Token Time - Start Time
-            ttft = response_metrics.output_token_times[0] - m.start_time
-            ttft_values.append(ttft)
-
-            # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
-            duration = response_metrics.output_token_times[-1] - response_metrics.output_token_times[0]
-            tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
-            if tpot_output_tokens > 1:
-                tpot = duration / (tpot_output_tokens - 1)
-            else:
-                tpot = None
-            tpot_values.append(tpot)
-
-            # Add inter-token deltas
-            request_itl = []
-            for t1, t2 in zip(response_metrics.output_token_times, response_metrics.output_token_times[1:], strict=False):
-                inter_token_latencies.append(t2 - t1)
-                request_itl.append(t2 - t1)
-
-            if request_itl:
-                itl_values.append(sum(request_itl) / len(request_itl))
-            else:
-                itl_values.append(None)
-        else:
-            # Not streamable, so TTFT and TPOT are undefined
-            ttft_values.append(None)
-            tpot_values.append(None)
-            itl_values.append(None)
+        latency = compute_request_latency_metrics(m, use_server_output_tokens)
+        request_latency_values.append(latency["request_latency"])
+        ntpot_values.append(latency["normalized_time_per_output_token"])
+        ttft_values.append(latency["time_to_first_token"])
+        tpot_values.append(latency["time_per_output_token"])
+        itl_values.append(latency["inter_token_latency"])
+        inter_token_latencies.extend(latency["inter_token_latency_deltas"])
 
     # --- Calculate Goodput Metrics ---
     goodput_metrics = calculate_goodput_metrics(
@@ -683,7 +707,19 @@ def summarize_requests(
     )
 
 
-def build_per_request_lifecycle_entry(metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig) -> dict[str, Any]:
+def build_per_request_lifecycle_entry(
+    metric: RequestLifecycleMetric,
+    fields: PerRequestFieldsConfig,
+    tokenizer: Optional[CustomTokenizer] = None,
+    use_server_output_tokens: bool = False,
+) -> dict[str, Any]:
+    if fields.computed_metrics and metric.error is None:
+        # Correct output_token_times from raw chunks before the info dump and computed_metrics
+        # below, so both reflect the same tokenizer-corrected timings that summary/per-stage
+        # reports use. Skipped when computed_metrics is off so the raw per-request output is
+        # untouched.
+        correct_streamed_response_metrics(metric, tokenizer)
+
     entry: dict[str, Any] = {
         "start_time": metric.start_time,
         "end_time": metric.end_time,
@@ -703,6 +739,21 @@ def build_per_request_lifecycle_entry(metric: RequestLifecycleMetric, fields: Pe
             if isinstance(response_metrics, dict):
                 response_metrics.pop("response_chunks", None)
         entry["info"] = info
+
+    if fields.computed_metrics and metric.error is None:
+        latency = compute_request_latency_metrics(metric, use_server_output_tokens)
+        entry["computed_metrics"] = {
+            "request_latency": latency["request_latency"],
+            "normalized_time_per_output_token": latency["normalized_time_per_output_token"],
+            "time_to_first_token": latency["time_to_first_token"],
+            "time_per_output_token": latency["time_per_output_token"],
+            "inter_token_latency": latency["inter_token_latency"],
+            "inter_token_latencies": latency["inter_token_latency_deltas"],
+            "input_tokens": metric.info.request_metrics.text.input_tokens,
+            "output_tokens": metric.info.response_metrics.output_tokens if metric.info.response_metrics else None,
+            "ttft_slo_sec": metric.ttft_slo_sec,
+            "tpot_slo_sec": metric.tpot_slo_sec,
+        }
 
     return entry
 
@@ -809,7 +860,10 @@ class ReportGenerator:
             fields = report_config.request_lifecycle.per_request_fields
             report_file = ReportFile(
                 name="per_request_lifecycle_metrics",
-                contents=[build_per_request_lifecycle_entry(metric, fields) for metric in request_metrics],
+                contents=[
+                    build_per_request_lifecycle_entry(metric, fields, tokenizer, use_server_output_tokens)
+                    for metric in request_metrics
+                ],
             )
             lifecycle_reports.append(report_file)
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -35,6 +35,7 @@ from inference_perf.config import (
     ReportConfig,
     SessionLifecycleReportConfig,
     GoodputConfig,
+    PerRequestFieldsConfig,
 )
 from inference_perf.metrics import SessionMetricsCollector
 from inference_perf.utils import ReportFile
@@ -682,6 +683,32 @@ def summarize_requests(
     )
 
 
+def build_per_request_lifecycle_entry(
+    metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig
+) -> dict[str, Any]:
+    entry = {
+        "start_time": metric.start_time,
+        "end_time": metric.end_time,
+        "error": metric.error.model_dump() if metric.error else None,
+    }
+
+    if fields.request:
+        entry["request"] = metric.request_data
+
+    if fields.response:
+        entry["response"] = metric.response_data
+
+    if fields.info:
+        info = metric.info.model_dump() if metric.info else None
+        if info and not fields.response_chunks:
+            response_metrics = info.get("response_metrics")
+            if isinstance(response_metrics, dict):
+                response_metrics.pop("response_chunks", None)
+        entry["info"] = info
+
+    return entry
+
+
 class ReportGenerator:
     def __init__(
         self,
@@ -781,19 +808,10 @@ class ReportGenerator:
                 lifecycle_reports.append(report_file)
 
         if report_config.request_lifecycle.per_request:
+            fields = report_config.request_lifecycle.per_request_fields
             report_file = ReportFile(
                 name="per_request_lifecycle_metrics",
-                contents=[
-                    {
-                        "start_time": metric.start_time,
-                        "end_time": metric.end_time,
-                        "request": metric.request_data,
-                        "response": metric.response_data,
-                        "info": metric.info.model_dump() if metric.info else None,
-                        "error": metric.error.model_dump() if metric.error else None,
-                    }
-                    for metric in request_metrics
-                ],
+                contents=[build_per_request_lifecycle_entry(metric, fields) for metric in request_metrics],
             )
             lifecycle_reports.append(report_file)
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -773,7 +773,7 @@ def summarize_requests(
 def build_per_request_lifecycle_entry(
     metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig
 ) -> dict[str, Any]:
-    entry = {
+    entry: dict[str, Any] = {
         "start_time": metric.start_time,
         "end_time": metric.end_time,
         "error": metric.error.model_dump() if metric.error else None,

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -503,6 +503,107 @@ def summarize_prometheus_metrics(metrics: ModelServerMetrics) -> ResponsesSummar
     )
 
 
+def correct_streamed_response_metrics(m: RequestLifecycleMetric, tokenizer: Optional[CustomTokenizer]) -> bool:
+    """Re-derive output_token_times for a streamed response from its raw chunks.
+
+    Mutates m.info.response_metrics in place so that the summary, per-stage, and
+    per-request reports all see the same tokenizer-corrected token timings.
+    Returns True if the tokenizer-derived token count doesn't match the
+    server-reported completion_tokens.
+    """
+    if not (
+        isinstance(m.info.response_metrics, StreamedResponseMetrics) and m.info.response_metrics.response_chunks and tokenizer
+    ):
+        return False
+
+    output_token_times = []
+    accumulated_tokens = 0
+    parsed_chunks = []
+    expected_output_tokens = (
+        m.info.response_metrics.server_usage.get("completion_tokens") if m.info.response_metrics.server_usage else None
+    )
+
+    for chunk_str, chunk_time in zip(
+        m.info.response_metrics.response_chunks, m.info.response_metrics.chunk_times, strict=True
+    ):
+        try:
+            data = json.loads(chunk_str)
+            if choices := data.get("choices"):
+                delta = choices[0]
+                text = delta.get("text") or delta.get("delta", {}).get("content")
+                if text:
+                    parsed_chunks.append((text, chunk_time))
+        except json.JSONDecodeError:
+            continue
+
+    for text, chunk_time in parsed_chunks:
+        # Count each chunk as a sequence fragment (add_special_tokens=False): re-tokenizing a
+        # chunk with special tokens prepends a BOS per chunk, which inflates the count (~2x at
+        # one token per chunk) and, since these timestamps are the basis for ITL, deflates ITL
+        # by the same factor. See #564.
+        tokens_in_chunk = tokenizer.count_tokens(text, add_special_tokens=False)
+        if tokens_in_chunk > 0:
+            # Assign every token in a chunk the chunk's arrival time to match user-perceived
+            # latency: intra-chunk ITL is 0, inter-chunk ITL absorbs the full gap. TPOT still
+            # reports the smoothed average.
+            for _ in range(tokens_in_chunk):
+                output_token_times.append(chunk_time)
+            accumulated_tokens += tokens_in_chunk
+
+    m.info.response_metrics.output_token_times = output_token_times
+    # Do not overwrite output_tokens with the per-chunk sum. Keep the API layer's whole-message
+    # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
+
+    return expected_output_tokens is not None and accumulated_tokens != expected_output_tokens
+
+
+def compute_request_latency_metrics(m: RequestLifecycleMetric, use_server_output_tokens: bool = False) -> dict[str, Any]:
+    """Compute per-request latency metrics for a single successful request.
+
+    Uses the same formulas as the aggregation loop in summarize_requests() so
+    per-request values stay consistent with the summary/per-stage reports.
+    Assumes correct_streamed_response_metrics() has already been applied.
+    """
+    request_latency = m.end_time - m.start_time
+    response_metrics = m.info.response_metrics
+
+    # NTPOT: (End - Start) / Output Tokens
+    ntpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
+    ntpot = request_latency / ntpot_output_tokens if ntpot_output_tokens > 0 else 0.0
+
+    ttft: Optional[float] = None
+    tpot: Optional[float] = None
+    itl: Optional[float] = None
+    itl_deltas: List[float] = []
+
+    # Check if streamable: Must have more than 1 output token timestamp
+    if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
+        # TTFT: First Token Time - Start Time
+        ttft = response_metrics.output_token_times[0] - m.start_time
+
+        # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
+        duration = response_metrics.output_token_times[-1] - response_metrics.output_token_times[0]
+        tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
+        if tpot_output_tokens > 1:
+            tpot = duration / (tpot_output_tokens - 1)
+
+        itl_deltas = [
+            t2 - t1
+            for t1, t2 in zip(response_metrics.output_token_times, response_metrics.output_token_times[1:], strict=False)
+        ]
+        if itl_deltas:
+            itl = sum(itl_deltas) / len(itl_deltas)
+
+    return {
+        "request_latency": request_latency,
+        "normalized_time_per_output_token": ntpot,
+        "time_to_first_token": ttft,
+        "time_per_output_token": tpot,
+        "inter_token_latency": itl,
+        "inter_token_latency_deltas": itl_deltas,
+    }
+
+
 def summarize_requests(
     metrics: List[RequestLifecycleMetric],
     percentiles: List[float],
@@ -552,93 +653,16 @@ def summarize_requests(
 
     mismatched_requests = 0
     for m in all_successful:
-        request_latency_values.append(m.end_time - m.start_time)
+        if correct_streamed_response_metrics(m, tokenizer):
+            mismatched_requests += 1
 
-        # Process raw chunks if present and tokenizer is available
-        if (
-            isinstance(m.info.response_metrics, StreamedResponseMetrics)
-            and m.info.response_metrics.response_chunks
-            and tokenizer
-        ):
-            output_token_times = []
-            accumulated_tokens = 0
-            parsed_chunks = []
-            expected_output_tokens = (
-                m.info.response_metrics.server_usage.get("completion_tokens") if m.info.response_metrics.server_usage else None
-            )
-
-            for chunk_str, chunk_time in zip(
-                m.info.response_metrics.response_chunks, m.info.response_metrics.chunk_times, strict=True
-            ):
-                try:
-                    data = json.loads(chunk_str)
-                    if choices := data.get("choices"):
-                        delta = choices[0]
-                        text = delta.get("text") or delta.get("delta", {}).get("content")
-                        if text:
-                            parsed_chunks.append((text, chunk_time))
-                except json.JSONDecodeError:
-                    continue
-
-            for text, chunk_time in parsed_chunks:
-                # Count each chunk as a sequence fragment (add_special_tokens=False): re-tokenizing a
-                # chunk with special tokens prepends a BOS per chunk, which inflates the count (~2x at
-                # one token per chunk) and, since these timestamps are the basis for ITL, deflates ITL
-                # by the same factor. See #564.
-                tokens_in_chunk = tokenizer.count_tokens(text, add_special_tokens=False)
-                if tokens_in_chunk > 0:
-                    # Assign every token in a chunk the chunk's arrival time to match user-perceived
-                    # latency: intra-chunk ITL is 0, inter-chunk ITL absorbs the full gap. TPOT still
-                    # reports the smoothed average.
-                    for _ in range(tokens_in_chunk):
-                        output_token_times.append(chunk_time)
-                    accumulated_tokens += tokens_in_chunk
-
-            m.info.response_metrics.output_token_times = output_token_times
-            # Do not overwrite output_tokens with the per-chunk sum. Keep the API layer's whole-message
-            # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
-
-            if expected_output_tokens is not None and accumulated_tokens != expected_output_tokens:
-                mismatched_requests += 1
-
-        # NTPOT: (End - Start) / Output Tokens (Calculated for ALL successful requests)
-        ntpot_output_tokens = effective_output_tokens(m.info.response_metrics, use_server_output_tokens)
-        if ntpot_output_tokens > 0:
-            ntpot_values.append((m.end_time - m.start_time) / ntpot_output_tokens)
-        else:
-            ntpot_values.append(0.0)
-
-        # Check if streamable: Must have more than 1 output token timestamp
-        response_metrics = m.info.response_metrics
-        if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
-            # TTFT: First Token Time - Start Time
-            ttft = response_metrics.output_token_times[0] - m.start_time
-            ttft_values.append(ttft)
-
-            # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
-            duration = response_metrics.output_token_times[-1] - response_metrics.output_token_times[0]
-            tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
-            if tpot_output_tokens > 1:
-                tpot = duration / (tpot_output_tokens - 1)
-            else:
-                tpot = None
-            tpot_values.append(tpot)
-
-            # Add inter-token deltas
-            request_itl = []
-            for t1, t2 in zip(response_metrics.output_token_times, response_metrics.output_token_times[1:], strict=False):
-                inter_token_latencies.append(t2 - t1)
-                request_itl.append(t2 - t1)
-
-            if request_itl:
-                itl_values.append(sum(request_itl) / len(request_itl))
-            else:
-                itl_values.append(None)
-        else:
-            # Not streamable, so TTFT and TPOT are undefined
-            ttft_values.append(None)
-            tpot_values.append(None)
-            itl_values.append(None)
+        latency = compute_request_latency_metrics(m, use_server_output_tokens)
+        request_latency_values.append(latency["request_latency"])
+        ntpot_values.append(latency["normalized_time_per_output_token"])
+        ttft_values.append(latency["time_to_first_token"])
+        tpot_values.append(latency["time_per_output_token"])
+        itl_values.append(latency["inter_token_latency"])
+        inter_token_latencies.extend(latency["inter_token_latency_deltas"])
 
     # --- Calculate Goodput Metrics ---
     goodput_metrics = calculate_goodput_metrics(
@@ -770,7 +794,19 @@ def summarize_requests(
     )
 
 
-def build_per_request_lifecycle_entry(metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig) -> dict[str, Any]:
+def build_per_request_lifecycle_entry(
+    metric: RequestLifecycleMetric,
+    fields: PerRequestFieldsConfig,
+    tokenizer: Optional[CustomTokenizer] = None,
+    use_server_output_tokens: bool = False,
+) -> dict[str, Any]:
+    if fields.computed_metrics and metric.error is None:
+        # Correct output_token_times from raw chunks before the info dump and computed_metrics
+        # below, so both reflect the same tokenizer-corrected timings that summary/per-stage
+        # reports use. Skipped when computed_metrics is off so the raw per-request output is
+        # untouched.
+        correct_streamed_response_metrics(metric, tokenizer)
+
     entry: dict[str, Any] = {
         "start_time": metric.start_time,
         "end_time": metric.end_time,
@@ -790,6 +826,21 @@ def build_per_request_lifecycle_entry(metric: RequestLifecycleMetric, fields: Pe
             if isinstance(response_metrics, dict):
                 response_metrics.pop("response_chunks", None)
         entry["info"] = info
+
+    if fields.computed_metrics and metric.error is None:
+        latency = compute_request_latency_metrics(metric, use_server_output_tokens)
+        entry["computed_metrics"] = {
+            "request_latency": latency["request_latency"],
+            "normalized_time_per_output_token": latency["normalized_time_per_output_token"],
+            "time_to_first_token": latency["time_to_first_token"],
+            "time_per_output_token": latency["time_per_output_token"],
+            "inter_token_latency": latency["inter_token_latency"],
+            "inter_token_latencies": latency["inter_token_latency_deltas"],
+            "input_tokens": metric.info.request_metrics.text.input_tokens,
+            "output_tokens": metric.info.response_metrics.output_tokens if metric.info.response_metrics else None,
+            "ttft_slo_sec": metric.ttft_slo_sec,
+            "tpot_slo_sec": metric.tpot_slo_sec,
+        }
 
     return entry
 
@@ -900,7 +951,10 @@ class ReportGenerator:
             fields = report_config.request_lifecycle.per_request_fields
             report_file = ReportFile(
                 name="per_request_lifecycle_metrics",
-                contents=[build_per_request_lifecycle_entry(metric, fields) for metric in request_metrics],
+                contents=[
+                    build_per_request_lifecycle_entry(metric, fields, tokenizer, use_server_output_tokens)
+                    for metric in request_metrics
+                ],
             )
             lifecycle_reports.append(report_file)
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -36,6 +36,7 @@ from inference_perf.config import (
     ReportConfig,
     SessionLifecycleReportConfig,
     GoodputConfig,
+    PerRequestFieldsConfig,
 )
 from inference_perf.metrics import SessionMetricsCollector
 from inference_perf.utils import ReportFile
@@ -769,6 +770,32 @@ def summarize_requests(
     )
 
 
+def build_per_request_lifecycle_entry(
+    metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig
+) -> dict[str, Any]:
+    entry = {
+        "start_time": metric.start_time,
+        "end_time": metric.end_time,
+        "error": metric.error.model_dump() if metric.error else None,
+    }
+
+    if fields.request:
+        entry["request"] = metric.request_data
+
+    if fields.response:
+        entry["response"] = metric.response_data
+
+    if fields.info:
+        info = metric.info.model_dump() if metric.info else None
+        if info and not fields.response_chunks:
+            response_metrics = info.get("response_metrics")
+            if isinstance(response_metrics, dict):
+                response_metrics.pop("response_chunks", None)
+        entry["info"] = info
+
+    return entry
+
+
 class ReportGenerator:
     def __init__(
         self,
@@ -872,19 +899,10 @@ class ReportGenerator:
                 lifecycle_reports.append(report_file)
 
         if report_config.request_lifecycle.per_request:
+            fields = report_config.request_lifecycle.per_request_fields
             report_file = ReportFile(
                 name="per_request_lifecycle_metrics",
-                contents=[
-                    {
-                        "start_time": metric.start_time,
-                        "end_time": metric.end_time,
-                        "request": metric.request_data,
-                        "response": metric.response_data,
-                        "info": metric.info.model_dump() if metric.info else None,
-                        "error": metric.error.model_dump() if metric.error else None,
-                    }
-                    for metric in request_metrics
-                ],
+                contents=[build_per_request_lifecycle_entry(metric, fields) for metric in request_metrics],
             )
             lifecycle_reports.append(report_file)
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -810,7 +810,6 @@ def build_per_request_lifecycle_entry(
     entry: dict[str, Any] = {
         "start_time": metric.start_time,
         "end_time": metric.end_time,
-        "error": metric.error.model_dump() if metric.error else None,
     }
 
     if fields.request:
@@ -841,6 +840,8 @@ def build_per_request_lifecycle_entry(
             "ttft_slo_sec": metric.ttft_slo_sec,
             "tpot_slo_sec": metric.tpot_slo_sec,
         }
+
+    entry["error"] = metric.error.model_dump() if metric.error else None
 
     return entry
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -770,9 +770,7 @@ def summarize_requests(
     )
 
 
-def build_per_request_lifecycle_entry(
-    metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig
-) -> dict[str, Any]:
+def build_per_request_lifecycle_entry(metric: RequestLifecycleMetric, fields: PerRequestFieldsConfig) -> dict[str, Any]:
     entry: dict[str, Any] = {
         "start_time": metric.start_time,
         "end_time": metric.end_time,

--- a/scripts/sync_cli_flags_doc.py
+++ b/scripts/sync_cli_flags_doc.py
@@ -78,7 +78,7 @@ def main() -> None:
     expected_content = generate_doc()
 
     if args.check:
-        with open(doc_path, "r") as f:
+        with open(doc_path, "r", encoding="utf-8") as f:
             current_content = f.read()
 
         if current_content != expected_content:
@@ -97,7 +97,7 @@ def main() -> None:
         else:
             print("docs/cli_flags.md is in sync.")
     else:
-        with open(doc_path, "w") as f:
+        with open(doc_path, "w", encoding="utf-8") as f:
             f.write(expected_content)
         print("Updated docs/cli_flags.md")
 

--- a/tests/required/reportgen/test_per_request_fields.py
+++ b/tests/required/reportgen/test_per_request_fields.py
@@ -1,7 +1,14 @@
-from inference_perf.apis import InferenceInfo, RequestLifecycleMetric, StreamedResponseMetrics
+import pytest
+
+from inference_perf.apis import ErrorResponseInfo, InferenceInfo, RequestLifecycleMetric, StreamedResponseMetrics
 from inference_perf.config import PerRequestFieldsConfig
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.reportgen.base import build_per_request_lifecycle_entry
+
+
+class _FakeTokenizer:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
+        return len(text.split())
 
 
 def _metric() -> RequestLifecycleMetric:
@@ -60,3 +67,83 @@ def test_per_request_fields_can_omit_response_chunks_without_mutating_metric() -
     assert response_metrics["output_token_times"] == [1.5]
     assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
     assert metric.info.response_metrics.response_chunks == ['{"choices": [{"text": "hello"}]}']
+
+
+def test_per_request_fields_computed_metrics_disabled_by_default() -> None:
+    entry = build_per_request_lifecycle_entry(_metric(), PerRequestFieldsConfig())
+
+    assert "computed_metrics" not in entry
+
+
+def test_per_request_fields_computed_metrics_can_be_enabled() -> None:
+    entry = build_per_request_lifecycle_entry(_metric(), PerRequestFieldsConfig(computed_metrics=True))
+
+    assert entry["computed_metrics"] == {
+        "request_latency": 1.0,
+        "normalized_time_per_output_token": 0.5,
+        "time_to_first_token": None,
+        "time_per_output_token": None,
+        "inter_token_latency": None,
+        "inter_token_latencies": [],
+        "input_tokens": 5,
+        "output_tokens": 2,
+        "ttft_slo_sec": None,
+        "tpot_slo_sec": None,
+    }
+
+
+def test_per_request_fields_disabled_computed_metrics_does_not_mutate_token_metrics() -> None:
+    metric = _metric()
+
+    build_per_request_lifecycle_entry(metric, PerRequestFieldsConfig(computed_metrics=False), tokenizer=_FakeTokenizer())
+
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    assert metric.info.response_metrics.output_tokens == 2
+    assert metric.info.response_metrics.output_token_times == [1.5]
+
+
+def test_per_request_fields_computed_metrics_omitted_for_failed_requests() -> None:
+    metric = _metric()
+    metric.error = ErrorResponseInfo(error_type="TimeoutError", error_msg="boom")
+
+    entry = build_per_request_lifecycle_entry(metric, PerRequestFieldsConfig(computed_metrics=True))
+
+    assert "computed_metrics" not in entry
+
+
+def test_per_request_fields_computed_metrics_uses_tokenizer_corrected_chunks() -> None:
+    metric = RequestLifecycleMetric(
+        stage_id=0,
+        scheduled_time=0.0,
+        start_time=1.0,
+        end_time=2.0,
+        request_data="raw request",
+        response_data="raw response",
+        info=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=3,
+                response_chunks=[
+                    '{"choices": [{"text": "hello"}]}',
+                    '{"choices": [{"text": " world foo"}]}',
+                ],
+                chunk_times=[1.2, 1.6],
+                output_token_times=[],
+            ),
+        ),
+        error=None,
+    )
+
+    entry = build_per_request_lifecycle_entry(
+        metric, PerRequestFieldsConfig(computed_metrics=True), tokenizer=_FakeTokenizer()
+    )
+
+    assert entry["info"]["response_metrics"]["output_token_times"] == pytest.approx([1.2, 1.6, 1.6])
+    assert entry["computed_metrics"]["time_to_first_token"] == pytest.approx(0.2)
+    assert entry["computed_metrics"]["time_per_output_token"] == pytest.approx(0.2)
+    assert entry["computed_metrics"]["inter_token_latency"] == pytest.approx(0.2)
+    assert entry["computed_metrics"]["inter_token_latencies"] == pytest.approx([0.4, 0.0])
+    assert entry["computed_metrics"]["input_tokens"] == 5
+    # The correction sets output_token_times only; output_tokens keeps the API layer's
+    # whole-message count (see #564).
+    assert entry["computed_metrics"]["output_tokens"] == 3

--- a/tests/required/reportgen/test_per_request_fields.py
+++ b/tests/required/reportgen/test_per_request_fields.py
@@ -1,0 +1,62 @@
+from inference_perf.apis import InferenceInfo, RequestLifecycleMetric, StreamedResponseMetrics
+from inference_perf.config import PerRequestFieldsConfig
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.reportgen.base import build_per_request_lifecycle_entry
+
+
+def _metric() -> RequestLifecycleMetric:
+    return RequestLifecycleMetric(
+        stage_id=0,
+        scheduled_time=0.0,
+        start_time=1.0,
+        end_time=2.0,
+        request_data="raw request",
+        response_data="raw response",
+        info=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=2,
+                response_chunks=['{"choices": [{"text": "hello"}]}'],
+                chunk_times=[1.5],
+                output_token_times=[1.5],
+            ),
+        ),
+        error=None,
+    )
+
+
+def test_per_request_fields_default_preserves_full_report_shape() -> None:
+    entry = build_per_request_lifecycle_entry(_metric(), PerRequestFieldsConfig())
+
+    assert entry["start_time"] == 1.0
+    assert entry["end_time"] == 2.0
+    assert entry["request"] == "raw request"
+    assert entry["response"] == "raw response"
+    assert entry["info"]["response_metrics"]["response_chunks"] == ['{"choices": [{"text": "hello"}]}']
+    assert entry["error"] is None
+
+
+def test_per_request_fields_can_omit_top_level_raw_fields() -> None:
+    entry = build_per_request_lifecycle_entry(
+        _metric(),
+        PerRequestFieldsConfig(request=False, response=False, info=False),
+    )
+
+    assert "request" not in entry
+    assert "response" not in entry
+    assert "info" not in entry
+    assert entry["start_time"] == 1.0
+    assert entry["end_time"] == 2.0
+    assert entry["error"] is None
+
+
+def test_per_request_fields_can_omit_response_chunks_without_mutating_metric() -> None:
+    metric = _metric()
+    entry = build_per_request_lifecycle_entry(metric, PerRequestFieldsConfig(response_chunks=False))
+
+    response_metrics = entry["info"]["response_metrics"]
+    assert "response_chunks" not in response_metrics
+    assert response_metrics["chunk_times"] == [1.5]
+    assert response_metrics["output_token_times"] == [1.5]
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    assert metric.info.response_metrics.response_chunks == ['{"choices": [{"text": "hello"}]}']

--- a/tests/required/reportgen/test_per_request_fields.py
+++ b/tests/required/reportgen/test_per_request_fields.py
@@ -127,7 +127,7 @@ def test_per_request_fields_computed_metrics_uses_tokenizer_corrected_chunks() -
         info=InferenceInfo(
             request_metrics=RequestMetrics(text=Text(input_tokens=5)),
             response_metrics=StreamedResponseMetrics(
-                output_tokens=3,
+                output_tokens=4,
                 response_chunks=[
                     '{"choices": [{"text": "hello"}]}',
                     '{"choices": [{"text": " world foo"}]}',
@@ -145,10 +145,10 @@ def test_per_request_fields_computed_metrics_uses_tokenizer_corrected_chunks() -
 
     assert entry["info"]["response_metrics"]["output_token_times"] == pytest.approx([1.2, 1.6, 1.6])
     assert entry["computed_metrics"]["time_to_first_token"] == pytest.approx(0.2)
-    assert entry["computed_metrics"]["time_per_output_token"] == pytest.approx(0.2)
+    assert entry["computed_metrics"]["time_per_output_token"] == pytest.approx(0.1333333333333334)
     assert entry["computed_metrics"]["inter_token_latency"] == pytest.approx(0.2)
     assert entry["computed_metrics"]["inter_token_latencies"] == pytest.approx([0.4, 0.0])
     assert entry["computed_metrics"]["input_tokens"] == 5
     # The correction sets output_token_times only; output_tokens keeps the API layer's
     # whole-message count (see #564).
-    assert entry["computed_metrics"]["output_tokens"] == 3
+    assert entry["computed_metrics"]["output_tokens"] == 4

--- a/tests/required/reportgen/test_per_request_fields.py
+++ b/tests/required/reportgen/test_per_request_fields.py
@@ -1,9 +1,12 @@
+from typing import cast
+
 import pytest
 
 from inference_perf.apis import ErrorResponseInfo, InferenceInfo, RequestLifecycleMetric, StreamedResponseMetrics
 from inference_perf.config import PerRequestFieldsConfig
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.reportgen.base import build_per_request_lifecycle_entry
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
 class _FakeTokenizer:
@@ -95,7 +98,9 @@ def test_per_request_fields_computed_metrics_can_be_enabled() -> None:
 def test_per_request_fields_disabled_computed_metrics_does_not_mutate_token_metrics() -> None:
     metric = _metric()
 
-    build_per_request_lifecycle_entry(metric, PerRequestFieldsConfig(computed_metrics=False), tokenizer=_FakeTokenizer())
+    build_per_request_lifecycle_entry(
+        metric, PerRequestFieldsConfig(computed_metrics=False), tokenizer=cast(CustomTokenizer, _FakeTokenizer())
+    )
 
     assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
     assert metric.info.response_metrics.output_tokens == 2
@@ -135,7 +140,7 @@ def test_per_request_fields_computed_metrics_uses_tokenizer_corrected_chunks() -
     )
 
     entry = build_per_request_lifecycle_entry(
-        metric, PerRequestFieldsConfig(computed_metrics=True), tokenizer=_FakeTokenizer()
+        metric, PerRequestFieldsConfig(computed_metrics=True), tokenizer=cast(CustomTokenizer, _FakeTokenizer())
     )
 
     assert entry["info"]["response_metrics"]["output_token_times"] == pytest.approx([1.2, 1.6, 1.6])


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When `per_request` is enabled, `per_request_lifecycle_metrics.json` stores the raw request/response payloads and streaming chunks for every request. On high-QPS runs this file can grow to several GB and significantly slow down report generation, even when users only care about per-request timing.

This PR adds granular field controls so the heavy raw payloads can be dropped from the per-request report while keeping the data that matters. A new `per_request_fields` config controls each field independently:

```yaml
report:
  request_lifecycle:
    per_request: true
    per_request_fields:
      request: true          # raw prompt
      response: true         # raw response
      info: true             # structured info (request/response metrics, etc.)
      response_chunks: true  # raw streaming chunks inside info.response_metrics
```

All fields default to `true`, so existing output is unchanged (backward compatible).

The recommended lightweight configuration keeps `info` enabled while disabling the raw payloads:

```yaml
per_request_fields:
  request: false
  response: false
  info: true
  response_chunks: false
```

This removes the main size drivers (raw request/response text and the duplicated streaming chunks) while preserving the structured timing data such as `output_token_times`, so per-request latency can still be analyzed. Setting `info: false` as well produces a minimal entry (timestamps + error only).

**Implementation notes**:

- `response_chunks` lives under `info.response_metrics.response_chunks`, so when `info: true, response_chunks: false`, only that nested field is removed (the rest of `info` is kept).
- Removal is done on the `metric.info.model_dump()` copy, never on the original metric object — so other reports (summary / per_stage) and the tokenizer-based `output_token_times` correction in `summarize_requests()` still see the original `response_chunks`.

**UPDATE**:

This PR now also adds the computed per-request latency metrics requested in #522, fully closing it. A new opt-in per_request_fields.computed_metrics toggle (default false) adds a computed_metrics block to each successful entry with request_latency, normalized_time_per_output_token, time_to_first_token, time_per_output_token, inter_token_latency (mean), inter_token_latencies (per-token deltas), input_tokens, output_tokens, and the request's ttft_slo_sec/tpot_slo_sec.

The tokenizer-based output_token_times correction was extracted from summarize_requests() into a shared helper (correct_streamed_response_metrics()), so per-request values are computed with exactly the same formulas as the summary/per-stage reports. The correction only runs when computed_metrics is enabled, so existing per-request output is unchanged when the toggle is off (backward compatible).

The metrics-only configuration from the issue becomes:


per_request_fields:
  request: false
  response: false
  info: false
  response_chunks: false
  computed_metrics: true

**Which issue(s) this PR fixes**:

 Fixes #522

/cc @jjk-g @achandrasekar

**Does this PR introduce a user-facing change?**

```release-note
Add `report.request_lifecycle.per_request_fields` to control which fields are included in `per_request_lifecycle_metrics.json`: raw fields (`request`, `response`, `info`, `response_chunks`) can be disabled for smaller reports on high-QPS runs, and an opt-in `computed_metrics` field adds per-request latency metrics (request latency, TTFT, TPOT, ITL, NTPOT, token counts, SLOs) consistent with the summary report.
```