### PR TITLE
[WIP] test(e2e): add inference-perf vs vllm bench parity test

### DIFF
--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -46,11 +46,13 @@ jobs:
         continue-on-error: true
         run: |
           set -euxo pipefail
-          # Single source of truth for the version is vllm_bench.py.
+          # Single source of truth for the version and compat pins is vllm_bench.py.
           VLLM_REF="$(grep -oP 'VLLM_PINNED_REF = "\K[^"]+' e2e/utils/vllm_bench.py)"
+          VLLM_COMPAT_PINS="$(grep -oP 'VLLM_COMPAT_PINS = "\K[^"]+' e2e/utils/vllm_bench.py)"
           python -m pip install --upgrade pip
           # CPU-only client bench: it just drives an OpenAI-compatible server.
-          python -m pip install "vllm==${VLLM_REF#v}"
+          # Word-splitting of the pin list is intentional.
+          python -m pip install "vllm==${VLLM_REF#v}" $VLLM_COMPAT_PINS
           echo "VLLM_BENCH_BIN=$(python -c 'import shutil; print(shutil.which("vllm") or "")')" >> "$GITHUB_ENV"
 
       - name: Run end-to-end tests

--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -26,6 +26,33 @@ jobs:
         run: |
           nix develop -c pdm sync -d
 
+      # The tool-parity test (e2e/tests/test_tool_parity.py) compares
+      # inference-perf against `vllm bench serve`. vllm publishes no wheels for
+      # the nix devshell's Python (3.14), so install it under a separate 3.12
+      # and hand the test its path via $VLLM_BENCH_BIN. Both steps are
+      # best-effort: if provisioning fails (e.g. the pinned version is not yet
+      # on PyPI), the parity test skips gracefully and the rest of the e2e
+      # suite is unaffected.
+      - name: Set up Python 3.12 for vllm
+        id: setup-vllm-python
+        continue-on-error: true
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install pinned vllm for parity test (best-effort)
+        id: install-vllm
+        continue-on-error: true
+        run: |
+          set -euxo pipefail
+          # Single source of truth for the version is vllm_bench.py.
+          VLLM_REF="$(grep -oP 'VLLM_PINNED_REF = "\K[^"]+' e2e/utils/vllm_bench.py)"
+          python -m pip install --upgrade pip
+          # CPU-only client bench: it just drives an OpenAI-compatible server.
+          python -m pip install "vllm==${VLLM_REF#v}"
+          echo "VLLM_BENCH_BIN=$(python -c 'import shutil; print(shutil.which("vllm") or "")')" >> "$GITHUB_ENV"
+
       - name: Run end-to-end tests
         run: |
           set -euxo pipefail

--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python 3.12 for vllm
         id: setup-vllm-python
         continue-on-error: true
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: pip

--- a/e2e/tests/test_tool_parity.py
+++ b/e2e/tests/test_tool_parity.py
@@ -1,0 +1,260 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tool-parity end-to-end test: inference-perf vs `vllm bench serve`.
+
+WHY THIS EXISTS
+We observed inference-perf and vllm's serving benchmark report materially
+different numbers when pointed at the *same* server. This test pins down that
+discrepancy by running both tools against a single configurable mock
+(llm-d-inference-sim) whose TTFT / ITL we set explicitly, across a table of
+scenarios that each isolate one axis (load mode, sequence lengths, tokenizer).
+
+The PRIMARY assertion is strict tool-vs-tool agreement within reasonable
+bounds. As a SECONDARY sanity check, where it is meaningful, each tool's TPOT
+is compared against the configured per-token latency (ground truth). TPOT is
+used for ground truth rather than TTFT because TTFT absorbs queue wait under
+load, whereas per-token spacing stays ~constant.
+
+This doubles as the regression fixture for the perf-diff investigation: on
+failure, the logged comparison table shows which metric diverged and by how
+much.
+
+REQUIREMENTS (cases auto-skip if unmet, like the other e2e tests):
+  * llm-d-inference-sim on PATH (nix develop provides it).
+  * a runnable vllm: either $VLLM_BENCH_BIN, or $VLLM_BENCH_PROVISION=1 (see
+    utils/vllm_bench.py).
+  * for non-bundled tokenizers: network to fetch them from HF (the case skips
+    if offline). Bundle a tokenizer-only tarball under e2e/testdata/models and
+    add it to BUNDLED_TOKENIZERS to make a tokenizer hermetic.
+"""
+
+import logging
+import os
+import socket
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from utils.benchmark import run_benchmark_minimal
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
+from utils.scenario import (
+    Scenario,
+    compare,
+    format_comparison_table,
+    ground_truth,
+    normalize_inference_perf,
+    normalize_vllm_bench,
+)
+from utils.testdata import extract_tarball
+from utils.vllm_bench import (
+    VllmUnavailable,
+    ensure_vllm_bench_bin,
+    run_vllm_bench,
+    warn_if_pin_stale,
+)
+
+logger = logging.getLogger(__name__)
+
+# Server model is held constant (bundled gemma tokenizer) so the sim is always
+# offline-reliable; only the *client* tokenizer varies across cases.
+SERVER_MODEL = "google/gemma-3-270m"
+
+# Tokenizers resolvable without network (tokenizer-only tarballs in testdata).
+# Add entries here (and drop the tarball in) to make a tokenizer hermetic.
+BUNDLED_TOKENIZERS: Dict[str, str] = {
+    "google/gemma-3-270m": "e2e/testdata/models/google_gemma-3-270m.tar.gz",
+}
+
+# Default tool-vs-tool tolerances (relative). Strict, but mindful that neither
+# tool recovers a configured latency exactly and ITL is the noisiest metric
+# (per-chunk effects, cf. inference-perf #566). Tune as real deltas come in.
+DEFAULT_TOL = {
+    "median_ttft_ms": 0.20,
+    "median_tpot_ms": 0.20,
+    "median_itl_ms": 0.30,
+    "output_throughput_tok_s": 0.20,
+}
+GROUND_TRUTH_TPOT_TOL = 0.40
+
+
+@dataclass
+class ParityCase:
+    """A scenario plus how strictly to judge it."""
+
+    scenario: Scenario
+    # TPOT-vs-configured is only meaningful when the client tokenizer matches
+    # what the server generated; with a mismatched tokenizer the client
+    # re-tokenizes to a different count and TPOT drifts (which is exactly the
+    # tokenizer-driven divergence we want tool-vs-tool to still agree on).
+    check_tpot_ground_truth: bool = True
+    tol: Dict[str, float] = field(default_factory=lambda: dict(DEFAULT_TOL))
+
+
+def _base(**overrides: object) -> Scenario:
+    """Shared baseline; override per case."""
+    defaults: Dict[str, object] = dict(
+        model_name=SERVER_MODEL,
+        num_prompts=40,
+        input_len=128,
+        output_len=64,
+        load_mode="rate",
+        request_rate=8.0,
+        num_workers=32,
+        ttft_ms=200.0,
+        itl_ms=10.0,
+    )
+    defaults.update(overrides)
+    return Scenario(**defaults)  # type: ignore[arg-type]
+
+
+# The table. Each case isolates one axis; runtimes are kept bounded by trimming
+# num_prompts / itl_ms for the long-output cases.
+CASES = [
+    # (a) fixed request rate (open loop)
+    pytest.param(ParityCase(_base(load_mode="rate", request_rate=8.0)), id="a_fixed_rate"),
+    # (b) fixed concurrency (closed loop). TTFT absorbs queue wait, so judge on
+    # tool-vs-tool + TPOT ground truth only.
+    pytest.param(
+        ParityCase(_base(load_mode="concurrency", concurrency=16, num_prompts=48)),
+        id="b_fixed_concurrency",
+    ),
+    # (c) 1k in / 1k out
+    pytest.param(
+        ParityCase(_base(input_len=1024, output_len=1024, itl_ms=2.0, request_rate=4.0, num_prompts=20)),
+        id="c_1k_in_1k_out",
+    ),
+    # (d) 1k in / 4k out
+    pytest.param(
+        ParityCase(_base(input_len=1024, output_len=4096, itl_ms=1.0, request_rate=2.0, num_prompts=12)),
+        id="d_1k_in_4k_out",
+    ),
+    # (e) multiple tokenizers. Gemma matches the server (ground truth holds);
+    # gpt2 is a mismatched tokenizer (no BOS injection) so only tool-vs-tool is
+    # asserted -- this is the case most likely to expose tokenizer-driven drift.
+    pytest.param(ParityCase(_base(tokenizer="google/gemma-3-270m")), id="e_tokenizer_gemma"),
+    pytest.param(
+        ParityCase(_base(tokenizer="gpt2"), check_tpot_ground_truth=False),
+        id="e_tokenizer_gpt2",
+    ),
+]
+
+
+def _free_port() -> int:
+    """Pick an ephemeral free port so parametrized cases never collide."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _resolve_tokenizer(name: str) -> str:
+    """Return a local path (bundled) or HF id for the client tokenizer.
+
+    Skips the case if a non-bundled tokenizer cannot be loaded (e.g. offline),
+    so the suite degrades gracefully rather than failing on a network hiccup.
+    """
+    if name in BUNDLED_TOKENIZERS:
+        return str(extract_tarball(BUNDLED_TOKENIZERS[name]))
+    try:
+        from transformers import AutoTokenizer
+
+        AutoTokenizer.from_pretrained(name)
+    except Exception as e:  # noqa: BLE001 - offline / gated / missing
+        pytest.skip(f"tokenizer {name!r} unavailable (offline?): {e}")
+    return name
+
+
+@pytest.fixture(scope="module")
+def vllm_bin() -> str:
+    """Provision a runnable vllm or skip the whole module."""
+    warn_if_pin_stale(check_upstream=False)
+    try:
+        return ensure_vllm_bench_bin()
+    except VllmUnavailable as e:
+        pytest.skip(f"vllm bench unavailable: {e}")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not LLMDInferenceSimRunner.is_available(),
+    reason="local environment missing llm-d-inference-sim",
+)
+@pytest.mark.parametrize("case", CASES)
+async def test_inference_perf_vs_vllm_bench_parity(case: ParityCase, vllm_bin: str) -> None:
+    scenario = case.scenario
+    tokenizer = _resolve_tokenizer(scenario.tokenizer or scenario.model_name)
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+
+    async with LLMDInferenceSimRunner(scenario.model_name, *scenario.sim_latency_args(), port=port):
+        # --- inference-perf ---
+        ip_result = await run_benchmark_minimal(
+            scenario.inference_perf_config(base_url=base_url, tokenizer_path=tokenizer),
+        )
+        assert ip_result.success, f"inference-perf run failed:\n{ip_result.stdout}"
+        assert ip_result.reports, "inference-perf produced no reports"
+
+        # --- vllm bench (same server, same workload, same tokenizer) ---
+        with tempfile.TemporaryDirectory(prefix="vllm-bench-parity-") as td:
+            result_file = str(Path(td) / "vllm_bench_result.json")
+            vb_result = await run_vllm_bench(
+                scenario.vllm_bench_args(base_url=base_url, result_path=result_file, tokenizer=tokenizer),
+                vllm_bin=vllm_bin,
+                work_dir=Path(td),
+                result_filename=result_file,
+            )
+            assert vb_result.success, f"vllm bench run failed:\n{vb_result.stdout}"
+            assert vb_result.result_json, "vllm bench produced no result JSON"
+            vb = normalize_vllm_bench(vb_result.result_json)
+
+    ip = normalize_inference_perf(ip_result.reports["summary_lifecycle_metrics.json"])
+    gt = ground_truth(scenario)
+
+    # --- Always emit the comparison artifact (the regression record). ---
+    tables = {
+        "inference-perf vs vllm-bench": compare(ip, vb),
+        "ground-truth vs inference-perf": compare(gt, ip),
+        "ground-truth vs vllm-bench": compare(gt, vb),
+    }
+    rendered = format_comparison_table(tables)
+    logger.info("tool parity comparison:%s", rendered)
+    artifact = Path(os.environ.get("PARITY_ARTIFACT_DIR", tempfile.gettempdir())) / "tool_parity.txt"
+    with artifact.open("a") as f:
+        f.write(rendered + "\n")
+
+    # --- Primary gate: the two tools must agree within bounds. ---
+    tool_table = tables["inference-perf vs vllm-bench"]
+    failures = []
+    for metric, tol in case.tol.items():
+        rel = tool_table[metric]["rel_diff"]
+        if rel is None:
+            failures.append(f"{metric}: missing from one tool ({tool_table[metric]})")
+        elif rel > tol:
+            failures.append(f"{metric}: rel_diff {rel:.1%} > tol {tol:.0%} ({tool_table[metric]})")
+    assert not failures, "inference-perf and vllm-bench disagree:\n" + "\n".join(failures) + rendered
+
+    # --- Secondary: TPOT should track the configured per-token latency. ---
+    # TPOT is load-invariant (unlike TTFT), so this holds even under
+    # concurrency; it is skipped only when the client tokenizer is mismatched.
+    if case.check_tpot_ground_truth:
+        for name, tool in (("inference-perf", ip), ("vllm-bench", vb)):
+            vals = compare(gt, tool, fields=("median_tpot_ms",))["median_tpot_ms"]
+            rel = vals["rel_diff"]
+            assert rel is not None and rel <= GROUND_TRUTH_TPOT_TOL, (
+                f"{name} median_tpot_ms off from configured {scenario.itl_ms}ms by "
+                f"{rel:.1%} (>{GROUND_TRUTH_TPOT_TOL:.0%}): {vals}{rendered}"
+            )

--- a/e2e/tests/test_tool_parity.py
+++ b/e2e/tests/test_tool_parity.py
@@ -200,7 +200,7 @@ async def test_inference_perf_vs_vllm_bench_parity(case: ParityCase, vllm_bin: s
     port = _free_port()
     base_url = f"http://127.0.0.1:{port}"
 
-    async with LLMDInferenceSimRunner(scenario.model_name, *scenario.sim_latency_args(), port=port):
+    async with LLMDInferenceSimRunner(scenario.model_name, *scenario.sim_args(), port=port):
         # --- inference-perf ---
         ip_result = await run_benchmark_minimal(
             scenario.inference_perf_config(base_url=base_url, tokenizer_path=tokenizer),

--- a/e2e/utils/scenario.py
+++ b/e2e/utils/scenario.py
@@ -126,13 +126,22 @@ class Scenario:
 
     # ------------------------------------------------------------------ mocks
 
-    def sim_latency_args(self) -> List[str]:
-        """CLI flags for llm-d-inference-sim to emulate this scenario's latency.
+    def sim_args(self) -> List[str]:
+        """CLI flags for llm-d-inference-sim to emulate this scenario.
 
         Flag names verified against llm-d-inference-sim v0.6.1 (the version
         pinned in flake.nix). See its README "latency simulation" section.
         """
+        # The sim's context window defaults to 1024 tokens and it 400s any
+        # request where prompt + completion exceeds it, so size it to the
+        # scenario. Doubled for headroom: the sim counts prompt tokens with its
+        # own tokenizer, which can exceed the client's intended input_len when
+        # the client tokenizer differs (and chat adds template tokens). The sim
+        # is a mock, so an oversized window costs nothing.
+        max_model_len = max(1024, 2 * (self.input_len + self.output_len))
         args = [
+            "--max-model-len",
+            str(max_model_len),
             "--time-to-first-token",
             str(int(self.ttft_ms)),
             "--inter-token-latency",

--- a/e2e/utils/scenario.py
+++ b/e2e/utils/scenario.py
@@ -235,7 +235,10 @@ class Scenario:
             raise ValueError(f"unknown load_mode: {self.load_mode!r}")
 
         if not self.streaming:
-            args.append("--disable-stream")  # TODO: verify flag name for the pinned ref
+            # The pinned vllm bench cannot disable response streaming: its
+            # request funcs hardcode "stream": True, and its only stream
+            # flag (--no-stream) controls HF dataset loading, not responses.
+            raise ValueError("vllm bench serve (pinned ref) only supports streaming scenarios")
         return args
 
 

--- a/e2e/utils/scenario.py
+++ b/e2e/utils/scenario.py
@@ -1,0 +1,371 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Single source of truth for a tool-parity benchmark scenario.
+
+The whole point of the parity test is to drive *both* inference-perf and
+`vllm bench serve` with an identical workload against the same configurable
+mock server, then compare what each tool reports. The discrepancies we have
+seen historically almost certainly live in how each tool *interprets* a
+workload (request-rate vs concurrency semantics, warmup, tokenization) and how
+each *computes* TTFT / ITL / TPOT from a stream -- not in the runners
+themselves.
+
+So the mapping from one `Scenario` to each tool's inputs is deliberately
+centralized here, in plain sight, because that mapping is the thing under test.
+If the two tools disagree, this file is the first place to look for an
+asymmetry.
+
+Units note (load-bearing):
+  * inference-perf reports latency in SECONDS.
+  * `vllm bench serve` reports latency in MILLISECONDS (`*_ms`).
+  * `llm-d-inference-sim` is configured in MILLISECONDS.
+The normalizers below convert everything to milliseconds so comparisons and
+ground-truth assertions are apples-to-apples.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """A single workload, plus the latency the mock is configured to emulate.
+
+    Because the mock is configured from the same object, `ttft_ms` / `itl_ms`
+    are *ground truth*: the value each tool should recover. That is strictly
+    stronger than only comparing the two tools to each other, since it tells us
+    which tool drifts (and by how much), not merely that they disagree.
+    """
+
+    model_name: str  # model sent in requests; the sim is launched with this
+    # --- Workload ---
+    num_prompts: int  # total requests across the run
+    input_len: int  # prompt tokens per request
+    output_len: int  # generated tokens per request (with ignore_eos)
+
+    # Load mode -- the two axes we most want to compare:
+    #   "rate"        -> open-loop: arrivals at `request_rate` QPS (Poisson for
+    #                    vllm, constant for inference-perf). num_workers must be
+    #                    high enough not to bottleneck the offered rate.
+    #   "concurrency" -> closed-loop: exactly `concurrency` requests in flight,
+    #                    a new one launched as each completes.
+    load_mode: str = "rate"  # "rate" | "concurrency"
+    request_rate: float = 4.0  # used when load_mode == "rate"
+    concurrency: int = 8  # used when load_mode == "concurrency"
+    num_workers: int = 16  # inference-perf worker pool (cap on in-flight for rate mode)
+
+    streaming: bool = True
+    api: str = "completion"  # "completion" | "chat"
+
+    # Client-side tokenizer: a bundled-tarball key or an HF id. Kept separate
+    # from model_name so we can hold the server constant (the bundled gemma
+    # tokenizer) and vary ONLY the tokenizer -- isolating tokenizer-driven
+    # divergence (e.g. BOS/special-token handling, cf. #566) from everything
+    # else. The test resolves this to a path/id; defaults to model_name.
+    tokenizer: Optional[str] = None
+
+    # vllm bench's --random-range-ratio controls how much input/output lengths
+    # vary around the requested length. THIS IS THE KNOWN ROOT CAUSE of the
+    # inference-perf-vs-vllm discrepancy we are chasing: a wrong value makes
+    # vllm sample lengths from a wide range while inference-perf uses fixed
+    # lengths, so the two tools benchmark different workloads.
+    #
+    # SEMANTICS ARE VERSION-DEPENDENT (reconcile when bumping the vllm pin):
+    #   * old benchmarks/benchmark_serving.py: range is [len*ratio, len];
+    #       ratio=1.0 -> FIXED, ratio=0.0 -> Uniform[0, len].
+    #   * new `vllm bench serve`: range is [len*(1-ratio), len*(1+ratio)];
+    #       ratio=0.0 -> FIXED, ratio=1.0 -> Uniform[0, 2*len].
+    # Default below targets FIXED lengths for the pinned (new-CLI) ref so the
+    # workload matches inference-perf. If this test ever passes only by
+    # accident, check this value first.
+    random_range_ratio: float = 0.0
+
+    # --- Mock ground-truth latencies (milliseconds) ---
+    ttft_ms: float = 0.0  # time-to-first-token
+    itl_ms: float = 0.0  # inter-token latency == per-output-token time for the sim
+    # Keep noise off by default so per-request timing is deterministic and the
+    # ground-truth assertions are not fighting the mock's own variance.
+    ttft_std_dev_ms: float = 0.0
+    itl_std_dev_ms: float = 0.0
+
+    @property
+    def duration_sec(self) -> float:
+        """For rate mode, inference-perf drives load by (rate, duration); derive
+        the duration so it issues the same number of requests as vllm."""
+        return self.num_prompts / self.request_rate
+
+    def _inference_perf_load(self) -> Dict[str, Any]:
+        """Load section for inference-perf, branched on load mode."""
+        if self.load_mode == "concurrency":
+            return {
+                "type": "concurrent",
+                "stages": [{"num_requests": self.num_prompts, "concurrency_level": self.concurrency}],
+                "num_workers": max(self.num_workers, self.concurrency),
+            }
+        if self.load_mode == "rate":
+            return {
+                "type": "constant",
+                "stages": [{"rate": self.request_rate, "duration": self.duration_sec}],
+                "num_workers": self.num_workers,
+            }
+        raise ValueError(f"unknown load_mode: {self.load_mode!r}")
+
+    # ------------------------------------------------------------------ mocks
+
+    def sim_latency_args(self) -> List[str]:
+        """CLI flags for llm-d-inference-sim to emulate this scenario's latency.
+
+        Flag names verified against llm-d-inference-sim v0.6.1 (the version
+        pinned in flake.nix). See its README "latency simulation" section.
+        """
+        args = [
+            "--time-to-first-token",
+            str(int(self.ttft_ms)),
+            "--inter-token-latency",
+            str(int(self.itl_ms)),
+        ]
+        if self.ttft_std_dev_ms:
+            args += ["--time-to-first-token-std-dev", str(int(self.ttft_std_dev_ms))]
+        if self.itl_std_dev_ms:
+            args += ["--inter-token-latency-std-dev", str(int(self.itl_std_dev_ms))]
+        return args
+
+    # ----------------------------------------------------------- inference-perf
+
+    def inference_perf_config(self, *, base_url: str, tokenizer_path: str) -> Dict[str, Any]:
+        """Render this scenario as an inference-perf config dict.
+
+        Uses synthetic data with fixed input/output lengths so the workload is
+        identical to vllm bench's `--dataset-name random`.
+        """
+        return {
+            "data": {
+                "type": "synthetic",
+                # Fixed distributions => exactly input_len/output_len tokens,
+                # matching vllm bench's fixed --random-{input,output}-len so the
+                # two tools issue byte-for-byte comparable requests.
+                "input_distribution": {
+                    "type": "fixed",
+                    "min": self.input_len,
+                    "max": self.input_len,
+                    "mean": self.input_len,
+                },
+                "output_distribution": {
+                    "type": "fixed",
+                    "min": self.output_len,
+                    "max": self.output_len,
+                    "mean": self.output_len,
+                },
+            },
+            "load": self._inference_perf_load(),
+            "api": {"type": self.api, "streaming": self.streaming},
+            "server": {
+                "type": "vllm",
+                "model_name": self.model_name,
+                "base_url": base_url,
+                "ignore_eos": True,  # force exactly output_len tokens, like vllm bench
+            },
+            "tokenizer": {"pretrained_model_name_or_path": tokenizer_path},
+            "report": {
+                "request_lifecycle": {"summary": True, "per_stage": True, "per_request": True},
+            },
+        }
+
+    # -------------------------------------------------------------- vllm bench
+
+    def vllm_bench_args(self, *, base_url: str, result_path: str, tokenizer: str) -> List[str]:
+        """Render this scenario as `vllm bench serve` CLI args.
+
+        NOTE: flag names track the pinned vllm ref (see vllm_bench.py). If you
+        bump the pin and the CLI changed, this is the place to reconcile.
+        """
+        endpoint = "/v1/chat/completions" if self.api == "chat" else "/v1/completions"
+        backend = "openai-chat" if self.api == "chat" else "openai"
+        args = [
+            "--backend",
+            backend,
+            "--model",
+            self.model_name,
+            "--tokenizer",
+            tokenizer,
+            "--base-url",
+            base_url,
+            "--endpoint",
+            endpoint,
+            "--dataset-name",
+            "random",
+            "--random-input-len",
+            str(self.input_len),
+            "--random-output-len",
+            str(self.output_len),
+            # See Scenario.random_range_ratio: pin this explicitly, it is the
+            # known root cause of workload mismatch between the two tools.
+            "--random-range-ratio",
+            str(self.random_range_ratio),
+            "--num-prompts",
+            str(self.num_prompts),
+            "--ignore-eos",
+            "--percentile-metrics",
+            "ttft,tpot,itl",
+            "--save-result",
+            "--result-filename",
+            result_path,
+        ]
+        # Load mode: rate (open-loop arrivals) vs concurrency (closed-loop).
+        if self.load_mode == "concurrency":
+            # Unbounded arrivals, capped to `concurrency` in flight == closed loop.
+            args += ["--request-rate", "inf", "--max-concurrency", str(self.concurrency)]
+        elif self.load_mode == "rate":
+            args += ["--request-rate", str(self.request_rate)]
+        else:
+            raise ValueError(f"unknown load_mode: {self.load_mode!r}")
+
+        if not self.streaming:
+            args.append("--disable-stream")  # TODO: verify flag name for the pinned ref
+        return args
+
+
+@dataclass
+class NormalizedMetrics:
+    """Comparable metrics extracted from either tool. All latencies in ms."""
+
+    source: str  # "inference-perf" | "vllm-bench" | "ground-truth"
+    request_count: int
+    mean_ttft_ms: Optional[float] = None
+    median_ttft_ms: Optional[float] = None
+    mean_itl_ms: Optional[float] = None
+    median_itl_ms: Optional[float] = None
+    mean_tpot_ms: Optional[float] = None
+    median_tpot_ms: Optional[float] = None
+    output_throughput_tok_s: Optional[float] = None
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+
+def _sec_to_ms(v: Optional[float]) -> Optional[float]:
+    return None if v is None else v * 1000.0
+
+
+def normalize_inference_perf(summary_report: Dict[str, Any]) -> NormalizedMetrics:
+    """Pull comparable metrics out of inference-perf's summary_lifecycle_metrics.json.
+
+    Shape (see inference_perf/reportgen/base.py):
+      successes.latency.{time_to_first_token,inter_token_latency,
+                         time_per_output_token}.{mean,median,...}   # SECONDS
+      successes.throughput.output_tokens_per_sec
+    """
+    s = summary_report["successes"]
+    lat = s["latency"]
+    return NormalizedMetrics(
+        source="inference-perf",
+        request_count=s["count"],
+        mean_ttft_ms=_sec_to_ms(lat["time_to_first_token"].get("mean")),
+        median_ttft_ms=_sec_to_ms(lat["time_to_first_token"].get("median")),
+        mean_itl_ms=_sec_to_ms(lat["inter_token_latency"].get("mean")),
+        median_itl_ms=_sec_to_ms(lat["inter_token_latency"].get("median")),
+        mean_tpot_ms=_sec_to_ms(lat["time_per_output_token"].get("mean")),
+        median_tpot_ms=_sec_to_ms(lat["time_per_output_token"].get("median")),
+        output_throughput_tok_s=s.get("throughput", {}).get("output_tokens_per_sec"),
+        raw=summary_report,
+    )
+
+
+def normalize_vllm_bench(result: Dict[str, Any]) -> NormalizedMetrics:
+    """Pull comparable metrics out of `vllm bench serve --save-result` JSON.
+
+    vllm already reports milliseconds (`mean_ttft_ms`, etc.). Key names are
+    stable across recent vllm releases but should be re-checked when the pin
+    moves; unknown keys simply come back as None rather than KeyError.
+    """
+    return NormalizedMetrics(
+        source="vllm-bench",
+        request_count=result.get("completed", result.get("num_prompts", 0)),
+        mean_ttft_ms=result.get("mean_ttft_ms"),
+        median_ttft_ms=result.get("median_ttft_ms"),
+        mean_itl_ms=result.get("mean_itl_ms"),
+        median_itl_ms=result.get("median_itl_ms"),
+        mean_tpot_ms=result.get("mean_tpot_ms"),
+        median_tpot_ms=result.get("median_tpot_ms"),
+        output_throughput_tok_s=result.get("output_throughput"),
+        raw=result,
+    )
+
+
+def ground_truth(scenario: Scenario) -> NormalizedMetrics:
+    """The latency the mock was configured to emulate -- the value both tools
+    should recover. ITL and TPOT collapse to the same per-token figure for the
+    sim, which generates one token per inter-token interval."""
+    return NormalizedMetrics(
+        source="ground-truth",
+        request_count=scenario.num_prompts,
+        mean_ttft_ms=scenario.ttft_ms,
+        median_ttft_ms=scenario.ttft_ms,
+        mean_itl_ms=scenario.itl_ms,
+        median_itl_ms=scenario.itl_ms,
+        mean_tpot_ms=scenario.itl_ms,
+        median_tpot_ms=scenario.itl_ms,
+    )
+
+
+# Metrics compared by the parity test, with their per-metric tolerance. Strict
+# tool-vs-tool parity, but with reasonable bounds: neither tool will recover a
+# configured TTFT/TPOT perfectly, and ITL is the noisiest (per-chunk effects,
+# cf. inference-perf #566). Tune these as real deltas come in.
+PARITY_FIELDS = ("median_ttft_ms", "median_tpot_ms", "median_itl_ms", "output_throughput_tok_s")
+
+
+def compare(
+    a: NormalizedMetrics,
+    b: NormalizedMetrics,
+    *,
+    fields: tuple[str, ...] = PARITY_FIELDS,
+) -> Dict[str, Dict[str, Optional[float]]]:
+    """Return a per-field {a, b, abs_diff, rel_diff} table for reporting and
+    assertions. rel_diff is relative to max(|a|,|b|) so it is symmetric and
+    well-defined when one value is ~0."""
+    table: Dict[str, Dict[str, Optional[float]]] = {}
+    for f in fields:
+        av = getattr(a, f)
+        bv = getattr(b, f)
+        if av is None or bv is None:
+            table[f] = {"a": av, "b": bv, "abs_diff": None, "rel_diff": None}
+            continue
+        abs_diff = abs(av - bv)
+        denom = max(abs(av), abs(bv))
+        rel_diff = abs_diff / denom if denom > 0 else 0.0
+        table[f] = {"a": av, "b": bv, "abs_diff": abs_diff, "rel_diff": rel_diff}
+    return table
+
+
+def format_comparison_table(rows: Dict[str, Dict[str, Dict[str, Optional[float]]]]) -> str:
+    """Render named comparison tables (e.g. {"inference-perf vs vllm-bench": ...})
+    as a human-readable artifact for the test log / regression record."""
+    out: List[str] = []
+    for title, table in rows.items():
+        out.append(f"\n=== {title} ===")
+        out.append(f"{'metric':<28}{'a':>14}{'b':>14}{'abs_diff':>14}{'rel_diff':>12}")
+        for metric, vals in table.items():
+
+            def fmt(x: Optional[float], pct: bool = False) -> str:
+                if x is None:
+                    return "n/a"
+                return f"{x * 100:.1f}%" if pct else f"{x:.3f}"
+
+            out.append(
+                f"{metric:<28}{fmt(vals['a']):>14}{fmt(vals['b']):>14}"
+                f"{fmt(vals['abs_diff']):>14}{fmt(vals['rel_diff'], pct=True):>12}"
+            )
+    return "\n".join(out)

--- a/e2e/utils/scenario.py
+++ b/e2e/utils/scenario.py
@@ -142,6 +142,15 @@ class Scenario:
         args = [
             "--max-model-len",
             str(max_model_len),
+            # The sim also caps in-flight requests (--max-num-seqs, default 5)
+            # well below what these scenarios offer (~7-16 in flight), so with
+            # the default the requests queue and measured TTFT becomes queue
+            # wait -- which depends on each tool's arrival process (Poisson for
+            # vllm bench, constant for inference-perf), not on the measurement
+            # under test. Give the mock vLLM's own default (256) so both tools
+            # observe the configured ttft_ms rather than the queue.
+            "--max-num-seqs",
+            "256",
             "--time-to-first-token",
             str(int(self.ttft_ms)),
             "--inter-token-latency",

--- a/e2e/utils/vllm_bench.py
+++ b/e2e/utils/vllm_bench.py
@@ -53,6 +53,11 @@ logger = logging.getLogger(__name__)
 # drives the offline staleness warning (no network needed). The optional
 # upstream check (see warn_if_pin_stale) is best-effort on top of this.
 VLLM_PINNED_REF = "v0.10.0"  # TODO: confirm the tag whose `vllm bench serve` CLI we target
+# Extra pip specs installed alongside the pinned vllm (space-separated; the CI
+# workflow greps this constant too). vllm leaves transformers unbounded above,
+# and transformers 5 removed tokenizer attrs (all_special_tokens_extended)
+# that this vllm still reads at bench startup. Review when bumping the pin.
+VLLM_COMPAT_PINS = "transformers<5"
 VLLM_PIN_DATE = datetime.date(2026, 1, 15)
 VLLM_STALENESS_WARN_DAYS = 180
 VLLM_REPO_URL = "https://github.com/vllm-project/vllm.git"
@@ -227,7 +232,7 @@ def ensure_vllm_bench_bin(cache_dir: Optional[Path] = None) -> str:
         # CPU-only client bench: no GPU needed to drive an OpenAI-compatible
         # server. This is still a large install (torch); it is cached above.
         _run([pip, "install", "--upgrade", "pip"])
-        _run([pip, "install", str(clone_dir)])
+        _run([pip, "install", str(clone_dir), *VLLM_COMPAT_PINS.split()])
     except subprocess.CalledProcessError as e:
         raise VllmUnavailable(f"failed to provision vllm: {e.stderr or e}") from e
 

--- a/e2e/utils/vllm_bench.py
+++ b/e2e/utils/vllm_bench.py
@@ -1,0 +1,236 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Run `vllm bench serve` against a server, for tool-parity comparison.
+
+Design intent (per request): vllm is NOT a dependency of inference-perf. We
+instead clone a *pinned* vllm at test time and invoke its bench CLI, and we
+warn (loudly, non-fatally) if the pin has drifted too far from upstream so the
+comparison does not silently rot against a stale tool.
+
+Resolution order for *how* to invoke vllm, fastest first:
+  1. $VLLM_BENCH_BIN  -- path to an already-installed `vllm` executable. Skips
+     all clone/install work. The fast path for local iteration.
+  2. A cached, isolated venv under the e2e cache dir with the pinned vllm clone
+     installed into it. Heavy one-time setup (vllm pulls torch); cached across
+     runs. This is the CI path.
+
+Any failure to provision vllm results in a SkipReason, so the parity test
+degrades gracefully (skips) exactly like the llm-d-inference-sim tests do when
+the sim is absent -- it never hard-fails the suite on a missing tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- pin
+#
+# Bump these together. VLLM_PIN_DATE is the date the pin was last reviewed and
+# drives the offline staleness warning (no network needed). The optional
+# upstream check (see warn_if_pin_stale) is best-effort on top of this.
+VLLM_PINNED_REF = "v0.10.0"  # TODO: confirm the tag whose `vllm bench serve` CLI we target
+VLLM_PIN_DATE = datetime.date(2026, 1, 15)
+VLLM_STALENESS_WARN_DAYS = 180
+VLLM_REPO_URL = "https://github.com/vllm-project/vllm.git"
+
+# Cache lives outside the repo tree by default; override for CI persistence.
+_DEFAULT_CACHE = Path(os.environ.get("VLLM_BENCH_CACHE_DIR", Path(tempfile.gettempdir()) / "inference-perf-vllm-bench"))
+
+
+@dataclass
+class VllmBenchResult:
+    success: bool
+    timed_out: bool
+    return_code: int
+    stdout: str
+    result_json: Optional[Dict[str, Any]]  # parsed --save-result output, if produced
+
+
+class VllmUnavailable(Exception):
+    """Raised when vllm could not be provisioned; callers should pytest.skip."""
+
+
+def warn_if_pin_stale(*, check_upstream: bool = False) -> None:
+    """Emit a warning if the pinned vllm ref looks out of date.
+
+    Offline check: how long since the pin was reviewed. Optional online check:
+    compare the pinned tag against GitHub's latest release. Both are advisory --
+    a stale pin still runs, it just gets a loud log line so the comparison does
+    not quietly drift against an old vllm.
+    """
+    age_days = (datetime.date.today() - VLLM_PIN_DATE).days
+    if age_days > VLLM_STALENESS_WARN_DAYS:
+        logger.warning(
+            "vllm pin %s was last reviewed %d days ago (> %d). Consider bumping "
+            "VLLM_PINNED_REF and re-checking the bench CLI flags in scenario.py.",
+            VLLM_PINNED_REF,
+            age_days,
+            VLLM_STALENESS_WARN_DAYS,
+        )
+
+    if not check_upstream:
+        return
+    try:  # best-effort; never fail the test on a network hiccup
+        import urllib.request
+
+        with urllib.request.urlopen("https://api.github.com/repos/vllm-project/vllm/releases/latest", timeout=5) as resp:
+            latest = json.loads(resp.read()).get("tag_name")
+        if latest and latest != VLLM_PINNED_REF:
+            logger.warning("vllm pin %s is behind upstream latest release %s.", VLLM_PINNED_REF, latest)
+    except Exception as e:  # noqa: BLE001 - advisory only
+        logger.debug("upstream vllm staleness check skipped: %s", e)
+
+
+def _run(cmd: List[str]) -> "subprocess.CompletedProcess[str]":
+    logger.debug("running: %s", " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+
+def ensure_vllm_bench_bin(cache_dir: Optional[Path] = None) -> str:
+    """Return a path to a runnable `vllm` executable, or raise VllmUnavailable.
+
+    Resolution:
+      1. $VLLM_BENCH_BIN -> use it directly (the path CI uses: a vllm installed
+         under a compatible interpreter). Fast, no build.
+      2. $VLLM_BENCH_PROVISION truthy -> opt in to the HEAVY path: clone the
+         pinned vllm and pip-install it (with torch) into a cached venv.
+      3. otherwise -> raise VllmUnavailable so the parity test skips cleanly.
+
+    The default is to skip, NOT to silently kick off a multi-GB build during a
+    normal `pdm run test:e2e`. The heavy path is also gated on interpreter
+    compatibility: vllm supports Python <=3.12, while this repo runs 3.14, so
+    the in-tree interpreter usually cannot build it -- hence CI installs vllm
+    under a separate 3.12 and points $VLLM_BENCH_BIN at it.
+    """
+    override = os.environ.get("VLLM_BENCH_BIN")
+    if override:
+        if shutil.which(override) or Path(override).exists():
+            return override
+        raise VllmUnavailable(f"$VLLM_BENCH_BIN set but not executable: {override}")
+
+    if not os.environ.get("VLLM_BENCH_PROVISION"):
+        raise VllmUnavailable(
+            "no vllm available: set $VLLM_BENCH_BIN to a vllm executable, or "
+            "$VLLM_BENCH_PROVISION=1 to clone+install the pinned vllm (heavy; "
+            "needs a Python <=3.12 interpreter via $VLLM_PYTHON)"
+        )
+
+    cache = cache_dir or _DEFAULT_CACHE
+    cache.mkdir(parents=True, exist_ok=True)
+    clone_dir = cache / f"vllm-{VLLM_PINNED_REF}"
+    venv_dir = cache / f"venv-{VLLM_PINNED_REF}"
+    vllm_bin = venv_dir / "bin" / "vllm"
+
+    if vllm_bin.exists():
+        return str(vllm_bin)
+
+    if not shutil.which("git"):
+        raise VllmUnavailable("git not available to clone vllm")
+
+    # vllm does not yet publish wheels for Python 3.14; let callers point at a
+    # compatible interpreter (e.g. python3.12) for the isolated venv.
+    venv_python = os.environ.get("VLLM_PYTHON", "python")
+
+    try:
+        if not clone_dir.exists():
+            logger.info("cloning pinned vllm %s (shallow) -> %s", VLLM_PINNED_REF, clone_dir)
+            _run(["git", "clone", "--depth", "1", "--branch", VLLM_PINNED_REF, VLLM_REPO_URL, str(clone_dir)])
+
+        logger.info("creating isolated venv for vllm at %s (python=%s)", venv_dir, venv_python)
+        _run([venv_python, "-m", "venv", str(venv_dir)])
+        pip = str(venv_dir / "bin" / "pip")
+        # CPU-only client bench: no GPU needed to drive an OpenAI-compatible
+        # server. This is still a large install (torch); it is cached above.
+        _run([pip, "install", "--upgrade", "pip"])
+        _run([pip, "install", str(clone_dir)])
+    except subprocess.CalledProcessError as e:
+        raise VllmUnavailable(f"failed to provision vllm: {e.stderr or e}") from e
+
+    if not vllm_bin.exists():
+        raise VllmUnavailable(f"vllm install completed but no executable at {vllm_bin}")
+    return str(vllm_bin)
+
+
+async def run_vllm_bench(
+    args: List[str],
+    *,
+    vllm_bin: str,
+    work_dir: Optional[Path] = None,
+    result_filename: str = "vllm_bench_result.json",
+    timeout_sec: Optional[int] = 300,
+) -> VllmBenchResult:
+    """Invoke `vllm bench serve <args>` and parse its --save-result JSON.
+
+    `args` should already contain `--save-result --result-filename <path>`
+    (Scenario.vllm_bench_args does this). We read that file back here.
+    """
+    wd = Path(work_dir) if work_dir else Path(tempfile.mkdtemp(prefix="vllm-bench-e2e-"))
+    wd.mkdir(parents=True, exist_ok=True)
+
+    full = [vllm_bin, "bench", "serve", *args]
+    logger.debug("starting vllm bench: %s", " ".join(full))
+    proc = await asyncio.create_subprocess_exec(
+        *full,
+        cwd=str(wd),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    timed_out = False
+    return_code = -1
+    stdout = ""
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_sec)
+        stdout = out.decode()
+        assert proc.returncode is not None
+        return_code = proc.returncode
+    except asyncio.TimeoutError:
+        timed_out = True
+        return_code = -9
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+
+    # --result-filename may be absolute (Scenario passes one); fall back to wd.
+    rf = Path(result_filename)
+    result_path = rf if rf.is_absolute() else wd / rf
+    result_json = None
+    if result_path.exists():
+        try:
+            result_json = json.loads(result_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning("vllm bench result file present but unparseable: %s", result_path)
+
+    return VllmBenchResult(
+        success=(return_code == 0 and not timed_out),
+        timed_out=timed_out,
+        return_code=return_code,
+        stdout=stdout,
+        result_json=result_json,
+    )

--- a/e2e/utils/vllm_bench.py
+++ b/e2e/utils/vllm_bench.py
@@ -105,9 +105,33 @@ def warn_if_pin_stale(*, check_upstream: bool = False) -> None:
         logger.debug("upstream vllm staleness check skipped: %s", e)
 
 
+# Env vars that redirect a Python process's module resolution. The e2e suite
+# typically runs inside this repo's dev environment (nix devshell + venv, which
+# exports PYTHONPATH entries for its own interpreter), while vllm runs under a
+# separate interpreter. PYTHONPATH outranks the child's site-packages, so
+# inheriting these makes vllm import packages built for the wrong CPython ABI
+# (e.g. the devshell's torch) and crash on startup. LD_LIBRARY_PATH is left
+# alone: CI's hosted Python needs its entry to find libpython.
+_HOST_PYTHON_ENV_VARS = frozenset(
+    {
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONSTARTUP",
+        "NIX_PYTHONPATH",
+        "VIRTUAL_ENV",
+        "VIRTUAL_ENV_PROMPT",
+    }
+)
+
+
+def _isolated_env() -> Dict[str, str]:
+    """os.environ minus the vars that leak the host Python's packages into vllm's."""
+    return {k: v for k, v in os.environ.items() if k not in _HOST_PYTHON_ENV_VARS}
+
+
 def _run(cmd: List[str]) -> "subprocess.CompletedProcess[str]":
     logger.debug("running: %s", " ".join(cmd))
-    return subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return subprocess.run(cmd, capture_output=True, text=True, check=True, env=_isolated_env())
 
 
 def ensure_vllm_bench_bin(cache_dir: Optional[Path] = None) -> str:
@@ -196,6 +220,7 @@ async def run_vllm_bench(
     proc = await asyncio.create_subprocess_exec(
         *full,
         cwd=str(wd),
+        env=_isolated_env(),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
     )

--- a/e2e/utils/vllm_bench.py
+++ b/e2e/utils/vllm_bench.py
@@ -129,6 +129,43 @@ def _isolated_env() -> Dict[str, str]:
     return {k: v for k, v in os.environ.items() if k not in _HOST_PYTHON_ENV_VARS}
 
 
+# The `vllm` CLI cannot run `bench serve` on a machine with no accelerator:
+# main() eagerly builds every subparser, and the `vllm serve` (server) one
+# instantiates a default DeviceConfig, whose platform inference raises
+# "Failed to infer device type" when no device is present -- true of CI
+# runners and GPU-less workstations. The bench serve code itself is a pure
+# HTTP client that never touches a device, so run it directly instead. This
+# shim reproduces exactly what the CLI subcommand does
+# (vllm/entrypoints/cli/benchmark/serve.py: add_cli_args + main), minus the
+# unrelated broken subparsers.
+_BENCH_SERVE_SHIM = (
+    "import argparse\n"
+    "try:\n"
+    "    from vllm.utils import FlexibleArgumentParser as Parser\n"
+    "except Exception:\n"
+    "    Parser = argparse.ArgumentParser\n"
+    "from vllm.benchmarks.serve import add_cli_args, main\n"
+    "parser = Parser(description='vllm bench serve (direct module invocation)')\n"
+    "add_cli_args(parser)\n"
+    "main(parser.parse_args())\n"
+)
+
+
+def _bench_serve_cmd(vllm_bin: str, args: List[str]) -> List[str]:
+    """Build the argv for `vllm bench serve <args>` semantics.
+
+    Prefer the shim above under the vllm install's own interpreter (the
+    `python` sibling of the `vllm` executable, present in any venv or
+    setup-python install). Fall back to the real CLI when no sibling python
+    exists, e.g. if $VLLM_BENCH_BIN points at a wrapper script.
+    """
+    resolved = shutil.which(vllm_bin) or vllm_bin
+    python = Path(resolved).parent / "python"
+    if python.exists():
+        return [str(python), "-c", _BENCH_SERVE_SHIM, *args]
+    return [vllm_bin, "bench", "serve", *args]
+
+
 def _run(cmd: List[str]) -> "subprocess.CompletedProcess[str]":
     logger.debug("running: %s", " ".join(cmd))
     return subprocess.run(cmd, capture_output=True, text=True, check=True, env=_isolated_env())
@@ -215,7 +252,7 @@ async def run_vllm_bench(
     wd = Path(work_dir) if work_dir else Path(tempfile.mkdtemp(prefix="vllm-bench-e2e-"))
     wd.mkdir(parents=True, exist_ok=True)
 
-    full = [vllm_bin, "bench", "serve", *args]
+    full = _bench_serve_cmd(vllm_bin, args)
     logger.debug("starting vllm bench: %s", " ".join(full))
     proc = await asyncio.create_subprocess_exec(
         *full,

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -326,9 +326,12 @@ def test_use_server_output_tokens_flag_switches_tpot_ntpot_divisor() -> None:
     assert server.successes["latency"]["normalized_time_per_output_token"]["mean"] == pytest.approx(10.0 / 5.0)
 
     # Both raw counts remain reported regardless of the flag: output_len is the
-    # client count, output_tokens is the server count.
+    # client count, output_tokens is the server count (a single request, so its
+    # per-request distribution collapses to that count).
     assert server.successes["output_len"]["mean"] == pytest.approx(10.0)
-    assert server.successes["output_tokens"] == {"total": 5.0}
+    assert server.successes["output_tokens"] == pytest.approx(
+        {"total": 5.0, "mean": 5.0, "min": 5.0, "max": 5.0, "median": 5.0}
+    )
 
 
 def test_use_server_output_tokens_falls_back_without_usage() -> None:


### PR DESCRIPTION
## What

Adds an end-to-end test that drives both **inference-perf** and **`vllm bench serve`** against the same configurable `llm-d-inference-sim` mock (with a known TTFT/ITL) and asserts the two tools agree within reasonable bounds. Because the mock's latency is configured, it doubles as ground truth, so each tool is also checked against the value we dialed in.

## Why

We observed inference-perf and vllm's serving benchmark reporting materially different numbers when pointed at the same server. This test pins that down and becomes the regression fixture for the investigation: when it fails, the logged comparison table shows which metric diverged and by how much.

## How

- `e2e/utils/scenario.py` - a single `Scenario` rendered into **both** tools' inputs (the workload-parity mapping is kept in plain sight, since that mapping is the thing under test) plus metric normalizers (inference-perf reports seconds, vllm reports ms) and comparison helpers. Sets `--random-range-ratio` explicitly, the known root cause of input/output length mismatch between the two tools (semantics differ between the old `benchmark_serving.py` and the new `vllm bench serve`, documented inline).
- `e2e/utils/vllm_bench.py` - runs vllm's serving benchmark and parses its `--save-result` JSON. **vllm is not added as a dependency**: it is resolved via `$VLLM_BENCH_BIN`, or an opt-in (`$VLLM_BENCH_PROVISION=1`) clone+install of a pinned version, with a non-fatal staleness warning. Any failure to provision results in a clean skip. Two mechanics here were forced by live CI runs:
  - The subprocess gets a **sanitized environment** (no `PYTHONPATH` / `VIRTUAL_ENV` / etc.): the suite runs inside the repo's nix devshell, whose Python 3.13 `torch` otherwise leaks via `PYTHONPATH` into vllm's separate 3.12 interpreter and kills it at import with a CPython ABI mismatch.
  - The bench module (`vllm.benchmarks.serve`) is **invoked directly** under vllm's own interpreter rather than through the `vllm` CLI: the CLI eagerly builds every subparser, and the unrelated `vllm serve` (server) one instantiates a default `DeviceConfig` whose platform inference raises `Failed to infer device type` on any machine without an accelerator, CI runners included. Unfixed upstream through v0.24.0, so bumping the pin would not help. The shim reproduces exactly what the CLI subcommand does (`add_cli_args` + `main`), and falls back to the real CLI if `$VLLM_BENCH_BIN` has no sibling `python` (e.g. a wrapper script).
- `e2e/tests/test_tool_parity.py` - the test. Reuses the existing `LLMDInferenceSimRunner` and `run_benchmark_minimal`. Skips gracefully when the sim or vllm is unavailable, mirroring the other e2e tests, so it runs alongside the existing suite without destabilizing it.
- CI: `e2e_test-on-change.yml` installs the pinned vllm under a separate Python 3.12 (vllm has no 3.14 wheels) and exports `$VLLM_BENCH_BIN`. Both steps are best-effort/cached, so the parity test skips and the suite stays green if provisioning fails.

## Draft / open items

Opened as a draft because these still need confirmation against a live run:
- ~~Confirm `VLLM_PINNED_REF` (currently a `v0.10.0` placeholder) and reconcile its bench CLI~~ Reconciled against a real `vllm==0.10.0` install: every flag `Scenario` renders exists in its bench parser. `--disable-stream` does not exist in this ref, and response streaming is hardcoded on in its request funcs, so non-streaming scenarios now raise a clear error instead of passing a bogus flag.
- Decide new `vllm bench serve` vs the old `benchmarks/benchmark_serving.py`.
- Tune tolerances once real deltas are observed (result-JSON key parsing is exercised by the CI parity run).
