### PR TITLE
Add `numeric/expression`

### DIFF
--- a/inference_perf/utils/numeric/expression/__init__.py
+++ b/inference_perf/utils/numeric/expression/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .expression import Expression
+
+__all__ = ["Expression"]

--- a/inference_perf/utils/numeric/expression/expression.py
+++ b/inference_perf/utils/numeric/expression/expression.py
@@ -1,0 +1,377 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""First-class numeric expressions for config values.
+
+An :class:`Expression` turns a numeric config knob (a constant, a function of
+stage time ``t``, and/or a draw from a ``sympy.stats`` random variable) into a
+single object that is parsed and validated once at construction and sampled
+many times. It is the string-grammar counterpart to
+:mod:`inference_perf.utils.numeric.distribution`, which remains the fast,
+vectorised path for structured ``Distribution`` configs.
+
+Grammar: constants, the single time variable ``t``, standard math, and
+``sympy.stats`` distribution constructors (``Normal(512, 200)``,
+``Uniform(10, 50)``, ``Poisson(10)``, ...). Each call site decides whether ``t``
+and random variables are permitted, and may constrain the value range so that,
+for example, a request-rate expression can never evaluate negative.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Optional, Union
+
+import numpy as np
+import sympy
+import sympy.stats
+from numpy.typing import NDArray
+from sympy import Interval, Symbol, oo
+from sympy.calculus.util import function_range
+from sympy.core.function import AppliedUndef
+from sympy.parsing.sympy_parser import parse_expr
+
+logger = logging.getLogger(__name__)
+
+# sympy maintains its own per-distribution numpy samplers in a singledispatch
+# registry; the implementation registered to ``object`` is a stub that raises.
+# Resolving this dispatch ourselves (rather than calling the ``sympy.stats.sample``
+# wrapper, which re-does all of its symbolic bookkeeping on every call) lets us
+# sample any distribution sympy supports at near-numpy speed, with no hardcoded
+# table to keep in sync. The import is guarded: if a future sympy moves this
+# internal module we degrade to the slow but always-correct sampling path.
+try:
+    from sympy.stats.sampling.sample_numpy import do_sample_numpy
+
+    _NO_NUMPY_SAMPLER = do_sample_numpy.dispatch(object)
+except Exception:  # pragma: no cover - defensive: sympy internal layout changed
+    do_sample_numpy = None  # type: ignore[assignment]
+    _NO_NUMPY_SAMPLER = None
+
+# The single time variable the grammar ever permits.
+_T = Symbol("t")
+
+
+def _distribution_constructors() -> dict[str, Any]:
+    """Collect every ``sympy.stats`` distribution constructor (name-first)."""
+    ctors: dict[str, Any] = {}
+    for name in dir(sympy.stats):
+        if name.startswith("_") or not name[0].isupper():
+            continue
+        obj = getattr(sympy.stats, name)
+        try:
+            params = list(inspect.signature(obj).parameters)
+        except (TypeError, ValueError):
+            continue
+        if params and params[0] == "name":
+            ctors[name] = obj
+    return ctors
+
+
+# Built once at import; the set of sympy.stats distributions is static.
+_DISTRIBUTION_CTORS = _distribution_constructors()
+
+
+def _parse_namespace(counter: list[int]) -> dict[str, Any]:
+    """A fresh distribution namespace whose constructors take no name argument.
+
+    Config strings read ``Normal(512, 200)`` rather than ``Normal("x", ...)``,
+    so each constructor binds a name for us. Crucially the name is *unique per
+    occurrence* (``rv_1``, ``rv_2``, ...) via the shared ``counter``, so that an
+    expression with two draws of the same distribution (e.g. a skew-normal built
+    from two independent normals) yields two independent random variables rather
+    than one aliased symbol.
+    """
+    namespace: dict[str, Any] = {}
+    for name, ctor in _DISTRIBUTION_CTORS.items():
+
+        def bound(*args: Any, _ctor: Any = ctor, _counter: list[int] = counter) -> Any:
+            _counter[0] += 1
+            return _ctor(f"rv_{_counter[0]}", *args)
+
+        namespace[name] = bound
+    return namespace
+
+
+def _is_random_symbol(sym: Any) -> bool:
+    return isinstance(sym, sympy.stats.rv.RandomSymbol)
+
+
+class Expression:
+    """A numeric config value: constant, time-varying (``t``), and/or random.
+
+    The expression is parsed and validated when constructed, then sampled via
+    :meth:`sample`. Construction raises :class:`ValueError` for unparseable
+    input, unknown symbols or functions, a disallowed time variable or random
+    variable, or a value range that is provably outside ``[minimum, maximum]``.
+
+    Args:
+        raw: The expression as a string (``"10 + 5*sin(2*pi*t/60)"``) or a bare
+            number.
+        allow_time: Whether the time variable ``t`` may appear. ``t`` is the
+            only variable the grammar permits; when ``False`` the expression
+            must be constant (and/or random).
+        allow_random: Whether ``sympy.stats`` random variables may appear.
+        minimum: Lower bound for sampled values, or ``None`` for unbounded.
+        maximum: Upper bound for sampled values, or ``None`` for unbounded.
+        duration: The upper end of the ``t`` domain (stage duration, seconds).
+            Required to statically bound a time-varying expression; without it
+            a bounded time-varying expression is checked at sample time instead.
+    """
+
+    def __init__(
+        self,
+        raw: Union[str, int, float],
+        *,
+        allow_time: bool = True,
+        allow_random: bool = True,
+        minimum: Optional[float] = None,
+        maximum: Optional[float] = None,
+        duration: Optional[float] = None,
+    ) -> None:
+        if minimum is not None and maximum is not None and minimum > maximum:
+            raise ValueError(f"minimum ({minimum}) cannot be greater than maximum ({maximum}).")
+
+        self.raw = raw
+        self.minimum = minimum
+        self.maximum = maximum
+        self._expr = self._parse(raw)
+
+        # Reject unknown functions, e.g. a misspelled distribution InvalidDist(10).
+        undefined = {f.func.__name__ for f in self._expr.atoms(AppliedUndef)}
+        if undefined:
+            raise ValueError(f"Expression {raw!r} uses unknown function(s): {sorted(undefined)}.")
+
+        free = self._expr.free_symbols
+        self._random_symbols = sorted((s for s in free if _is_random_symbol(s)), key=str)
+        self._is_random = bool(self._random_symbols)
+        self._free_symbols = {str(s) for s in free if not _is_random_symbol(s)}
+
+        if self._is_random and not allow_random:
+            raise ValueError(f"Expression {raw!r} contains a random variable, which is not permitted here.")
+
+        allowed = {"t"} if allow_time else set()
+        disallowed = self._free_symbols - allowed
+        if disallowed:
+            permitted = sorted(allowed) if allowed else "constants only"
+            raise ValueError(f"Expression {raw!r} uses disallowed symbol(s) {sorted(disallowed)}; permitted: {permitted}.")
+
+        # Resolve the range policy once, raising now for provable violations.
+        self._clip_random = self._is_random and (minimum is not None or maximum is not None)
+        self._runtime_check = False
+        self._validate_range(duration)
+        self._compile_random_sampler()
+
+    def _compile_random_sampler(self) -> None:
+        """Precompute a numpy-vectorised sampler for the random fast path.
+
+        Splits the parsed tree into random *leaves* (the ``RandomSymbol`` atoms)
+        and a deterministic *skeleton* (the arithmetic/time combination of them).
+        Each leaf is drawn through sympy's own per-distribution numpy sampler
+        (``do_sample_numpy``), resolved once here because the expression is fixed
+        at construction; the skeleton is compiled once with ``sympy.lambdify``. At
+        sample time we draw the leaves with numpy and feed them through the
+        lambdified closure, never touching the slow ``sympy.stats.sample`` wrapper.
+        If any leaf distribution has no numpy sampler (or the sympy internal is
+        unavailable) we set ``_fallback`` and keep the sympy path.
+        """
+        self._random_leaves: list[tuple[Any, Any]] = []
+        self._lambdified: Optional[Any] = None
+        self._fallback = False
+        if not self._is_random:
+            return
+
+        if do_sample_numpy is None:
+            self._fallback = True
+            return
+
+        placeholders: dict[Any, Any] = {}
+        for i, rv in enumerate(self._random_symbols):
+            dist = rv.pspace.distribution
+            if do_sample_numpy.dispatch(type(dist)) is _NO_NUMPY_SAMPLER:
+                self._fallback = True
+                self._random_leaves = []
+                return
+            placeholder = Symbol(f"_leaf_{i}")
+            placeholders[rv] = placeholder
+            self._random_leaves.append((placeholder, dist))
+
+        skeleton = self._expr.xreplace(placeholders)
+        order = [ph for ph, _dist in self._random_leaves] + [_T]
+        self._lambdified = sympy.lambdify(order, skeleton, "numpy")
+
+    def _parse(self, raw: Union[str, int, float]) -> Any:
+        if isinstance(raw, bool):
+            raise TypeError("Expression does not accept bool input.")
+        if isinstance(raw, (int, float)):
+            return sympy.sympify(raw)
+        if isinstance(raw, str):
+            try:
+                return parse_expr(raw, local_dict=_parse_namespace([0]))
+            except (SyntaxError, TypeError, AttributeError, sympy.SympifyError) as e:
+                raise ValueError(f"Could not parse expression {raw!r}: {e}") from e
+        raise TypeError(f"Expression accepts str or number, got {type(raw).__name__}.")
+
+    def _validate_range(self, duration: Optional[float]) -> None:
+        if self.minimum is None and self.maximum is None:
+            return
+
+        bounds = Interval(
+            sympy.Float(self.minimum) if self.minimum is not None else -oo,
+            sympy.Float(self.maximum) if self.maximum is not None else oo,
+        )
+        static_range = self._static_range(duration)
+
+        if static_range is None:
+            # Undecided: defer to sample time. Random draws are clamped; a
+            # deterministic value out of range is a config error and raises.
+            if not self._is_random:
+                self._runtime_check = True
+            return
+
+        contained = static_range.is_subset(bounds)
+        if contained is True:
+            return
+        if contained is False:
+            raise ValueError(
+                f"Expression {self.raw!r} can evaluate to {static_range}, which is outside the permitted range {bounds}."
+            )
+        # is_subset returned None (couldn't decide): treat as undecided.
+        if not self._is_random:
+            self._runtime_check = True
+
+    def _static_range(self, duration: Optional[float]) -> Any:
+        """Best-effort provable value range, or ``None`` when undecidable."""
+        if self._is_random:
+            # Only a bare random variable has a readily available support set.
+            # Transformed/mixed random expressions are left for the sample-time
+            # clamp.
+            if _is_random_symbol(self._expr):
+                try:
+                    return self._expr.pspace.distribution.set
+                except Exception:
+                    return None
+            return None
+
+        if not self._free_symbols:
+            value = float(self._expr.evalf())
+            return Interval(value, value)
+
+        # Time-varying: the range is only knowable over a bounded t domain.
+        if duration is None:
+            return None
+        try:
+            return function_range(self._expr, _T, Interval(0, sympy.Float(duration)))
+        except Exception:
+            return None
+
+    @property
+    def is_constant(self) -> bool:
+        """True when the value never varies: no time variable and no randomness."""
+        return not self._is_random and not self._free_symbols
+
+    @property
+    def is_random(self) -> bool:
+        """True when the expression contains a random variable."""
+        return self._is_random
+
+    @property
+    def free_symbols(self) -> set[str]:
+        """Names of non-random free symbols (a subset of ``{"t"}``)."""
+        return set(self._free_symbols)
+
+    def sample(
+        self,
+        t: Optional[float] = None,
+        *,
+        rng: Optional[np.random.Generator] = None,
+        size: int = 1,
+    ) -> Union[float, NDArray[np.float64]]:
+        """Draw value(s) from the expression.
+
+        Args:
+            t: Stage time in seconds, substituted for ``t`` when present.
+            rng: numpy Generator for deterministic random draws. Ignored for
+                non-random expressions; defaults to a fresh Generator otherwise.
+            size: Number of values to draw. ``1`` returns a float; ``>1`` returns
+                a numpy array.
+
+        Returns:
+            A float when ``size == 1``, otherwise a numpy array of floats.
+        """
+        if size < 1:
+            raise ValueError(f"size must be a positive integer, got {size}.")
+
+        expr = self._expr
+        if t is not None:
+            expr = expr.subs(_T, sympy.Float(t))
+
+        remaining = {str(s) for s in expr.free_symbols if not _is_random_symbol(s)}
+        if remaining:
+            raise ValueError(f"Expression {self.raw!r} requires {sorted(remaining)} but none was provided to sample().")
+
+        if not self._is_random:
+            value = float(expr.evalf())
+            if self._runtime_check and not self._within_bounds(value):
+                raise ValueError(
+                    f"Expression {self.raw!r} evaluated to {value}"
+                    f"{f' at t={t}' if t is not None else ''}, outside the permitted range "
+                    f"[{self.minimum}, {self.maximum}]."
+                )
+            return value if size == 1 else np.full(size, value, dtype=np.float64)
+
+        if rng is None:
+            rng = np.random.default_rng()
+
+        if self._fallback:
+            # Some leaf distribution has no direct numpy sampler; fall back to
+            # the (slower) symbolic sampler for correctness.
+            draw = sympy.stats.sample(
+                expr,
+                size=(size,) if size > 1 else (),
+                library="numpy",
+                seed=rng,
+            )
+            samples = np.asarray(draw, dtype=np.float64)
+        else:
+            # Fast path: draw each leaf via sympy's per-distribution numpy
+            # sampler (independent draws, since the shared rng advances between
+            # leaves), then evaluate the lambdified deterministic skeleton over
+            # the drawn arrays.
+            leaf_draws = [np.asarray(do_sample_numpy(dist, (size,), rng), dtype=np.float64) for _ph, dist in self._random_leaves]
+            tval = 0.0 if t is None else float(t)
+            out = self._lambdified(*leaf_draws, tval)  # type: ignore[misc]
+            samples = np.asarray(out, dtype=np.float64)
+            if samples.shape == ():
+                samples = np.full(size, float(samples), dtype=np.float64)
+
+        if self._clip_random:
+            samples = np.clip(
+                samples,
+                self.minimum if self.minimum is not None else -np.inf,
+                self.maximum if self.maximum is not None else np.inf,
+            )
+        # The fallback yields a 0-d scalar for size==1 while the numpy fast path
+        # yields a shape-(1,) array; flatten before scalarising so both work.
+        return float(samples.reshape(-1)[0]) if size == 1 else samples
+
+    def _within_bounds(self, value: float) -> bool:
+        if self.minimum is not None and value < self.minimum:
+            return False
+        if self.maximum is not None and value > self.maximum:
+            return False
+        return True
+
+    def __repr__(self) -> str:
+        return f"Expression({self.raw!r})"

