### PR TITLE
Addressed inflated streamed output_len by adding server-sourced output_tokens metric 

### DIFF
--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -84,6 +84,29 @@ def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric]) -> dict[
     }
 
 
+def summarize_output_token_usage(metrics: List[RequestLifecycleMetric]) -> dict[str, float]:
+    """Total output tokens as reported by the server (usage.completion_tokens).
+
+    The server-side count is exact (a count of decode steps), unlike a
+    client-side re-tokenization of the streamed text. Falls back to the
+    client-side output_tokens when the server does not report usage. Mirrors
+    summarize_prompt_token_usage on the input side.
+    """
+    output_tokens_total = 0.0
+
+    for metric in metrics:
+        response_metrics = metric.info.response_metrics
+        server_usage = response_metrics.server_usage if isinstance(response_metrics, StreamedResponseMetrics) else None
+        completion_tokens = (
+            server_usage.get("completion_tokens")
+            if server_usage
+            else (response_metrics.output_tokens if response_metrics else None)
+        )
+        output_tokens_total += safe_float(completion_tokens)
+
+    return {"total": output_tokens_total}
+
+
 class ResponsesSummary(BaseModel):
     benchmark_time_seconds: float
     load_summary: dict[str, Any]
@@ -453,7 +476,9 @@ def summarize_requests(
                     accumulated_tokens += tokens_in_chunk
 
             m.info.response_metrics.output_token_times = output_token_times
-            m.info.response_metrics.output_tokens = accumulated_tokens
+            # Do not overwrite output_tokens with the per-chunk sum: re-tokenizing each chunk
+            # inflates the count (e.g. a BOS per chunk). Keep the API layer's whole-message
+            # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
 
             if expected_output_tokens is not None and accumulated_tokens != expected_output_tokens:
                 mismatched_requests += 1
@@ -596,6 +621,7 @@ def summarize_requests(
             ],
             percentiles,
         ),
+        "output_tokens": summarize_output_token_usage(all_successful),
         "token_count_mismatches": mismatched_requests,
     }
     if goodput_metrics:

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -60,7 +60,10 @@ def test_summarize_requests_with_chunks() -> None:
     info = InferenceInfo(
         request_metrics=RequestMetrics(text=Text(input_tokens=5)),
         response_metrics=StreamedResponseMetrics(
-            response_chunks=['{"choices": [{"text": "hello"}]}', '{"choices": [{"text": "world"}]}'], chunk_times=[1.0, 2.0]
+            # output_tokens is the API layer's whole-message count; chunks drive timing (TPOT/TTFT).
+            output_tokens=5,
+            response_chunks=['{"choices": [{"text": "hello"}]}', '{"choices": [{"text": "world"}]}'],
+            chunk_times=[1.0, 2.0],
         ),
     )
 
@@ -78,6 +81,90 @@ def test_summarize_requests_with_chunks() -> None:
 
     ttft_summary = successes["latency"]["time_to_first_token"]
     assert ttft_summary["mean"] == pytest.approx(1.0)
+
+
+def test_summarize_requests_multiple_tokens_same_timestamp() -> None:
+    from unittest.mock import Mock
+
+    mock_tokenizer = Mock()
+    mock_tokenizer.count_tokens.side_effect = lambda text: 3 if "hello" in text else 0
+
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+        response_metrics=StreamedResponseMetrics(response_chunks=['{"choices": [{"text": "hello"}]}'], chunk_times=[1.0]),
+    )
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="test_request", info=info, error=None
+    )
+
+    summarize_requests([metric], [50], tokenizer=mock_tokenizer)
+
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    assert metric.info.response_metrics.output_token_times == [1.0, 1.0, 1.0]
+
+
+def test_summarize_requests_surfaces_output_token_usage() -> None:
+    """successes.output_tokens reports the server's completion_tokens, summed.
+
+    Mirrors the input-side prompt_tokens metric (PR #473): the exact server
+    count surfaced separately from the client-side output_len distribution.
+    """
+    metrics = []
+    for completion_tokens in (3, 7):
+        info = InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=10)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=completion_tokens,
+                server_usage={"prompt_tokens": 10, "completion_tokens": completion_tokens},
+            ),
+        )
+        metrics.append(
+            RequestLifecycleMetric(scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None)
+        )
+
+    result = summarize_requests(metrics, [50])
+
+    assert result.successes["output_tokens"] == {"total": 10.0}
+
+
+def test_summarize_requests_output_tokens_falls_back_to_client_count() -> None:
+    """Without server usage, output_tokens.total falls back to the client count."""
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=10)),
+        response_metrics=StreamedResponseMetrics(output_tokens=4),  # no server_usage
+    )
+    metric = RequestLifecycleMetric(scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None)
+
+    result = summarize_requests([metric], [50])
+
+    assert result.successes["output_tokens"] == {"total": 4.0}
+
+
+def test_output_len_not_recomputed_from_chunks() -> None:
+    """Regression for issue #564: output_len keeps the API layer's whole-message
+    output_tokens and is NOT re-derived by summing per-chunk re-tokenizations
+    (which inflate the count, e.g. a BOS added per chunk)."""
+    from unittest.mock import Mock
+
+    mock_tokenizer = Mock()
+    # Each chunk re-tokenizes to 2, so a per-chunk sum would be 4 (double).
+    mock_tokenizer.count_tokens.side_effect = lambda text: 2 if text else 0
+
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+        response_metrics=StreamedResponseMetrics(
+            output_tokens=2,  # API layer's whole-message count
+            response_chunks=['{"choices": [{"text": "a"}]}', '{"choices": [{"text": "b"}]}'],
+            chunk_times=[1.0, 2.0],
+        ),
+    )
+    metric = RequestLifecycleMetric(scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None)
+
+    result = summarize_requests([metric], [50], tokenizer=mock_tokenizer)
+
+    # output_len stays the whole-message count (2), not the per-chunk sum (4).
+    assert result.successes["output_len"]["mean"] == pytest.approx(2.0)
 
 
 def test_summarize_requests_token_mismatch() -> None:
