### PR TITLE
Feature: Add per-stage error metrics report with session and request breakdowns

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -245,6 +245,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--report.request_lifecycle.per_adapter_stage` | boolean | Matches report.request_lifecycle.per_adapter_stage in config |
 | `--report.request_lifecycle.percentiles` | JSON | Matches report.request_lifecycle.percentiles in config |
 | `--report.request_lifecycle.use_server_output_tokens` | boolean | Matches report.request_lifecycle.use_server_output_tokens in config |
+| `--report.request_lifecycle.max_error_messages` | int | Matches report.request_lifecycle.max_error_messages in config |
 | `--report.prometheus.summary` | boolean | Matches report.prometheus.summary in config |
 | `--report.prometheus.per_stage` | boolean | Matches report.prometheus.per_stage in config |
 | `--report.session_lifecycle.summary` | boolean | Matches report.session_lifecycle.summary in config |

--- a/docs/config.md
+++ b/docs/config.md
@@ -248,6 +248,8 @@ report:
     per_adapter_stage: false  # Generate metrics grouped by adapter and stage
     percentiles: [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9] # List of percentiles to calculate
     use_server_output_tokens: false # Treat the server's usage.completion_tokens as the source of truth for output tokens.
+    max_error_messages: 100   # Max number of unique error messages retained per error label (failures.by_label) and per bad tool call substitution entry
+    use_server_output_tokens: false # Treat the server's usage.completion_tokens as the source of truth for output tokens.
   prometheus:
     summary: true             # Include Prometheus metrics summary
     per_stage: false          # Disable Prometheus stage breakdown

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -35,6 +35,44 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
       "requests_per_sec": 1.02,
       "total_tokens_per_sec": 676.12
     }
+  },
+  "failures": {
+    "count": 3,
+    "request_latency": {
+      "mean": 9.948665728999458,
+      "min": 0.5831485409980814,
+      "p90": 11.684405915999378
+    },
+    "prompt_len": {
+      "mean": 0.0,
+      "min": 0.0,
+      "p90": 0.0,
+    },
+    "by_label": {
+      "504 - Gateway Timeout": {
+        "count": 2,
+        "messages": [
+          {
+            "message": "...504 Gateway Time-out...",
+            "session_ids": [
+              "trace1715_066de3655406_a9687407",
+              "trace2210_1f9b0c4d7e21_b3c58120"
+            ]
+          }
+        ]
+      },
+      "400 - Invalid JSON": {
+        "count": 1,
+        "messages": [
+          {
+            "message": "...Invalid JSON: EOF while parsing a string at line 202 column 31...",
+            "session_ids": [
+              "trace42_9f000393d262_f395c930"
+            ]
+          }
+        ]
+      }
+    }
   }
 }
 ```
@@ -45,5 +83,5 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
 
 - **`load_summary`**: Details about the requested vs achieved load.
 - **`successes`**: Metrics for successful requests.
-- **`failures`**: Metrics for failed requests.
+- **`failures`**: Metrics for failed requests, including the per-label error breakdown.
 - **`goodput_metrics`**: (Optional) Goodput statistics if constraints were configured.

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -24,6 +24,9 @@ class RequestLifecycleMetricsReportConfig(BaseModel):
     per_adapter_stage: Optional[bool] = False
     percentiles: List[float] = [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9]
     use_server_output_tokens: bool = False
+    # Cap on the number of per-error example messages retained per error label
+    # (in failures.by_label) and per substitution entry
+    max_error_messages: int = 100
 
 
 class PrometheusMetricsReportConfig(BaseModel):

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import logging
 import json
+import re
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
@@ -40,6 +41,120 @@ from inference_perf.metrics import SessionMetricsCollector
 from inference_perf.utils import ReportFile
 
 logger = logging.getLogger(__name__)
