### PR TITLE
Fix: Randomize prompt prefixes in SyntheticDataGenerator

### DIFF
--- a/inference_perf/datagen/multimodal_datagen.py
+++ b/inference_perf/datagen/multimodal_datagen.py
@@ -51,14 +51,20 @@ class MultimodalDataGenerator(DataGenerator, LazyLoadDataMixin):
     live on the request lifecycle metric.
     """
 
-    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
+    def __init__(
+        self,
+        api_config: APIConfig,
+        config: DataConfig,
+        tokenizer: Optional[CustomTokenizer],
+        seed: Optional[int] = None,
+    ) -> None:
         super().__init__(api_config, config, tokenizer)
 
         if config.multimodal is None:
             raise ValueError("Multimodal config is required for MultimodalDataGenerator")
 
         self.multimodal_config = config.multimodal
-        self.rng: np.random.Generator = np.random.default_rng()
+        self.rng: np.random.Generator = np.random.default_rng(seed)
 
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for MultimodalDataGenerator")

--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -36,8 +36,11 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
         api_config: APIConfig,
         config: DataConfig,
         tokenizer: Optional[CustomTokenizer],
+        seed: Optional[int] = None,
     ) -> None:
         super().__init__(api_config, config, tokenizer)
+
+        self.rng: np.random.Generator = np.random.default_rng(seed)
 
         if self.trace is None:
             # let's read the trace file and get the input and output lengths
@@ -53,6 +56,7 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
                 self.input_distribution.mean,
                 self.input_distribution.std_dev,
                 self.input_distribution.total_count,
+                rng=self.rng,
             )
             self.output_lengths = generate_distribution(
                 self.output_distribution.min,
@@ -60,6 +64,7 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
                 self.output_distribution.mean,
                 self.output_distribution.std_dev,
                 self.output_distribution.total_count,
+                rng=self.rng,
             )
         else:
             # let's read the trace file and get the input and output lengths
@@ -83,7 +88,6 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
             raise ValueError("Tokenizer is required for RandomDataGenerator")
 
         self.vocab_size, self.special_token_ids, self.valid_token_ids = init_vocab_sampling(self.tokenizer)
-        self.rng: np.random.Generator = np.random.default_rng()
 
     def _generate_random_token_ids(self, length: int) -> List[int]:
         """Generates a list of random token IDs of a specified length."""

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -17,6 +17,8 @@ import time
 from pathlib import Path
 from typing import Generator, List, Optional
 
+import numpy as np
+
 from inference_perf.apis import CompletionAPIData, InferenceAPIData, LazyLoadInferenceAPIData
 from inference_perf.config import APIConfig, APIType, DataConfig
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
@@ -34,7 +36,13 @@ _PROGRESS_LOG_INTERVAL_SEC = 10.0
 
 
 class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
-    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
+    def __init__(
+        self,
+        api_config: APIConfig,
+        config: DataConfig,
+        tokenizer: Optional[CustomTokenizer],
+        seed: Optional[int] = None,
+    ) -> None:
         super().__init__(api_config, config, tokenizer)
 
         if self.input_distribution is None or self.output_distribution is None or self.tokenizer is None:
@@ -43,12 +51,15 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.input_distribution.total_count is None or self.output_distribution.total_count is None:
             raise ValueError("IODistribution requires total_count to be set")
 
+        self.rng: np.random.Generator = np.random.default_rng(seed)
+
         self.input_lengths = generate_distribution(
             self.input_distribution.min,
             self.input_distribution.max,
             self.input_distribution.mean,
             self.input_distribution.std_dev,
             self.input_distribution.total_count,
+            rng=self.rng,
         )
         self.output_lengths = generate_distribution(
             self.output_distribution.min,
@@ -56,6 +67,7 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
             self.output_distribution.mean,
             self.output_distribution.std_dev,
             self.output_distribution.total_count,
+            rng=self.rng,
         )
         if self.config and self.config.corpus_file_path:
             corpus_path = Path(self.config.corpus_file_path)
@@ -95,11 +107,17 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
         if self.tokenizer is None:
             raise ValueError("Tokenizer is required for generating exact length prompts.")
 
+        # Select a random start offset to ensure unique prompts
+        max_start = len(self.token_ids) - target_len
+        start_idx = 0
+        if max_start > 0:
+            start_idx = int(self.rng.integers(0, max_start))
+
         # Start with a slice of target_len
         current_slice_len = target_len
 
         initial_slice_len = min(target_len, len(self.token_ids))
-        initial_tokens = self.token_ids[:initial_slice_len]
+        initial_tokens = self.token_ids[start_idx : start_idx + initial_slice_len]
 
         def adjust_tokens(current_tokens: List[int], current_len: int, target_len: int) -> List[int]:
             nonlocal current_slice_len
@@ -113,7 +131,11 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
                     current_slice_len = 1  # Keep at least one
 
             slice_to_use = min(current_slice_len, len(self.token_ids))
-            return self.token_ids[:slice_to_use]
+            end_idx = start_idx + slice_to_use
+            if end_idx > len(self.token_ids):
+                adjusted_start = max(0, len(self.token_ids) - slice_to_use)
+                return self.token_ids[adjusted_start : adjusted_start + slice_to_use]
+            return self.token_ids[start_idx:end_idx]
 
         text, _ = converge_to_exact_length_text(
             tokenizer=self.tokenizer,

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -347,11 +347,11 @@ def main_cli() -> None:
             datagen = CNNDailyMailDataGenerator(config.api, config.data, tokenizer)
         elif config.data.type == DataGenType.Synthetic:
             if config.data.multimodal:
-                datagen = MultimodalDataGenerator(config.api, config.data, tokenizer)
+                datagen = MultimodalDataGenerator(config.api, config.data, tokenizer, seed=config.load.base_seed)
             else:
-                datagen = SyntheticDataGenerator(config.api, config.data, tokenizer)
+                datagen = SyntheticDataGenerator(config.api, config.data, tokenizer, seed=config.load.base_seed)
         elif config.data.type == DataGenType.Random:
-            datagen = RandomDataGenerator(config.api, config.data, tokenizer)
+            datagen = RandomDataGenerator(config.api, config.data, tokenizer, seed=config.load.base_seed)
         elif config.data.type == DataGenType.SharedPrefix:
             datagen = SharedPrefixDataGenerator(config.api, config.data, tokenizer)
         elif config.data.type == DataGenType.ConversationReplay:

--- a/tests/required/loadgen/test_worker_rng.py
+++ b/tests/required/loadgen/test_worker_rng.py
@@ -29,6 +29,7 @@ from inference_perf.config import (
     StandardLoadStage,
 )
 from inference_perf.datagen.random_datagen import RandomDataGenerator
+from inference_perf.datagen.synthetic_datagen import SyntheticDataGenerator
 from inference_perf.loadgen.load_generator import LoadGenerator
 from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
@@ -50,6 +51,12 @@ class _DummyHFTokenizer:
 
     def decode(self, tokens: list[int], **kwargs: Any) -> str:
         return " ".join(str(t) for t in tokens)
+
+    def encode(self, text: str) -> list[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return list(range(10, 10010))
 
 
 class _DummyCustomTokenizer(CustomTokenizer):
@@ -84,6 +91,45 @@ class TestWorkerRNGUniqueness(unittest.IsolatedAsyncioTestCase):
             output_distribution=Distribution(min=5, max=5, mean=5.0, std_dev=0.0, total_count=num_requests),
         )
         datagen = RandomDataGenerator(api_config, data_config, _DummyCustomTokenizer())
+
+        collector = MultiprocessRequestMetricCollector()
+        client = MockModelServerClient(collector, api_config, mock_latency=0)
+
+        load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            num_workers=num_workers,
+            worker_max_concurrency=10,
+            stages=[StandardLoadStage(rate=num_requests, duration=1)],
+            base_seed=42,
+        )
+        load_gen = LoadGenerator(datagen, load_config)
+
+        async with collector.start():
+            await load_gen.mp_run(client)
+
+        metrics = collector.get_metrics()
+        self.assertEqual(len(metrics), num_requests, f"Expected {num_requests} completed requests")
+
+        prompts = [ast.literal_eval(m.request_data)["prompt"] for m in metrics]
+        self.assertEqual(
+            len(set(prompts)),
+            num_requests,
+            f"Expected {num_requests} unique prompts across {num_workers} workers, got duplicates:\n"
+            + "\n".join(f"  [{i}] {p!r}" for i, p in enumerate(prompts)),
+        )
+
+    async def test_multiworker_synthetic_prompts_unique_with_zero_stdev(self) -> None:
+        """All synthetic prompts must be distinct even when std_dev=0 forces identical input lengths."""
+        num_requests = 6
+        num_workers = 2
+
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        data_config = DataConfig(
+            type=DataGenType.Synthetic,
+            input_distribution=Distribution(min=10, max=10, mean=10.0, std_dev=0.0, total_count=num_requests),
+            output_distribution=Distribution(min=5, max=5, mean=5.0, std_dev=0.0, total_count=num_requests),
+        )
+        datagen = SyntheticDataGenerator(api_config, data_config, _DummyCustomTokenizer())
 
         collector = MultiprocessRequestMetricCollector()
         client = MockModelServerClient(collector, api_config, mock_latency=0)


### PR DESCRIPTION
Fixes #569 

Every prompt using the SyntheticDataGenerator previously shared the same prefix because it was deterministic (always sliced from index 0).

This commit:
- Chooses a random start offset in the token corpus for each prompt, ensuring unique prompts and prefixes.
- Adds seed support to SyntheticDataGenerator, RandomDataGenerator, and MultimodalDataGenerator, allowing reproducible runs.
- Passes the base_seed to datagens in main.py.
- Adds test cases to verify unique prompts across workers.