@@ -107,27 +194,6 @@ def test_summarize_requests_token_mismatch() -> None:
     assert result is not None
     successes = result.successes
     assert successes["token_count_mismatches"] == 1
-
-
-def test_summarize_requests_multiple_tokens_same_timestamp() -> None:
-    from unittest.mock import Mock
-
-    mock_tokenizer = Mock()
-    mock_tokenizer.count_tokens.side_effect = lambda text: 3 if "hello" in text else 0
-
-    info = InferenceInfo(
-        request_metrics=RequestMetrics(text=Text(input_tokens=5)),
-        response_metrics=StreamedResponseMetrics(response_chunks=['{"choices": [{"text": "hello"}]}'], chunk_times=[1.0]),
-    )
-
-    metric = RequestLifecycleMetric(
-        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="test_request", info=info, error=None
-    )
-
-    summarize_requests([metric], [50], tokenizer=mock_tokenizer)
-
-    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
-    assert metric.info.response_metrics.output_token_times == [1.0, 1.0, 1.0]
 
 
 def test_summarize_requests_surfaces_prompt_cache_usage() -> None:

--- a/tests/test_streaming_multi_token_chunks.py
+++ b/tests/test_streaming_multi_token_chunks.py
@@ -99,14 +99,16 @@ async def test_multi_token_chunks_count_tokens_not_chunks() -> None:
     metric = RequestLifecycleMetric(
         scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="prompt", info=info, error=None
     )
-    summarize_requests([metric], [50], tokenizer=tokenizer)
+    result = summarize_requests([metric], [50], tokenizer=tokenizer)
 
+    assert result is not None
     assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
-    # Sum of per-chunk tokens, NOT chunk count. This is the assertion that
-    # would fail under the pre-#410 implementation.
-    assert metric.info.response_metrics.output_tokens == 8
-    assert metric.info.response_metrics.output_tokens != len(chunk_texts)
-    # Per-token timestamps expanded so TPOT/ITL distributions are accurate.
+    # The authoritative output token total comes from the server (completion_tokens),
+    # surfaced as output_tokens.total. It reflects real tokens, NOT the chunk count
+    # (the #364 bug).
+    assert result.successes["output_tokens"]["total"] == 8
+    assert result.successes["output_tokens"]["total"] != len(chunk_texts)
+    # Per-token timestamps still expand per chunk so TPOT/ITL distributions are accurate.
     assert len(metric.info.response_metrics.output_token_times) == 8
 
 
@@ -139,11 +141,10 @@ async def test_multi_token_chunks_match_server_usage() -> None:
     )
     result = summarize_requests([metric], [50], tokenizer=tokenizer)
 
+    assert result is not None
     assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
-    assert metric.info.response_metrics.output_tokens == expected_total
     assert metric.info.response_metrics.server_usage == {"completion_tokens": expected_total}
 
-    # No mismatches between client tokenization and server usage when the
-    # tokenizer matches; this is the normal-operation expectation.
-    assert result is not None
-    assert result.successes["token_count_mismatches"] == 0
+    # The authoritative output token total comes from the server's completion_tokens,
+    # which is what eliminates the gap against `vllm bench`.
+    assert result.successes["output_tokens"]["total"] == expected_total


### PR DESCRIPTION
Addresses #564

## Problem

For streamed responses, `summarize_requests` recomputed each request's output token count by **summing per-chunk re-tokenizations** of the streamed text. Real tokenizers prepend a BOS token on every call, so counting per chunk adds one BOS per chunk and inflates the count (~2x at one token per chunk, ~1.75x in practice). That pushed the reported `output_len` above the configured `max_tokens` cap (mean ~14382 for an 8192 cap in #564).

## Fix

Stop recomputing the output count from per-chunk sums. `output_len` now keeps the API layer's single whole-message `count_tokens` value, the same methodology already used for `prompt_len`. The per-chunk loop is retained only for per-token timing (ITL / TPOT).

## New `output_tokens` metric

Adds `successes.output_tokens` `{total}`, sourced from the server's `usage.completion_tokens` (the exact decode-step count), falling back to the client-side count when the server reports no usage. This mirrors the input-side `prompt_tokens` metric added in #473, so the report now carries both a client distribution and a server total on each side:

| | client distribution | server total |
|---|---|---|
| input | `prompt_len` | `prompt_tokens` |
| output | `output_len` | `output_tokens` |

`token_count_mismatches` is unchanged: it still reports how often the client-side per-chunk count differs from the server's `completion_tokens`.