+
+# Labels derived purely from the HTTP status code. These are authoritative: the
+# code comes from response.status, not from free-text, so a 400 can never be
+# mislabeled as "Internal Server Error" because its message happens to contain
+# "500". Code-specific semantics belong here, NOT in _HTTP_ERROR_LABELS.
+_HTTP_CODE_LABELS: dict[str, str] = {
+    "429": "Rate Limit",
+    "500": "Internal Server Error",
+    "502": "Bad Gateway",
+    "503": "Service Unavailable",
+    "504": "Gateway Timeout",
+}
+
+# Labels inferred from the error message body. Only include semantics that the
+# status code alone does NOT determine.
+_HTTP_ERROR_LABELS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"context.window|context length|maximum context|max.?tokens|token.?limit", re.I), "Context Window"),
+    (
+        re.compile(
+            r"invalid.?json|json.?parse|malformed.?json|unexpected.?token|expecting value|unterminated string|expecting ',' delimiter",
+            re.I,
+        ),
+        "Invalid JSON",
+    ),
+    (re.compile(r"timeout|timed.?out", re.I), "Timeout"),
+    (re.compile(r"model.?not.?found|no such model", re.I), "Model Not Found"),
+]
+
+_NON_HTTP_ERROR_LABELS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"timeout|timed.?out", re.I), "Timeout"),
+    (re.compile(r"connection.?refused|connect", re.I), "Connection Error"),
+]
+
+
+def parse_error_message(raw: str) -> str:
+    """Extract the human-readable message from a raw error_msg string.
+
+    error_msg is typically a JSON body like:
+      {"error": {"message": "...", "type": "...", ...}}
+    Returns the inner message string when present, otherwise raw as-is.
+    """
+    try:
+        body = json.loads(raw)
+        if isinstance(body, dict):
+            error = body.get("error") or body
+            if isinstance(error, dict) and "message" in error:
+                return str(error["message"])
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+    return raw
+
+
+def make_concise_label(error_type: str, error_msg: str) -> str:
+    """Produce a short human-readable label for an error entry.
+
+    For HTTP errors (error_type == "HTTP Error <code>"), returns "<code> - <label>".
+    The label is derived, in order, from: the status code itself
+    (_HTTP_CODE_LABELS), then message-specific patterns (_HTTP_ERROR_LABELS),
+    else "other".
+    For non-HTTP errors, matches against _NON_HTTP_ERROR_LABELS, falling back to a
+    lowercased error_type.
+    """
+    if error_type.startswith("HTTP Error "):
+        try:
+            code = error_type.split()[-1]
+        except IndexError:
+            code = "?"
+        code_label = _HTTP_CODE_LABELS.get(code)
+        if code_label is not None:
+            return f"{code} - {code_label}"
+        for pattern, label in _HTTP_ERROR_LABELS:
+            if pattern.search(error_msg):
+                return f"{code} - {label}"
+        return f"{code} - other"
+    for pattern, label in _NON_HTTP_ERROR_LABELS:
+        if pattern.search(error_msg):
+            return label
+    return error_type.lower().strip()
+
+
+def build_error_counts(metrics_errors: list[tuple[str, str, Optional[str]]], max_error_messages: int) -> dict[str, Any]:
+    """Build a {<label>: {count, messages}} dict from (error_type, error_msg, id) triples.
+
+    ``count`` reflects the true total number of errors for each label.
+    Identical messages within a label are merged into a single entry of the form
+    ``{"message": <text>, "session_ids": [...]}``; ``session_ids`` collects the ids
+    of every occurrence (omitted when no ids are present). The number of distinct
+    messages retained per label is capped at ``max_error_messages``.
+    Entries are sorted by descending count.
+    """
+    label_counts: dict[str, int] = defaultdict(int)
+    # Per label, merge by message text: message -> ordered list of session ids.
+    label_messages: dict[str, dict[str, list[str]]] = defaultdict(dict)
+    for error_type, error_msg, entity_id in metrics_errors:
+        parsed_msg = parse_error_message(error_msg)
+        label = make_concise_label(error_type, parsed_msg)
+        label_counts[label] += 1
+        merged = label_messages[label]
+        if parsed_msg in merged:
+            if entity_id is not None:
+                merged[parsed_msg].append(entity_id)
+        elif len(merged) < max_error_messages:
+            merged[parsed_msg] = [entity_id] if entity_id is not None else []
+
+    result: dict[str, Any] = {}
+    for label in sorted(label_counts, key=lambda k: -label_counts[k]):
+        messages: list[dict[str, Any]] = []
+        for message, session_ids in label_messages[label].items():
+            entry: dict[str, Any] = {"message": message}
+            if session_ids:
+                entry["session_ids"] = session_ids
+            messages.append(entry)
+        result[label] = {"count": label_counts[label], "messages": messages}
+    return result
 
 
 def safe_float(value: Any) -> float:
@@ -430,6 +545,7 @@ def summarize_requests(
     goodput_config: Optional[GoodputConfig] = None,
     tokenizer: Optional[CustomTokenizer] = None,
     use_server_output_tokens: bool = False,
+    max_error_messages: int = 100,
 ) -> ResponsesSummary:
     all_successful: List[RequestLifecycleMetric] = [x for x in metrics if x.error is None]
     all_failed: List[RequestLifecycleMetric] = [x for x in metrics if x.error is not None]
@@ -679,6 +795,10 @@ def summarize_requests(
             "prompt_len": summarize(
                 [safe_float(failed.info.request_metrics.text.input_tokens) for failed in all_failed], percentiles
             ),
+            "by_label": build_error_counts(
+                [(m.error.error_type, m.error.error_msg, m.session_id) for m in all_failed if m.error is not None],
+                max_error_messages,
+            ),
         },
     )
 
