### PR TITLE
Add disable_output_substitution flag and fix tool-call replay fidelity

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -141,6 +141,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--data.otel_trace_replay.filter` | str | Lambda expression to filter trace records. Applied uniformly to all data sources.
 Example: "lambda x: x['benchmark'] == 'gsm8k'" or "lambda x: 'spans' in x and len(x['spans']) > 5"
 Security: Filter expressions use eval() and should only contain trusted input. |
+| `--data.otel_trace_replay.disable_output_substitution` | boolean | When True, replay each call with its recorded assistant output (text and tool calls) instead of substituting the live output from predecessor calls. Dependency timing (waiting for predecessors) is still enforced. Default False preserves faithful live-output replay. |
 | `--data.otel_trace_replay.attribute_to_header_map` | JSON | Map OTel span attributes to HTTP headers |
 | `--data.otel_trace_replay.attribute_to_label_map` | JSON | Map OTel span attributes to metrics reporting labels |
 | `--data.otel_trace_replay.bad_tool_call_handling` | Enum (none, use_recorded) | How to handle tool_calls whose function.arguments is not valid JSON. none (default): no mitigation, bytes propagate and vLLM may return HTTP 400 on the next turn. use_recorded: discard the live response and substitute the recorded assistant message at the affected slot; the recorded tool_call_id flows into the recorded role:tool successor unchanged. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -446,6 +446,9 @@ data:
     # Tool-call mitigation (client-side, default disabled)
     bad_tool_call_handling: none                  # none|use_recorded — see docs/otel_trace_replay.md#bad-tool-call-handling
 
+    # Output replay fidelity (default disabled)
+    disable_output_substitution: false            # true = send recorded assistant outputs as-is (no live substitution); conflicts with inject_random_session_id / duplicate_sessions_target
+
 load:
   type: trace_session_replay                      # Required for otel_trace_replay
   stages:

--- a/docs/otel_trace_replay.md
+++ b/docs/otel_trace_replay.md
@@ -116,6 +116,7 @@ The `data.otel_trace_replay` section controls what traces to replay and how to p
 | `skip_invalid_files` | boolean | No (default: `false`) | Skip invalid traces instead of failing. Covers both file-level parse errors (bad JSON, missing file) and graph-build errors (malformed spans). Skipped sessions are logged and silently omitted from the run. |
 | `filter` | string | No | Lambda expression applied to each trace record before replay. Evaluated via `eval()` — use only with trusted inputs. Example: `"lambda x: x['benchmark'] == 'gsm8k'"`. Applies uniformly across all three trace sources |
 | `bad_tool_call_handling` | enum | No (default: `none`) | How to handle tool_calls whose `function.arguments` is not valid JSON. `none`: no mitigation (upstream behavior). `use_recorded`: substitute the recorded assistant message at the affected slot. See [Bad tool-call handling](#bad-tool-call-handling) |
+| `disable_output_substitution` | boolean | No (default: `false`) | When `true`, replay each call with its recorded assistant output (text and tool calls) instead of substituting the live output from predecessor calls. Predecessor wait timing is still enforced. Cannot be combined with `inject_random_session_id` or `duplicate_sessions_target` (those trigger substitution and would contradict this flag — config validation rejects the combination) |
 
 **Examples:**
 

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -168,6 +168,15 @@ class OTelTraceReplayConfig(SessionReplayConfig):
             "Security: Filter expressions use eval() and should only contain trusted input."
         ),
     )
+    disable_output_substitution: bool = Field(
+        False,
+        description=(
+            "When True, replay each call with its recorded assistant output "
+            "(text and tool calls) instead of substituting the live output from "
+            "predecessor calls. Dependency timing (waiting for predecessors) is "
+            "still enforced. Default False preserves faithful live-output replay."
+        ),
+    )
     attribute_to_header_map: Optional[Dict[str, str]] = Field(None, description="Map OTel span attributes to HTTP headers")
     attribute_to_label_map: Optional[Dict[str, str]] = Field(
         None, description="Map OTel span attributes to metrics reporting labels"
@@ -207,6 +216,33 @@ class OTelTraceReplayConfig(SessionReplayConfig):
             raise ValueError(
                 "Cannot specify multiple trace sources; choose one of: trace_directory, trace_files, or hf_dataset_path"
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_output_substitution(self) -> "OTelTraceReplayConfig":
+        # disable_output_substitution sends recorded assistant outputs verbatim.
+        # Random session-ID injection (via inject_random_session_id or session
+        # duplication) rewrites 'unique' segments, which runs the substitution
+        # pass that also replaces 'output'/'shared' segments with live predecessor
+        # output — the exact behavior disable_output_substitution asks to turn off.
+        # The two settings contradict, so reject the combination up front rather
+        # than silently substituting anyway.
+        if self.disable_output_substitution:
+            conflicting = []
+            if self.inject_random_session_id:
+                conflicting.append("inject_random_session_id")
+            if self.duplicate_sessions_target is not None:
+                conflicting.append("duplicate_sessions_target")
+            if conflicting:
+                raise ValueError(
+                    "disable_output_substitution=True cannot be combined with "
+                    f"{' or '.join(conflicting)}: those options trigger random "
+                    "session-ID injection, which substitutes live predecessor "
+                    "output into output/shared segments — the opposite of replaying "
+                    "recorded outputs as-is. Disable "
+                    f"{' and '.join(conflicting)} to replay recorded outputs, or "
+                    "set disable_output_substitution=False to allow substitution."
+                )
         return self
 
 

--- a/inference_perf/datagen/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/otel_trace_to_replay_graph.py
@@ -194,6 +194,13 @@ def _replay_message_to_dict(x: ReplayMessage) -> Dict[str, Any]:
     which drops structured tool calls and tool-result linkage. ``x.text`` stays
     the flattened form and is still used for token counting and causal dependency
     matching; only the wire dict returned here carries structure.
+
+    A tool result's stored role varies by capture harness: OpenAI-native traces
+    put it on a ``role: "tool"`` message, while Anthropic-native traces put it on a ``role: "user"`` message.
+    Either way the OpenAI-compatible wire target this graph replays against
+    only defines tool results as ``role: "tool"`` messages, so we detect the
+    result by its part type (``tool_call_response``),
+    and normalize the emitted role to ``"tool"``.
     """
     if isinstance(x, ComplexReplayMessage) and isinstance(x.message_info, dict):
         info = x.message_info
@@ -222,10 +229,12 @@ def _replay_message_to_dict(x: ReplayMessage) -> Dict[str, Any]:
                     tool_calls.append(_normalize_tool_call(part))
             if responses:
                 first = responses[0]
-                # tool_call_id belongs on a role:tool message only; don't leak it
-                # onto other roles even if the trace stored one.
-                if role == "tool":
-                    msg["tool_call_id"] = first.get("id", "")
+                # A tool result is identified by its part type, not the stored
+                # role (see docstring) — normalize to role:tool on the wire
+                msg["role"] = "tool"
+                tool_call_id = first.get("id")
+                if tool_call_id:
+                    msg["tool_call_id"] = tool_call_id
                 text_parts.append(_coerce_text(first.get("result", "")))
             if tool_calls:
                 msg["tool_calls"] = tool_calls
@@ -240,9 +249,9 @@ def _replay_message_to_dict(x: ReplayMessage) -> Dict[str, Any]:
         msg = {"role": role}
         content = info.get("content")
 
-        # A role:tool message may carry its result as a tool_call_response parts
-        # list under `content` (rather than a string). Reconstruct the tool_call_id
-        # and flatten the result to string content.
+        # A tool result may carry its content as a tool_call_response parts list
+        # (rather than a plain string). Reconstruct the tool_call_id and flatten
+        # the result to string content.
         if isinstance(content, list):
             responses = [p for p in content if isinstance(p, dict) and p.get("type") == "tool_call_response"]
             if responses:
@@ -255,8 +264,10 @@ def _replay_message_to_dict(x: ReplayMessage) -> Dict[str, Any]:
                         responses[0].get("id"),
                     )
                 first = responses[0]
-                if role == "tool":
-                    msg["tool_call_id"] = first.get("id", "")
+                msg["role"] = "tool"
+                tool_call_id = first.get("id")
+                if tool_call_id:
+                    msg["tool_call_id"] = tool_call_id
                 msg["content"] = _coerce_text(first.get("result", ""))
                 return msg
 

--- a/inference_perf/datagen/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/otel_trace_to_replay_graph.py
@@ -113,20 +113,164 @@ def message_tokens(msg: ReplayMessage) -> int:
     return estimate_tokens(message_content_text(msg))
 
 
+def _coerce_text(value: Any) -> str:
+    """Flatten a text value that may be a string or a list of content blocks.
+
+    Recorded ``text`` / tool-result values are usually strings, but some traces
+    carry a list of blocks, e.g. ``[{"type": "text", "text": "..."}]``. Extract
+    the text so the wire ``content`` is always a string.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        out: List[str] = []
+        for block in value:
+            if isinstance(block, dict):
+                out.append(str(block.get("text", block.get("content", "")) or ""))
+            else:
+                out.append(str(block))
+        return "".join(out)
+    return str(value)
+
+
+def _normalize_tool_call(tc: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise a recorded tool call to OpenAI ``function`` format.
+
+    Accepts both the nested OpenAI shape
+    ``{"id", "type": "function", "function": {"name", "arguments"}}`` and the
+    "direct"/parts shape ``{"id", "name", "arguments"}``.
+
+    Raises ``ValueError`` if the tool call has no ``id``. OpenAI/vLLM reject a
+    ``tool_calls[].id`` of ``null`` with a 400, and the recorded ``role:tool``
+    result that answers this call is linked by that id — a call with no id cannot
+    be replayed faithfully. Raising here lets ``build_graph``'s caller skip the
+    whole trace with a logged reason rather than emit an invalid request.
+    """
+    fn = tc.get("function")
+    if isinstance(fn, dict):
+        name = fn.get("name")
+        arguments = fn.get("arguments")
+    else:
+        # No nested function dict (either absent or a malformed non-dict value):
+        # fall back to the direct/parts shape carrying name/arguments at top level.
+        name = tc.get("name")
+        arguments = tc.get("arguments")
+    # OpenAI/vLLM require function.arguments to be a JSON-encoded STRING. Recorded
+    # traces often carry it as a parsed object/array — serialise those so the wire
+    # request is valid (a raw object triggers a 400 unmarshalling error).
+    if arguments is None:
+        arguments = ""
+    elif not isinstance(arguments, str):
+        arguments = json.dumps(arguments)
+    tc_id = tc.get("id")
+    if tc_id is None:
+        raise ValueError(f"tool call has no id (name={name!r}); cannot replay it faithfully")
+    return {
+        "id": tc_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
 def _replay_message_to_dict(x: ReplayMessage) -> Dict[str, Any]:
     """Convert a ReplayMessage to an OpenAI-compatible dict for the graph.
 
-    For ComplexReplayMessage with tool_call_response parts, extracts tool_call_id
-    so it survives into the replay runtime for ID rewriting.
+    A ComplexReplayMessage carries the structured message in ``message_info``, in
+    one of two shapes:
+
+    - "parts" format: ``{"role", "parts": [{"type": "text"|"tool_call"|
+      "tool_call_response", ...}]}`` (produced by
+      ``_convert_content_and_tool_calls_to_parts`` / OTel output reconstruction).
+    - raw OpenAI dict: the original message, e.g.
+      ``{"role": "assistant", "tool_calls": [...]}``, a ``role:tool`` message
+      with ``tool_call_id``, or a ``role:tool`` message whose ``content`` is a
+      ``tool_call_response`` parts list.
+
+    We reconstruct the OpenAI wire fields (``tool_calls`` / ``tool_call_id``) from
+    ``message_info`` so tool turns replay structurally. Falling back to ``x.text``
+    would send the flattened ``<|tool_call|>...`` marker string as plain content,
+    which drops structured tool calls and tool-result linkage. ``x.text`` stays
+    the flattened form and is still used for token counting and causal dependency
+    matching; only the wire dict returned here carries structure.
     """
-    if isinstance(x, ComplexReplayMessage):
+    if isinstance(x, ComplexReplayMessage) and isinstance(x.message_info, dict):
         info = x.message_info
-        parts = info.get("parts")
-        if parts and x.role == "tool":
-            tool_result_parts = [p for p in parts if p.get("type") == "tool_call_response"]
-            if tool_result_parts:
-                result_part = tool_result_parts[0]
-                return {"role": "tool", "content": result_part.get("result", ""), "tool_call_id": result_part.get("id", "")}
+
+        # Shape 1: "parts" format — reassemble text / tool_calls / tool result.
+        if "parts" in info:
+            role = info.get("role", x.role)
+            msg: Dict[str, Any] = {"role": role}
+            text_parts: List[str] = []
+            tool_calls: List[Dict[str, Any]] = []
+            responses = [p for p in info["parts"] if p.get("type") == "tool_call_response"]
+            if len(responses) > 1:
+                # One OpenAI wire message answers exactly one tool_call_id, so a
+                # message bundling several tool results cannot be represented
+                # faithfully. Keep the first and drop the rest.
+                logger.debug(
+                    "Message has %d tool_call_response parts; keeping only the first (id=%s) and dropping the rest.",
+                    len(responses),
+                    responses[0].get("id"),
+                )
+            for part in info["parts"]:
+                part_type = part.get("type")
+                if part_type == "text":
+                    text_parts.append(_coerce_text(part.get("content", "")))
+                elif part_type == "tool_call":
+                    tool_calls.append(_normalize_tool_call(part))
+            if responses:
+                first = responses[0]
+                # tool_call_id belongs on a role:tool message only; don't leak it
+                # onto other roles even if the trace stored one.
+                if role == "tool":
+                    msg["tool_call_id"] = first.get("id", "")
+                text_parts.append(_coerce_text(first.get("result", "")))
+            if tool_calls:
+                msg["tool_calls"] = tool_calls
+            # Emit content for text / tool-result messages. For an assistant
+            # message that is only tool calls, omit content (matches OpenAI).
+            if text_parts or not tool_calls:
+                msg["content"] = "".join(text_parts)
+            return msg
+
+        # Shape 2: raw OpenAI dict.
+        role = info.get("role", x.role)
+        msg = {"role": role}
+        content = info.get("content")
+
+        # A role:tool message may carry its result as a tool_call_response parts
+        # list under `content` (rather than a string). Reconstruct the tool_call_id
+        # and flatten the result to string content.
+        if isinstance(content, list):
+            responses = [p for p in content if isinstance(p, dict) and p.get("type") == "tool_call_response"]
+            if responses:
+                if len(responses) > 1:
+                    # See the parts-format branch above: multiple tool results
+                    # cannot be represented in one message; keep the first.
+                    logger.debug(
+                        "Message has %d tool_call_response parts; keeping only the first (id=%s) and dropping the rest.",
+                        len(responses),
+                        responses[0].get("id"),
+                    )
+                first = responses[0]
+                if role == "tool":
+                    msg["tool_call_id"] = first.get("id", "")
+                msg["content"] = _coerce_text(first.get("result", ""))
+                return msg
+
+        if info.get("tool_calls") is not None:
+            msg["tool_calls"] = [_normalize_tool_call(tc) for tc in info["tool_calls"]]
+        # tool_call_id belongs on a role:tool message only.
+        if role == "tool" and info.get("tool_call_id") is not None:
+            msg["tool_call_id"] = info["tool_call_id"]
+        if content is not None:
+            # Coerce list-of-blocks content to a string; pass strings through.
+            msg["content"] = content if isinstance(content, str) else _coerce_text(content)
+        elif "tool_calls" not in msg:
+            msg["content"] = x.text
+        return msg
 
     return {"role": x.role, "content": x.text}
 
@@ -181,16 +325,18 @@ def _convert_content_and_tool_calls_to_parts(message: Dict[str, Any]) -> Dict[st
     for tc in tool_calls:
         if isinstance(tc, dict):
             # OpenAI format: {"id": "...", "type": "function", "function": {"name": "...", "arguments": "..."}}
-            if "function" in tc:
+            fn = tc.get("function")
+            if isinstance(fn, dict):
                 parts.append(
                     {
                         "type": "tool_call",
                         "id": tc.get("id"),  # type: ignore[dict-item]
-                        "name": tc["function"].get("name"),
-                        "arguments": tc["function"].get("arguments"),
+                        "name": fn.get("name"),  # type: ignore[dict-item]
+                        "arguments": fn.get("arguments"),  # type: ignore[dict-item]
                     }
                 )
-            # Direct format: {"name": "...", "arguments": "..."}
+            # Direct format: {"name": "...", "arguments": "..."} (also the fallback
+            # when `function` is present but malformed/non-dict).
             elif "name" in tc:
                 parts.append(
                     {
@@ -245,7 +391,16 @@ def extract_messages(span: Dict[str, Any]) -> Tuple[List["ReplayMessage"], int]:
                         )
                     )
                 elif isinstance(content, str):
-                    res.append(ReplayMessage(role=role, text=content))  # type: ignore[arg-type]
+                    # A string-content message that also carries tool linkage
+                    # (a role:tool result with tool_call_id, or an assistant
+                    # message with tool_calls) must retain that structure, so
+                    # keep it as a ComplexReplayMessage rather than a plain one.
+                    if x.get("tool_call_id") is not None or x.get("tool_calls") is not None:
+                        res.append(
+                            ComplexReplayMessage(role=role, message_info=x, raw_reconstructed_text=reconstruct_llm_input(x))
+                        )
+                    else:
+                        res.append(ReplayMessage(role=role, text=content))  # type: ignore[arg-type]
                 else:
                     res.append(
                         ComplexReplayMessage(role=role, message_info=x, raw_reconstructed_text=reconstruct_llm_input(x))

--- a/inference_perf/datagen/otel_trace_utils.py
+++ b/inference_perf/datagen/otel_trace_utils.py
@@ -189,11 +189,11 @@ def _extract_tool_calls(message: Dict[str, Any]) -> List[Dict[str, Any]]:
         for tc in message["tool_calls"]:
             if isinstance(tc, dict):
                 # OpenAI format: {"id": "...", "type": "function", "function": {"name": "...", "arguments": "..."}}
-                if "function" in tc:
-                    tool_calls.append(
-                        {"id": tc.get("id"), "name": tc["function"].get("name"), "arguments": tc["function"].get("arguments")}
-                    )
-                # Direct format: {"name": "...", "arguments": "..."}
+                fn = tc.get("function")
+                if isinstance(fn, dict):
+                    tool_calls.append({"id": tc.get("id"), "name": fn.get("name"), "arguments": fn.get("arguments")})
+                # Direct format: {"name": "...", "arguments": "..."} (also the
+                # fallback when `function` is present but malformed/non-dict).
                 elif "name" in tc:
                     tool_calls.append(tc)
 

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -336,6 +336,10 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     # `none` (default) is byte-identical to upstream main; `use_recorded`
     # substitutes the recorded assistant message at the affected slot.
     bad_tool_call_handling: BadToolCallHandling = BadToolCallHandling.NONE
+    # When True, output/shared segments are NOT substituted with live predecessor
+    # output; the recorded assistant messages are sent as-is. Predecessor wait
+    # timing is still enforced.
+    disable_output_substitution: bool = False
     # Set by _build_messages_with_substitution when it calls record_failure
     # early (e.g. recorded fallback also malformed). Lets the caller pass the
     # right reason string to _fail_and_notify instead of a generic fallback.
@@ -473,7 +477,9 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             await asyncio.sleep(wait_sec)
 
         # Substitute output segments with actual predecessor outputs, or inject random session ID into unique segments
-        needs_substitution = any(seg.type == "output" or seg.type == "shared" for seg in self.input_segments)
+        needs_substitution = (not self.disable_output_substitution) and any(
+            seg.type == "output" or seg.type == "shared" for seg in self.input_segments
+        )
         # Inject random string if flag is enabled OR session is a duplicate
         is_duplicate = ReplayGraphSessionGeneratorBase.is_duplicate_session(session_id)
         needs_random_injection = (self.inject_random_session_id or is_duplicate) and any(
@@ -1528,11 +1534,17 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                 reasoning_content = getattr(msg, "reasoning", None) or getattr(msg, "reasoning_content", None)
 
             if tool_calls is not None:
-                chat_messages.append(ChatMessage(role=role, tool_calls=tool_calls, reasoning_content=reasoning_content))
-                orig_msg: Dict[str, Any] = {"role": role, "tool_calls": tool_calls}
+                # Preserve any assistant preamble content alongside the tool calls
+                # so chat_messages (which becomes the wire payload when no
+                # substitution/injection runs) is not lossy.
+                tc_content = content if isinstance(content, str) and content else None
+                chat_messages.append(ChatMessage(role=role, content=tc_content, tool_calls=tool_calls, reasoning_content=reasoning_content))
+                tc_msg: Dict[str, Any] = {"role": role, "tool_calls": tool_calls}
+                if tc_content is not None:
+                    tc_msg["content"] = tc_content
                 if reasoning_content:
-                    orig_msg["reasoning_content"] = reasoning_content
-                original_messages.append(orig_msg)
+                    tc_msg["reasoning_content"] = reasoning_content
+                original_messages.append(tc_msg)
                 continue
 
             if isinstance(content, list):
@@ -1548,10 +1560,15 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                 content = " ".join(content_parts)
 
             content_str = str(content)
-            chat_messages.append(ChatMessage(role=role, content=content_str, reasoning_content=reasoning_content))
-            orig_msg = {"role": role, "content": content_str}
-            if tool_call_id is not None:
-                orig_msg["tool_call_id"] = tool_call_id
+            # Carry tool_call_id onto the ChatMessage too (not just original_messages),
+            # so role:tool linkage survives on the wire when substitution is disabled.
+            # tool_call_id belongs on a role:tool message only — don't leak it onto
+            # user/assistant messages even if the recorded message carried one.
+            wire_tool_call_id = tool_call_id if role == "tool" else None
+            chat_messages.append(ChatMessage(role=role, content=content_str, tool_call_id=wire_tool_call_id, reasoning_content=reasoning_content))
+            orig_msg: Dict[str, Any] = {"role": role, "content": content_str}
+            if wire_tool_call_id is not None:
+                orig_msg["tool_call_id"] = wire_tool_call_id
             if reasoning_content:
                 orig_msg["reasoning_content"] = reasoning_content
             original_messages.append(orig_msg)
@@ -1593,6 +1610,9 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             bad_tool_call_handling=getattr(self.replay_config, "bad_tool_call_handling", BadToolCallHandling.NONE)
             if self.replay_config
             else BadToolCallHandling.NONE,
+            disable_output_substitution=getattr(self.replay_config, "disable_output_substitution", False)
+            if self.replay_config
+            else False,
             # Back-reference so the event can evict this session from the worker once drained.
             generator=self,
         )

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -1538,7 +1538,9 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                 # so chat_messages (which becomes the wire payload when no
                 # substitution/injection runs) is not lossy.
                 tc_content = content if isinstance(content, str) and content else None
-                chat_messages.append(ChatMessage(role=role, content=tc_content, tool_calls=tool_calls, reasoning_content=reasoning_content))
+                chat_messages.append(
+                    ChatMessage(role=role, content=tc_content, tool_calls=tool_calls, reasoning_content=reasoning_content)
+                )
                 tc_msg: Dict[str, Any] = {"role": role, "tool_calls": tool_calls}
                 if tc_content is not None:
                     tc_msg["content"] = tc_content
@@ -1565,7 +1567,11 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             # tool_call_id belongs on a role:tool message only — don't leak it onto
             # user/assistant messages even if the recorded message carried one.
             wire_tool_call_id = tool_call_id if role == "tool" else None
-            chat_messages.append(ChatMessage(role=role, content=content_str, tool_call_id=wire_tool_call_id, reasoning_content=reasoning_content))
+            chat_messages.append(
+                ChatMessage(
+                    role=role, content=content_str, tool_call_id=wire_tool_call_id, reasoning_content=reasoning_content
+                )
+            )
             orig_msg: Dict[str, Any] = {"role": role, "content": content_str}
             if wire_tool_call_id is not None:
                 orig_msg["tool_call_id"] = wire_tool_call_id

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -2162,6 +2162,46 @@ class TestStructuredToolCallPreservation:
         )
         assert msgs[0]["tool_calls"][0]["function"]["name"] == "get_weather"
 
+    def test_tool_result_on_user_role_parts_format_normalizes_to_tool(self) -> None:
+        # Anthropic-native harnesses put a tool result on a
+        # role:user message, rather than a dedicated
+        # role:tool message. The OpenAI-compatible wire target only defines tool results as role:tool
+        # messages, so the emitted role must be normalized.
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "type": "tool_call_response",
+                            "id": "call_cad5f02bc9c8424abdc072de",
+                            "result": '[{"type": "text", "text": "Todos have been modified successfully."}]',
+                        }
+                    ],
+                },
+            ]
+        )
+        tool_msg = msgs[0]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "call_cad5f02bc9c8424abdc072de"
+        assert "Todos have been modified successfully" in tool_msg["content"]
+
+    def test_tool_result_on_user_role_content_list_format_normalizes_to_tool(self) -> None:
+        # Same normalization as above, but for the raw-dict "content" list shape
+        # (Shape 2) rather than the "parts" shape (Shape 1).
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "tool_call_response", "id": "c1", "result": '{"temp_c": 18}'}],
+                },
+            ]
+        )
+        tool_msg = msgs[0]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "c1"
+        assert "18" in tool_msg.get("content", "")
+
     def test_multiple_tool_results_keeps_first(self) -> None:
         # One OpenAI wire message answers exactly one tool_call_id. A message that
         # bundles several tool_call_response parts keeps the FIRST (id + result)

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -41,6 +41,7 @@ from typing import Any, List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 # Ensure project root is on path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -57,7 +58,7 @@ from inference_perf.datagen.replay_graph_session_datagen import (
     SessionInferenceInfo,
     WorkerSessionTracker,
 )
-from inference_perf.config.datagen.replay import BadToolCallHandling
+from inference_perf.config.datagen.replay import BadToolCallHandling, OTelTraceReplayConfig
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.datagen.otel_trace_to_replay_graph import (
     build_graph,
@@ -419,6 +420,48 @@ class TestSessionChatCompletionAPIData:
         # Messages should be substituted
         assert len(api_data.messages) == 2
         assert api_data.messages[1].content == "Predecessor output"
+
+    @pytest.mark.asyncio
+    async def test_disable_output_substitution_keeps_recorded(self) -> None:
+        """With disable_output_substitution=True, predecessors are still awaited
+        but the recorded assistant message is sent as-is (no live substitution)."""
+        registry = EventOutputRegistry()
+        tracker = WorkerSessionTracker()
+
+        # Predecessor produced a *different* live output than what was recorded.
+        registry.record("session_1:event_0", "Predecessor output", [])
+
+        messages = [
+            {"role": "user", "content": "Question"},
+            {"role": "assistant", "content": "RECORDED"},
+        ]
+        segments = [
+            InputSegment(type="unique", message_count=1, token_count=5),
+            InputSegment(type="output", message_count=1, token_count=10, source_event_id="session_1:event_0"),
+        ]
+
+        api_data = SessionChatCompletionAPIData(
+            messages=[ChatMessage(role="user", content="Question"), ChatMessage(role="assistant", content="RECORDED")],
+            max_tokens=50,
+            event_id="session_1:event_1",
+            registry=registry,
+            worker_tracker=tracker,
+            completion_queue=None,
+            total_events_in_session=2,
+            predecessor_event_ids=["session_1:event_0"],
+            input_segments=segments,
+            original_messages=messages,
+            disable_output_substitution=True,
+        )
+
+        await api_data.wait_for_predecessors_and_substitute()
+
+        # Predecessor was awaited (no failure / skip) ...
+        assert api_data.skip_request is False
+        assert tracker.is_session_failed("session_1") is False
+        # ... but the recorded assistant content is preserved, NOT substituted
+        # with the live "Predecessor output".
+        assert api_data.messages[1].content == "RECORDED"
 
 
 # ---------------------------------------------------------------------------
@@ -1919,3 +1962,348 @@ class TestUnbuildableSessionSlot:
             "is_session_buildable returned True for a zero-event session — "
             "dispatch would add it to active_session_indices with nothing to complete it"
         )
+
+
+# ---------------------------------------------------------------------------
+# Structured tool-call preservation through the real graph-build path.
+#
+# These tests exercise extract_messages -> build_graph (via build_raw_calls)
+# and assert on GraphCall.messages — the dicts that become the wire payload.
+# They guard against _replay_message_to_dict flattening recorded tool calls
+# into the internal "<|tool_call|>...<|end|>" marker string, which would drop
+# structured tool_calls and tool-result tool_call_id linkage.
+# ---------------------------------------------------------------------------
+
+
+def _graph_messages_from_input(input_messages: List[dict[str, Any]]) -> List[dict[str, Any]]:
+    """Run input messages through the real span-extraction + graph builder and
+    return the resulting GraphCall.messages (the wire dicts)."""
+    span = {
+        "trace_id": "t",
+        "span_id": "s",
+        "parent_span_id": None,
+        "name": "chat gpt-4",
+        "start_time": "2026-01-01T00:00:00.000000",
+        "end_time": "2026-01-01T00:00:01.000000",
+        "attributes": {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.request.model": "gpt-4",
+            "gen_ai.input.messages": json.dumps(input_messages),
+            "gen_ai.output.text": "ok",
+        },
+        "resource_attributes": {"service.name": "t"},
+        "status": {"code": 1, "message": ""},
+    }
+    raw_calls = build_raw_calls([span])
+    graph = build_graph(raw_calls, source_file="t")
+    return next(iter(graph.events.values())).call.messages
+
+
+class TestStructuredToolCallPreservation:
+    """GraphCall.messages must carry structured tool_calls / tool_call_id."""
+
+    def test_assistant_tool_calls_only_openai_format(self) -> None:
+        msgs = _graph_messages_from_input(
+            [
+                {"role": "user", "content": "weather in Paris?"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                        }
+                    ],
+                },
+            ]
+        )
+        assistant = msgs[1]
+        assert "<|tool_call|>" not in json.dumps(assistant), "tool call must not be flattened to marker text"
+        assert assistant["tool_calls"][0]["id"] == "c1"
+        assert assistant["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert assistant["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    def test_assistant_content_plus_tool_calls(self) -> None:
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "assistant",
+                    "content": "Let me check.",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                        }
+                    ],
+                },
+            ]
+        )
+        assistant = msgs[0]
+        assert "<|tool_call|>" not in json.dumps(assistant)
+        assert assistant["tool_calls"][0]["function"]["name"] == "get_weather"
+        # Preamble text is preserved alongside the structured call.
+        assert "Let me check." in assistant.get("content", "")
+
+    def test_assistant_tool_calls_direct_format(self) -> None:
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "assistant",
+                    "tool_calls": [{"id": "c1", "name": "get_weather", "arguments": '{"city": "Paris"}'}],
+                },
+            ]
+        )
+        assistant = msgs[0]
+        assert "<|tool_call|>" not in json.dumps(assistant)
+        assert assistant["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert assistant["tool_calls"][0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    def test_tool_result_parts_list_keeps_tool_call_id(self) -> None:
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "tool",
+                    "content": [{"type": "tool_call_response", "id": "c1", "result": '{"temp_c": 18}'}],
+                },
+            ]
+        )
+        tool_msg = msgs[0]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "c1"
+        assert "18" in tool_msg.get("content", "")
+
+    def test_tool_result_string_content_keeps_tool_call_id(self) -> None:
+        # A role:tool result with STRING content + a sibling tool_call_id must
+        # retain tool_call_id on the wire (previously it became a plain
+        # ReplayMessage in extract_messages and the id was dropped).
+        msgs = _graph_messages_from_input(
+            [
+                {"role": "tool", "tool_call_id": "c1", "content": '{"temp_c": 18}'},
+            ]
+        )
+        tool_msg = msgs[0]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "c1"
+        assert "18" in tool_msg.get("content", "")
+
+    def test_tool_call_object_arguments_serialized_to_json_string(self) -> None:
+        # OpenAI/vLLM require function.arguments to be a JSON string. Recorded
+        # traces often carry it as a parsed object; it must be serialised, not
+        # passed through as an object (which triggers a 400 on the server).
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "c1",
+                            "type": "function",
+                            "function": {"name": "make_todos", "arguments": {"todos": ["a", "b"]}},
+                        }
+                    ],
+                },
+            ]
+        )
+        args = msgs[0]["tool_calls"][0]["function"]["arguments"]
+        assert isinstance(args, str), "arguments must be a JSON string, not an object"
+        assert json.loads(args) == {"todos": ["a", "b"]}
+
+    def test_tool_result_with_nested_block_list_result(self) -> None:
+        # A tool_call_response whose `result` is itself a list of content blocks
+        # (e.g. [{"type": "text", "text": "..."}]) must flatten to string content,
+        # not crash the "".join and not leave a list on the wire.
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool_call_response",
+                            "id": "c1",
+                            "result": [{"type": "text", "text": '{"temp_c": 18}'}],
+                        }
+                    ],
+                },
+            ]
+        )
+        tool_msg = msgs[0]
+        assert tool_msg["tool_call_id"] == "c1"
+        assert isinstance(tool_msg.get("content"), str)
+        assert "18" in tool_msg["content"]
+
+    def test_tool_call_missing_id_skips_trace(self) -> None:
+        # A tool_call with no id cannot be replayed faithfully (OpenAI/vLLM reject
+        # tool_calls[].id=null with a 400, and the role:tool result is linked by
+        # that id). build_graph's caller wraps build_graph in try/except and skips
+        # the trace, so _normalize_tool_call must raise rather than emit id:null.
+        with pytest.raises(ValueError, match="no id"):
+            _graph_messages_from_input(
+                [
+                    {
+                        "role": "assistant",
+                        "tool_calls": [{"type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+                    },
+                ]
+            )
+
+    def test_tool_call_non_dict_function_does_not_crash(self) -> None:
+        # A malformed tool_call whose `function` is a bare string (not a nested
+        # dict) must not raise AttributeError; it falls back to the direct/parts
+        # shape (top-level name/arguments).
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "assistant",
+                    "tool_calls": [{"id": "c1", "function": "get_weather", "name": "get_weather", "arguments": "{}"}],
+                },
+            ]
+        )
+        assert msgs[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+    def test_multiple_tool_results_keeps_first(self) -> None:
+        # One OpenAI wire message answers exactly one tool_call_id. A message that
+        # bundles several tool_call_response parts keeps the FIRST (id + result)
+        # and drops the rest, rather than concatenating results under one id.
+        msgs = _graph_messages_from_input(
+            [
+                {
+                    "role": "tool",
+                    "content": [
+                        {"type": "tool_call_response", "id": "c1", "result": "first"},
+                        {"type": "tool_call_response", "id": "c2", "result": "second"},
+                    ],
+                },
+            ]
+        )
+        tool_msg = msgs[0]
+        assert tool_msg["tool_call_id"] == "c1"
+        assert tool_msg["content"] == "first"
+        assert "second" not in tool_msg["content"]
+
+    def test_tool_call_id_not_leaked_onto_user_message(self) -> None:
+        # tool_call_id belongs on a role:tool message only. A role:user message
+        # carrying a stray tool_call_id must not emit it on the wire (OpenAI/vLLM
+        # reject tool_call_id on non-tool roles).
+        msgs = _graph_messages_from_input(
+            [
+                {"role": "user", "tool_call_id": "c1", "content": "hello"},
+            ]
+        )
+        assert "tool_call_id" not in msgs[0]
+
+
+class TestLoadLazyDataPreservesToolLinkage:
+    """load_lazy_data must build ChatMessages (the wire payload when no
+    substitution runs, e.g. disable_output_substitution=true) that retain
+    tool_call_id and structured tool_calls — not just original_messages."""
+
+    def _make_gen_from_input(self, input_messages: List[dict[str, Any]]) -> Any:
+        span = {
+            "trace_id": "t",
+            "span_id": "s",
+            "parent_span_id": None,
+            "name": "chat gpt-4",
+            "start_time": "2026-01-01T00:00:00.000000",
+            "end_time": "2026-01-01T00:00:01.000000",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4",
+                "gen_ai.input.messages": json.dumps(input_messages),
+                "gen_ai.output.text": "ok",
+            },
+            "resource_attributes": {"service.name": "t"},
+            "status": {"code": 1, "message": ""},
+        }
+        graph = build_graph(build_raw_calls([span]), source_file="t")
+        session_id = "session_0"
+        gc = next(iter(graph.events.values()))
+        event = ReplaySessionEvent(
+            call_id=gc.call.call_id,
+            event_id=f"{session_id}:{gc.event_id}",
+            session_index=0,
+            t_start_ms=gc.t_start_ms,
+            t_end_ms=gc.t_end_ms,
+            model=gc.call.model,
+            messages=gc.call.messages,
+            expected_output=gc.call.expected_output,
+            input_segments=gc.call.input_segments,
+            expected_output_tokens=gc.call.expected_output_tokens,
+            temperature=gc.call.temperature,
+            max_tokens_recorded=gc.call.max_tokens_recorded,
+            predecessor_event_ids=[],
+            wait_ms=0,
+        )
+        gen = object.__new__(OTelTraceReplayDataGenerator)
+        gen.all_events = [event]
+        gen.output_registry = EventOutputRegistry()
+        gen.worker_tracker = WorkerSessionTracker()
+        gen.session_completion_queue = None
+        gen.api_config = make_api_config()
+        cfg = MagicMock()
+        cfg.attribute_to_header_map = {}
+        cfg.attribute_to_label_map = {}
+        cfg.bad_tool_call_handling = BadToolCallHandling.NONE
+        gen.otel_config = cfg
+        gen.replay_config = cfg
+        gen.session_graph_state = {session_id: MagicMock(graph=graph, random_string=None)}
+        return gen
+
+    def test_tool_result_chatmessage_keeps_tool_call_id(self) -> None:
+        from inference_perf.apis import LazyLoadInferenceAPIData
+
+        gen = self._make_gen_from_input(
+            [
+                {"role": "user", "content": "weather?"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+                },
+                {"role": "tool", "tool_call_id": "c1", "content": '{"temp_c": 18}'},
+            ]
+        )
+        api_data = gen.load_lazy_data(LazyLoadInferenceAPIData(data_index=0))
+        # The role:tool ChatMessage must carry tool_call_id (the wire payload
+        # when disable_output_substitution=true skips the substitution rebuild).
+        tool_cm = next(m for m in api_data.messages if m.role == "tool")
+        assert tool_cm.tool_call_id == "c1"
+        assert "tool_call_id" in tool_cm.to_dict()
+        # The assistant ChatMessage must carry structured tool_calls.
+        asst_cm = next(m for m in api_data.messages if m.role == "assistant")
+        assert asst_cm.tool_calls is not None
+        assert asst_cm.tool_calls[0]["function"]["name"] == "get_weather"
+
+
+class TestDisableOutputSubstitutionValidation:
+    """disable_output_substitution contradicts random session-ID injection, so
+    the config validator must reject the combination up front rather than let
+    the substitution pass run anyway (and silently ignore the flag)."""
+
+    def test_disable_substitution_alone_is_valid(self) -> None:
+        cfg = OTelTraceReplayConfig(trace_files=["/tmp/t.json"], disable_output_substitution=True)
+        assert cfg.disable_output_substitution is True
+
+    def test_disable_substitution_with_random_injection_raises(self) -> None:
+        with pytest.raises(ValidationError, match="inject_random_session_id"):
+            OTelTraceReplayConfig(
+                trace_files=["/tmp/t.json"],
+                disable_output_substitution=True,
+                inject_random_session_id=True,
+            )
+
+    def test_disable_substitution_with_duplicate_sessions_raises(self) -> None:
+        with pytest.raises(ValidationError, match="duplicate_sessions_target"):
+            OTelTraceReplayConfig(
+                trace_files=["/tmp/t.json"],
+                disable_output_substitution=True,
+                duplicate_sessions_target=10,
+            )
+
+    def test_random_injection_without_disable_substitution_is_valid(self) -> None:
+        cfg = OTelTraceReplayConfig(
+            trace_files=["/tmp/t.json"],
+            inject_random_session_id=True,
+            duplicate_sessions_target=10,
+        )
+        assert cfg.disable_output_substitution is False

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -1994,7 +1994,7 @@ def _graph_messages_from_input(input_messages: List[dict[str, Any]]) -> List[dic
         "resource_attributes": {"service.name": "t"},
         "status": {"code": 1, "message": ""},
     }
-    raw_calls = build_raw_calls([span])
+    raw_calls, _ = build_raw_calls([span])
     graph = build_graph(raw_calls, source_file="t")
     return next(iter(graph.events.values())).call.messages
 
@@ -2256,7 +2256,8 @@ class TestLoadLazyDataPreservesToolLinkage:
             "resource_attributes": {"service.name": "t"},
             "status": {"code": 1, "message": ""},
         }
-        graph = build_graph(build_raw_calls([span]), source_file="t")
+        raw_calls, _ = build_raw_calls([span])
+        graph = build_graph(raw_calls, source_file="t")
         session_id = "session_0"
         gc = next(iter(graph.events.values()))
         event = ReplaySessionEvent(
@@ -2277,6 +2278,7 @@ class TestLoadLazyDataPreservesToolLinkage:
         )
         gen = object.__new__(OTelTraceReplayDataGenerator)
         gen.all_events = [event]
+        gen._session_events = {0: [event]}
         gen.output_registry = EventOutputRegistry()
         gen.worker_tracker = WorkerSessionTracker()
         gen.session_completion_queue = None


### PR DESCRIPTION
## What

Adds an OTel trace replay config flag `disable_output_substitution` that replays each call with its **recorded** assistant output (text and tool calls) instead of substituting the **live** output produced by predecessor calls.

```yaml
data:
  otel_trace_replay:
    disable_output_substitution: true   # default: false
