### PR TITLE
fix: pass reasoning_content through to server for KV-cache fidelity

### DIFF
--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -170,6 +170,7 @@ def _clean_parameters(obj: Any) -> Any:
 class ChatMessage(BaseModel):
     role: str
     content: Optional[Union[str, list[dict[str, Any]]]] = None
+    reasoning_content: Optional[str] = None
     tool_calls: Optional[List[Dict[str, Any]]] = None
     tool_call_id: Optional[str] = None
 
@@ -195,6 +196,9 @@ class ChatMessage(BaseModel):
                 msg["content"] = self.content
         else:
             msg["content"] = self.content if self.content is not None else ""
+        if self.reasoning_content is not None:
+            msg["reasoning_content"] = self.reasoning_content
+            msg["reasoning"] = self.reasoning_content
         return msg
 
 

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -266,13 +266,13 @@ class openAIModelServerClientSession(ModelServerClientSession):
                             delta = choices[0].get("delta", {})
                             if delta.get("content"):
                                 output_parts.append(delta["content"])
-                            if delta.get("reasoning_content"):
-                                reasoning_parts.append(delta["reasoning_content"])
+                            reasoning_chunk = delta.get("reasoning") or delta.get("reasoning_content")
+                            if reasoning_chunk:
+                                reasoning_parts.append(reasoning_chunk)
                             if delta.get("tool_calls"):
                                 tool_call_parts.append(delta)
 
-                        if output_parts:
-                            otel_response_info["output_text"] = "".join(output_parts)
+                        otel_response_info["output_text"] = "".join(output_parts)
                         if reasoning_parts:
                             otel_response_info["reasoning_text"] = "".join(reasoning_parts)
                         if tool_call_parts:
@@ -284,7 +284,7 @@ class openAIModelServerClientSession(ModelServerClientSession):
                         if "message" in choices[0]:
                             msg_out = choices[0].get("message", {})
                             output_text = msg_out.get("content") or ""
-                            reasoning_content = msg_out.get("reasoning_content")
+                            reasoning_content = msg_out.get("reasoning") or msg_out.get("reasoning_content")
 
                             otel_response_info["output_text"] = output_text
                             if reasoning_content:

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -771,7 +771,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 response, extract_content=_extract_streaming_content
             )
 
-            # Combine reasoning_content with output text for the content field
+            # Combine reasoning_content with text_content in output_text (used for token count)
             reasoning_text = "".join(reasoning_content_chunks) if reasoning_content_chunks else ""
             if reasoning_text:
                 output_text = reasoning_text + text_content

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -1330,8 +1330,11 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                 reasoning_content = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
 
             if tool_calls is not None:
-                chat_messages.append(ChatMessage(role=role, tool_calls=tool_calls))
-                original_messages.append({"role": role, "tool_calls": tool_calls})
+                chat_messages.append(ChatMessage(role=role, tool_calls=tool_calls, reasoning_content=reasoning_content))
+                orig_msg: Dict[str, Any] = {"role": role, "tool_calls": tool_calls}
+                if reasoning_content:
+                    orig_msg["reasoning_content"] = reasoning_content
+                original_messages.append(orig_msg)
                 continue
 
             if isinstance(content, list):
@@ -1348,7 +1351,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
 
             content_str = str(content)
             chat_messages.append(ChatMessage(role=role, content=content_str, reasoning_content=reasoning_content))
-            orig_msg: Dict[str, Any] = {"role": role, "content": content_str}
+            orig_msg = {"role": role, "content": content_str}
             if tool_call_id is not None:
                 orig_msg["tool_call_id"] = tool_call_id
             if reasoning_content:

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -426,6 +426,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 ChatMessage(
                     role=m["role"],
                     content=m.get("content"),
+                    reasoning_content=m.get("reasoning") or m.get("reasoning_content"),
                     tool_calls=m.get("tool_calls"),
                     tool_call_id=m.get("tool_call_id"),
                 )
@@ -758,8 +759,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     if chunk.get("id"):
                         tool_call_chunks[idx]["id"] = chunk["id"]
 
-                # Accumulate reasoning_content chunks
-                reasoning_chunk = delta.get("reasoning_content")
+                # Accumulate reasoning chunks (prefer "reasoning", fall back to "reasoning_content")
+                reasoning_chunk = delta.get("reasoning") or delta.get("reasoning_content")
                 if reasoning_chunk is not None:
                     reasoning_content_chunks.append(str(reasoning_chunk))
 