@@ -720,6 +840,7 @@ class ReportGenerator:
         lifecycle_reports = []
         percentiles = report_config.request_lifecycle.percentiles
         use_server_output_tokens = report_config.request_lifecycle.use_server_output_tokens
+        max_error_messages = report_config.request_lifecycle.max_error_messages
 
         tokenizer = None
         if self.config.tokenizer:
@@ -742,6 +863,7 @@ class ReportGenerator:
                         goodput_config=report_config.goodput,
                         tokenizer=tokenizer,
                         use_server_output_tokens=use_server_output_tokens,
+                        max_error_messages=max_error_messages,
                     ).model_dump(),
                 )
                 lifecycle_reports.append(report_file)
@@ -765,6 +887,7 @@ class ReportGenerator:
                             goodput_config=report_config.goodput,
                             tokenizer=tokenizer,
                             use_server_output_tokens=use_server_output_tokens,
+                            max_error_messages=max_error_messages,
                         ).model_dump(),
                     )
                 else:
@@ -777,6 +900,7 @@ class ReportGenerator:
                             goodput_config=report_config.goodput,
                             tokenizer=tokenizer,
                             use_server_output_tokens=use_server_output_tokens,
+                            max_error_messages=max_error_messages,
                         ).model_dump(),
                     )
                 lifecycle_reports.append(report_file)
@@ -812,6 +936,7 @@ class ReportGenerator:
                         goodput_config=report_config.goodput,
                         tokenizer=tokenizer,
                         use_server_output_tokens=use_server_output_tokens,
+                        max_error_messages=max_error_messages,
                     ).model_dump(),
                 )
                 lifecycle_reports.append(report_file)
@@ -833,6 +958,7 @@ class ReportGenerator:
                         goodput_config=report_config.goodput,
                         tokenizer=tokenizer,
                         use_server_output_tokens=use_server_output_tokens,
+                        max_error_messages=max_error_messages,
                     ).model_dump(),
                 )
                 lifecycle_reports.append(report_file)
@@ -849,13 +975,16 @@ class ReportGenerator:
                 report_config.session_lifecycle,
                 percentiles,
                 runtime_parameters,
+                max_error_messages,
             )
             lifecycle_reports.extend(session_reports)
 
         lifecycle_reports.append(self.generate_config_report())
         return lifecycle_reports
 
-    def summarize_sessions(self, metrics: List[SessionLifecycleMetric], percentiles: List[float]) -> Dict[str, Any]:
+    def summarize_sessions(
+        self, metrics: List[SessionLifecycleMetric], percentiles: List[float], max_error_messages: int = 100
+    ) -> Dict[str, Any]:
         """Compute aggregated stats across a list of session lifecycle metrics."""
         num_sessions = len(metrics)
         num_succeeded = sum(1 for m in metrics if m.success is True)
@@ -870,9 +999,23 @@ class ReportGenerator:
         sessions_with_recorded_substitution = sum(
             1 for m in metrics if m.n_recorded_substitutions is not None and m.n_recorded_substitutions > 0
         )
-        total_recorded_substitutions = sum(
-            m.n_recorded_substitutions for m in metrics if m.n_recorded_substitutions is not None
-        )
+        sessions_with_substitutions = [
+            m for m in metrics if m.n_recorded_substitutions is not None and m.n_recorded_substitutions > 0
+        ]
+        # total_recorded_substitutions carries the aggregate count plus a capped
+        # sample of per-session example messages
+        total_recorded_substitutions = {
+            "count": sum(
+                m.n_recorded_substitutions for m in sessions_with_substitutions if m.n_recorded_substitutions is not None
+            ),
+            "messages": [
+                {
+                    "message": f"substitutions={m.n_recorded_substitutions} event_ids={m.recorded_substitution_event_ids}",
+                    "session_ids": [m.session_id],
+                }
+                for m in sessions_with_substitutions[:max_error_messages]
+            ],
+        }
 
         sessions_per_second = 0.0
         if num_sessions > 0:
@@ -943,6 +1086,7 @@ class ReportGenerator:
         report_config: SessionLifecycleReportConfig,
         percentiles: List[float],
         runtime_parameters: PerfRuntimeParameters,
+        max_error_messages: int,
     ) -> List[ReportFile]:
         """Generate session-level lifecycle reports."""
         reports: List[ReportFile] = []
@@ -954,7 +1098,7 @@ class ReportGenerator:
             reports.append(
                 ReportFile(
                     name="summary_session_lifecycle_metrics",
-                    contents=self.summarize_sessions(session_metrics, percentiles),
+                    contents=self.summarize_sessions(session_metrics, percentiles, max_error_messages),
                 )
             )
 
