### PR TITLE
Add Anthropic Messages API support

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -4,7 +4,7 @@ These command line flags are automatically generated from the internal `Config` 
 
 | Flag | Type | Description |
 | --- | --- | --- |
-| `--api.type` | Enum (completion, chat) | Matches api.type in config |
+| `--api.type` | Enum (completion, chat, anthropic_messages) | Matches api.type in config |
 | `--api.streaming` | boolean | Matches api.streaming in config |
 | `--api.headers` | JSON | Matches api.headers in config |
 | `--api.slo_unit` | str | Matches api.slo_unit in config |

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,7 +28,7 @@ Controls the API interaction behavior. If SLO headers are present, each request 
 
 ```yaml
 api:
-  type: completion             # API type (completion|chat). completion is default since chat may require extra server config
+  type: completion             # API type (completion|chat|anthropic_messages)
   streaming: true             # Enable streaming for TTFT, ITL, and TPOT metrics
   headers:                     # Optional custom HTTP headers
     x-inference-model: llama

--- a/docs/otel_trace_replay.md
+++ b/docs/otel_trace_replay.md
@@ -69,7 +69,7 @@ OTel trace replay requires two configuration sections: `data` (what to replay) a
 
 ```yaml
 api:
-  type: chat                           # Required: chat or completion
+  type: chat                           # Required: chat or anthropic_messages
   streaming: true                      # Optional: enable streaming responses
 
 server:

--- a/inference_perf/apis/__init__.py
+++ b/inference_perf/apis/__init__.py
@@ -24,6 +24,7 @@ from .base import (
 )
 from .chat import ChatCompletionAPIData, ChatMessage
 from .completion import CompletionAPIData
+from .anthropic_messages import AnthropicMessagesAPIData
 
 __all__ = [
     "InferenceAPIData",
@@ -36,6 +37,7 @@ __all__ = [
     "ChatMessage",
     "CompletionAPIData",
     "ResponseMetrics",
+    "AnthropicMessagesAPIData",
     "UnaryResponseMetrics",
     "StreamedResponseMetrics",
 ]

--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -1,0 +1,261 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Any, Dict, List, Optional
+
+from aiohttp import ClientResponse
+
+from inference_perf.apis.base import InferenceAPIData, InferenceInfo, StreamedResponseMetrics, UnaryResponseMetrics
+from inference_perf.apis.chat import ChatMessage, _clean_parameters
+from inference_perf.apis.streaming_parser import parse_sse_stream
+from inference_perf.config import APIConfig, APIType
+from inference_perf.payloads import RequestBody, RequestMetrics, Text
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+
+def _content_text(content: Optional[str | list[dict[str, Any]]]) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    return "".join(
+        part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") in ("text", "input_text")
+    )
+
+
+def _tool_input(arguments: Any) -> dict[str, Any]:
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str) and arguments:
+        try:
+            parsed = json.loads(arguments)
+            return parsed if isinstance(parsed, dict) else {"value": parsed}
+        except json.JSONDecodeError:
+            return {"arguments": arguments}
+    return {}
+
+
+def _tool_arguments(tool_input: Any) -> str:
+    if isinstance(tool_input, str):
+        return tool_input
+    return json.dumps(tool_input if isinstance(tool_input, dict) else {}, ensure_ascii=False)
+
+
+def _anthropic_content(content: Optional[str | list[dict[str, Any]]]) -> str | list[dict[str, Any]]:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+
+    blocks: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type in ("text", "tool_use", "tool_result"):
+            blocks.append(block)
+        elif block_type == "input_text":
+            blocks.append({"type": "text", "text": block.get("text", "")})
+    return blocks
+
+
+def _anthropic_message(message: ChatMessage) -> Optional[dict[str, Any]]:
+    if message.role == "system":
+        return None
+
+    if message.role == "tool":
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": message.tool_call_id or "",
+                    "content": _content_text(message.content),
+                }
+            ],
+        }
+
+    if message.tool_calls:
+        content_blocks: list[dict[str, Any]] = []
+        text = _content_text(message.content)
+        if text:
+            content_blocks.append({"type": "text", "text": text})
+        for tool_call in message.tool_calls:
+            function = tool_call.get("function") or {}
+            content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tool_call.get("id", ""),
+                    "name": function.get("name", ""),
+                    "input": _tool_input(function.get("arguments")),
+                }
+            )
+        return {"role": "assistant", "content": content_blocks}
+
+    role = "assistant" if message.role == "assistant" else "user"
+    return {"role": role, "content": _anthropic_content(message.content)}
+
+
+def _anthropic_tool(tool: dict[str, Any]) -> dict[str, Any]:
+    function_candidate = tool.get("function")
+    function: dict[str, Any] = function_candidate if isinstance(function_candidate, dict) else tool
+    name = function.get("name", "")
+    result = {
+        "name": name,
+        "input_schema": _clean_parameters(function.get("parameters") or {"type": "object", "properties": {}}),
+    }
+    if function.get("description") is not None:
+        result["description"] = function["description"]
+    return result
+
+
+def _parse_anthropic_content(content: Any) -> tuple[str, Optional[dict[str, Any]]]:
+    text_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+
+    if not isinstance(content, list):
+        return "", None
+
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            text_parts.append(str(block.get("text", "")))
+        elif block.get("type") == "tool_use":
+            tool_calls.append(
+                {
+                    "id": block.get("id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": _tool_arguments(block.get("input")),
+                    },
+                }
+            )
+
+    output_text = "".join(text_parts)
+    if tool_calls:
+        output_message: dict[str, Any] = {"role": "assistant", "tool_calls": tool_calls}
+        if output_text:
+            output_message["content"] = output_text
+        return output_text, output_message
+    return output_text, {"role": "assistant", "content": output_text}
+
+
+def _build_anthropic_request_body(
+    messages: List[ChatMessage],
+    tool_definitions: Optional[List[Dict[str, Any]]],
+    effective_model_name: str,
+    max_tokens: int,
+    streaming: bool,
+) -> RequestBody:
+    system_prompt = "\n\n".join(_content_text(message.content) for message in messages if message.role == "system")
+    anthropic_messages = [converted for message in messages if (converted := _anthropic_message(message)) is not None]
+
+    payload: Dict[str, Any] = {
+        "model": effective_model_name,
+        "messages": anthropic_messages,
+        "max_tokens": max_tokens,
+        "stream": streaming,
+    }
+    if system_prompt:
+        payload["system"] = system_prompt
+    if tool_definitions:
+        payload["tools"] = [_anthropic_tool(tool) for tool in tool_definitions]
+    return payload
+
+
+def _count_anthropic_prompt_tokens(messages: List[ChatMessage], tokenizer: CustomTokenizer) -> int:
+    return sum(tokenizer.count_tokens(_content_text(message.content)) for message in messages)
+
+
+class AnthropicMessagesAPIData(InferenceAPIData):
+    messages: List[ChatMessage]
+    max_tokens: int = 0
+    tool_definitions: Optional[List[Dict[str, Any]]] = None
+
+    def get_api_type(self) -> APIType:
+        return APIType.AnthropicMessages
+
+    def get_route(self) -> str:
+        return "/v1/messages"
+
+    async def to_request_body(
+        self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
+    ) -> RequestBody:
+        if self.max_tokens == 0:
+            self.max_tokens = max_tokens
+        return _build_anthropic_request_body(
+            self.messages,
+            self.tool_definitions,
+            effective_model_name,
+            self.max_tokens,
+            streaming,
+        )
+
+    def _count_prompt_tokens(self, tokenizer: CustomTokenizer) -> int:
+        return _count_anthropic_prompt_tokens(self.messages, tokenizer)
+
+    async def process_response(
+        self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: Optional[str] = None
+    ) -> InferenceInfo:
+        if config.streaming:
+            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+                response,
+                extract_content=lambda data: (
+                    data.get("delta", {}).get("text")
+                    if data.get("type") == "content_block_delta" and data.get("delta", {}).get("type") == "text_delta"
+                    else None
+                ),
+            )
+            input_tokens = (server_usage or {}).get("input_tokens")
+            output_tokens = (server_usage or {}).get("output_tokens")
+            output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)
+            return InferenceInfo(
+                request_metrics=RequestMetrics(
+                    text=Text(
+                        input_tokens=int(input_tokens) if input_tokens is not None else self._count_prompt_tokens(tokenizer)
+                    )
+                ),
+                response_metrics=StreamedResponseMetrics(
+                    response_chunks=response_chunks,
+                    chunk_times=chunk_times,
+                    output_tokens=output_len,
+                    output_token_times=chunk_times,
+                    server_usage=server_usage,
+                ),
+                lora_adapter=lora_adapter,
+                extra_info={"raw_response": raw_content, "output_text": output_text},
+            )
+
+        data = await response.json()
+        usage = data.get("usage") or {}
+        output_text, output_message = _parse_anthropic_content(data.get("content"))
+        input_tokens = usage.get("input_tokens")
+        output_tokens = usage.get("output_tokens")
+        output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)
+        extra_info: dict[str, Any] = {
+            "stop_reason": data.get("stop_reason"),
+            "output_message": output_message,
+            "output_text": output_text,
+        }
+        return InferenceInfo(
+            request_metrics=RequestMetrics(
+                text=Text(input_tokens=int(input_tokens) if input_tokens is not None else self._count_prompt_tokens(tokenizer))
+            ),
+            response_metrics=UnaryResponseMetrics(output_tokens=output_len),
+            lora_adapter=lora_adapter,
+            extra_info=extra_info,
+        )

