### PR TITLE
Capture and replay session token header for router session affinity

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -18,6 +18,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--api.response_format.name` | str | Name given to the JSON schema in the request payload. |
 | `--api.response_format.json_schema` | JSON | JSON schema the model output must conform to when type is 'json_schema'. |
 | `--api.session_id_header_key` | str | Header used to send the session ID with each request in multi-turn benchmarks. |
+| `--api.session_token_header_key` | str | Response header carrying a server-assigned session token, replayed as a request header on later requests of the same session to keep router session affinity. |
 | `--data.type` | Enum (mock, shareGPT, synthetic, random, shared_prefix, cnn_dailymail, infinity_instruct, billsum_conversations, otel_trace_replay, weka_trace_replay, conversation_replay, visionarena) | Dataset or generator used to produce prompts. |
 | `--data.path` | str | Path to the downloaded ShareGPT dataset. Only used by the 'shareGPT' type. |
 | `--data.corpus_file_path` | str | Path to a text file to use as the prompt tokenization corpus instead of the default hardcoded sonnet |

--- a/docs/conversation_replay.md
+++ b/docs/conversation_replay.md
@@ -12,6 +12,7 @@ deterministically seeded for reproducible A/B comparisons.
 - [Configuration Guide](#configuration-guide)
 - [Distribution types](#distribution-types)
 - [Tool call latency simulation](#tool-call-latency-simulation)
+- [Router session affinity](#router-session-affinity)
 - [How it fits together](#how-it-fits-together)
 
 ## When to use conversation replay
@@ -143,6 +144,24 @@ models offline agentic workloads without artificially lowering throughput.
 
 Omit `tool_call_latency_sec` (or set it to a `fixed` distribution with `mean: 0`) to measure
 pure back-to-back GPU throughput.
+
+## Router session affinity
+
+When benchmarking through a router that implements token-based session affinity — such as the
+[llm-d-router session affinity plugins](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity)
+— set `api.session_token_header_key` so each conversation replays the router's session token on
+its later turns:
+
+```yaml
+api:
+  type: chat
+  session_token_header_key: x-session-token  # header carrying the router's session token
+```
+
+The first turn of a conversation goes out without the header, the router picks an endpoint and
+returns the token, and every later turn of that conversation carries it so the router keeps the
+whole conversation on the same endpoint. See
+[Router Session Affinity](otel_trace_replay.md#router-session-affinity) for the full description.
 
 ## How it fits together
 

--- a/docs/otel_trace_replay.md
+++ b/docs/otel_trace_replay.md
@@ -96,6 +96,22 @@ load:
 >
 > **Note on `worker_max_concurrency`:** Set this high for trace replay. All events in a session are enqueued immediately, and events waiting for predecessors hold concurrency slots. However, waiting is done via `asyncio.Event` (zero threads—just suspended coroutines), so high values have negligible cost. **Rule of thumb:** `concurrent_sessions × 50` to `concurrent_sessions × 100` depending on your trace complexity.
 
+### Router Session Affinity
+
+When benchmarking through a router that implements token-based session affinity — such as the [llm-d-router session affinity plugins](https://github.com/llm-d/llm-d-router/tree/main/pkg/epp/framework/plugins/scheduling/scorer/sessionaffinity) — the router returns a session token in a response header (`x-session-token` by default) and expects the client to echo that header on subsequent requests of the same session. Set `api.session_token_header_key` to make the client behave that way:
+
+```yaml
+api:
+  type: chat
+  session_token_header_key: x-session-token  # header carrying the router's session token
+```
+
+The token received in a session's response is stored per session and sent as a request header on that session's subsequent requests, allowing the router to route the whole session to the same endpoint.
+
+This differs from `api.session_id_header_key`, which unconditionally sends the replay-side session ID as a request header and does not involve any server-assigned token.
+
+The setting applies to any workload that has a session identity, not just trace replay — `conversation_replay` and `shared_prefix` are covered too.
+
 ### Data Configuration: `otel_trace_replay`
 
 The `data.otel_trace_replay` section controls what traces to replay and how to process them.

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -211,6 +211,11 @@ class openAIModelServerClientSession(ModelServerClientSession):
 
         self.client = client
         self.session = aiohttp.ClientSession(timeout=timeout, connector=connector)
+        # Server-assigned session tokens keyed by session identity, captured from
+        # the response header named by api_config.session_token_header_key.
+        # Sessions are pinned to a worker (preferred_worker_id), so a per-worker
+        # store sees every request of its sessions.
+        self._session_tokens: dict[str, str] = {}
 
     def _get_session_otel_context(self, data: InferenceAPIData) -> Optional[Dict[str, str]]:
         """Get session OTEL context if available (for OTel trace replay)."""
@@ -382,10 +387,18 @@ class openAIModelServerClientSession(ModelServerClientSession):
         if data.headers:
             _update_headers_case_insensitive(headers, data.headers)
 
-        if self.client.api_config.session_id_header_key:
-            session_id = getattr(data, "session_id", None) or getattr(data, "user_session_id", None)
-            if session_id:
-                headers[self.client.api_config.session_id_header_key] = session_id
+        # Trace replay carries session identity as session_id (stamped by the loadgen);
+        # conversation_replay and shared_prefix carry it as user_session_id.
+        session_id = getattr(data, "session_id", None) or getattr(data, "user_session_id", None)
+
+        if self.client.api_config.session_id_header_key and session_id:
+            headers[self.client.api_config.session_id_header_key] = session_id
+
+        session_token_header = self.client.api_config.session_token_header_key
+        if session_id and session_token_header:
+            session_token = self._session_tokens.get(session_id)
+            if session_token:
+                headers[session_token_header] = session_token
 
         request_data = json.dumps(payload)
 
@@ -417,6 +430,10 @@ class openAIModelServerClientSession(ModelServerClientSession):
             try:
                 async with self.session.post(self.client.uri + data.get_route(), headers=headers, data=request_data) as resp:
                     response = resp
+                    if session_id and session_token_header:
+                        received_token = resp.headers.get(session_token_header)
+                        if received_token:
+                            self._session_tokens[session_id] = received_token
                     try:
                         if self.client.api_config.streaming and response.status == 200:
                             info = await data.process_response(

--- a/inference_perf/config/apis/config.py
+++ b/inference_perf/config/apis/config.py
@@ -82,3 +82,11 @@ class APIConfig(StrictBaseModel):
     session_id_header_key: Optional[str] = Field(
         default=None, description="Header used to send the session ID with each request in multi-turn benchmarks."
     )
+    # Response header carrying a server-assigned session token (e.g. x-session-token
+    # from the llm-d-router session affinity plugin). When set, the token received in
+    # a session's response is echoed as a request header on subsequent requests of
+    # the same session so the router can maintain session affinity.
+    session_token_header_key: Optional[str] = Field(
+        default=None,
+        description="Response header carrying a server-assigned session token, replayed as a request header on later requests of the same session to keep router session affinity.",
+    )

--- a/tests/required/client/modelserver/test_openai_client.py
+++ b/tests/required/client/modelserver/test_openai_client.py
@@ -381,3 +381,86 @@ async def test_process_request_success(mock_client: MagicMock, mock_data: MagicM
     assert metric.info == expected_info
     assert metric.response_data == "success_response_text"
     assert metric.error is None
+
+
+def _session_token_test_setup(
+    mock_client: MagicMock, mock_data: MagicMock, response_token: str
+) -> tuple[openAIModelServerClientSession, MagicMock]:
+    """Configure client/data mocks for session token tests and return a client session
+    whose mocked POST responds with the given session token header, along with the
+    mocked HTTP session for inspecting sent requests."""
+    mock_client.otel.enabled = False
+    mock_client.api_config.streaming = False
+    mock_client.api_config.session_id_header_key = None
+    mock_client.api_config.session_token_header_key = "x-session-token"
+    mock_data.session_id = "trace0_session0"
+    mock_data.headers = None
+
+    session = openAIModelServerClientSession(mock_client)
+    mock_http_session = MagicMock()
+    session.session = mock_http_session
+
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.text = AsyncMock(return_value="{}")
+    mock_response.headers = {"x-session-token": response_token}
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_http_session.post.return_value = mock_post_ctx
+    return session, mock_http_session
+
+
+@pytest.mark.asyncio
+async def test_session_token_captured_and_replayed(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    session, mock_http_session = _session_token_test_setup(mock_client, mock_data, response_token="encoded-pod-a")
+
+    # First request of the session: no token captured yet, header must be absent.
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+    first_headers = mock_http_session.post.call_args.kwargs["headers"]
+    assert "x-session-token" not in first_headers
+
+    # Second request of the same session replays the token from the first response.
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+    second_headers = mock_http_session.post.call_args.kwargs["headers"]
+    assert second_headers["x-session-token"] == "encoded-pod-a"
+
+
+@pytest.mark.asyncio
+async def test_session_token_not_shared_across_sessions(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    session, mock_http_session = _session_token_test_setup(mock_client, mock_data, response_token="encoded-pod-a")
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    # A different session must not inherit the first session's token.
+    mock_data.session_id = "trace0_session1"
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+    headers_passed = mock_http_session.post.call_args.kwargs["headers"]
+    assert "x-session-token" not in headers_passed
+
+
+@pytest.mark.asyncio
+async def test_session_token_not_captured_when_header_key_is_none(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    session, mock_http_session = _session_token_test_setup(mock_client, mock_data, response_token="encoded-pod-a")
+    mock_client.api_config.session_token_header_key = None
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    headers_passed = mock_http_session.post.call_args.kwargs["headers"]
+    assert "x-session-token" not in headers_passed
+
+
+@pytest.mark.asyncio
+async def test_session_token_replayed_for_user_session_id_workloads(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    """conversation_replay and shared_prefix carry session identity as user_session_id
+    rather than the loadgen-stamped session_id used by trace replay."""
+    session, mock_http_session = _session_token_test_setup(mock_client, mock_data, response_token="encoded-pod-a")
+    mock_data.session_id = None
+    mock_data.user_session_id = "conv_0"
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+    assert "x-session-token" not in mock_http_session.post.call_args.kwargs["headers"]
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+    assert mock_http_session.post.call_args.kwargs["headers"]["x-session-token"] == "encoded-pod-a"


### PR DESCRIPTION
Adds `api.session_token_header_key` for token based session affinity (#582).

The llm-d-router session affinity plugin sends back a session token in a response header (`x-session-token` by default) and expects the client to send it back on the next requests of the same session. Right now inference-perf just drops that header, so there is no way to benchmark session affinity.

With this change, when `session_token_header_key` is set the client stores the token it got for a session and puts it on that session's later requests. First request of a session goes out without the header, router assigns the endpoint and returns the token.

Few things about the approach:
- store is per worker, which is fine because sessions are already pinned to workers via `preferred_worker_id`
- latest token always wins, so if the router moves a session we follow it
- off by default, nothing changes unless you set it
- vllm/sglang/tgi clients share the openai client request path so they all get this

Added 3 tests (capture+replay, no leak between sessions, option unset does nothing). `tests/required` passing, ruff/mypy clean. Also added a small section in `docs/otel_trace_replay.md` and regenerated `cli_flags.md` with the sync script.

Fixes #582