--- a/inference_perf/utils/numeric/expression/expression.py
+++ b/inference_perf/utils/numeric/expression/expression.py
@@ -23,8 +23,11 @@ vectorised path for structured ``Distribution`` configs.
 Grammar: constants, the single time variable ``t``, standard math, and
 ``sympy.stats`` distribution constructors (``Normal(512, 200)``,
 ``Uniform(10, 50)``, ``Poisson(10)``, ...). Each call site decides whether ``t``
-and random variables are permitted, and may constrain the value range so that,
-for example, a request-rate expression can never evaluate negative.
+and random variables are permitted, and may constrain the value range. Bounds
+are assertions by default: a value that can provably escape them is rejected at
+construction, and an escape only detectable at sample time raises there. A call
+site that would rather truncate random draws, e.g. so a request-rate expression
+can never go negative, opts in with ``clip=True``.
 """
 
 from __future__ import annotations
@@ -56,7 +59,7 @@ try:
 
     _NO_NUMPY_SAMPLER = do_sample_numpy.dispatch(object)
 except Exception:  # pragma: no cover - defensive: sympy internal layout changed
-    do_sample_numpy = None  # type: ignore[assignment]
+    do_sample_numpy = None
     _NO_NUMPY_SAMPLER = None
 
 # The single time variable the grammar ever permits.
@@ -123,8 +126,18 @@ class Expression:
             only variable the grammar permits; when ``False`` the expression
             must be constant (and/or random).
         allow_random: Whether ``sympy.stats`` random variables may appear.
-        minimum: Lower bound for sampled values, or ``None`` for unbounded.
-        maximum: Upper bound for sampled values, or ``None`` for unbounded.
+        minimum: Lower bound for the value, or ``None`` for unbounded. Bounds
+            are assertions: a value that can provably escape them is rejected
+            at construction, and an escape only detectable at sample time
+            raises there. See ``clip`` for the truncating alternative.
+        maximum: Upper bound for the value, or ``None`` for unbounded.
+        clip: Truncate instead of assert for *random* draws: samples are
+            clamped into ``[minimum, maximum]``. This piles the out-of-range
+            probability mass onto the bounds, which is why it is opt-in.
+            Requires at least one bound, and rejects at construction an
+            expression whose value provably never intersects the bounds
+            (every draw would collapse onto a single bound). Deterministic
+            values are always asserted, never clamped, even with ``clip``.
         duration: The upper end of the ``t`` domain (stage duration, seconds).
             Required to statically bound a time-varying expression; without it
             a bounded time-varying expression is checked at sample time instead.
@@ -138,14 +151,18 @@ class Expression:
         allow_random: bool = True,
         minimum: Optional[float] = None,
         maximum: Optional[float] = None,
+        clip: bool = False,
         duration: Optional[float] = None,
     ) -> None:
         if minimum is not None and maximum is not None and minimum > maximum:
             raise ValueError(f"minimum ({minimum}) cannot be greater than maximum ({maximum}).")
+        if clip and minimum is None and maximum is None:
+            raise ValueError("clip=True requires minimum and/or maximum to clip to.")
 
         self.raw = raw
         self.minimum = minimum
         self.maximum = maximum
+        self.clip = clip
         self._expr = self._parse(raw)
 
         # Reject unknown functions, e.g. a misspelled distribution InvalidDist(10).
@@ -168,7 +185,7 @@ class Expression:
             raise ValueError(f"Expression {raw!r} uses disallowed symbol(s) {sorted(disallowed)}; permitted: {permitted}.")
 
         # Resolve the range policy once, raising now for provable violations.
-        self._clip_random = self._is_random and (minimum is not None or maximum is not None)
+        self._clip_random = clip and self._is_random
         self._runtime_check = False
         self._validate_range(duration)
         self._compile_random_sampler()
@@ -217,6 +234,9 @@ class Expression:
         if isinstance(raw, (int, float)):
             return sympy.sympify(raw)
         if isinstance(raw, str):
+            # parse_expr ultimately eval()s the transformed string, so an
+            # expression is only as trustworthy as the config it came from.
+            # These strings are config-author input, never end-user input.
             try:
                 return parse_expr(raw, local_dict=_parse_namespace([0]))
             except (SyntaxError, TypeError, AttributeError, sympy.SympifyError) as e:
@@ -234,22 +254,32 @@ class Expression:
         static_range = self._static_range(duration)
 
         if static_range is None:
-            # Undecided: defer to sample time. Random draws are clamped; a
-            # deterministic value out of range is a config error and raises.
-            if not self._is_random:
-                self._runtime_check = True
+            # Undecided: defer to sample time. With ``clip`` random draws are
+            # clamped; otherwise any out-of-range value raises when sampled.
+            self._runtime_check = not self._clip_random
+            return
+
+        if self._clip_random:
+            # Truncation is opted into, so a support wider than the bounds is
+            # fine; only a support entirely outside them is rejected, because
+            # every draw would collapse onto a single bound.
+            if static_range.intersect(bounds) == sympy.S.EmptySet:
+                raise ValueError(
+                    f"Expression {self.raw!r} evaluates within {static_range}, which never "
+                    f"intersects the permitted range {bounds}; clipping would collapse every draw to a bound."
+                )
             return
 
         contained = static_range.is_subset(bounds)
         if contained is True:
             return
         if contained is False:
+            hint = " Pass clip=True to clamp random draws into range instead." if self._is_random else ""
             raise ValueError(
-                f"Expression {self.raw!r} can evaluate to {static_range}, which is outside the permitted range {bounds}."
+                f"Expression {self.raw!r} can evaluate to {static_range}, which is outside the permitted range {bounds}.{hint}"
             )
         # is_subset returned None (couldn't decide): treat as undecided.
-        if not self._is_random:
-            self._runtime_check = True
+        self._runtime_check = True
 
     def _static_range(self, duration: Optional[float]) -> Any:
         """Best-effort provable value range, or ``None`` when undecidable."""
@@ -349,7 +379,9 @@ class Expression:
             # sampler (independent draws, since the shared rng advances between
             # leaves), then evaluate the lambdified deterministic skeleton over
             # the drawn arrays.
-            leaf_draws = [np.asarray(do_sample_numpy(dist, (size,), rng), dtype=np.float64) for _ph, dist in self._random_leaves]
+            leaf_draws = [
+                np.asarray(do_sample_numpy(dist, (size,), rng), dtype=np.float64) for _ph, dist in self._random_leaves
+            ]
             tval = 0.0 if t is None else float(t)
             out = self._lambdified(*leaf_draws, tval)  # type: ignore[misc]
             samples = np.asarray(out, dtype=np.float64)
@@ -362,6 +394,16 @@ class Expression:
                 self.minimum if self.minimum is not None else -np.inf,
                 self.maximum if self.maximum is not None else np.inf,
             )
+        elif self._runtime_check:
+            lo = self.minimum if self.minimum is not None else -np.inf
+            hi = self.maximum if self.maximum is not None else np.inf
+            out_of_range = (samples < lo) | (samples > hi)
+            if bool(np.any(out_of_range)):
+                offender = float(samples.reshape(-1)[np.argmax(out_of_range.reshape(-1))])
+                raise ValueError(
+                    f"Expression {self.raw!r} drew {offender}, outside the permitted range "
+                    f"[{self.minimum}, {self.maximum}]. Pass clip=True to clamp draws into range instead."
+                )
         # The fallback yields a 0-d scalar for size==1 while the numpy fast path
         # yields a shape-(1,) array; flatten before scalarising so both work.
         return float(samples.reshape(-1)[0]) if size == 1 else samples

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "analysis", "dev", "lint", "otel", "test", "types"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:e3933d2724dfc873315aabb0ed8d439041fcb9a28a15675d15a5b86f37bbe6cd"
+content_hash = "sha256:5f8164a94745122183abeb521c0080133b0eee9a66cc8596caafd232712682b2"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -1840,6 +1840,16 @@ files = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+summary = "Python library for arbitrary-precision floating-point arithmetic"
+groups = ["default"]
+files = [
+    {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
+    {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 requires_python = ">=3.9"
@@ -3299,6 +3309,20 @@ dependencies = [
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+requires_python = ">=3.9"
+summary = "Computer algebra system (CAS) in Python"
+groups = ["default"]
+dependencies = [
+    "mpmath<1.4,>=1.1.0",
+]
+files = [
+    {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
+    {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "analysis", "dev", "lint", "otel", "test", "types"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5f8164a94745122183abeb521c0080133b0eee9a66cc8596caafd232712682b2"
+content_hash = "sha256:97dafa07cf7d28f27b928595a45f23058148a897445d5c846f4c7065645eaf80"
 
 [[metadata.targets]]
 requires_python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "av>=13.0.0",
     "pillow>=10.0.0",
     "prometheus-client>=0.20.0",
+    "sympy>=1.13.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"
@@ -178,6 +179,7 @@ module = [
     "opentelemetry.*",
     "google.cloud.*",
     "PIL.*",
+    "sympy.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "av>=13.0.0",
     "pillow>=10.0.0",
     "prometheus-client>=0.20.0",
-    "sympy>=1.13.0",
+    "sympy>=1.13.0,<1.15",
 ]
 requires-python = ">=3.12"
 readme = "README.md"

--- a/tests/required/utils/numeric/distribution/test_contract.py
+++ b/tests/required/utils/numeric/distribution/test_contract.py
@@ -1,0 +1,124 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Characterization tests for the Distribution sampling API.
+
+``utils.numeric.expression`` is intended to subsume this API. These tests pin
+the current behavioral contract, especially where it differs from Expression
+semantics (silent clipping vs assert-by-default bounds, integer rounding,
+parameters that are reinterpreted or ignored per distribution type), so the
+migration changes each behavior knowingly rather than accidentally.
+"""
+
+import numpy as np
+import pytest
+
+from inference_perf.config import Distribution, DistributionType
+from inference_perf.utils.numeric.distribution import generate_distribution, sample_from_distribution
+
+
+class TestSampleFromDistributionContract:
+    def test_out_of_range_mass_silently_clips_to_bounds(self) -> None:
+        # Draws beyond [min, max] are clipped, piling probability mass onto the
+        # exact bound values. Expression makes this an explicit clip=True opt-in.
+        config = Distribution(type=DistributionType.NORMAL, mean=500.0, min=400, max=600, std_dev=300.0)
+        result = sample_from_distribution(config, 2000, rng=np.random.default_rng(0))
+        assert 400 in result
+        assert 600 in result
+
+    def test_mean_outside_bounds_accepted_and_collapses_to_bound(self) -> None:
+        # No mean-within-bounds validation: every draw clips to the near bound.
+        # (Contrast generate_distribution, which rejects this for "normal".)
+        config = Distribution(type=DistributionType.NORMAL, mean=1000.0, min=0, max=100, std_dev=10.0)
+        result = sample_from_distribution(config, 100, rng=np.random.default_rng(0))
+        assert all(v == 100 for v in result)
+
+    def test_always_returns_rounded_integers(self) -> None:
+        # Output is always rounded to an integer dtype; Expression returns floats.
+        config = Distribution(type=DistributionType.NORMAL, mean=100.5, min=0, max=200, std_dev=10.0)
+        result = sample_from_distribution(config, 100, rng=np.random.default_rng(0))
+        assert np.issubdtype(result.dtype, np.integer)
+
+    def test_fixed_truncates_mean_instead_of_rounding(self) -> None:
+        config = Distribution(type=DistributionType.FIXED, mean=99.9, min=0, max=200)
+        result = sample_from_distribution(config, 10, rng=np.random.default_rng(0))
+        assert all(v == 99 for v in result)
+
+    def test_uniform_ignores_mean_and_std_dev(self) -> None:
+        a = Distribution(type=DistributionType.UNIFORM, mean=20.0, min=1, max=10, std_dev=5.0)
+        b = Distribution(type=DistributionType.UNIFORM, mean=80.0, min=1, max=10, std_dev=50.0)
+        result_a = sample_from_distribution(a, 100, rng=np.random.default_rng(7))
+        result_b = sample_from_distribution(b, 100, rng=np.random.default_rng(7))
+        np.testing.assert_array_equal(result_a, result_b)
+
+    def test_uniform_reaches_both_endpoints(self) -> None:
+        # Draws come from [min, max + 1) then clip, so max is fully reachable
+        # rather than a half-weight rounding edge.
+        config = Distribution(type=DistributionType.UNIFORM, mean=5.0, min=1, max=10)
+        values = set(sample_from_distribution(config, 5000, rng=np.random.default_rng(1)).tolist())
+        assert 1 in values
+        assert 10 in values
+
+    def test_poisson_nonpositive_mean_falls_back_to_lambda_one(self) -> None:
+        config = Distribution(type=DistributionType.POISSON, mean=0.0, min=0, max=50, std_dev=0.0)
+        result = sample_from_distribution(config, 5000, rng=np.random.default_rng(2))
+        assert abs(float(result.mean()) - 1.0) < 0.15
+
+    def test_poisson_ignores_std_dev(self) -> None:
+        a = Distribution(type=DistributionType.POISSON, mean=10.0, min=0, max=100, std_dev=1.0)
+        b = Distribution(type=DistributionType.POISSON, mean=10.0, min=0, max=100, std_dev=99.0)
+        result_a = sample_from_distribution(a, 100, rng=np.random.default_rng(3))
+        result_b = sample_from_distribution(b, 100, rng=np.random.default_rng(3))
+        np.testing.assert_array_equal(result_a, result_b)
+
+    def test_skew_normal_mean_param_is_location_not_mean(self) -> None:
+        # The Azzalini construction treats "mean" as the location parameter, so
+        # positive skew shifts the actual sample mean well above it.
+        config = Distribution(type=DistributionType.SKEW_NORMAL, mean=100.0, min=-1000, max=1000, std_dev=50.0, skew=5.0)
+        result = sample_from_distribution(config, 10000, rng=np.random.default_rng(4))
+        assert float(result.mean()) > 110.0
+
+    def test_lognormal_is_moment_matched(self) -> None:
+        # mean/std_dev describe the lognormal itself, not the underlying normal.
+        config = Distribution(type=DistributionType.LOGNORMAL, mean=150.0, min=1, max=100000, std_dev=60.0)
+        result = sample_from_distribution(config, 20000, rng=np.random.default_rng(5))
+        assert abs(float(result.mean()) - 150.0) < 5.0
+
+    def test_unseeded_calls_are_not_reproducible(self) -> None:
+        # rng=None means a fresh default generator per call; reproducible runs
+        # must thread a seeded Generator. Expression keeps this contract.
+        config = Distribution(type=DistributionType.NORMAL, mean=500.0, min=0, max=1000, std_dev=100.0)
+        result_a = sample_from_distribution(config, 100)
+        result_b = sample_from_distribution(config, 100)
+        assert not np.array_equal(result_a, result_b)
+
+
+class TestGenerateDistributionContract:
+    def test_normal_mean_outside_bounds_rejected(self) -> None:
+        # The legacy entry point validates mean against the bounds for "normal";
+        # sample_from_distribution does not (see the collapse test above).
+        with pytest.raises(ValueError, match="[Mm]ean"):
+            generate_distribution(min=0, max=100, mean=1000, std_dev=10, total_count=10)
+
+    def test_unknown_dist_type_rejected(self) -> None:
+        with pytest.raises(ValueError, match="dist_type"):
+            generate_distribution(min=0, max=100, mean=50, std_dev=10, total_count=10, dist_type="zipf")
+
+    def test_lognormal_is_shifted_by_min(self) -> None:
+        # The legacy lognormal moment-matches the distribution of (value - min),
+        # then shifts by min; the floor is min, not zero.
+        result = generate_distribution(
+            min=100, max=100000, mean=150, std_dev=30, total_count=5000, rng=np.random.default_rng(6)
+        )
+        assert result.min() >= 100
+        assert abs(float(result.mean()) - 150.0) < 5.0