--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import json
-from typing import Any, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any
 
 from aiohttp import ClientResponse
 
@@ -25,7 +26,10 @@ from inference_perf.payloads import RequestBody, RequestMetrics, Text
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
-def _content_text(content: Optional[str | list[dict[str, Any]]]) -> str:
+ANTHROPIC_VERSION = "2023-06-01"
+
+
+def _content_text(content: str | list[dict[str, Any]] | None) -> str:
     if content is None:
         return ""
     if isinstance(content, str):
@@ -53,7 +57,7 @@ def _tool_arguments(tool_input: Any) -> str:
     return json.dumps(tool_input if isinstance(tool_input, dict) else {}, ensure_ascii=False)
 
 
-def _anthropic_content(content: Optional[str | list[dict[str, Any]]]) -> str | list[dict[str, Any]]:
+def _anthropic_content(content: str | list[dict[str, Any]] | None) -> str | list[dict[str, Any]]:
     if content is None:
         return ""
     if isinstance(content, str):
@@ -71,7 +75,7 @@ def _anthropic_content(content: Optional[str | list[dict[str, Any]]]) -> str | l
     return blocks
 
 
-def _anthropic_message(message: ChatMessage) -> Optional[dict[str, Any]]:
+def _anthropic_message(message: ChatMessage) -> dict[str, Any] | None:
     if message.role == "system":
         return None
 