@@ -781,15 +782,13 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             if tool_call_chunks:
                 live_tool_calls = [tool_call_chunks[i] for i in sorted(tool_call_chunks)]
                 streaming_output_message = {"role": "assistant", "tool_calls": live_tool_calls}
-                if output_text:
-                    streaming_output_message["content"] = output_text
+                if text_content:
+                    streaming_output_message["content"] = text_content
             else:
-                streaming_output_message = {"role": "assistant", "content": output_text}
+                streaming_output_message = {"role": "assistant", "content": text_content}
 
-            # Keep separate reasoning_content and output_content fields
             if reasoning_text:
                 streaming_output_message["reasoning_content"] = reasoning_text
-                streaming_output_message["output_content"] = text_content
 
             prompt_text = "".join([_get_text(msg.content) for msg in self.messages if msg.content])
             prompt_len = tokenizer.count_tokens(prompt_text)
@@ -825,7 +824,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 msg_dict = choices[0].get("message", {})
                 text_content = msg_dict.get("content", "") or ""
                 tool_calls = msg_dict.get("tool_calls")
-                reasoning_content = msg_dict.get("reasoning_content")
+                reasoning_content = msg_dict.get("reasoning") or msg_dict.get("reasoning_content")
 
                 # Combine reasoning_content with output text for the content field
                 if reasoning_content:
@@ -835,15 +834,13 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
 
                 if tool_calls:
                     output_message = {"role": "assistant", "tool_calls": tool_calls}
-                    if output_text:
-                        output_message["content"] = output_text
+                    if text_content:
+                        output_message["content"] = text_content
                 else:
-                    output_message = {"role": "assistant", "content": output_text}
+                    output_message = {"role": "assistant", "content": text_content}
 
-                # Keep separate reasoning_content and output_content fields
                 if reasoning_content:
                     output_message["reasoning_content"] = reasoning_content
-                    output_message["output_content"] = text_content
             usage = data.get("usage") or {}
             server_completion_tokens = usage.get("completion_tokens")
             if server_completion_tokens is not None:
@@ -1324,11 +1321,13 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                 content = msg.get("content", "")
                 tool_calls = msg.get("tool_calls")
                 tool_call_id = msg.get("tool_call_id")
+                reasoning_content = msg.get("reasoning") or msg.get("reasoning_content")
             else:
                 role = getattr(msg, "role", "user")
                 content = getattr(msg, "text", "")
                 tool_calls = getattr(msg, "tool_calls", None)
                 tool_call_id = getattr(msg, "tool_call_id", None)
+                reasoning_content = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
 
             if tool_calls is not None:
                 chat_messages.append(ChatMessage(role=role, tool_calls=tool_calls))
@@ -1348,10 +1347,12 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                 content = " ".join(content_parts)
 
             content_str = str(content)
-            chat_messages.append(ChatMessage(role=role, content=content_str))
+            chat_messages.append(ChatMessage(role=role, content=content_str, reasoning_content=reasoning_content))
             orig_msg: Dict[str, Any] = {"role": role, "content": content_str}
             if tool_call_id is not None:
                 orig_msg["tool_call_id"] = tool_call_id
+            if reasoning_content:
+                orig_msg["reasoning_content"] = reasoning_content
             original_messages.append(orig_msg)
 
         max_tokens = event.expected_output_tokens

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -539,6 +539,10 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                         logger.debug(
                             f"Registry get for event {self.event_id} output segment from {seg.source_event_id} generated: {actual_output}"
                         )
+                        logger.warning(
+                            f"Event {self.event_id}: unable to get the actual output message from {seg.source_event_id}. "
+                            f"Using output text instead. "
+                        )
                         if actual_output:
                             if self.expected_output_is_tool_call:
                                 # The live model returned plain text where a tool call was

--- a/tests/test_reasoning_output_support.py
+++ b/tests/test_reasoning_output_support.py
@@ -37,6 +37,7 @@ from inference_perf.datagen.replay_graph_session_datagen import (
     SessionInferenceInfo,
     WorkerSessionTracker,
 )
+from inference_perf.datagen.replay_graph_types import InputSegment
 
 
 # ---------------------------------------------------------------------------
@@ -297,9 +298,8 @@ class TestReasoningRegistryIntegration:
         msg = registry.get_message_by_event_id("session_1:event_0")
         assert msg is not None
         assert msg["role"] == "assistant"