--- a/tests/required/utils/numeric/expression/test_expression.py
+++ b/tests/required/utils/numeric/expression/test_expression.py
@@ -1,0 +1,175 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import pytest
+
+from inference_perf.utils.numeric.expression import Expression
+
+
+class TestConstant:
+    def test_int(self) -> None:
+        expr = Expression(10)
+        assert expr.is_constant
+        assert not expr.is_random
+        assert expr.sample() == 10.0
+
+    def test_float_string(self) -> None:
+        assert Expression("3.5").sample() == 3.5
+
+    def test_t_does_not_affect_constant(self) -> None:
+        assert Expression("10").sample(t=100) == 10.0
+
+    def test_size_broadcasts(self) -> None:
+        result = Expression("7").sample(size=4)
+        assert isinstance(result, np.ndarray)
+        assert result.tolist() == [7.0, 7.0, 7.0, 7.0]
+
+
+class TestTimeVarying:
+    def test_linear(self) -> None:
+        expr = Expression("10 + t")
+        assert expr.free_symbols == {"t"}
+        assert expr.sample(t=0) == 10.0
+        assert expr.sample(t=5) == 15.0
+
+    def test_division(self) -> None:
+        assert Expression("t / 2").sample(t=10) == 5.0
+
+    def test_oscillating(self) -> None:
+        expr = Expression("10 + 5*sin(2*pi*t/60)")
+        assert expr.sample(t=0) == pytest.approx(10.0)
+        assert expr.sample(t=15) == pytest.approx(15.0)
+
+    def test_requires_t_when_missing(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("10 + t").sample()
+
+
+class TestVariablePermissions:
+    def test_t_disallowed(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("10 + t", allow_time=False)
+
+    def test_t_allowed_by_default(self) -> None:
+        assert Expression("10 + t").sample(t=1) == 11.0
+
+    def test_only_t_is_a_valid_variable(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("10 + x")
+
+    def test_invalid_bareword_is_disallowed_symbol(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("invalid_expr")
+
+    def test_unknown_function_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("InvalidDist(10)")
+
+    def test_unparseable(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            Expression("10 +* 2")
+
+
+class TestRandom:
+    def test_normal_returns_float(self) -> None:
+        expr = Expression("Normal(512, 200)")
+        assert expr.is_random
+        assert isinstance(expr.sample(), float)
+
+    def test_uniform_in_support(self) -> None:
+        val = Expression("Uniform(10, 50)").sample(rng=np.random.default_rng(0))
+        assert 10 <= val <= 50
+
+    def test_poisson(self) -> None:
+        assert isinstance(Expression("Poisson(10)").sample(), float)
+
+    def test_random_disallowed(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("Normal(10, 2)", allow_random=False)
+
+    def test_size_returns_array(self) -> None:
+        result = Expression("Uniform(10, 50)").sample(size=100, rng=np.random.default_rng(1))
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (100,)
+        assert result.min() >= 10 and result.max() <= 50
+
+    def test_reproducible_with_seed(self) -> None:
+        a = Expression("Normal(10, 2)").sample(size=50, rng=np.random.default_rng(42))
+        b = Expression("Normal(10, 2)").sample(size=50, rng=np.random.default_rng(42))
+        np.testing.assert_array_equal(a, b)
+
+    def test_mixed_time_and_random(self) -> None:
+        # 10 + Normal(0, 1) shifted by t; just needs to produce a float.
+        expr = Expression("10 + t + Normal(0, 1)")
+        assert expr.is_random
+        assert isinstance(expr.sample(t=5, rng=np.random.default_rng(0)), float)
+
+    def test_distribution_beyond_legacy_fast_path(self) -> None:
+        # Rayleigh was never in the hand-written sampler table; it is served by
+        # sympy's own numpy dispatcher on the fast path (not the slow fallback)
+        # and its draws stay within the [0, oo) support.
+        expr = Expression("Rayleigh(2)")
+        assert expr.is_random
+        assert not expr._fallback
+        result = expr.sample(size=200, rng=np.random.default_rng(7))
+        assert result.min() >= 0
+
+
+class TestRangeValidation:
+    def test_constant_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("-5", minimum=0)
+
+    def test_constant_within_range_ok(self) -> None:
+        assert Expression("5", minimum=0, maximum=10).sample() == 5.0
+
+    def test_time_varying_provably_out_of_range_rejected(self) -> None:
+        # 10 + 5*sin(...) dips to 5 over the domain; min=8 is violated.
+        with pytest.raises(ValueError):
+            Expression("10 + 5*sin(2*pi*t/60)", minimum=8, duration=120)
+
+    def test_time_varying_provably_in_range_ok(self) -> None:
+        # Range over [0, 120] is [5, 15]; bounds [0, 20] contain it.
+        expr = Expression("10 + 5*sin(2*pi*t/60)", minimum=0, maximum=20, duration=120)
+        assert expr.sample(t=0) == pytest.approx(10.0)
+
+    def test_unbounded_support_random_rejected(self) -> None:
+        # Normal has support (-oo, oo); a non-negative rate is impossible to guarantee.
+        with pytest.raises(ValueError):
+            Expression("Normal(10, 2)", minimum=0)
+
+    def test_bounded_support_random_ok(self) -> None:
+        # Uniform(10, 50) support is within [0, 100].
+        expr = Expression("Uniform(10, 50)", minimum=0, maximum=100)
+        assert 10 <= expr.sample(rng=np.random.default_rng(0)) <= 50
+
+    def test_random_undecided_support_is_clamped(self) -> None:
+        # Mixed random support is undecidable statically, so values are clamped.
+        expr = Expression("100 + 50*Normal(0, 1)", minimum=0, maximum=120)
+        result = expr.sample(size=500, rng=np.random.default_rng(3))
+        assert isinstance(result, np.ndarray)
+        assert result.min() >= 0
+        assert result.max() <= 120
+
+    def test_deterministic_undecided_raises_at_sample_time(self) -> None:
+        # No duration given, so the t range can't be proven up front; the
+        # negative value surfaces when sampled.
+        expr = Expression("10 - t", minimum=0)
+        assert expr.sample(t=5) == 5.0
+        with pytest.raises(ValueError):
+            expr.sample(t=20)
+
+    def test_min_greater_than_max_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("5", minimum=10, maximum=0)

--- a/tests/required/utils/numeric/expression/test_expression.py
+++ b/tests/required/utils/numeric/expression/test_expression.py
@@ -123,6 +123,7 @@ class TestRandom:
         assert expr.is_random
         assert not expr._fallback
         result = expr.sample(size=200, rng=np.random.default_rng(7))
+        assert isinstance(result, np.ndarray)
         assert result.min() >= 0
 
 
@@ -154,14 +155,6 @@ class TestRangeValidation:
         expr = Expression("Uniform(10, 50)", minimum=0, maximum=100)
         assert 10 <= expr.sample(rng=np.random.default_rng(0)) <= 50
 
-    def test_random_undecided_support_is_clamped(self) -> None:
-        # Mixed random support is undecidable statically, so values are clamped.
-        expr = Expression("100 + 50*Normal(0, 1)", minimum=0, maximum=120)
-        result = expr.sample(size=500, rng=np.random.default_rng(3))
-        assert isinstance(result, np.ndarray)
-        assert result.min() >= 0
-        assert result.max() <= 120
-
     def test_deterministic_undecided_raises_at_sample_time(self) -> None:
         # No duration given, so the t range can't be proven up front; the
         # negative value surfaces when sampled.
@@ -173,3 +166,80 @@ class TestRangeValidation:
     def test_min_greater_than_max_rejected(self) -> None:
         with pytest.raises(ValueError):
             Expression("5", minimum=10, maximum=0)
+
+
+class TestClipPolicy:
+    """Bounds assert by default; ``clip=True`` opts random draws into truncation."""
+
+    def test_clip_clamps_bare_rv_with_unbounded_support(self) -> None:
+        # Without clip this exact expression is rejected at construction
+        # (see test_unbounded_support_random_rejected).
+        expr = Expression("Normal(512, 200)", minimum=0, clip=True)
+        result = expr.sample(size=500, rng=np.random.default_rng(0))
+        assert isinstance(result, np.ndarray)
+        assert result.min() >= 0
+
+    def test_clip_clamps_transformed_rv(self) -> None:
+        expr = Expression("100 + 50*Normal(0, 1)", minimum=0, maximum=120, clip=True)
+        result = expr.sample(size=500, rng=np.random.default_rng(3))
+        assert isinstance(result, np.ndarray)
+        assert result.min() >= 0
+        assert result.max() <= 120
+
+    def test_random_undecided_without_clip_raises_on_out_of_range_draw(self) -> None:
+        # Transformed randomness is statically undecidable, so construction
+        # succeeds; every draw lands in [10, 11] and violates maximum=5.
+        expr = Expression("Uniform(0, 1) + 10", maximum=5)
+        with pytest.raises(ValueError, match="clip=True"):
+            expr.sample(size=10, rng=np.random.default_rng(0))
+
+    def test_random_undecided_without_clip_in_range_ok(self) -> None:
+        expr = Expression("Uniform(0, 1) + 10", minimum=0, maximum=20)
+        val = expr.sample(rng=np.random.default_rng(0))
+        assert 10 <= val <= 11
+
+    def test_clip_rejects_provably_disjoint_support(self) -> None:
+        # Uniform(10, 20) never intersects (-oo, 5]; clipping would collapse
+        # every draw to the bound, which is a config error even with clip.
+        with pytest.raises(ValueError):
+            Expression("Uniform(10, 20)", maximum=5, clip=True)
+
+    def test_clip_requires_bounds(self) -> None:
+        with pytest.raises(ValueError):
+            Expression("Normal(0, 1)", clip=True)
+
+    def test_clip_never_clamps_deterministic_values(self) -> None:
+        # A deterministic out-of-range value is a config error regardless of
+        # clip: provable violations raise at construction, time-varying ones
+        # at sample time.
+        with pytest.raises(ValueError):
+            Expression("-5", minimum=0, clip=True)
+        expr = Expression("10 - t", minimum=0, clip=True)
+        assert expr.sample(t=5) == 5.0
+        with pytest.raises(ValueError):
+            expr.sample(t=20)
+
+
+class TestSympyInternalsFence:
+    """Fail loudly if a sympy upgrade breaks the internals the fast path leans on.
+
+    Both fences guard silent degradation: if sympy moves ``do_sample_numpy``
+    or reshapes its distribution constructors, Expression would still work but
+    every random draw would take the slow symbolic path.
+    """
+
+    def test_numpy_fast_path_compiled(self) -> None:
+        from inference_perf.utils.numeric.expression import expression as mod
+
+        # getattr rather than attribute access: do_sample_numpy is an import,
+        # not a definition, so mypy --strict flags cross-module access to it.
+        assert getattr(mod, "do_sample_numpy", None) is not None
+        expr = Expression("Normal(0, 1) + Uniform(0, 1) + t")
+        assert not expr._fallback
+        assert expr._lambdified is not None
+
+    def test_distribution_constructors_discovered(self) -> None:
+        from inference_perf.utils.numeric.expression import expression as mod
+
+        for name in ("Normal", "Uniform", "Poisson", "Exponential", "LogNormal", "Gamma"):
+            assert name in mod._DISTRIBUTION_CTORS, f"sympy.stats constructor discovery lost {name}"


### PR DESCRIPTION
Adds `utils/numeric/expression`: a first-class `Expression` type that turns a numeric config knob written as a string into an object parsed and validated once at construction, then sampled cheaply many times.

## Motivation

Numeric config knobs today are fixed scalars or structured `Distribution` configs. There is no compact way to express time-varying load shapes (ramps, sinusoids, bursts) or ad-hoc randomness, and every new shape means new config surface. This adds one string grammar covering all three ingredients and their combinations:

- constants: `"3.5"`
- functions of stage time: `"10 + 5*sin(2*pi*t/60)"`
- draws from any `sympy.stats` distribution: `"Normal(512, 200)"`, `"100 + 50*Normal(0, 1)"`

Each call site decides which ingredients are permitted (`allow_time`, `allow_random`) and may bound the value range, so a request-rate knob can forbid negatives. `Expression` complements `numeric.distribution` rather than replacing it; that module remains the vectorised path for structured `Distribution` configs.

## Change structure

`inference_perf/utils/numeric/expression/expression.py`:

- **`do_sample_numpy` guarded import**: resolves sympy's internal numpy-sampler registry once; if a future sympy moves it, sampling degrades to the symbolic path instead of breaking.
- **`_T`**: the one permitted time symbol, `t`.
- **`_distribution_constructors()` / `_DISTRIBUTION_CTORS`**: discovers every `sympy.stats` constructor at import, so any sympy distribution works without a hardcoded table.
- **`_parse_namespace()`**: parser namespace whose constructors need no name argument; auto-generated unique names make repeated draws independent.
- **`Expression.__init__`**: parse, reject unknown functions, enforce `allow_time` / `allow_random`, resolve the range policy, precompile the sampler; config errors raise `ValueError` at load time.
- **`_validate_range` / `_static_range`**: prove the value range statically when possible. Bounds assert by default; `clip=True` opts random draws into truncation (requires a bound, never applies to deterministic values, rejects disjoint supports).
- **`_compile_random_sampler`**: splits the tree into random leaves plus a lambdified deterministic skeleton, resolving each leaf's sampler once.
- **`sample(t, rng, size)`**: deterministic eval, numpy fast path, or symbolic fallback; clips or asserts per policy; float for `size == 1`, else array.
- **`is_constant` / `is_random` / `free_symbols`**: let call sites branch on what the author wrote.

Supporting changes:

- `tests/.../expression/test_expression.py`: suites for constants, time-varying expressions, symbol permissions, random sampling, range validation, the clip policy, and canary tests that fail loudly if a sympy upgrade breaks the internals.
- `tests/.../distribution/test_contract.py`: characterization tests pinning the current `Distribution` sampling contract this API is meant to subsume (silent clipping, integer rounding, per-type parameter reinterpretation), so migration changes each behavior knowingly.
- `pyproject.toml` / `pdm.lock`: adds `sympy>=1.13.0,<1.15`.

## Notes

- **Bounds semantics are deliberate**: assert by default, truncate only on explicit `clip=True`, because clipping piles out-of-range probability mass onto the bounds and callers should opt in knowingly. Error messages point at `clip=True` when it applies.
- **Trust boundary**: `parse_expr` ultimately evaluates the transformed string, so expressions are config-author input, never end-user input (noted in the code).
- **sympy internals**: the fast path leans on `do_sample_numpy` (internal) and name-first constructor discovery (conventional), both fenced by the canary tests and the `<1.15` pin; a bump past the pin should update both together.
- **Performance shape**: construction can be slow in the worst case (`function_range` on ugly expressions), sampling is numpy-speed; construct once at config load, sample per request.
- **Reproducibility**: `sample()` accepts a `numpy.random.Generator`; unseeded calls use a fresh generator and are not reproducible, so benchmark call sites should thread the run's seeded generator.

Future work:

- Wire the first consumer (request-rate stages and/or datagen length fields); this PR intentionally lands the primitive alone.
- Broader integration where the distribution layer accepts expressions directly (prototyped on the `expression-distribution` branch), guided by the contract tests above.
- A pydantic field type wrapping `Expression` so schemas declare per-knob policy (`allow_time`, bounds, `clip`) declaratively.