```

- `false` (default): unchanged — a predecessor's live output is substituted into successor prompts.
- `true`: each call replays exactly as recorded. Predecessor **dependency timing is still enforced** (calls still wait for predecessors and honor `wait_ms`); only content substitution is disabled.

Use it for deterministic, recorded-as-is replay rather than live-output-dependent replay.

## Fix: faithful tool-call replay

Building this flag surfaced a gap in `_replay_message_to_dict`, which collapsed recorded **tool calls** into an internal flattened text form (`<|tool_call|>...`) and dropped the structured `tool_calls` / `tool_call_id` from the trace. It now emits OpenAI-shaped messages from `message_info`:

- normalizes tool calls to `{id, type: function, function: {name, arguments}}` (nested and direct formats);
- JSON-encodes object `arguments` (a raw object otherwise triggers a server 400 — `arguments` must be a JSON string);
- coerces list-of-blocks text/results to strings;
- keeps string-content tool messages structured in `extract_messages` so `tool_call_id` survives;
- carries `tool_call_id` / `tool_calls` through `load_lazy_data` onto the wire message.

Under the default this was masked (live substitution overwrites the slot with structured output). It was exposed by `disable_output_substitution=true`, and also affected the `bad_tool_call_handling=use_recorded` fallback, whose recorded substitution and safety check previously operated on a flattened message.

### Cases it resolves

| Recorded shape | Before | After |
|---|---|---|
| Assistant `tool_calls` (OpenAI or direct `{name,arguments}`) | flattened to text | structured `tool_calls` |
| Assistant `content` + `tool_calls` | one text blob | `content` + structured `tool_calls` |
| Tool call with object `arguments` | server 400 | `arguments` JSON-encoded → accepted |
| Tool result with `tool_call_id` | id dropped | id preserved |
| Tool result with nested block-list content | Python-repr blob | clean text |

Non-tool messages are unchanged.

Note: When a recorded r`ole:tool` message bundles multiple tool_call_response results, only the first is kept (one OpenAI role:tool message carries exactly one tool_call_id); faithfully splitting these into one message per result is deferred to a separate issue.

## Tests

Adds tests that drive `extract_messages -> build_graph` and assert on the resulting wire messages for each tool-call shape.