-        assert msg["content"] == "Reasoning. The answer."
+        assert msg["content"] == "The answer."
         assert msg["reasoning_content"] == "Reasoning. "
-        assert msg["output_content"] == "The answer."
 
     @pytest.mark.asyncio
     async def test_streaming_output_message_has_separate_fields(self) -> None:
@@ -317,9 +317,8 @@ class TestReasoningRegistryIntegration:
         msg = registry.get_message_by_event_id("session_1:event_0")
         assert msg is not None
         assert msg["role"] == "assistant"
-        assert msg["content"] == "Think. Result."
+        assert msg["content"] == "Result."
         assert msg["reasoning_content"] == "Think. "
-        assert msg["output_content"] == "Result."
 
     @pytest.mark.asyncio
     async def test_registry_message_without_reasoning_has_no_extra_fields(self) -> None:
@@ -335,7 +334,172 @@ class TestReasoningRegistryIntegration:
         assert msg["role"] == "assistant"
         assert msg["content"] == "Plain answer."
         assert "reasoning_content" not in msg
-        assert "output_content" not in msg
+
+
+# ---------------------------------------------------------------------------
+# ChatMessage.to_dict() tests — verify reasoning_content survives serialization
+# ---------------------------------------------------------------------------
+
+
+class TestChatMessageToDict:
+    """Test that ChatMessage.to_dict() correctly includes reasoning_content."""
+
+    def test_to_dict_includes_reasoning_content(self) -> None:
+        msg = ChatMessage(role="assistant", content="Answer", reasoning_content="Thinking")
+        d = msg.to_dict()
+        assert d["role"] == "assistant"
+        assert d["content"] == "Answer"
+        assert d["reasoning_content"] == "Thinking"
+
+    def test_to_dict_omits_reasoning_content_when_none(self) -> None:
+        msg = ChatMessage(role="assistant", content="Answer")
+        d = msg.to_dict()
+        assert "reasoning_content" not in d
+
+    def test_to_dict_with_tool_calls_and_reasoning(self) -> None:
+        tool_calls = [{"id": "call_1", "type": "function", "function": {"name": "fn", "arguments": "{}"}}]
+        msg = ChatMessage(role="assistant", content="Text", reasoning_content="Think", tool_calls=tool_calls)
+        d = msg.to_dict()
+        assert d["tool_calls"] == tool_calls
+        assert d["content"] == "Text"
+        assert d["reasoning_content"] == "Think"
+
+
+# ---------------------------------------------------------------------------
+# Substitution tests — verify reasoning_content survives ChatMessage conversion
+# ---------------------------------------------------------------------------
+
+
+class TestSubstitutionPreservesReasoning:
+    """Test that reasoning_content from registry survives the substitution → ChatMessage conversion."""
+
+    @pytest.mark.asyncio
+    async def test_substitution_preserves_reasoning_content(self) -> None:
+        """After substitution, ChatMessage should carry reasoning_content through to to_dict()."""
+        registry = EventOutputRegistry()
+        # Simulate predecessor completing with reasoning
+        registry.record(
+            "session_1:event_0",
+            "Think. Answer.",
+            [],
+            output_message={"role": "assistant", "content": "Answer.", "reasoning_content": "Think. "},
+        )
+
+        # Build a successor that references the predecessor
+        tracker = WorkerSessionTracker()
+        api_data = SessionChatCompletionAPIData(
+            messages=[ChatMessage(role="user", content="Hello")],
+            max_tokens=500,
+            event_id="session_1:event_1",
+            registry=registry,
+            worker_tracker=tracker,
+            completion_queue=None,
+            total_events_in_session=2,
+            predecessor_event_ids=["session_1:event_0"],
+            input_segments=[
+                InputSegment(type="output", message_count=1, token_count=10, source_event_id="session_1:event_0"),
+                InputSegment(type="unique", message_count=1, token_count=5, source_event_id=None),
+            ],
+            original_messages=[
+                {"role": "assistant", "content": "placeholder"},
+                {"role": "user", "content": "Hello"},
+            ],
+        )
+
+        # Run substitution
+        substituted = api_data._build_messages_with_substitution()
+
+        # Convert to ChatMessage (same as production code line 348-356)
+        chat_messages = [
+            ChatMessage(
+                role=m["role"],
+                content=m.get("content"),
+                reasoning_content=m.get("reasoning") or m.get("reasoning_content"),
+                tool_calls=m.get("tool_calls"),
+                tool_call_id=m.get("tool_call_id"),
+            )
+            for m in substituted
+        ]
+
+        # Verify the substituted assistant message has reasoning_content
+        assistant_msg = chat_messages[0]
+        assert assistant_msg.role == "assistant"
+        assert assistant_msg.content == "Answer."
+        assert assistant_msg.reasoning_content == "Think. "
+
+        # Verify it survives to_dict()
+        d = assistant_msg.to_dict()
+        assert d["content"] == "Answer."
+        assert d["reasoning_content"] == "Think. "
+
+
+# ---------------------------------------------------------------------------
+# "reasoning" field fallback tests — verify new vLLM field name is supported
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningFieldFallback:
+    """Test that the new 'reasoning' field name (vLLM migration) is correctly handled."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_reasoning_field_name(self) -> None:
+        """Streaming: 'reasoning' field in delta should be captured."""
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+        deltas = [
+            {"reasoning": "New field. "},
+            {"content": "Result."},
+        ]
+        response = _make_streaming_response(deltas, completion_tokens=4)
+
+        info = await api_data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+        assert info.output_text == "New field. Result."
+        msg = registry.get_message_by_event_id("session_1:event_0")
+        assert msg is not None
+        assert msg["content"] == "Result."
+        assert msg["reasoning_content"] == "New field. "
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_reasoning_field_name(self) -> None:
+        """Non-streaming: 'reasoning' field in message should be captured."""
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+
+        # Build response with "reasoning" instead of "reasoning_content"
+        message = {"role": "assistant", "content": "Answer.", "reasoning": "Thinking. "}
+        response = MagicMock()
+        response.json = AsyncMock(return_value={"choices": [{"message": message}]})
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        assert info.output_text == "Thinking. Answer."
+        msg = registry.get_message_by_event_id("session_1:event_0")
+        assert msg is not None
+        assert msg["content"] == "Answer."
+        assert msg["reasoning_content"] == "Thinking. "
+
+    @pytest.mark.asyncio
+    async def test_reasoning_preferred_over_reasoning_content(self) -> None:
+        """When both fields present, 'reasoning' takes precedence."""
+        registry = EventOutputRegistry()
+        api_data = _make_session_api_data(registry=registry)
+
+        message = {
+            "role": "assistant",
+            "content": "Answer.",
+            "reasoning": "New field wins.",
+            "reasoning_content": "Old field ignored.",
+        }
+        response = MagicMock()
+        response.json = AsyncMock(return_value={"choices": [{"message": message}]})
+
+        info = await api_data.process_response(response, _make_config(), _make_tokenizer())
+
+        assert info.output_text == "New field wins.Answer."
+        msg = registry.get_message_by_event_id("session_1:event_0")
+        assert msg is not None
+        assert msg["reasoning_content"] == "New field wins."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**
Add end-to-end support for the reasoning_content field (used by reasoning models like Qwen3) through the replay pipeline. This ensures reasoning content is preserved in the output registry, carried through substitution into successor requests, and correctly serialized in the messages sent to the server.

**Motivation**
When replaying traces from reasoning models (e.g. Qwen3 with --enable-reasoning), the model returns reasoning in a separate reasoning_content (or reasoning) field alongside the visible content. For KV-cache reuse in multi-turn conversations, the server's chat template needs to see this field in the input messages so it can reconstruct the correct token sequence.
Previously, reasoning_content was dropped during output registration and substitution — only the visible content was preserved. This meant successor requests lost the reasoning, and the server couldn't reconstruct the original prefix for cache hits.

**Changes**
- ChatMessage (chat.py): Added reasoning_content field. to_dict() emits both reasoning_content and reasoning for compatibility with different vLLM versions.
- Response reading (replay_graph_session_datagen.py, openai_client.py): Read reasoning field first with fallback to reasoning_content from API responses (both streaming and non-streaming), supporting vLLM's field name migration.
- Output registry: Store reasoning_content separately in output_message (not concatenated into content), so substitution can inject it as a proper field.
- Substitution → ChatMessage conversion: Carry reasoning_content from the registry through to ChatMessage and into the request payload.
- Input loading: Preserve reasoning_content from trace data when constructing initial messages.
- Streaming OTEL: Always set output_text (even when empty) to avoid missing the field in traces.

**Notes on server-side behavior**
vLLM also has a known issue (#38488 (https://github.com/vllm-project/vllm/issues/38488)) where the input parser drops reasoning_content — only reasoning is read. We emit both fields to maximize compatibility.