### PR TITLE
Fix SSE parser to handle delta.reasoning tokens from reasoning models

### DIFF
--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -540,7 +540,12 @@ class ChatCompletionAPIData(InferenceAPIData):
     ) -> InferenceInfo:
         if config.streaming:
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
+                response,
+                extract_content=lambda data: (
+                    data.get("choices", [{}])[0].get("delta", {}).get("content")
+                    or data.get("choices", [{}])[0].get("delta", {}).get("reasoning")
+                    or data.get("choices", [{}])[0].get("delta", {}).get("reasoning_content")
+                ),
             )
             prompt_len = self._count_prompt_tokens(tokenizer)
             output_len = tokenizer.count_tokens(output_text)

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -136,3 +136,78 @@ async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
     # The bytes received before the break are retained, not discarded.
     assert "Hello" in err.raw_content
     assert "world" in err.raw_content
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_tokens() -> None:
+    """Reasoning models emit delta.reasoning (or delta.reasoning_content) before
+    delta.content. The extract_content function used by ChatCompletionAPIData must
+    count both reasoning and content tokens so output metrics are accurate."""
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    chunks = [
+        b'data: {"choices": [{"delta": {"role": "assistant", "content": ""}}]}\n\n',
+        b'data: {"choices": [{"delta": {"reasoning": "Let me"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"reasoning": " think"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": "The answer is 4."}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+
+    mock_content.iter_any = mock_iter_any
+
+    def extract_content(data: dict[str, Any]) -> Optional[str]:
+        return (
+            data.get("choices", [{}])[0].get("delta", {}).get("content")
+            or data.get("choices", [{}])[0].get("delta", {}).get("reasoning")
+            or data.get("choices", [{}])[0].get("delta", {}).get("reasoning_content")
+        )
+
+    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+        mock_response, extract_content
+    )
+
+    assert output_text == "Let me thinkThe answer is 4."
+    assert len(chunk_times) == 3
+    assert len(response_chunks) == 3
+    assert len(chunk_times) == len(response_chunks)
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_content_field() -> None:
+    """Some models (e.g. DeepSeek-R1) use delta.reasoning_content instead of
+    delta.reasoning. The extraction must handle both field names."""
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    chunks = [
+        b'data: {"choices": [{"delta": {"reasoning_content": "Step 1: "}}]}\n\n',
+        b'data: {"choices": [{"delta": {"reasoning_content": "analyze"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": "Result."}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+
+    mock_content.iter_any = mock_iter_any
+
+    def extract_content(data: dict[str, Any]) -> Optional[str]:
+        return (
+            data.get("choices", [{}])[0].get("delta", {}).get("content")
+            or data.get("choices", [{}])[0].get("delta", {}).get("reasoning")
+            or data.get("choices", [{}])[0].get("delta", {}).get("reasoning_content")
+        )
+
+    output_text, chunk_times, _, response_chunks, _ = await parse_sse_stream(mock_response, extract_content)
+
+    assert output_text == "Step 1: analyzeResult."
+    assert len(chunk_times) == 3
+    assert len(response_chunks) == 3


### PR DESCRIPTION
## Summary
- The `extract_content` lambda in the chat SSE parser only read `delta.content`, causing reasoning models (GLM-5.2, DeepSeek-R1) to report `output_len≈0` and meaningless TPOT/ITL/TTFT metrics
- Updated the lambda to fall through `content → reasoning → reasoning_content` so all generated tokens are counted
- Added tests covering both `delta.reasoning` and `delta.reasoning_content` field names

Fixes #592

## Test plan
- [x] Existing streaming parser tests pass
- [x] New test: `test_parse_sse_stream_reasoning_tokens` — verifies `delta.reasoning` tokens are extracted
- [x] New test: `test_parse_sse_stream_reasoning_content_field` — verifies `delta.reasoning_content` (DeepSeek-R1 style) tokens are extracted
- [ ] Manual validation against a reasoning model endpoint (GLM-5.2 or DeepSeek-R1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)