@@ -965,7 +1109,7 @@ class ReportGenerator:
             for stage_id, stage_metrics in stage_buckets.items():
                 # Get stage runtime info and build metadata
                 stage_info = runtime_parameters.stages.get(stage_id)
-                stage_summary = self.summarize_sessions(stage_metrics, percentiles)
+                stage_summary = self.summarize_sessions(stage_metrics, percentiles, max_error_messages)
 
                 if stage_info:
                     # Determine status string

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -47,6 +47,8 @@ def print_summary_table(reports: List[ReportFile]) -> None:
 
     if not stage_reports:
         rprint("[yellow]No per-stage lifecycle metrics found to display summary table.[/yellow]")
+        print_session_summary_tables(reports)
+        print_error_summary_table(reports)
         return
 
     # Sort stages by ID
@@ -281,6 +283,7 @@ def print_summary_table(reports: List[ReportFile]) -> None:
 
     # Print session-level metrics if available
     print_session_summary_tables(reports)
+    print_error_summary_table(reports)
 
 
 def print_session_summary_tables(reports: List[ReportFile]) -> None:
@@ -352,7 +355,12 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
         total_events_completed = contents.get("total_events_completed", 0)
         total_events_cancelled = contents.get("total_events_cancelled", 0)
         sessions_per_second = contents.get("sessions_per_second", 0.0)
-        total_recorded_substitutions = contents.get("total_recorded_substitutions", 0)
+        # total_recorded_substitutions is a {count, messages} dict; fall back to a
+        # bare int for older report shapes.
+        substitutions_entry = contents.get("total_recorded_substitutions", 0)
+        total_recorded_substitutions = (
+            substitutions_entry.get("count", 0) if isinstance(substitutions_entry, dict) else substitutions_entry
+        )
 
         # Color code succeeded/failed sessions
         succeeded_str = f"[green]{num_sessions_succeeded}[/]"
@@ -434,3 +442,79 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
     console.print(session_summary_table)
     console.print(session_duration_table)
     console.print(session_tokens_table)
+
+
+def _collect_error_labels(failures_by_stage: Dict[int, Dict[str, Any]]) -> list[str]:
+    """Return the ordered union of error labels (from failures.by_label) across all stages."""
+    seen: list[str] = []
+    for by_label in failures_by_stage.values():
+        for key in by_label:
+            if key not in seen:
+                seen.append(key)
+    return seen
+
+
+def _build_error_table(
+    sorted_stages: list[int],
+    successes_by_stage: Dict[int, int],
+    failures_by_stage: Dict[int, Dict[str, Any]],
+    substitutions_by_stage: Dict[int, int],
+) -> Table:
+    """Build the per-stage error summary table."""
+    labels = _collect_error_labels(failures_by_stage)
+    has_substitutions = any(substitutions_by_stage.get(s, 0) > 0 for s in sorted_stages)
+    table = Table(title="[bold magenta]Request Error Summary[/bold magenta]", show_header=True, header_style="bold cyan")
+    table.add_column("Stage", justify="right")
+    table.add_column("Successes", justify="right")
+    if has_substitutions:
+        table.add_column("Bad Tool Calls Substitutions", justify="right")
+    for label in labels:
+        table.add_column(label, justify="right")
+
+    for stage_id in sorted_stages:
+        successes = successes_by_stage.get(stage_id, 0)
+        row = [str(stage_id), f"[green]{successes}[/green]"]
+        if has_substitutions:
+            sub_count = substitutions_by_stage.get(stage_id, 0)
+            color = "yellow" if sub_count > 0 else "green"
+            row.append(f"[{color}]{sub_count}[/]")
+        by_label = failures_by_stage.get(stage_id, {})
+        for label in labels:
+            entry = by_label.get(label)
+            count = entry["count"] if isinstance(entry, dict) else 0
+            color = "red" if count > 0 else "green"
+            row.append(f"[{color}]{count}[/]")
+        table.add_row(*row)
+    return table
+
+
+def print_error_summary_table(reports: List[ReportFile]) -> None:
+    """Print a per-stage error summary table, joining the folded lifecycle reports.
+
+    Per-stage successes and error-label breakdown come from
+    ``stage_N_lifecycle_metrics`` and substitution counts from
+    ``stage_N_session_lifecycle_metrics``.
+    """
+    successes_by_stage: Dict[int, int] = {}
+    failures_by_stage: Dict[int, Dict[str, Any]] = {}
+    substitutions_by_stage: Dict[int, int] = {}
+
+    for report in reports:
+        stage_id = extract_stage_id(report.name)
+        if stage_id is not None:
+            successes = report.contents.get("successes", {})
+            successes_by_stage[stage_id] = successes.get("count", 0) if isinstance(successes, dict) else 0
+            failures = report.contents.get("failures", {})
+            failures_by_stage[stage_id] = failures.get("by_label", {}) if isinstance(failures, dict) else {}
+            continue
+        session_stage_id = extract_session_stage_id(report.name)
+        if session_stage_id is not None:
+            sub_entry = report.contents.get("total_recorded_substitutions", 0)
+            substitutions_by_stage[session_stage_id] = sub_entry.get("count", 0) if isinstance(sub_entry, dict) else sub_entry
+
+    if not successes_by_stage and not failures_by_stage:
+        return
+
+    sorted_stages = sorted(set(successes_by_stage) | set(failures_by_stage))
+    console = Console()
+    console.print(_build_error_table(sorted_stages, successes_by_stage, failures_by_stage, substitutions_by_stage))

