### PR TITLE
Address ITL deflation from per-chunk BOS in streamed timing

### DIFF
--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -466,7 +466,11 @@ def summarize_requests(
                     continue
 
             for text, chunk_time in parsed_chunks:
-                tokens_in_chunk = tokenizer.count_tokens(text)
+                # Count each chunk as a sequence fragment (add_special_tokens=False): re-tokenizing a
+                # chunk with special tokens prepends a BOS per chunk, which inflates the count (~2x at
+                # one token per chunk) and, since these timestamps are the basis for ITL, deflates ITL
+                # by the same factor. See #564.
+                tokens_in_chunk = tokenizer.count_tokens(text, add_special_tokens=False)
                 if tokens_in_chunk > 0:
                     # Assign every token in a chunk the chunk's arrival time to match user-perceived
                     # latency: intra-chunk ITL is 0, inter-chunk ITL absorbs the full gap. TPOT still
@@ -476,8 +480,7 @@ def summarize_requests(
                     accumulated_tokens += tokens_in_chunk
 
             m.info.response_metrics.output_token_times = output_token_times
-            # Do not overwrite output_tokens with the per-chunk sum: re-tokenizing each chunk
-            # inflates the count (e.g. a BOS per chunk). Keep the API layer's whole-message
+            # Do not overwrite output_tokens with the per-chunk sum. Keep the API layer's whole-message
             # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
 
             if expected_output_tokens is not None and accumulated_tokens != expected_output_tokens:

--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -22,15 +22,21 @@ class CustomTokenizer:
             config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
         )
 
-    def count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         if text == "":
             return 0
 
+        # add_special_tokens=False is for counting a fragment of a larger sequence (e.g. a single
+        # streamed chunk), where prepending a BOS per call would over-count by one token per fragment.
         # Some tokenizers don't set model_max_length which defaults to VERY_LARGE_INTEGER.
         # Prevent overflow and log spam by skipping truncation.
         if self.tokenizer.model_max_length == VERY_LARGE_INTEGER:
-            return len(self.tokenizer(text).input_ids)
-        return len(self.tokenizer(text, truncation=True, max_length=self.tokenizer.model_max_length).input_ids)
+            return len(self.tokenizer(text, add_special_tokens=add_special_tokens).input_ids)
+        return len(
+            self.tokenizer(
+                text, truncation=True, max_length=self.tokenizer.model_max_length, add_special_tokens=add_special_tokens
+            ).input_ids
+        )
 
     def get_tokenizer(self) -> PreTrainedTokenizerBase:
         return self.tokenizer

--- a/tests/required/datagen/test_datagen_utils.py
+++ b/tests/required/datagen/test_datagen_utils.py
@@ -25,7 +25,7 @@ class DummyCustomTokenizer(CustomTokenizer):
     def get_tokenizer(self) -> Any:
         return DummyTokenizer()
 
-    def count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         return len(text.split())
 
 

--- a/tests/required/datagen/test_random_datagen.py
+++ b/tests/required/datagen/test_random_datagen.py
@@ -28,7 +28,7 @@ class DummyCustomTokenizer(CustomTokenizer):
     def get_tokenizer(self) -> Any:
         return DummyTokenizer()
 
-    def count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         return len(text.split())
 
 

--- a/tests/required/datagen/test_shared_prefix.py
+++ b/tests/required/datagen/test_shared_prefix.py
@@ -21,7 +21,7 @@ class MockCustomTokenizer(CustomTokenizer):
     def get_tokenizer(self) -> Any:
         return MockHFTokenizer()
 
-    def count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         return len(text.split())
 
 

--- a/tests/required/datagen/test_shared_prefix_datagen.py
+++ b/tests/required/datagen/test_shared_prefix_datagen.py
@@ -263,7 +263,7 @@ class DummyCustomTokenizer(CustomTokenizer):
     def get_tokenizer(self) -> Any:
         return DummyTokenizer()
 
-    def count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         return len(text.split())
 
 

--- a/tests/required/datagen/test_synthetic_datagen.py
+++ b/tests/required/datagen/test_synthetic_datagen.py
@@ -30,7 +30,7 @@ class DummyCustomTokenizer(CustomTokenizer):
     def get_tokenizer(self) -> Any:
         return DummyTokenizer()
 
-    def count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         return len(text.split())
 
 

--- a/tests/required/loadgen/test_worker_rng.py
+++ b/tests/required/loadgen/test_worker_rng.py
@@ -59,7 +59,7 @@ class _DummyCustomTokenizer(CustomTokenizer):
     def get_tokenizer(self) -> Any:
         return _DummyHFTokenizer()
 
-    def count_tokens(self, text: str) -> int:
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         # Each space-separated integer is one token.
         return len(text.split()) if text else 0
 

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -55,7 +55,7 @@ def test_summarize_requests_with_chunks() -> None:
 
     mock_tokenizer = Mock()
     # Assume 1 chunk has 2 tokens, another has 3 tokens
-    mock_tokenizer.count_tokens.side_effect = lambda text: 2 if "hello" in text else (3 if "world" in text else 0)
+    mock_tokenizer.count_tokens.side_effect = lambda text, **kwargs: 2 if "hello" in text else (3 if "world" in text else 0)
 
     info = InferenceInfo(
         request_metrics=RequestMetrics(text=Text(input_tokens=5)),
@@ -87,7 +87,7 @@ def test_summarize_requests_multiple_tokens_same_timestamp() -> None:
     from unittest.mock import Mock
 
     mock_tokenizer = Mock()
-    mock_tokenizer.count_tokens.side_effect = lambda text: 3 if "hello" in text else 0
+    mock_tokenizer.count_tokens.side_effect = lambda text, **kwargs: 3 if "hello" in text else 0
 
     info = InferenceInfo(
         request_metrics=RequestMetrics(text=Text(input_tokens=5)),
@@ -102,6 +102,63 @@ def test_summarize_requests_multiple_tokens_same_timestamp() -> None:
 
     assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
     assert metric.info.response_metrics.output_token_times == [1.0, 1.0, 1.0]
+
+
+def test_itl_not_inflated_by_per_chunk_bos() -> None:
+    """Regression for the ITL half of #564, using the real
+    neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8 tokenizer, which prepends a BOS
+    on every call. Re-tokenizing each streamed chunk with special tokens adds
+    one phantom token per chunk (doubling len(output_token_times) and halving
+    ITL); counting with add_special_tokens=False keeps the per-token timestamp
+    series at the true token count, so ITL lands on the same basis as TPOT.
+    """
+    import json
+    from inference_perf.config import CustomTokenizerConfig
+    from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+    try:
+        tokenizer = CustomTokenizer(
+            CustomTokenizerConfig(pretrained_model_name_or_path="neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8")
+        )
+    except Exception as e:  # offline CI / HF hub unreachable
+        pytest.skip(f"real tokenizer unavailable: {e}")
+    hf = tokenizer.get_tokenizer()
+
+    # Build a one-token-per-chunk stream by decoding each real token id back to text.
+    text = "The quick brown fox jumps over the lazy dog"
+    ids = hf.encode(text, add_special_tokens=False)
+    chunk_texts = [hf.decode([i]) for i in ids]
+    n = len(ids)
+
+    # Sanity: with the BOS the per-chunk sum is inflated by exactly one token per
+    # chunk (the bug); without it, it matches the whole-message count (the fix).
+    assert sum(tokenizer.count_tokens(c, add_special_tokens=True) for c in chunk_texts) == n + len(chunk_texts)
+    assert sum(tokenizer.count_tokens(c, add_special_tokens=False) for c in chunk_texts) == n
+
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+        response_metrics=StreamedResponseMetrics(
+            output_tokens=n,  # whole-message count
+            response_chunks=[json.dumps({"choices": [{"text": t}]}) for t in chunk_texts],
+            chunk_times=[float(i + 1) for i in range(n)],  # 1s between tokens
+            server_usage={"completion_tokens": n},
+        ),
+    )
+    metric = RequestLifecycleMetric(scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None)
+
+    result = summarize_requests([metric], [50], tokenizer=tokenizer)
+
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    # One timestamp per real token, not one-per-token-plus-a-BOS-per-chunk.
+    assert len(metric.info.response_metrics.output_token_times) == n
+
+    # ITL is now consistent with TPOT: both average 1.0s/token over the n-1 gaps.
+    itl_mean = result.successes["latency"]["inter_token_latency"]["mean"]
+    tpot_mean = result.successes["latency"]["time_per_output_token"]["mean"]
+    assert itl_mean == pytest.approx(1.0)
+    assert tpot_mean == pytest.approx(1.0)
+    # Client per-chunk count now agrees with the server's completion_tokens.
+    assert result.successes["token_count_mismatches"] == 0
 
 
 def test_summarize_requests_surfaces_output_token_usage() -> None:
@@ -149,7 +206,7 @@ def test_output_len_not_recomputed_from_chunks() -> None:
 
     mock_tokenizer = Mock()
     # Each chunk re-tokenizes to 2, so a per-chunk sum would be 4 (double).
-    mock_tokenizer.count_tokens.side_effect = lambda text: 2 if text else 0
+    mock_tokenizer.count_tokens.side_effect = lambda text, **kwargs: 2 if text else 0
 
     info = InferenceInfo(
         request_metrics=RequestMetrics(text=Text(input_tokens=5)),
@@ -171,7 +228,7 @@ def test_summarize_requests_token_mismatch() -> None:
     from unittest.mock import Mock
 
     mock_tokenizer = Mock()
-    mock_tokenizer.count_tokens.side_effect = lambda text: 2 if "hello" in text else (3 if "world" in text else 0)
+    mock_tokenizer.count_tokens.side_effect = lambda text, **kwargs: 2 if "hello" in text else (3 if "world" in text else 0)
 
     info = InferenceInfo(
         request_metrics=RequestMetrics(text=Text(input_tokens=5)),

--- a/tests/test_streaming_multi_token_chunks.py
+++ b/tests/test_streaming_multi_token_chunks.py
@@ -85,7 +85,7 @@ async def test_multi_token_chunks_count_tokens_not_chunks() -> None:
     response = FakeStreamingResponse([sse])
 
     tokenizer = MagicMock()
-    tokenizer.count_tokens = MagicMock(side_effect=lambda text: len(text.split()))
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
 
     config = APIConfig(type=APIType.Chat, streaming=True)
     data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="prompt")], max_tokens=100)
@@ -130,7 +130,7 @@ async def test_multi_token_chunks_match_server_usage() -> None:
     response = FakeStreamingResponse([sse])
 
     tokenizer = MagicMock()
-    tokenizer.count_tokens = MagicMock(side_effect=lambda text: len(text.split()))
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
 
     config = APIConfig(type=APIType.Chat, streaming=True)
     data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="prompt")], max_tokens=expected_total)


### PR DESCRIPTION
Addresses #564

**NOTE: this bug impacts ITL measurements when streaming is enabled (currently the default) for all Tokenizers that prepend special tokens (ex. BOS) to each chunk. This includes the Gemma, Llama, OPT, and Mistral families. TTFT, TPOT, and NTPOT are not affected.**

#565 fixed the output token count but ITL is still derived from `output_token_times`, whose length is inflated by a BOS re-tokenized into every streamed chunk, which roughly halves ITL. This counts each chunk with `add_special_tokens=False` so the per-token timestamp series matches the true token count and ITL lands on the same basis as TPOT.