### PR TITLE
Add per-request distribution to server-sourced token metrics

### DIFF
--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -64,9 +64,16 @@ def summarize(items: List[float], percentiles: List[float]) -> Optional[dict[str
     return result
 
 
-def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric]) -> dict[str, float]:
+def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric], percentiles: List[float]) -> dict[str, float]:
+    """Input tokens as reported by the server (usage.prompt_tokens).
+
+    Reports the aggregate total/cached/uncached split alongside the per-request
+    distribution (min/mean/max/percentiles). Falls back to the client-side
+    input_tokens when the server does not report usage.
+    """
     prompt_tokens_total = 0.0
     prompt_tokens_cached = 0.0
+    per_request: List[float] = []
 
     for metric in metrics:
         response_metrics = metric.info.response_metrics
@@ -74,25 +81,32 @@ def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric]) -> dict[
         prompt_tokens = server_usage.get("prompt_tokens") if server_usage else metric.info.request_metrics.text.input_tokens
         prompt_tokens_details = server_usage.get("prompt_tokens_details", {}) if server_usage else {}
 
-        prompt_tokens_total += safe_float(prompt_tokens)
+        prompt_tokens_value = safe_float(prompt_tokens)
+        prompt_tokens_total += prompt_tokens_value
+        per_request.append(prompt_tokens_value)
         prompt_tokens_cached += safe_float(prompt_tokens_details.get("cached_tokens"))
 
-    return {
+    result = {
         "total": prompt_tokens_total,
         "cached": prompt_tokens_cached,
         "uncached": max(prompt_tokens_total - prompt_tokens_cached, 0.0),
     }
+    if distribution := summarize(per_request, percentiles):
+        result.update(distribution)
+    return result
 
 
-def summarize_output_token_usage(metrics: List[RequestLifecycleMetric]) -> dict[str, float]:
-    """Total output tokens as reported by the server (usage.completion_tokens).
+def summarize_output_token_usage(metrics: List[RequestLifecycleMetric], percentiles: List[float]) -> dict[str, float]:
+    """Output tokens as reported by the server (usage.completion_tokens).
 
     The server-side count is exact (a count of decode steps), unlike a
-    client-side re-tokenization of the streamed text. Falls back to the
-    client-side output_tokens when the server does not report usage. Mirrors
-    summarize_prompt_token_usage on the input side.
+    client-side re-tokenization of the streamed text. Reports the aggregate
+    total alongside the per-request distribution (min/mean/max/percentiles).
+    Falls back to the client-side output_tokens when the server does not report
+    usage. Mirrors summarize_prompt_token_usage on the input side.
     """
     output_tokens_total = 0.0
+    per_request: List[float] = []
 
     for metric in metrics:
         response_metrics = metric.info.response_metrics
@@ -102,9 +116,14 @@ def summarize_output_token_usage(metrics: List[RequestLifecycleMetric]) -> dict[
             if server_usage
             else (response_metrics.output_tokens if response_metrics else None)
         )
-        output_tokens_total += safe_float(completion_tokens)
+        completion_tokens_value = safe_float(completion_tokens)
+        output_tokens_total += completion_tokens_value
+        per_request.append(completion_tokens_value)
 
-    return {"total": output_tokens_total}
+    result = {"total": output_tokens_total}
+    if distribution := summarize(per_request, percentiles):
+        result.update(distribution)
+    return result
 
 
 class ResponsesSummary(BaseModel):
@@ -615,7 +634,7 @@ def summarize_requests(
             "seconds": summarize([safe_float(inst.seconds) for inst in all_audios], percentiles),
             "bytes": summarize([safe_float(inst.bytes) for inst in all_audios], percentiles),
         },
-        "prompt_tokens": summarize_prompt_token_usage(all_successful),
+        "prompt_tokens": summarize_prompt_token_usage(all_successful, percentiles),
         "output_len": summarize(
             [
                 float(v)
@@ -624,7 +643,7 @@ def summarize_requests(
             ],
             percentiles,
         ),
-        "output_tokens": summarize_output_token_usage(all_successful),
+        "output_tokens": summarize_output_token_usage(all_successful, percentiles),
         "token_count_mismatches": mismatched_requests,
     }
     if goodput_metrics:

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -1,7 +1,11 @@
 import pytest
 from inference_perf.reportgen.base import summarize_requests
 from inference_perf.apis.base import RequestLifecycleMetric, InferenceInfo, StreamedResponseMetrics
+from inference_perf.config.reportgen.config import RequestLifecycleMetricsReportConfig
 from inference_perf.payloads import RequestMetrics, Text
+
+# The percentile list real reports use; the token-usage metrics must surface all of these.
+DEFAULT_PERCENTILES = RequestLifecycleMetricsReportConfig().percentiles
 
 
 def test_summarize_requests_tpot_calculation() -> None:
@@ -168,7 +172,9 @@ def test_summarize_requests_surfaces_output_token_usage() -> None:
     count surfaced separately from the client-side output_len distribution.
     """
     metrics = []
-    for completion_tokens in (3, 7):
+    # Values (0, 100) make every percentile p interpolate exactly to p, so the
+    # full default percentile list maps to a known dict.
+    for completion_tokens in (0, 100):
         info = InferenceInfo(
             request_metrics=RequestMetrics(text=Text(input_tokens=10)),
             response_metrics=StreamedResponseMetrics(
@@ -180,9 +186,44 @@ def test_summarize_requests_surfaces_output_token_usage() -> None:
             RequestLifecycleMetric(scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None)
         )
 
-    result = summarize_requests(metrics, [50])
+    result = summarize_requests(metrics, DEFAULT_PERCENTILES)
 
-    assert result.successes["output_tokens"] == {"total": 10.0}
+    expected = {"total": 100.0, "mean": 50.0, "min": 0.0, "max": 100.0}
+    for p in DEFAULT_PERCENTILES:
+        expected["median" if p == 50 else f"p{p:g}"] = float(p)
+    assert result.successes["output_tokens"] == pytest.approx(expected)
+
+
+def test_summarize_requests_token_usage_propagates_percentile_keys() -> None:
+    """The requested percentiles surface on both server-sourced token metrics.
+
+    output_tokens / prompt_tokens carry the same per-request distribution keys
+    as output_len / prompt_len: mean/min/max plus one key per requested
+    percentile (p50 -> 'median'). Locks in that whatever percentile list the
+    run passes feeds these metrics too.
+    """
+    metrics = []
+    for completion_tokens in range(1, 101):  # 1..100
+        info = InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=10)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=completion_tokens,
+                server_usage={"prompt_tokens": 10, "completion_tokens": completion_tokens},
+            ),
+        )
+        metrics.append(
+            RequestLifecycleMetric(scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None)
+        )
+
+    result = summarize_requests(metrics, [0.1, 1, 5, 50, 90, 99, 99.9])
+
+    expected_keys = {"mean", "min", "max", "p0.1", "p1", "p5", "median", "p90", "p99", "p99.9"}
+    assert expected_keys <= result.successes["output_tokens"].keys()
+    assert expected_keys <= result.successes["prompt_tokens"].keys()
+    # p50 is keyed as 'median', never 'p50'.
+    assert "p50" not in result.successes["output_tokens"]
+    # Distribution keys mirror output_len exactly (same summarize() call).
+    assert result.successes["output_tokens"].keys() - {"total"} == result.successes["output_len"].keys()
 
 
 def test_summarize_requests_output_tokens_falls_back_to_client_count() -> None:
