### PR TITLE
fix: normalize 'developer' message role to 'system' for non-OpenAI model servers

### DIFF
--- a/inference_perf/datagen/otel_trace_replay_datagen.py
+++ b/inference_perf/datagen/otel_trace_replay_datagen.py
@@ -70,6 +70,7 @@ from inference_perf.datagen.replay_graph_session_datagen import (
     ReplayGraphSessionGeneratorBase,
     SessionChatCompletionAPIData,
 )
+import inference_perf.datagen.otel_trace_to_replay_graph as otel_graph
 from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_raw_calls,
     build_graph,
@@ -460,6 +461,14 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
         random.seed(self.base_seed)
         random.shuffle(sessions)
         logger.info(f"Randomized session order using seed: {self.base_seed}")
+
+        msg_count = otel_graph._developer_role_normalized_count
+        if msg_count > 0:
+            logger.warning(
+                f"Normalized {msg_count} 'developer' role message(s) to 'system' "
+                f"for compatibility with model servers that only accept standard roles."
+            )
+            otel_graph._developer_role_normalized_count = 0
 
         return sessions
 

--- a/inference_perf/datagen/otel_trace_replay_datagen.py
+++ b/inference_perf/datagen/otel_trace_replay_datagen.py
@@ -62,7 +62,7 @@ import logging
 import random
 from multiprocessing.managers import SyncManager
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from datasets import load_dataset, Dataset
 from inference_perf.config import APIConfig, DataConfig
 from inference_perf.datagen.replay_graph_session_datagen import (
@@ -70,7 +70,6 @@ from inference_perf.datagen.replay_graph_session_datagen import (
     ReplayGraphSessionGeneratorBase,
     SessionChatCompletionAPIData,
 )
-import inference_perf.datagen.otel_trace_to_replay_graph as otel_graph
 from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_raw_calls,
     build_graph,
@@ -443,10 +442,12 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
         """Process loaded trace data into sessions."""
         logger.info(f"Processing {len(self.trace_data_list)} trace records")
         sessions: List[ReplaySession] = []
+        total_normalized = 0
 
         for trace_index, trace_info in enumerate(self.trace_data_list):
             try:
-                session = self._process_trace_data(trace_info, trace_index)
+                session, normalized_count = self._process_trace_data(trace_info, trace_index)
+                total_normalized += normalized_count
                 if session:
                     sessions.append(session)
                     event_count = len(session.graph.events)
@@ -462,18 +463,19 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
         random.shuffle(sessions)
         logger.info(f"Randomized session order using seed: {self.base_seed}")
 
-        msg_count = otel_graph._developer_role_normalized_count
-        if msg_count > 0:
+        if total_normalized > 0:
             logger.warning(
-                f"Normalized {msg_count} 'developer' role message(s) to 'system' "
+                f"Normalized {total_normalized} 'developer' role message(s) to 'system' "
                 f"for compatibility with model servers that only accept standard roles."
             )
-            otel_graph._developer_role_normalized_count = 0
 
         return sessions
 
-    def _process_trace_data(self, trace_info: Dict[str, Any], trace_index: int) -> Optional[ReplaySession]:
-        """Process a single trace data dict into a ReplayGraph session."""
+    def _process_trace_data(self, trace_info: Dict[str, Any], trace_index: int) -> Tuple[Optional[ReplaySession], int]:
+        """Process a single trace data dict into a ReplayGraph session.
+
+        Returns a tuple of (session, developer_role_normalized_count).
+        """
         data = trace_info["data"]
         source_id = trace_info["source_id"]
         source_name = trace_info["source_name"]
@@ -481,13 +483,13 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
         spans = data.get("spans") or []
         if not spans:
             logger.warning(f"No spans found in {source_name}")
-            return None
+            return None, 0
 
         try:
-            raw_calls = build_raw_calls(spans, include_errors=self.otel_config.include_errors)
+            raw_calls, normalized_count = build_raw_calls(spans, include_errors=self.otel_config.include_errors)
             if not raw_calls:
                 logger.warning(f"No LLM calls found in {source_name}")
-                return None
+                return None, 0
 
             graph = build_graph(
                 raw_calls,
@@ -495,7 +497,7 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
             )
         except Exception as e:
             logger.error(f"Error building graph from {source_name}: {e}")
-            return None
+            return None, 0
 
         # Use trace_id from first call as session_id, but make it unique by adding trace_index
         # to handle cases where multiple sources have the same trace_id
@@ -507,7 +509,7 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
             source_id=source_id,
             session_index=trace_index,
             graph=graph,
-        )
+        ), normalized_count
 
     def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> SessionChatCompletionAPIData:
         api_data = super().load_lazy_data(data)