--- a/tests/required/reportgen/test_error_report.py
+++ b/tests/required/reportgen/test_error_report.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the error detail in the lifecycle reports."""
+
+from unittest.mock import Mock
+
+from inference_perf.apis.base import (
+    ErrorResponseInfo,
+    RequestLifecycleMetric,
+    SessionLifecycleMetric,
+)
+from inference_perf.config.reportgen.config import ReportConfig
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.apis.base import InferenceInfo
+from inference_perf.reportgen.base import ReportGenerator, summarize_requests
+
+
+PERCENTILES = [50.0, 90.0]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_generator() -> ReportGenerator:
+    """Minimal ReportGenerator with a real ReportConfig (no live clients)."""
+    config = Mock()
+    config.report = ReportConfig()
+    return ReportGenerator(
+        metrics_client=None,
+        metrics_collector=Mock(),
+        config=config,
+    )
+
+
+def _req(
+    *, error: ErrorResponseInfo | None = None, session_id: str | None = None, stage_id: int = 0
+) -> RequestLifecycleMetric:
+    return RequestLifecycleMetric(
+        stage_id=stage_id,
+        session_id=session_id,
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="prompt",
+        info=InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=10))),
+        error=error,
+    )
+
+
+def _sess(
+    *,
+    session_id: str = "s1",
+    success: bool | None = True,
+    error: ErrorResponseInfo | None = None,
+    n_recorded_substitutions: int | None = None,
+    recorded_substitution_event_ids: list[str] | None = None,
+) -> SessionLifecycleMetric:
+    return SessionLifecycleMetric(
+        session_id=session_id,
+        stage_id=0,
+        file_path="trace.json",
+        start_time=0.0,
+        end_time=1.0,
+        duration_sec=1.0,
+        num_events=3,
+        num_events_completed=3,
+        success=success,
+        error=error,
+        n_recorded_substitutions=n_recorded_substitutions,
+        recorded_substitution_event_ids=recorded_substitution_event_ids,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Request-lifecycle failures.by_label
+# ---------------------------------------------------------------------------
+
+
+class TestRequestFailuresByLabel:
+    def test_all_success_empty_by_label(self) -> None:
+        summary = summarize_requests([_req(), _req()], PERCENTILES)
+        assert summary.successes["count"] == 2
+        assert summary.failures["count"] == 0
+        assert summary.failures["by_label"] == {}
+
+    def test_mixed_errors_bucketed(self) -> None:
+        err = ErrorResponseInfo(error_type="HTTP Error 429", error_msg="rate limit exceeded")
+        summary = summarize_requests([_req(), _req(error=err), _req(error=err)], PERCENTILES)
+        assert summary.successes["count"] == 1
+        assert summary.failures["count"] == 2
+        bucket = summary.failures["by_label"]["429 - Rate Limit"]
+        assert bucket["count"] == 2
+        # The two failures share an identical message, so they merge into one entry.
+        assert len(bucket["messages"]) == 1
+        assert bucket["messages"][0]["message"] == "rate limit exceeded"
+
+    def test_labels_sorted_by_descending_count(self) -> None:
+        rate = ErrorResponseInfo(error_type="HTTP Error 429", error_msg="rate limit")
+        server = ErrorResponseInfo(error_type="HTTP Error 500", error_msg="Internal Server Error")
+        # 3 x 500, 1 x 429
+        metrics = [_req(error=server), _req(error=server), _req(error=server), _req(error=rate)]
+        summary = summarize_requests(metrics, PERCENTILES)
+        labels = list(summary.failures["by_label"].keys())
+        assert labels[0] == "500 - Internal Server Error"
+
+    def test_messages_capped_by_max_error_messages(self) -> None:
+        # Distinct messages so the cap on distinct messages is what limits the list.
+        metrics = [
+            _req(error=ErrorResponseInfo(error_type="HTTP Error 500", error_msg=f"Internal Server Error {i}"))
+            for i in range(5)
+        ]
+        summary = summarize_requests(metrics, PERCENTILES, max_error_messages=2)
+        bucket = list(summary.failures["by_label"].values())[0]
+        assert bucket["count"] == 5
+        assert len(bucket["messages"]) == 2  # capped on distinct messages
+
+    def test_session_id_attached_to_messages(self) -> None:
+        err = ErrorResponseInfo(error_type="HTTP Error 500", error_msg="boom")
+        summary = summarize_requests([_req(error=err, session_id="s7")], PERCENTILES)
+        bucket = list(summary.failures["by_label"].values())[0]
+        assert bucket["messages"][0]["session_ids"] == ["s7"]
+
+    def test_identical_messages_merged_with_session_ids(self) -> None:
+        err = ErrorResponseInfo(error_type="HTTP Error 500", error_msg="boom")
+        summary = summarize_requests(
+            [_req(error=err, session_id="s1"), _req(error=err, session_id="s2"), _req(error=err, session_id="s3")],
+            PERCENTILES,
+        )
+        bucket = list(summary.failures["by_label"].values())[0]
+        assert bucket["count"] == 3
+        assert len(bucket["messages"]) == 1
+        assert bucket["messages"][0]["message"] == "boom"
+        assert bucket["messages"][0]["session_ids"] == ["s1", "s2", "s3"]
+
+
+# ---------------------------------------------------------------------------
+# Session-lifecycle total_recorded_substitutions
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSubstitutions:
+    def test_substitutions_count_and_messages(self) -> None:
+        gen = _make_generator()
+        sessions = [
+            _sess(session_id="s1", n_recorded_substitutions=2, recorded_substitution_event_ids=["e1", "e2"]),
+            _sess(session_id="s2", n_recorded_substitutions=3, recorded_substitution_event_ids=["e3", "e4", "e5"]),
+            _sess(session_id="s3", n_recorded_substitutions=0),
+        ]
+        summary = gen.summarize_sessions(sessions, PERCENTILES)
+        subs = summary["total_recorded_substitutions"]
+        assert subs["count"] == 5  # 2 + 3
+        assert summary["sessions_with_recorded_substitution"] == 2  # s1, s2
+        ids = {sid for m in subs["messages"] for sid in m["session_ids"]}
+        assert ids == {"s1", "s2"}
+
+    def test_no_substitutions_zero_count_no_messages(self) -> None:
+        gen = _make_generator()
+        summary = gen.summarize_sessions([_sess(session_id="s1"), _sess(session_id="s2")], PERCENTILES)
+        subs = summary["total_recorded_substitutions"]
+        assert subs["count"] == 0
+        assert subs["messages"] == []
+
+    def test_substitution_messages_capped(self) -> None:
+        gen = _make_generator()
+        sessions = [
+            _sess(session_id=f"s{i}", n_recorded_substitutions=1, recorded_substitution_event_ids=[f"e{i}"]) for i in range(5)
+        ]
+        summary = gen.summarize_sessions(sessions, PERCENTILES, max_error_messages=2)
+        subs = summary["total_recorded_substitutions"]
+        assert subs["count"] == 5
+        assert len(subs["messages"]) == 2  # capped

--- a/tests/required/reportgen/test_failure_reporting.py
+++ b/tests/required/reportgen/test_failure_reporting.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the error detail in the lifecycle reports."""
+
+from unittest.mock import Mock
+
+from inference_perf.apis.base import (
+    ErrorResponseInfo,
+    RequestLifecycleMetric,
+    SessionLifecycleMetric,
+)
+from inference_perf.config.reportgen.config import ReportConfig
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.apis.base import InferenceInfo
+from inference_perf.reportgen.base import ReportGenerator, summarize_requests
+
+
+PERCENTILES = [50.0, 90.0]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_generator() -> ReportGenerator:
+    """Minimal ReportGenerator with a real ReportConfig (no live clients)."""
+    config = Mock()
+    config.report = ReportConfig()
+    return ReportGenerator(
+        metrics_client=None,
+        metrics_collector=Mock(),
+        config=config,
+    )
+
+
+def _req(
+    *, error: ErrorResponseInfo | None = None, session_id: str | None = None, stage_id: int = 0
+) -> RequestLifecycleMetric:
+    return RequestLifecycleMetric(
+        stage_id=stage_id,
+        session_id=session_id,
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="prompt",
+        info=InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=10))),
+        error=error,
+    )
+
+
+def _sess(
+    *,
+    session_id: str = "s1",
+    success: bool | None = True,
+    error: ErrorResponseInfo | None = None,
+    n_recorded_substitutions: int | None = None,
+    recorded_substitution_event_ids: list[str] | None = None,
+) -> SessionLifecycleMetric:
+    return SessionLifecycleMetric(
+        session_id=session_id,
+        stage_id=0,
+        file_path="trace.json",
+        start_time=0.0,
+        end_time=1.0,
+        duration_sec=1.0,
+        num_events=3,
+        num_events_completed=3,
+        success=success,
+        error=error,
+        n_recorded_substitutions=n_recorded_substitutions,
+        recorded_substitution_event_ids=recorded_substitution_event_ids,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Request-lifecycle failures.by_label
+# ---------------------------------------------------------------------------
+
+
+class TestRequestFailuresByLabel:
+    def test_all_success_empty_by_label(self) -> None:
+        summary = summarize_requests([_req(), _req()], PERCENTILES)
+        assert summary.successes["count"] == 2
+        assert summary.failures["count"] == 0
+        assert summary.failures["by_label"] == {}
+
+    def test_mixed_errors_bucketed(self) -> None:
+        err = ErrorResponseInfo(error_type="HTTP Error 429", error_msg="rate limit exceeded")
+        summary = summarize_requests([_req(), _req(error=err), _req(error=err)], PERCENTILES)
+        assert summary.successes["count"] == 1
+        assert summary.failures["count"] == 2
+        bucket = summary.failures["by_label"]["429 - Rate Limit"]
+        assert bucket["count"] == 2
+        # The two failures share an identical message, so they merge into one entry.
+        assert len(bucket["messages"]) == 1
+        assert bucket["messages"][0]["message"] == "rate limit exceeded"
+
+    def test_labels_sorted_by_descending_count(self) -> None:
+        rate = ErrorResponseInfo(error_type="HTTP Error 429", error_msg="rate limit")
+        server = ErrorResponseInfo(error_type="HTTP Error 500", error_msg="Internal Server Error")
+        # 3 x 500, 1 x 429
+        metrics = [_req(error=server), _req(error=server), _req(error=server), _req(error=rate)]
+        summary = summarize_requests(metrics, PERCENTILES)
+        labels = list(summary.failures["by_label"].keys())
+        assert labels[0] == "500 - Internal Server Error"
+
+    def test_messages_capped_by_max_error_messages(self) -> None:
+        # Distinct messages so the cap on distinct messages is what limits the list.
+        metrics = [
+            _req(error=ErrorResponseInfo(error_type="HTTP Error 500", error_msg=f"Internal Server Error {i}"))
+            for i in range(5)
+        ]
+        summary = summarize_requests(metrics, PERCENTILES, max_error_messages=2)
+        bucket = list(summary.failures["by_label"].values())[0]
+        assert bucket["count"] == 5
+        assert len(bucket["messages"]) == 2  # capped on distinct messages
+
+    def test_session_id_attached_to_messages(self) -> None:
+        err = ErrorResponseInfo(error_type="HTTP Error 500", error_msg="boom")
+        summary = summarize_requests([_req(error=err, session_id="s7")], PERCENTILES)
+        bucket = list(summary.failures["by_label"].values())[0]
+        assert bucket["messages"][0]["session_ids"] == ["s7"]
+
+    def test_identical_messages_merged_with_session_ids(self) -> None:
+        err = ErrorResponseInfo(error_type="HTTP Error 500", error_msg="boom")
+        summary = summarize_requests(
+            [_req(error=err, session_id="s1"), _req(error=err, session_id="s2"), _req(error=err, session_id="s3")],
+            PERCENTILES,
+        )
+        bucket = list(summary.failures["by_label"].values())[0]
+        assert bucket["count"] == 3
+        assert len(bucket["messages"]) == 1
+        assert bucket["messages"][0]["message"] == "boom"
+        assert bucket["messages"][0]["session_ids"] == ["s1", "s2", "s3"]
+
+
+# ---------------------------------------------------------------------------
+# Session-lifecycle total_recorded_substitutions
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSubstitutions:
+    def test_substitutions_count_and_messages(self) -> None:
+        gen = _make_generator()
+        sessions = [
+            _sess(session_id="s1", n_recorded_substitutions=2, recorded_substitution_event_ids=["e1", "e2"]),
+            _sess(session_id="s2", n_recorded_substitutions=3, recorded_substitution_event_ids=["e3", "e4", "e5"]),
+            _sess(session_id="s3", n_recorded_substitutions=0),
+        ]
+        summary = gen.summarize_sessions(sessions, PERCENTILES)
+        subs = summary["total_recorded_substitutions"]
+        assert subs["count"] == 5  # 2 + 3
+        assert summary["sessions_with_recorded_substitution"] == 2  # s1, s2
+        ids = {sid for m in subs["messages"] for sid in m["session_ids"]}
+        assert ids == {"s1", "s2"}
+
+    def test_no_substitutions_zero_count_no_messages(self) -> None:
+        gen = _make_generator()
+        summary = gen.summarize_sessions([_sess(session_id="s1"), _sess(session_id="s2")], PERCENTILES)
+        subs = summary["total_recorded_substitutions"]
+        assert subs["count"] == 0
+        assert subs["messages"] == []
+
+    def test_substitution_messages_capped(self) -> None:
+        gen = _make_generator()
+        sessions = [
+            _sess(session_id=f"s{i}", n_recorded_substitutions=1, recorded_substitution_event_ids=[f"e{i}"]) for i in range(5)
+        ]
+        summary = gen.summarize_sessions(sessions, PERCENTILES, max_error_messages=2)
+        subs = summary["total_recorded_substitutions"]
+        assert subs["count"] == 5
+        assert len(subs["messages"]) == 2  # capped

--- a/tests/required/reportgen/test_lifecycle_report_shape.py
+++ b/tests/required/reportgen/test_lifecycle_report_shape.py
@@ -17,7 +17,7 @@ that should be populated when a mix of multimodal requests is observed."""
 import typing
 from unittest.mock import Mock
 
-from inference_perf.apis import InferenceInfo, StreamedResponseMetrics
+from inference_perf.apis import ErrorResponseInfo, InferenceInfo, StreamedResponseMetrics
 from inference_perf.payloads import (
     RequestMetrics,
     Text,
@@ -214,7 +214,8 @@ def test_lifecycle_report_shape_with_failures() -> None:
     failure.start_time = 1.0
     failure.end_time = 1.2
     failure.scheduled_time = 1.0
-    failure.error = Mock()
+    failure.error = ErrorResponseInfo(error_type="HTTP Error 500", error_msg="Internal Server Error")
+    failure.session_id = None
     failure.ttft_slo_sec = None
     failure.tpot_slo_sec = None
     failure.request_data = "bad"
@@ -230,3 +231,4 @@ def test_lifecycle_report_shape_with_failures() -> None:
     assert report["failures"]["count"] == 1
     _assert_summary(report["failures"]["request_latency"])
     _assert_summary(report["failures"]["prompt_len"])
+    assert report["failures"]["by_label"]["500 - Internal Server Error"]["count"] == 1


### PR DESCRIPTION
## What

Adds structured failure detail to the existing lifecycle reports and a CLI error summary table. Error bucketing is folded directly into the reports that already exist — no new report files are introduced.

---

## Request lifecycle

**Files:** `stage_N_lifecycle_metrics.json` / `summary_lifecycle_metrics.json`

The `failures` block gains a `by_label` breakdown — errors grouped by a concise label (HTTP status code + semantic label), with capped per-label message samples. The exact error count is always preserved regardless of the cap.

```json
{
  "successes": { "count": 5, ... },
  "failures": {
    "count": 2,
    "request_latency": { "mean": 1.2, ... },
    "prompt_len": { "mean": 128, ... },
    "by_label": {
      "500 - Internal Server Error": {
        "count": 1,
        "messages": [
          { "message": "1 validation error for CompletionRequest ...", "session_ids": ["trace42_..."] }
        ]
      },
      "429 - Rate Limit": {
        "count": 1,
        "messages": [...]
      }
    }
  }
}
```

## Session lifecycle

**File:** `stage_N_session_lifecycle_metrics.json`

`total_recorded_substitutions` changes from a plain integer to an object, attaching capped example messages to the count. Sessions that succeeded via malformed tool-call substitution are surfaced here rather than silently counted as clean successes.

```json
{
  "total_recorded_substitutions": {
    "count": 3,
    "messages": [
      { "message": "substitutions=1 event_ids=['event_008_...']", "session_ids": ["trace1215_..."] }
    ]
  }
}
```

## Config

A new `max_error_messages` field (default 100) on RequestLifecycleMetricsReportConfig caps the number of distinct message samples stored per error label. The true count is always exact.

```
report:
  request_lifecycle:
    max_error_messages: 100
```

## CLI
`print_summary_table` now calls `print_error_summary_table`, which joins `stage_N_lifecycle_metrics `(failures/by_label) with `stage_N_session_lifecycle_metrics` (substitutions) to render a Rich table at run end — columns are the union of all error labels across stages, color-coded red/yellow/green.

<img width="938" height="110" alt="Screenshot 2026-07-12 at 12 15 21" src="https://github.com/user-attachments/assets/51dab6dd-3756-4b34-aa4e-733303c90617" />

Unit tests in `tests/required/reportgen/test_error_report.py` cover:

* All-success path (empty by_label)
* Mixed HTTP error bucketing and label ordering by descending count
* max_error_messages cap behavior
* Session IDs attached to message entries; identical messages merged
* Substitution count + messages structure
* Zero-substitution path

`tests/required/reportgen/test_lifecycle_report_shape.py` verifies `failures.by_label` is present and correctly populated in the shaped output.

Verified clean against ruff and mypy --strict.