### PR TITLE
fix(datagen): respect configured distribution types in Random/Synthetic generators

### DIFF
--- a/inference_perf/datagen/random_datagen.py
+++ b/inference_perf/datagen/random_datagen.py
@@ -56,6 +56,7 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
                 self.input_distribution.mean,
                 self.input_distribution.std_dev,
                 self.input_distribution.total_count,
+                dist_type=self.input_distribution.type,
                 rng=self.rng,
             )
             self.output_lengths = generate_distribution(
@@ -64,6 +65,7 @@ class RandomDataGenerator(DataGenerator, LazyLoadDataMixin):
                 self.output_distribution.mean,
                 self.output_distribution.std_dev,
                 self.output_distribution.total_count,
+                dist_type=self.output_distribution.type,
                 rng=self.rng,
             )
         else:

--- a/inference_perf/datagen/synthetic_datagen.py
+++ b/inference_perf/datagen/synthetic_datagen.py
@@ -59,6 +59,7 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
             self.input_distribution.mean,
             self.input_distribution.std_dev,
             self.input_distribution.total_count,
+            dist_type=self.input_distribution.type,
             rng=self.rng,
         )
         self.output_lengths = generate_distribution(
@@ -67,6 +68,7 @@ class SyntheticDataGenerator(DataGenerator, LazyLoadDataMixin):
             self.output_distribution.mean,
             self.output_distribution.std_dev,
             self.output_distribution.total_count,
+            dist_type=self.output_distribution.type,
             rng=self.rng,
         )
         if self.config and self.config.corpus_file_path:

--- a/tests/required/datagen/test_random_datagen.py
+++ b/tests/required/datagen/test_random_datagen.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from inference_perf.apis import CompletionAPIData, LazyLoadInferenceAPIData
-from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType, DistributionType
 from inference_perf.datagen.random_datagen import RandomDataGenerator
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from typing import Any
@@ -106,3 +106,38 @@ def test_random_datagen_excludes_special_tokens() -> None:
     encoded_ids = tokenizer.get_tokenizer().encode(real_data.prompt)
     for token in encoded_ids:
         assert token not in [1, 2, 3]
+
+
+def test_random_datagen_distribution_types() -> None:
+    api_config = APIConfig(type=APIType.Completion, streaming=True)
+    data_config = DataConfig(
+        type=DataGenType.Random,
+        input_distribution=Distribution(
+            type=DistributionType.FIXED,
+            min=10,
+            max=20,
+            mean=15,
+            std_dev=2,
+            total_count=5,
+        ),
+        output_distribution=Distribution(
+            type=DistributionType.FIXED,
+            min=5,
+            max=10,
+            mean=7,
+            std_dev=1,
+            total_count=5,
+        ),
+    )
+    tokenizer = DummyCustomTokenizer()
+
+    generator = RandomDataGenerator(api_config, data_config, tokenizer)
+
+    # With FIXED type, all generated lengths must be exactly equal to the mean
+    assert len(generator.input_lengths) == 5
+    for length in generator.input_lengths:
+        assert length == 15
+
+    assert len(generator.output_lengths) == 5
+    for length in generator.output_lengths:
+        assert length == 7

--- a/tests/required/datagen/test_synthetic_datagen.py
+++ b/tests/required/datagen/test_synthetic_datagen.py
@@ -3,7 +3,7 @@ from typing import Any, Iterator
 from unittest.mock import patch
 
 from inference_perf.apis import CompletionAPIData, LazyLoadInferenceAPIData
-from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType
+from inference_perf.config import APIConfig, APIType, DataConfig, Distribution, DataGenType, DistributionType
 from inference_perf.datagen import synthetic_datagen
 from inference_perf.datagen.synthetic_datagen import SyntheticDataGenerator
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
@@ -104,3 +104,38 @@ def test_synthetic_datagen_skips_progress_log_within_interval() -> None:
     # First call sets the baseline timestamp and logs; subsequent sub-interval
     # calls should be silent.
     assert mock_logger.info.call_count == 1
+
+
+def test_synthetic_datagen_distribution_types() -> None:
+    api_config = APIConfig(type=APIType.Completion)
+    data_config = DataConfig(
+        type=DataGenType.Synthetic,
+        input_distribution=Distribution(
+            type=DistributionType.FIXED,
+            min=10,
+            max=20,
+            mean=15,
+            std_dev=2,
+            total_count=5,
+        ),
+        output_distribution=Distribution(
+            type=DistributionType.FIXED,
+            min=5,
+            max=10,
+            mean=7,
+            std_dev=1,
+            total_count=5,
+        ),
+    )
+    tokenizer = DummyCustomTokenizer()
+
+    generator = SyntheticDataGenerator(api_config, data_config, tokenizer)
+
+    # With FIXED type, all generated lengths must be exactly equal to the mean
+    assert len(generator.input_lengths) == 5
+    for length in generator.input_lengths:
+        assert length == 15
+
+    assert len(generator.output_lengths) == 5
+    for length in generator.output_lengths:
+        assert length == 7


### PR DESCRIPTION
### Problem
Previously, both `RandomDataGenerator` and `SyntheticDataGenerator` were calling `generate_distribution()` without passing the `dist_type` argument. This caused all configurations to ignore configured distribution types (e.g. `fixed`, `uniform`, `lognormal`) and fall back to the default `normal` distribution.

### Solution
- Modified `random_datagen.py` and `synthetic_datagen.py` to explicitly forward the configured `type` attribute of the input/output distributions to the `generate_distribution()` helper.
- Added corresponding unit tests in `test_random_datagen.py` and `test_synthetic_datagen.py` asserting that using `DistributionType.FIXED` yields constant lengths equal to the configured mean.