--- a/inference_perf/datagen/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/otel_trace_to_replay_graph.py
@@ -74,6 +74,7 @@ from inference_perf.datagen.replay_graph_types import (
 )
 
 logger = logging.getLogger(__name__)
+_developer_role_normalized_count = 0
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +209,7 @@ def _convert_content_and_tool_calls_to_parts(message: Dict[str, Any]) -> Dict[st
 
 def extract_messages(span: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Extract messages from span attributes. Returns empty list if not found."""
+    global _developer_role_normalized_count
     attrs = span.get("attributes") or {}
     raw = attrs.get("gen_ai.input.messages")
     res = []
@@ -223,6 +225,9 @@ def extract_messages(span: Dict[str, Any]) -> List[Dict[str, Any]]:
         for x in raw:
             # sometimes the content field contains a dictionary with several properties
             role = x["role"]
+            if role == "developer":
+                role = "system"
+                _developer_role_normalized_count += 1
             if "content" in x:
                 content = x["content"]
                 # Check if message also has tool_calls - convert to parts format

--- a/inference_perf/datagen/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/otel_trace_to_replay_graph.py
@@ -56,7 +56,7 @@ from enum import Enum
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from inference_perf.datagen.export_replay_graph_to_dot import export_to_dot
 from inference_perf.datagen.otel_trace_utils import (
@@ -74,7 +74,6 @@ from inference_perf.datagen.replay_graph_types import (
 )
 
 logger = logging.getLogger(__name__)
-_developer_role_normalized_count = 0
 
 
 # ---------------------------------------------------------------------------
@@ -207,14 +206,17 @@ def _convert_content_and_tool_calls_to_parts(message: Dict[str, Any]) -> Dict[st
     return result
 
 
-def extract_messages(span: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Extract messages from span attributes. Returns empty list if not found."""
-    global _developer_role_normalized_count
+def extract_messages(span: Dict[str, Any]) -> Tuple[List["ReplayMessage"], int]:
+    """Extract messages from span attributes.
+
+    Returns a tuple of (messages, developer_role_normalized_count).
+    """
     attrs = span.get("attributes") or {}
     raw = attrs.get("gen_ai.input.messages")
     res = []
+    normalized_count = 0
     if raw is None:
-        return []
+        return [], 0
     if isinstance(raw, str):
         try:
             raw = json.loads(raw)
@@ -227,7 +229,8 @@ def extract_messages(span: Dict[str, Any]) -> List[Dict[str, Any]]:
             role = x["role"]
             if role == "developer":
                 role = "system"
-                _developer_role_normalized_count += 1
+                x["role"] = "system"
+                normalized_count += 1
             if "content" in x:
                 content = x["content"]
                 # Check if message also has tool_calls - convert to parts format
@@ -260,10 +263,10 @@ def extract_messages(span: Dict[str, Any]) -> List[Dict[str, Any]]:
 
                 """
                 res.append(ComplexReplayMessage(role=role, message_info=x, raw_reconstructed_text=reconstruct_llm_input(x)))
-        return res  # type: ignore[return-value]
+        return res, normalized_count  # type: ignore[return-value]
     else:
-        return []
-    return []
+        return [], 0
+    return [], 0
 
 
 def extract_output_message(span: Dict[str, Any]) -> Optional[ReplayMessage]:
@@ -367,26 +370,30 @@ def filter_duplicate_spans(spans: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return unique_spans
 
 
-def build_raw_calls(spans: List[Dict[str, Any]], include_errors: bool = False) -> List[RawCall]:
+def build_raw_calls(spans: List[Dict[str, Any]], include_errors: bool = False) -> Tuple[List[RawCall], int]:
     """Extract and sort raw LLM calls from spans.
 
     First filters out duplicate spans (identical start_time, end_time, and attributes),
     then extracts LLM calls from the remaining unique spans.
+
+    Returns a tuple of (calls, developer_role_normalized_count).
     """
     # Filter out duplicate spans first
     unique_spans = filter_duplicate_spans(spans)
 
     llm_spans = [s for s in unique_spans if is_llm_span(s, include_errors=include_errors)]
     if not llm_spans:
-        return []
+        return [], 0
 
     t0 = min(parse_iso(s["start_time"]) for s in llm_spans)
     llm_spans.sort(key=lambda s: (parse_iso(s["start_time"]), s.get("span_id", "")))
 
     calls: List[RawCall] = []
+    total_normalized = 0
     for s in llm_spans:
         attrs = s.get("attributes") or {}
-        messages = extract_messages(s)
+        messages, normalized_count = extract_messages(s)
+        total_normalized += normalized_count
         out_message = extract_output_message(s)
         t_start = int(round((parse_iso(s["start_time"]) - t0) * 1000))
         t_end = int(round((parse_iso(s["end_time"]) - t0) * 1000)) if s.get("end_time") else t_start
@@ -430,7 +437,7 @@ def build_raw_calls(spans: List[Dict[str, Any]], include_errors: bool = False) -
                 t_start_ms=t_start,
                 t_end_ms=t_end,
                 model=str(attrs.get("gen_ai.request.model") or ""),
-                messages=messages,  # type: ignore[arg-type]
+                messages=messages,
                 out_message=out_message,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
@@ -440,7 +447,7 @@ def build_raw_calls(spans: List[Dict[str, Any]], include_errors: bool = False) -
                 extra_attributes=extra_attrs,
             )
         )
-    return calls
+    return calls, total_normalized
 
 
 # ---------------------------------------------------------------------------
@@ -1361,7 +1368,7 @@ def main() -> None:
     if not spans:
         raise SystemExit("No spans found in trace JSON")
 
-    calls = build_raw_calls(spans, include_errors=args.include_errors)
+    calls, _ = build_raw_calls(spans, include_errors=args.include_errors)
     if not calls:
         raise SystemExit("No LLM spans found in trace file")
 

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -700,7 +700,7 @@ class TestEndToEndSimpleChain:
             pytest.skip(f"Test trace not found: {SIMPLE_CHAIN_JSON}")
         data = json.loads(SIMPLE_CHAIN_JSON.read_text())
         spans = data.get("spans", [])
-        calls = build_raw_calls(spans)
+        calls, _ = build_raw_calls(spans)
         graph = build_graph(calls)
         return graph, calls
 

--- a/tests/test_otel_trace_to_replay_graph.py
+++ b/tests/test_otel_trace_to_replay_graph.py
@@ -40,9 +40,11 @@ from typing import Any, Dict, List, Optional
 from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_graph,
     build_raw_calls,
+    extract_messages,
     print_graph,
     summarize_graph,
 )
+from inference_perf.datagen.replay_graph_types import ComplexReplayMessage
 
 
 # ---------------------------------------------------------------------------
@@ -173,7 +175,7 @@ def test_sequential_chain() -> None:
         span_C: SHARED(3msg ← event_001) + OUTPUT(1msg ← event_001) + UNIQUE(1msg)
     """
     spans = [SPAN_A, SPAN_B, SPAN_C]
-    calls = build_raw_calls(spans)
+    calls, _ = build_raw_calls(spans)
     graph = build_graph(calls)
 
     # Print for visual inspection when running with pytest -s or debugger
@@ -373,7 +375,7 @@ def test_parallel_fan_out() -> None:
         OUTPUT(1msg ← event_002)               [assistant: OUTPUT_P2]
     """
     spans = [SPAN_ROOT, SPAN_P1, SPAN_P2, SPAN_FINAL]
-    calls = build_raw_calls(spans)
+    calls, _ = build_raw_calls(spans)
     graph = build_graph(calls)
 
     print("\n" + "=" * 70)
@@ -547,7 +549,7 @@ def test_growing_prefix() -> None:
     KEY PROPERTY: shared prefix message count grows monotonically: 2 < 4 < 6
     """
     spans = [SPAN_T1, SPAN_T2, SPAN_T3, SPAN_T4]
-    calls = build_raw_calls(spans)
+    calls, _ = build_raw_calls(spans)
     graph = build_graph(calls)
 
     print("\n" + "=" * 70)
@@ -612,7 +614,7 @@ def test_tool_definitions_flow() -> None:
         "status": {"code": 1, "message": ""},
     }
 
-    calls = build_raw_calls([span])
+    calls, _ = build_raw_calls([span])
     assert len(calls) == 1
     assert calls[0].tool_definitions == tool_defs
 
@@ -637,9 +639,110 @@ def test_tool_definitions_absent() -> None:
         "status": {"code": 1, "message": ""},
     }
 