@@ -193,9 +234,13 @@ def test_summarize_requests_output_tokens_falls_back_to_client_count() -> None:
     )
     metric = RequestLifecycleMetric(scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None)
 
-    result = summarize_requests([metric], [50])
+    # Single value: every percentile collapses to it.
+    result = summarize_requests([metric], DEFAULT_PERCENTILES)
 
-    assert result.successes["output_tokens"] == {"total": 4.0}
+    expected = {"total": 4.0, "mean": 4.0, "min": 4.0, "max": 4.0}
+    for p in DEFAULT_PERCENTILES:
+        expected["median" if p == 50 else f"p{p:g}"] = 4.0
+    assert result.successes["output_tokens"] == pytest.approx(expected)
 
 
 def test_output_len_not_recomputed_from_chunks() -> None:
@@ -270,10 +315,10 @@ def test_summarize_requests_surfaces_prompt_cache_usage() -> None:
         scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="test_request", info=info, error=None
     )
 
-    result = summarize_requests([metric], [50])
+    # Single value: every percentile collapses to it.
+    result = summarize_requests([metric], DEFAULT_PERCENTILES)
 
-    assert result.successes["prompt_tokens"] == {
-        "total": 10.0,
-        "cached": 6.0,
-        "uncached": 4.0,
-    }
+    expected = {"total": 10.0, "cached": 6.0, "uncached": 4.0, "mean": 10.0, "min": 10.0, "max": 10.0}
+    for p in DEFAULT_PERCENTILES:
+        expected["median" if p == 50 else f"p{p:g}"] = 10.0
+    assert result.successes["prompt_tokens"] == pytest.approx(expected)


### PR DESCRIPTION
## What

Surface the per-request distribution (min/mean/max/percentiles) on the server-sourced `prompt_tokens` and `output_tokens` summaries, matching what the client-side `prompt_len`/`output_len` already report.

Previously these metrics only carried aggregate totals:
- `prompt_tokens`: `total` / `cached` / `uncached`
- `output_tokens`: `total`

So there was no way to see the per-request spread of the exact server counts (`usage.prompt_tokens` / `usage.completion_tokens`).

## How

`summarize_prompt_token_usage` and `summarize_output_token_usage` now take the run's percentile list, collect each request's server count, and merge the `summarize()` distribution into their result dicts. The existing aggregate keys are preserved, so anything reading `["total"]` is unaffected.

Example `output_tokens` after the change:

```json
"output_tokens": {
  "total": 327680.0,
  "mean": 1024.0, "min": 1024.0, "max": 1024.0,
  "p0.1": ..., "p1": ..., "median": 1024.0, "p99.9": ...
}
```

## Context

Motivated by #580: the client-side `output_len` distribution is noisy because re-tokenizing streamed text does not reproduce the server's token boundaries. The server count is exact, so giving it a full distribution lets us rely on it instead of `output_len`.

## Tests

- All token-usage tests assert the full default percentile set (`[0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9]`, sourced from config so they stay in sync) propagates to both metrics.
- Added a dedicated test confirming the percentile keys mirror `output_len` exactly and that `p50` is keyed as `median`.