@@ -121,7 +125,7 @@ def _anthropic_tool(tool: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-def _parse_anthropic_content(content: Any) -> tuple[str, Optional[dict[str, Any]]]:
+def parse_anthropic_content(content: Any) -> tuple[str, dict[str, Any] | None]:
     text_parts: list[str] = []
     tool_calls: list[dict[str, Any]] = []
 
@@ -154,9 +158,9 @@ def _parse_anthropic_content(content: Any) -> tuple[str, Optional[dict[str, Any]
     return output_text, {"role": "assistant", "content": output_text}
 
 
-def _build_anthropic_request_body(
-    messages: List[ChatMessage],
-    tool_definitions: Optional[List[Dict[str, Any]]],
+def build_anthropic_request_body(
+    messages: list[ChatMessage],
+    tool_definitions: list[dict[str, Any]] | None,
     effective_model_name: str,
     max_tokens: int,
     streaming: bool,
@@ -164,7 +168,7 @@ def _build_anthropic_request_body(
     system_prompt = "\n\n".join(_content_text(message.content) for message in messages if message.role == "system")
     anthropic_messages = [converted for message in messages if (converted := _anthropic_message(message)) is not None]
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "model": effective_model_name,
         "messages": anthropic_messages,
         "max_tokens": max_tokens,
@@ -177,14 +181,97 @@ def _build_anthropic_request_body(
     return payload
 
 
-def _count_anthropic_prompt_tokens(messages: List[ChatMessage], tokenizer: CustomTokenizer) -> int:
+def count_anthropic_prompt_tokens(messages: list[ChatMessage], tokenizer: CustomTokenizer) -> int:
     return sum(tokenizer.count_tokens(_content_text(message.content)) for message in messages)
 
 
+def _event_index(data: dict[str, Any], fallback: int) -> int:
+    index = data.get("index")
+    return index if isinstance(index, int) else fallback
+
+
+def _build_anthropic_stream_handlers() -> tuple[Callable[[dict[str, Any]], str | None], Callable[[str], dict[str, Any]]]:
+    tool_calls_by_index: dict[int, dict[str, Any]] = {}
+    tool_argument_parts: dict[int, list[str]] = {}
+
+    def extract_content(data: dict[str, Any]) -> str | None:
+        event_type = data.get("type")
+        if event_type == "content_block_start":
+            block = data.get("content_block") or {}
+            if not isinstance(block, dict):
+                return None
+
+            index = _event_index(data, len(tool_calls_by_index))
+            block_type = block.get("type")
+            if block_type == "tool_use":
+                tool_calls_by_index[index] = {
+                    "id": block.get("id", ""),
+                    "type": "function",
+                    "function": {"name": block.get("name", ""), "arguments": ""},
+                }
+                tool_input = block.get("input")
+                if tool_input:
+                    tool_argument_parts.setdefault(index, []).append(_tool_arguments(tool_input))
+            elif block_type == "text" and block.get("text"):
+                return str(block["text"])
+
+        elif event_type == "content_block_delta":
+            delta = data.get("delta") or {}
+            if not isinstance(delta, dict):
+                return None
+
+            delta_type = delta.get("type")
+            if delta_type == "text_delta":
+                text = delta.get("text", "")
+                return str(text) if text else None
+            if delta_type == "input_json_delta":
+                partial_json = delta.get("partial_json", "")
+                if partial_json:
+                    index = _event_index(data, 0)
+                    tool_argument_parts.setdefault(index, []).append(str(partial_json))
+
+        return None
+
+    def output_message(output_text: str) -> dict[str, Any]:
+        tool_calls: list[dict[str, Any]] = []
+        for index in sorted(tool_calls_by_index):
+            tool_call = tool_calls_by_index[index]
+            function = dict(tool_call["function"])
+            function["arguments"] = "".join(tool_argument_parts.get(index, []))
+            tool_calls.append(
+                {
+                    "id": tool_call["id"],
+                    "type": tool_call["type"],
+                    "function": function,
+                }
+            )
+
+        if tool_calls:
+            message: dict[str, Any] = {"role": "assistant", "tool_calls": tool_calls}
+            if output_text:
+                message["content"] = output_text
+            return message
+
+        return {"role": "assistant", "content": output_text}
+
+    return extract_content, output_message
+
+
+async def parse_anthropic_stream_response(
+    response: ClientResponse,
+) -> tuple[str, dict[str, Any], list[float], str, list[str], dict[str, Any] | None]:
+    extract_content, build_output_message = _build_anthropic_stream_handlers()
+    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+        response,
+        extract_content=extract_content,
+    )
+    return output_text, build_output_message(output_text), chunk_times, raw_content, response_chunks, server_usage
+
+
 class AnthropicMessagesAPIData(InferenceAPIData):
-    messages: List[ChatMessage]
+    messages: list[ChatMessage]
     max_tokens: int = 0
-    tool_definitions: Optional[List[Dict[str, Any]]] = None
+    tool_definitions: list[dict[str, Any]] | None = None
 
     def get_api_type(self) -> APIType:
         return APIType.AnthropicMessages
@@ -197,7 +284,7 @@ class AnthropicMessagesAPIData(InferenceAPIData):
     ) -> RequestBody:
         if self.max_tokens == 0:
             self.max_tokens = max_tokens
-        return _build_anthropic_request_body(
+        return build_anthropic_request_body(
             self.messages,
             self.tool_definitions,
             effective_model_name,
@@ -206,20 +293,20 @@ class AnthropicMessagesAPIData(InferenceAPIData):
         )
 
     def _count_prompt_tokens(self, tokenizer: CustomTokenizer) -> int:
-        return _count_anthropic_prompt_tokens(self.messages, tokenizer)
+        return count_anthropic_prompt_tokens(self.messages, tokenizer)
 
     async def process_response(
-        self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: Optional[str] = None
+        self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: str | None = None
     ) -> InferenceInfo:
         if config.streaming:
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response,
-                extract_content=lambda data: (
-                    data.get("delta", {}).get("text")
-                    if data.get("type") == "content_block_delta" and data.get("delta", {}).get("type") == "text_delta"
-                    else None
-                ),
-            )
+            (
+                output_text,
+                output_message,
+                chunk_times,
+                raw_content,
+                response_chunks,
+                server_usage,
+            ) = await parse_anthropic_stream_response(response)
             input_tokens = (server_usage or {}).get("input_tokens")
             output_tokens = (server_usage or {}).get("output_tokens")
             output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)
@@ -237,12 +324,12 @@ class AnthropicMessagesAPIData(InferenceAPIData):
                     server_usage=server_usage,
                 ),
                 lora_adapter=lora_adapter,
-                extra_info={"raw_response": raw_content, "output_text": output_text},
+                extra_info={"raw_response": raw_content, "output_message": output_message, "output_text": output_text},
             )
 
         data = await response.json()
         usage = data.get("usage") or {}
-        output_text, output_message = _parse_anthropic_content(data.get("content"))
+        output_text, output_message = parse_anthropic_content(data.get("content"))
         input_tokens = usage.get("input_tokens")
         output_tokens = usage.get("output_tokens")
         output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -68,9 +68,10 @@ async def parse_sse_stream(
         - raw_content: The raw string content of the stream
         - response_chunks: Raw JSON strings of content-bearing chunks, 1:1 with
           chunk_times.
-        - server_usage: Last-seen `usage` dict from any chunk that carried one
-          (e.g. trailing `{"choices":[],"usage":{...}}` when stream_options
-          include_usage=true). None if the server didn't emit usage.
+        - server_usage: Merged `usage` fields from chunks that carried one
+          (e.g. OpenAI trailing `{"choices":[],"usage":{...}}` or Anthropic
+          `message.usage`/`message_delta.usage`). None if the server didn't
+          emit usage.
     """
     output_text = ""
     chunk_times: List[float] = []
@@ -95,8 +96,13 @@ async def parse_sse_stream(
                             break
                         try:
                             data = json.loads(data_str)
-                            if usage := data.get("usage"):
-                                server_usage = usage
+                            usage = data.get("usage")
+                            if not isinstance(usage, dict):
+                                message_data = data.get("message")
+                                if isinstance(message_data, dict):
+                                    usage = message_data.get("usage")
+                            if isinstance(usage, dict):
+                                server_usage = {**(server_usage or {}), **usage}
                             if content := extract_content(data):
                                 output_text += content
                                 chunk_times.append(message_time)

--- a/inference_perf/client/modelserver/mock_client.py
+++ b/inference_perf/client/modelserver/mock_client.py
@@ -100,7 +100,7 @@ class MockModelServerClient(ModelServerClient):
             )
 
     def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Completion, APIType.Chat]
+        return [APIType.Completion, APIType.Chat, APIType.AnthropicMessages]
 
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         mock_prometheus_metric = ModelServerPrometheusMetric(

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -22,6 +22,7 @@ from inference_perf.apis import (
     ErrorResponseInfo,
     StreamedResponseMetrics,
 )
+from inference_perf.apis.anthropic_messages import _parse_anthropic_content
 from inference_perf.apis.streaming_parser import StreamInterruptedError
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.utils import CustomTokenizer
@@ -243,7 +244,17 @@ class openAIModelServerClientSession(ModelServerClientSession):
                     otel_response_info["input_prompt"] = data.prompt
 
                 # Extract output text (gen_ai.output.text)
-                if self.client.api_config.streaming and response_content:
+                if self.client.api_config.type == APIType.AnthropicMessages and response and response.status == 200:
+                    if not self.client.api_config.streaming and response_content:
+                        response_json = json.loads(response_content)
+                        output_text, output_message = _parse_anthropic_content(response_json.get("content"))
+                        if output_text:
+                            otel_response_info["output_text"] = output_text
+                        if output_message and output_message.get("tool_calls"):
+                            otel_response_info["output_message"] = json.dumps(output_message)
+                        if response_json.get("stop_reason"):
+                            otel_response_info["finish_reason"] = response_json["stop_reason"]
+                elif self.client.api_config.streaming and response_content:
                     stripped_response = response_content.strip()
                     if stripped_response.startswith("data:"):
                         output_parts = []
@@ -321,14 +332,18 @@ class openAIModelServerClientSession(ModelServerClientSession):
             streaming=self.client.api_config.streaming,
         )
 
-        # Add response_format for structured output if configured
-        if self.client.api_config.response_format:
+        # Add response_format for structured output if configured.
+        if self.client.api_config.type != APIType.AnthropicMessages and self.client.api_config.response_format:
             payload["response_format"] = self.client.api_config.response_format.to_api_format()
 
         headers = {"Content-Type": "application/json"}
 
         if self.client.api_key:
-            headers["Authorization"] = f"Bearer {self.client.api_key}"
+            if self.client.api_config.type == APIType.AnthropicMessages:
+                headers["x-api-key"] = self.client.api_key
+                headers["anthropic-version"] = "2023-06-01"
+            else:
+                headers["Authorization"] = f"Bearer {self.client.api_key}"
 
         if self.client.api_config.headers:
             _update_headers_case_insensitive(headers, self.client.api_config.headers)
@@ -344,7 +359,12 @@ class openAIModelServerClientSession(ModelServerClientSession):
         request_data = json.dumps(payload)
 
         # Determine operation name based on API type
-        operation_name = "chat.completions" if self.client.api_config.type == APIType.Chat else "completions"
+        if self.client.api_config.type == APIType.Chat:
+            operation_name = "chat.completions"
+        elif self.client.api_config.type == APIType.AnthropicMessages:
+            operation_name = "messages"
+        else:
+            operation_name = "completions"
 
         start = time.perf_counter()
         response: Optional[aiohttp.ClientResponse] = None

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -22,7 +22,7 @@ from inference_perf.apis import (
     ErrorResponseInfo,
     StreamedResponseMetrics,
 )
-from inference_perf.apis.anthropic_messages import _parse_anthropic_content
+from inference_perf.apis.anthropic_messages import ANTHROPIC_VERSION, parse_anthropic_content
 from inference_perf.apis.streaming_parser import StreamInterruptedError
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.utils import CustomTokenizer
@@ -247,7 +247,7 @@ class openAIModelServerClientSession(ModelServerClientSession):
                 if self.client.api_config.type == APIType.AnthropicMessages and response and response.status == 200:
                     if not self.client.api_config.streaming and response_content:
                         response_json = json.loads(response_content)
-                        output_text, output_message = _parse_anthropic_content(response_json.get("content"))
+                        output_text, output_message = parse_anthropic_content(response_json.get("content"))
                         if output_text:
                             otel_response_info["output_text"] = output_text
                         if output_message and output_message.get("tool_calls"):
@@ -341,7 +341,7 @@ class openAIModelServerClientSession(ModelServerClientSession):
         if self.client.api_key:
             if self.client.api_config.type == APIType.AnthropicMessages:
                 headers["x-api-key"] = self.client.api_key
-                headers["anthropic-version"] = "2023-06-01"
+                headers["anthropic-version"] = ANTHROPIC_VERSION
             else:
                 headers["Authorization"] = f"Bearer {self.client.api_key}"
 

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -57,7 +57,7 @@ class vLLMModelServerClient(openAIModelServerClient):
         self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
 
     def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Completion, APIType.Chat]
+        return [APIType.Completion, APIType.Chat, APIType.AnthropicMessages]
 
     def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
         return PrometheusMetricMetadata(

--- a/inference_perf/config/apis/config.py
+++ b/inference_perf/config/apis/config.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 class APIType(Enum):
     Completion = "completion"
     Chat = "chat"
+    AnthropicMessages = "anthropic_messages"
 
 
 class ResponseFormatType(Enum):

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -13,7 +13,13 @@
 # limitations under the License.
 import itertools
 import logging
-from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
+from inference_perf.apis import (
+    AnthropicMessagesAPIData,
+    ChatCompletionAPIData,
+    ChatMessage,
+    CompletionAPIData,
+    InferenceAPIData,
+)
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from .base import DataGenerator
 from inference_perf.config import APIConfig, APIType, DataConfig
@@ -67,7 +73,7 @@ class HFShareGPTDataGenerator(DataGenerator):
         next(self.sharegpt_dataset)
 
     def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Chat, APIType.Completion]
+        return [APIType.Chat, APIType.Completion, APIType.AnthropicMessages]
 
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         if self.sharegpt_dataset is None:
@@ -76,6 +82,8 @@ class HFShareGPTDataGenerator(DataGenerator):
             yield from self.get_completion_data()
         elif self.api_config.type == APIType.Chat:
             yield from self.get_chat_data()
+        elif self.api_config.type == APIType.AnthropicMessages:
+            yield from self.get_anthropic_messages_data()
         raise Exception("Unsupported API type")
 
     def get_completion_data(self) -> Generator[InferenceAPIData, None, None]:
@@ -155,6 +163,14 @@ class HFShareGPTDataGenerator(DataGenerator):
                 messages.append(ChatMessage(role=role, content=content))
 
             yield ChatCompletionAPIData(messages=messages)
+
+    def get_anthropic_messages_data(self) -> Generator[InferenceAPIData, None, None]:
+        if self.tokenizer is None:
+            raise Exception("Tokenizer is required for Anthropic Messages API of HFShareGPTDataGenerator")
+
+        for data in self.get_chat_data():
+            if isinstance(data, ChatCompletionAPIData):
+                yield AnthropicMessagesAPIData(messages=data.messages, max_tokens=data.max_tokens)
 
     def is_io_distribution_supported(self) -> bool:
         return True

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -171,6 +171,8 @@ class HFShareGPTDataGenerator(DataGenerator):
         for data in self.get_chat_data():
             if isinstance(data, ChatCompletionAPIData):
                 yield AnthropicMessagesAPIData(messages=data.messages, max_tokens=data.max_tokens)
+            else:
+                raise Exception(f"Expected ChatCompletionAPIData, got {type(data).__name__}")
 
     def is_io_distribution_supported(self) -> bool:
         return True

--- a/inference_perf/datagen/mock_datagen.py
+++ b/inference_perf/datagen/mock_datagen.py
@@ -14,7 +14,13 @@
 from typing import Generator, List, Optional
 from inference_perf.config import APIConfig, APIType, DataConfig
 from inference_perf.datagen.base import DataGenerator
-from inference_perf.apis import InferenceAPIData, CompletionAPIData, ChatCompletionAPIData, ChatMessage
+from inference_perf.apis import (
+    AnthropicMessagesAPIData,
+    ChatCompletionAPIData,
+    ChatMessage,
+    CompletionAPIData,
+    InferenceAPIData,
+)
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
@@ -23,7 +29,7 @@ class MockDataGenerator(DataGenerator):
         super().__init__(api_config, config, tokenizer)
 
     def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Completion, APIType.Chat]
+        return [APIType.Completion, APIType.Chat, APIType.AnthropicMessages]
 
     def get_data(self) -> Generator[InferenceAPIData, None, None]:
         i = 0
@@ -35,6 +41,10 @@ class MockDataGenerator(DataGenerator):
             while True:
                 i += 1
                 yield ChatCompletionAPIData(messages=[ChatMessage(role="user", content=f"mock prompt {i}")])
+        elif self.api_config.type == APIType.AnthropicMessages:
+            while True:
+                i += 1
+                yield AnthropicMessagesAPIData(messages=[ChatMessage(role="user", content=f"mock prompt {i}")])
         else:
             raise Exception("Unsupported API type")
 

--- a/inference_perf/datagen/otel_trace_replay_datagen.py
+++ b/inference_perf/datagen/otel_trace_replay_datagen.py
@@ -68,14 +68,13 @@ from inference_perf.config import APIConfig, DataConfig
 from inference_perf.datagen.replay_graph_session_datagen import (
     ReplaySession,
     ReplayGraphSessionGeneratorBase,
-    SessionChatCompletionAPIData,
 )
 from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_raw_calls,
     build_graph,
 )
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-from inference_perf.apis import LazyLoadInferenceAPIData
+from inference_perf.apis import InferenceAPIData, LazyLoadInferenceAPIData
 
 logger = logging.getLogger(__name__)
 
@@ -515,7 +514,7 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
             graph=graph,
         )
 
-    def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> SessionChatCompletionAPIData:
+    def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> InferenceAPIData:
         api_data = super().load_lazy_data(data)
 
         event = self._resolve_event(data)

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -45,9 +45,10 @@ from inference_perf.apis import (
     UnaryResponseMetrics,
 )
 from inference_perf.apis.anthropic_messages import (
-    _build_anthropic_request_body,
-    _count_anthropic_prompt_tokens,
-    _parse_anthropic_content,
+    build_anthropic_request_body,
+    count_anthropic_prompt_tokens,
+    parse_anthropic_content,
+    parse_anthropic_stream_response,
 )
 from inference_perf.apis.chat import ChatMessage
 from inference_perf.payloads import RequestMetrics, Text
@@ -1025,7 +1026,7 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
         if self.max_tokens == 0:
             self.max_tokens = max_tokens
 
-        payload = _build_anthropic_request_body(
+        payload = build_anthropic_request_body(
             self.messages,
             self.tool_definitions,
             effective_model_name,
@@ -1056,14 +1057,14 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
         logger.debug(f"process_response called for event {self.event_id}")
 
         if config.streaming:
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response,
-                extract_content=lambda data: (
-                    data.get("delta", {}).get("text")
-                    if data.get("type") == "content_block_delta" and data.get("delta", {}).get("type") == "text_delta"
-                    else None
-                ),
-            )
+            (
+                output_text,
+                output_message,
+                chunk_times,
+                raw_content,
+                response_chunks,
+                server_usage,
+            ) = await parse_anthropic_stream_response(response)
             input_tokens = (server_usage or {}).get("input_tokens")
             output_tokens = (server_usage or {}).get("output_tokens")
             output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)
@@ -1072,7 +1073,7 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
                     text=Text(
                         input_tokens=int(input_tokens)
                         if input_tokens is not None
-                        else _count_anthropic_prompt_tokens(self.messages, tokenizer)
+                        else count_anthropic_prompt_tokens(self.messages, tokenizer)
                     )
                 ),
                 response_metrics=StreamedResponseMetrics(
@@ -1083,13 +1084,12 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
                     server_usage=server_usage,
                 ),
                 lora_adapter=lora_adapter,
-                extra_info={"raw_response": raw_content, "output_text": output_text},
+                extra_info={"raw_response": raw_content, "output_message": output_message, "output_text": output_text},
             )
-            output_message: Optional[Dict[str, Any]] = {"role": "assistant", "content": output_text}
         else:
             data = await response.json()
             usage = data.get("usage") or {}
-            output_text, output_message = _parse_anthropic_content(data.get("content"))
+            output_text, output_message = parse_anthropic_content(data.get("content"))
             input_tokens = usage.get("input_tokens")
             output_tokens = usage.get("output_tokens")
             output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)
@@ -1098,7 +1098,7 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
                     text=Text(
                         input_tokens=int(input_tokens)
                         if input_tokens is not None
-                        else _count_anthropic_prompt_tokens(self.messages, tokenizer)
+                        else count_anthropic_prompt_tokens(self.messages, tokenizer)
                     )
                 ),
                 response_metrics=UnaryResponseMetrics(output_tokens=output_len),

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -37,11 +37,17 @@ from aiohttp import ClientResponse
 from inference_perf.apis import (
     ChatCompletionAPIData,
     ErrorResponseInfo,
+    InferenceAPIData,
     InferenceInfo,
     LazyLoadInferenceAPIData,
     SessionLifecycleMetric,
     StreamedResponseMetrics,
     UnaryResponseMetrics,
+)
+from inference_perf.apis.anthropic_messages import (
+    _build_anthropic_request_body,
+    _count_anthropic_prompt_tokens,
+    _parse_anthropic_content,
 )
 from inference_perf.apis.chat import ChatMessage
 from inference_perf.payloads import RequestMetrics, Text
@@ -1004,6 +1010,124 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
         )
 
 
+class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
+    """Anthropic Messages APIData subclass for graph-backed session replay."""
+
+    def get_api_type(self) -> APIType:
+        return APIType.AnthropicMessages
+
+    def get_route(self) -> str:
+        return "/v1/messages"
+
+    async def to_request_body(
+        self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
+    ) -> Dict[str, Any]:
+        if self.max_tokens == 0:
+            self.max_tokens = max_tokens
+
+        payload = _build_anthropic_request_body(
+            self.messages,
+            self.tool_definitions,
+            effective_model_name,
+            self.max_tokens,
+            streaming,
+        )
+
+        if self.expected_output_is_tool_call and self.tool_definitions:
+            if self.override_tool_call_max_tokens:
+                payload["max_tokens"] = max(payload.get("max_tokens", 0) * 4, 4096)
+
+            names = self.expected_output_tool_names or []
+            available = {t["name"] for t in payload.get("tools", []) if "name" in t}
+            if len(names) == 1 and names[0] in available:
+                payload["tool_choice"] = {"type": "tool", "name": names[0]}
+            else:
+                payload["tool_choice"] = {"type": "any"}
+
+        return payload
+
+    async def process_response(
+        self,
+        response: ClientResponse,
+        config: APIConfig,
+        tokenizer: CustomTokenizer,
+        lora_adapter: Optional[str] = None,
+    ) -> SessionInferenceInfo:
+        logger.debug(f"process_response called for event {self.event_id}")
+
+        if config.streaming:
+            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+                response,
+                extract_content=lambda data: (
+                    data.get("delta", {}).get("text")
+                    if data.get("type") == "content_block_delta" and data.get("delta", {}).get("type") == "text_delta"
+                    else None
+                ),
+            )
+            input_tokens = (server_usage or {}).get("input_tokens")
+            output_tokens = (server_usage or {}).get("output_tokens")
+            output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)
+            base_info = InferenceInfo(
+                request_metrics=RequestMetrics(
+                    text=Text(
+                        input_tokens=int(input_tokens)
+                        if input_tokens is not None
+                        else _count_anthropic_prompt_tokens(self.messages, tokenizer)
+                    )
+                ),
+                response_metrics=StreamedResponseMetrics(
+                    response_chunks=response_chunks,
+                    chunk_times=chunk_times,
+                    output_tokens=output_len,
+                    output_token_times=chunk_times,
+                    server_usage=server_usage,
+                ),
+                lora_adapter=lora_adapter,
+                extra_info={"raw_response": raw_content, "output_text": output_text},
+            )
+            output_message: Optional[Dict[str, Any]] = {"role": "assistant", "content": output_text}
+        else:
+            data = await response.json()
+            usage = data.get("usage") or {}
+            output_text, output_message = _parse_anthropic_content(data.get("content"))
+            input_tokens = usage.get("input_tokens")
+            output_tokens = usage.get("output_tokens")
+            output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)
+            base_info = InferenceInfo(
+                request_metrics=RequestMetrics(
+                    text=Text(
+                        input_tokens=int(input_tokens)
+                        if input_tokens is not None
+                        else _count_anthropic_prompt_tokens(self.messages, tokenizer)
+                    )
+                ),
+                response_metrics=UnaryResponseMetrics(output_tokens=output_len),
+                lora_adapter=lora_adapter,
+                extra_info={
+                    "stop_reason": data.get("stop_reason"),
+                    "output_message": output_message,
+                    "output_text": output_text,
+                },
+            )
+
+        info = SessionInferenceInfo(
+            request_metrics=base_info.request_metrics,
+            response_metrics=base_info.response_metrics,
+            lora_adapter=lora_adapter,
+            output_text=output_text or None,
+            output_message=output_message,
+            extra_info=base_info.extra_info,
+        )
+        self.on_completion(info)
+
+        if output_text:
+            logger.debug(f"Registered output for event {self.event_id}: {len(output_text)} chars : {output_text}")
+        else:
+            logger.debug(f"Registered empty output for event {self.event_id}")
+
+        return info
+
+
 @dataclass
 class ReplaySessionState:
     """Tracks graph traversal state for one session."""
@@ -1250,7 +1374,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
         return bool(re.search(r"_dup\d+$", session_id))
 
     def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Chat]
+        return [APIType.Chat, APIType.AnthropicMessages]
 
     def is_preferred_worker_requested(self) -> bool:
         return True
@@ -1514,7 +1638,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             raise IndexError(f"Event index {n} out of range (total: {len(self.all_events)})")
         return self.all_events[n]
 
-    def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> SessionChatCompletionAPIData:
+    def load_lazy_data(self, data: LazyLoadInferenceAPIData) -> InferenceAPIData:
         event = self._resolve_event(data)
 
         chat_messages = []
@@ -1588,7 +1712,11 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
 
         gc = state.graph.events[raw_event_id].call if state and raw_event_id in state.graph.events else None
 
-        return SessionChatCompletionAPIData(
+        api_data_class: type[SessionChatCompletionAPIData] = SessionChatCompletionAPIData
+        if self.api_config.type == APIType.AnthropicMessages:
+            api_data_class = SessionAnthropicMessagesAPIData
+
+        return api_data_class(
             messages=chat_messages,
             max_tokens=max_tokens,
             tool_definitions=event.tool_definitions,

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -1713,7 +1713,8 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
         gc = state.graph.events[raw_event_id].call if state and raw_event_id in state.graph.events else None
 
         api_data_class: type[SessionChatCompletionAPIData] = SessionChatCompletionAPIData
-        if self.api_config.type == APIType.AnthropicMessages:
+        api_config = getattr(self, "api_config", None)
+        if api_config is not None and api_config.type == APIType.AnthropicMessages:
             api_data_class = SessionAnthropicMessagesAPIData
 
         return api_data_class(

--- a/tests/required/apis/test_anthropic_messages.py
+++ b/tests/required/apis/test_anthropic_messages.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -35,6 +36,19 @@ def _mock_tokenizer() -> MagicMock:
 def _mock_response(payload: dict[str, Any]) -> MagicMock:
     response = MagicMock()
     response.json = AsyncMock(return_value=payload)
+    return response
+
+
+def _mock_stream_response(chunks: list[bytes]) -> MagicMock:
+    response = MagicMock()
+    content = MagicMock()
+    response.content = content
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+
+    content.iter_any = mock_iter_any
     return response
 
 
@@ -133,6 +147,34 @@ async def test_anthropic_messages_process_response_uses_anthropic_usage() -> Non
 
 
 @pytest.mark.asyncio
+async def test_anthropic_messages_streaming_preserves_usage_across_events() -> None:
+    data = AnthropicMessagesAPIData(messages=[ChatMessage(role="user", content="hello there")])
+    response = _mock_stream_response(
+        [
+            b'data: {"type": "message_start", "message": {"usage": {"input_tokens": 3}}}\n\n',
+            b'data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}\n\n',
+            b'data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hello"}}\n\n',
+            b'data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": " back"}}\n\n',
+            b'data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 5}}\n\n',
+            b'data: {"type": "message_stop"}\n\n',
+        ]
+    )
+
+    info = await data.process_response(
+        response=response,
+        config=APIConfig(type=APIType.AnthropicMessages, streaming=True),
+        tokenizer=_mock_tokenizer(),
+    )
+
+    assert info.request_metrics.text.input_tokens == 3
+    assert info.response_metrics is not None
+    assert info.response_metrics.output_tokens == 5
+    assert info.response_metrics.server_usage == {"input_tokens": 3, "output_tokens": 5}
+    assert info.extra_info["output_text"] == "hello back"
+    assert info.extra_info["output_message"] == {"role": "assistant", "content": "hello back"}
+
+
+@pytest.mark.asyncio
 async def test_session_anthropic_messages_records_tool_use_for_replay() -> None:
     registry = EventOutputRegistry()
     tracker = WorkerSessionTracker()
@@ -174,6 +216,64 @@ async def test_session_anthropic_messages_records_tool_use_for_replay() -> None:
                 "id": "toolu_01",
                 "type": "function",
                 "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+            }
+        ],
+    }
+    assert tracker.is_event_completed("session_1", "event_1")
+
+
+@pytest.mark.asyncio
+async def test_session_anthropic_messages_streaming_records_tool_use_for_replay() -> None:
+    registry = EventOutputRegistry()
+    tracker = WorkerSessionTracker()
+    data = SessionAnthropicMessagesAPIData(
+        messages=[ChatMessage(role="user", content="Use the weather tool")],
+        event_id="session_1:event_1",
+        registry=registry,
+        worker_tracker=tracker,
+        completion_queue=None,
+        total_events_in_session=1,
+    )
+    response = _mock_stream_response(
+        [
+            b'data: {"type": "message_start", "message": {"usage": {"input_tokens": 4}}}\n\n',
+            (
+                b'data: {"type": "content_block_start", "index": 0, '
+                b'"content_block": {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {}}}\n\n'
+            ),
+            (
+                b'data: {"type": "content_block_delta", "index": 0, '
+                b'"delta": {"type": "input_json_delta", "partial_json": "{\\"city\\":"}}\n\n'
+            ),
+            (
+                b'data: {"type": "content_block_delta", "index": 0, '
+                b'"delta": {"type": "input_json_delta", "partial_json": "\\"Paris\\"}"}}\n\n'
+            ),
+            b'data: {"type": "content_block_stop", "index": 0}\n\n',
+            b'data: {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 6}}\n\n',
+            b'data: {"type": "message_stop"}\n\n',
+        ]
+    )
+
+    info = await data.process_response(
+        response=response,
+        config=APIConfig(type=APIType.AnthropicMessages, streaming=True),
+        tokenizer=_mock_tokenizer(),
+    )
+
+    assert info.output_text is None
+    assert info.request_metrics.text.input_tokens == 4
+    assert info.response_metrics is not None
+    assert info.response_metrics.output_tokens == 6
+    assert info.response_metrics.server_usage == {"input_tokens": 4, "output_tokens": 6}
+    assert registry.get_output_by_event_id("session_1:event_1") == ""
+    assert registry.get_message_by_event_id("session_1:event_1") == {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "toolu_01",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city":"Paris"}'},
             }
         ],
     }

--- a/tests/required/apis/test_anthropic_messages.py
+++ b/tests/required/apis/test_anthropic_messages.py
@@ -1,0 +1,180 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from inference_perf.apis import AnthropicMessagesAPIData, ChatMessage
+from inference_perf.config import APIConfig, APIType
+from inference_perf.datagen.replay_graph_session_datagen import (
+    EventOutputRegistry,
+    SessionAnthropicMessagesAPIData,
+    WorkerSessionTracker,
+)
+
+
+def _mock_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens.side_effect = lambda text: len((text or "").split())
+    return tokenizer
+
+
+def _mock_response(payload: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.json = AsyncMock(return_value=payload)
+    return response
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_request_body_with_tools() -> None:
+    data = AnthropicMessagesAPIData(
+        messages=[
+            ChatMessage(role="system", content="Be concise."),
+            ChatMessage(role="user", content="What is the weather in Paris?"),
+            ChatMessage(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "toolu_01",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                    }
+                ],
+            ),
+            ChatMessage(role="tool", content="Sunny", tool_call_id="toolu_01"),
+        ],
+        tool_definitions=[
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get current weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        ],
+    )
+
+    assert data.get_api_type() == APIType.AnthropicMessages
+    assert data.get_route() == "/v1/messages"
+    assert await data.to_request_body("claude-sonnet", 128, False, False) == {
+        "model": "claude-sonnet",
+        "system": "Be concise.",
+        "messages": [
+            {"role": "user", "content": "What is the weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "get_weather",
+                        "input": {"city": "Paris"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "Sunny"}],
+            },
+        ],
+        "max_tokens": 128,
+        "stream": False,
+        "tools": [
+            {
+                "name": "get_weather",
+                "description": "Get current weather",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_process_response_uses_anthropic_usage() -> None:
+    data = AnthropicMessagesAPIData(messages=[ChatMessage(role="user", content="hello there")])
+    response = _mock_response(
+        {
+            "content": [{"type": "text", "text": "hello back"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 3, "output_tokens": 5},
+        }
+    )
+
+    info = await data.process_response(
+        response=response,
+        config=APIConfig(type=APIType.AnthropicMessages),
+        tokenizer=_mock_tokenizer(),
+    )
+
+    assert info.request_metrics.text.input_tokens == 3
+    assert info.response_metrics is not None
+    assert info.response_metrics.output_tokens == 5
+    assert info.extra_info["stop_reason"] == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_session_anthropic_messages_records_tool_use_for_replay() -> None:
+    registry = EventOutputRegistry()
+    tracker = WorkerSessionTracker()
+    data = SessionAnthropicMessagesAPIData(
+        messages=[ChatMessage(role="user", content="Use the weather tool")],
+        event_id="session_1:event_1",
+        registry=registry,
+        worker_tracker=tracker,
+        completion_queue=None,
+        total_events_in_session=1,
+    )
+    response = _mock_response(
+        {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"},
+                }
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 4, "output_tokens": 6},
+        }
+    )
+
+    info = await data.process_response(
+        response=response,
+        config=APIConfig(type=APIType.AnthropicMessages),
+        tokenizer=_mock_tokenizer(),
+    )
+
+    assert info.output_text is None
+    assert registry.get_output_by_event_id("session_1:event_1") == ""
+    assert registry.get_message_by_event_id("session_1:event_1") == {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "toolu_01",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+            }
+        ],
+    }
+    assert tracker.is_event_completed("session_1", "event_1")

--- a/tests/required/client/modelserver/test_openai_client.py
+++ b/tests/required/client/modelserver/test_openai_client.py
@@ -16,7 +16,8 @@ import asyncio
 import aiohttp
 from unittest.mock import AsyncMock, MagicMock
 from inference_perf.client.modelserver.openai_client import openAIModelServerClientSession
-from inference_perf.apis import ErrorResponseInfo, InferenceInfo
+from inference_perf.apis import AnthropicMessagesAPIData, ChatMessage, ErrorResponseInfo, InferenceInfo
+from inference_perf.config import APIType
 from inference_perf.payloads import RequestMetrics, Text
 
 
@@ -108,7 +109,6 @@ async def test_process_request_general_exception(mock_client: MagicMock, mock_da
 async def test_otel_records_output_from_sse_response(mock_client: MagicMock, mock_data: MagicMock) -> None:
     """OTEL metrics should correctly parse SSE streaming response content."""
     from contextlib import contextmanager
-    from inference_perf.config import APIType
 
     mock_client.api_config.streaming = True
     mock_client.api_config.type = APIType.Chat
@@ -165,6 +165,35 @@ async def test_otel_records_output_from_sse_response(mock_client: MagicMock, moc
     call_kwargs = mock_client.otel.record_response_metrics.call_args[1]
     response_info = call_kwargs["response_info"]
     assert response_info["output_text"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_request_uses_messages_route_and_headers(mock_client: MagicMock) -> None:
+    mock_client.api_config.type = APIType.AnthropicMessages
+    mock_client.api_config.streaming = False
+    mock_client.api_config.session_id_header_key = None
+    mock_client.api_key = "test-key"
+    mock_client.model_name = "claude-sonnet"
+    mock_client.max_completion_tokens = 128
+    mock_client.ignore_eos = True
+
+    data = AnthropicMessagesAPIData(messages=[ChatMessage(role="user", content="hello")])
+    session = openAIModelServerClientSession(mock_client)
+    session.session = MagicMock()
+
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("force exit"))
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    session.session.post.return_value = mock_post_ctx
+
+    await session.process_request(data, stage_id=1, scheduled_time=0.0)
+
+    assert session.session.post.call_args.args[0] == "http://test-uri/v1/messages"
+    headers_passed = session.session.post.call_args.kwargs["headers"]
+    assert headers_passed["x-api-key"] == "test-key"
+    assert headers_passed["anthropic-version"] == "2023-06-01"
+    assert "Authorization" not in headers_passed
+    assert '"ignore_eos"' not in session.session.post.call_args.kwargs["data"]
 
 
 @pytest.mark.asyncio

--- a/tests/required/client/modelserver/test_openai_client.py
+++ b/tests/required/client/modelserver/test_openai_client.py
@@ -17,6 +17,7 @@ import aiohttp
 from unittest.mock import AsyncMock, MagicMock
 from inference_perf.client.modelserver.openai_client import openAIModelServerClientSession
 from inference_perf.apis import AnthropicMessagesAPIData, ChatMessage, ErrorResponseInfo, InferenceInfo
+from inference_perf.apis.anthropic_messages import ANTHROPIC_VERSION
 from inference_perf.config import APIType
 from inference_perf.payloads import RequestMetrics, Text
 
@@ -191,7 +192,7 @@ async def test_anthropic_messages_request_uses_messages_route_and_headers(mock_c
     assert session.session.post.call_args.args[0] == "http://test-uri/v1/messages"
     headers_passed = session.session.post.call_args.kwargs["headers"]
     assert headers_passed["x-api-key"] == "test-key"
-    assert headers_passed["anthropic-version"] == "2023-06-01"
+    assert headers_passed["anthropic-version"] == ANTHROPIC_VERSION
     assert "Authorization" not in headers_passed
     assert '"ignore_eos"' not in session.session.post.call_args.kwargs["data"]
 

--- a/tests/required/datagen/test_hf_sharegpt_datagen.py
+++ b/tests/required/datagen/test_hf_sharegpt_datagen.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from inference_perf.apis import CompletionAPIData
 from inference_perf.datagen.hf_sharegpt_datagen import HFShareGPTDataGenerator
 
 
@@ -51,3 +52,12 @@ def test_get_conversation_turn_content_unsupported_type() -> None:
 
     with pytest.raises(Exception, match="Conversation from upstream gave unsupported type: list"):
         generator.get_conversation_turn_content(data, 1)
+
+
+def test_get_anthropic_messages_data_rejects_unexpected_chat_data() -> None:
+    generator = HFShareGPTDataGenerator.__new__(HFShareGPTDataGenerator)
+    generator.tokenizer = object()
+    generator.get_chat_data = lambda: iter([CompletionAPIData(prompt="hello")])
+
+    with pytest.raises(Exception, match="Expected ChatCompletionAPIData, got CompletionAPIData"):
+        next(generator.get_anthropic_messages_data())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,6 +71,19 @@ def test_deep_merge() -> None:
     assert merged["metrics"]["type"] == MetricsClientType.PROMETHEUS
 
 
+def test_read_config_accepts_anthropic_messages_api_type() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+        yaml.dump({"api": {"type": "anthropic_messages"}}, tmp)
+        tmp_path = tmp.name
+
+    try:
+        config = read_config(tmp_path)
+        assert config.api.type == APIType.AnthropicMessages
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
 def test_read_config_timestamp_substitution() -> None:
     # Create a minimalistic config with {timestamp} in the storage path
     config_content = {


### PR DESCRIPTION
Resolves #560

## Summary

Adds `api.type: anthropic_messages` support for the Anthropic Messages API.

This includes:

- request serialization for `/v1/messages`
- system prompt, `tool_use`, `tool_result`, and `input_schema` conversion
- non-streaming response parsing for text, tool calls, usage, and `stop_reason`
- streaming text delta parsing
- support in mock and vLLM clients
- mock, ShareGPT, and OTel trace replay data generator wiring
- docs and CLI flag updates
- unit coverage for request formatting, response parsing, client headers, config parsing, and replay tool-use capture

## Testing

- `uv run --extra dev ruff format --check ./inference_perf ./tests`
- `uv run --extra dev ruff check ./inference_perf ./tests`
- `uv run --extra dev --group types mypy --strict ./inference_perf ./tests`
- `uv run --extra dev python -m pytest tests/required/apis/test_anthropic_messages.py tests/required/client/modelserver/test_openai_client.py tests/test_config.py`
- `uv run --extra dev python -m pytest tests/test_otel_replay_datagen.py tests/test_otel_trace_to_replay_graph.py tests/test_tool_call_capture.py tests/test_reasoning_output_support.py tests/required/apis/test_user_session.py`
- `uv run --extra dev python scripts/sync_cli_flags_doc.py --check`