-    calls = build_raw_calls([span])
+    calls, _ = build_raw_calls([span])
     assert calls[0].tool_definitions is None
 
     graph = build_graph(calls)
     event = list(graph.events.values())[0]
     assert event.call.tool_definitions is None
+
+
+class TestDeveloperRoleNormalization:
+    """Tests for normalizing 'developer' role to 'system'."""
+
+    def test_developer_role_normalized_to_system(self) -> None:
+        """Messages with role 'developer' are normalized to 'system'."""
+        span = {
+            "attributes": {
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {"role": "developer", "content": "You are a helpful assistant."},
+                        {"role": "user", "content": "Hello"},
+                    ]
+                ),
+            },
+        }
+        messages, normalized_count = extract_messages(span)
+        assert len(messages) == 2
+        assert messages[0].role == "system"
+        assert messages[1].role == "user"
+        assert normalized_count == 1
+
+    def test_no_normalization_for_standard_roles(self) -> None:
+        """Standard roles are not modified and count is zero."""
+        span = {
+            "attributes": {
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {"role": "system", "content": "You are a helpful assistant."},
+                        {"role": "user", "content": "Hello"},
+                    ]
+                ),
+            },
+        }
+        messages, normalized_count = extract_messages(span)
+        assert len(messages) == 2
+        assert messages[0].role == "system"
+        assert messages[1].role == "user"
+        assert normalized_count == 0
+
+    def test_multiple_developer_roles_counted(self) -> None:
+        """Multiple 'developer' messages are all normalized and counted."""
+        span = {
+            "attributes": {
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {"role": "developer", "content": "System instruction 1"},
+                        {"role": "developer", "content": "System instruction 2"},
+                        {"role": "user", "content": "Hello"},
+                    ]
+                ),
+            },
+        }
+        messages, normalized_count = extract_messages(span)
+        assert messages[0].role == "system"
+        assert messages[1].role == "system"
+        assert normalized_count == 2
+
+    def test_developer_role_normalized_in_build_raw_calls(self) -> None:
+        """build_raw_calls returns the total normalized count."""
+        span = {
+            "trace_id": "trace_dev",
+            "span_id": "span_dev",
+            "name": "chat gpt-4",
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-01T00:00:01Z",
+            "attributes": {
+                "gen_ai.request.model": "gpt-4",
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {"role": "developer", "content": "Be concise."},
+                        {"role": "user", "content": "Hi"},
+                    ]
+                ),
+                "gen_ai.output.text": "Hello!",
+            },
+            "status": {"code": 1, "message": ""},
+        }
+        calls, normalized_count = build_raw_calls([span])
+        assert len(calls) == 1
+        assert calls[0].messages[0].role == "system"
+        assert normalized_count == 1
+
+    def test_developer_role_in_complex_message_info(self) -> None:
+        """message_info dict also has role normalized (not just ComplexReplayMessage.role)."""
+        span = {
+            "attributes": {
+                "gen_ai.input.messages": json.dumps(
+                    [
+                        {"role": "developer", "content": {"text": "system prompt", "metadata": "extra"}},
+                    ]
+                ),
+            },
+        }
+        messages, normalized_count = extract_messages(span)
+        msg = messages[0]
+        assert msg.role == "system"
+        assert isinstance(msg, ComplexReplayMessage)
+        assert msg.message_info["role"] == "system"
+        assert normalized_count == 1


### PR DESCRIPTION
The `Exgentic/agent-llm-traces` dataset contains traces from Gemini and DeepSeek harnesses that use the `"developer"` message role (an OpenAI/Gemini-specific alternative to `"system"`). When replayed against vLLM, the model server rejects these with HTTP 400: `"Unexpected message role."`.

**What this PR does:**

- Normalizes `"developer"` → `"system"` during message extraction in `extract_messages()` at ingestion time
- Counts all normalized messages and logs a summary warning after all sessions are loaded, so the operator knows the replacement happened without the log getting buried in per-session loading messages
- The warning only appears if the loaded dataset actually contains `"developer"` role messages

**How I tested:**

- Ran replay against vLLM-served model with traces containing `"developer"` role messages
- Without fix: requests fail with HTTP 400 ("Unexpected message role")
- With fix: requests go through successfully with `"role": "system"`, warning logged with count of normalized messages
- All checks pass

Fixes #553