### PR TITLE
chore: respect `use_server_output_tokens` for non-streaming + metrics

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -247,7 +247,7 @@ report:
     per_adapter: false        # Generate metrics grouped by LoRA adapter
     per_adapter_stage: false  # Generate metrics grouped by adapter and stage
     percentiles: [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9] # List of percentiles to calculate
-    use_server_output_tokens: false # Normalize TPOT/NTPOT by the server's usage.completion_tokens instead of the client re-tokenized count (both counts stay reported as output_tokens/output_len)
+    use_server_output_tokens: false # Treat the server's usage.completion_tokens as the source of truth for output tokens.
   prometheus:
     summary: true             # Include Prometheus metrics summary
     per_stage: false          # Disable Prometheus stage breakdown

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -23,6 +23,9 @@ from inference_perf.config import APIConfig, APIType
 
 class ResponseMetrics(BaseModel):
     output_tokens: int = 0
+    # Last-seen `usage` dict reported by the server (streaming: the trailing
+    # usage chunk; non-streaming: the response body's `usage`).
+    server_usage: Optional[dict[str, Any]] = None
 
 
 class UnaryResponseMetrics(ResponseMetrics):
@@ -33,7 +36,6 @@ class StreamedResponseMetrics(ResponseMetrics):
     response_chunks: List[str] = []
     chunk_times: List[float] = []
     output_token_times: List[float] = []
-    server_usage: Optional[dict[str, Any]] = None
 
 
 class InferenceInfo(BaseModel):

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -569,6 +569,6 @@ class ChatCompletionAPIData(InferenceAPIData):
         output_len = tokenizer.count_tokens(output_text)
         return InferenceInfo(
             request_metrics=self._build_request_metrics(prompt_len, output_len),
-            response_metrics=UnaryResponseMetrics(output_tokens=output_len),
+            response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=data.get("usage")),
             lora_adapter=lora_adapter,
         )

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -86,6 +86,6 @@ class CompletionAPIData(InferenceAPIData):
             self.model_response = output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
-                response_metrics=UnaryResponseMetrics(output_tokens=output_len),
+                response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=data.get("usage")),
                 lora_adapter=lora_adapter,
             )

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -23,8 +23,6 @@ class RequestLifecycleMetricsReportConfig(BaseModel):
     per_adapter: Optional[bool] = True
     per_adapter_stage: Optional[bool] = False
     percentiles: List[float] = [0.1, 1, 5, 10, 25, 50, 75, 90, 95, 99, 99.9]
-    # Normalize the per-output-token latency metrics (TPOT, NTPOT) by the server's
-    # reported usage.completion_tokens instead of the client-side re-tokenized count.
     use_server_output_tokens: bool = False
 
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -77,7 +77,7 @@ def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric], percenti
 
     for metric in metrics:
         response_metrics = metric.info.response_metrics
-        server_usage = response_metrics.server_usage if isinstance(response_metrics, StreamedResponseMetrics) else None
+        server_usage = response_metrics.server_usage if response_metrics else None
         prompt_tokens = server_usage.get("prompt_tokens") if server_usage else metric.info.request_metrics.text.input_tokens
         prompt_tokens_details = server_usage.get("prompt_tokens_details", {}) if server_usage else {}
 
@@ -110,7 +110,7 @@ def summarize_output_token_usage(metrics: List[RequestLifecycleMetric], percenti
 
     for metric in metrics:
         response_metrics = metric.info.response_metrics
-        server_usage = response_metrics.server_usage if isinstance(response_metrics, StreamedResponseMetrics) else None
+        server_usage = response_metrics.server_usage if response_metrics else None
         completion_tokens = (
             server_usage.get("completion_tokens")
             if server_usage
@@ -135,7 +135,7 @@ def effective_output_tokens(response_metrics: Optional[ResponseMetrics], use_ser
     """
     if response_metrics is None:
         return 0
-    if use_server_output_tokens and isinstance(response_metrics, StreamedResponseMetrics) and response_metrics.server_usage:
+    if use_server_output_tokens and response_metrics.server_usage:
         completion_tokens = response_metrics.server_usage.get("completion_tokens")
         if completion_tokens:
             return int(completion_tokens)
@@ -157,6 +157,7 @@ def calculate_goodput_metrics(
     ntpot_values: List[float],
     request_latency_values: List[float],
     itl_values: List[Optional[float]],
+    use_server_output_tokens: bool = False,
 ) -> Optional[dict[str, Any]]:
     has_constraints = False
     if goodput_config and goodput_config.constraints:
@@ -238,11 +239,7 @@ def calculate_goodput_metrics(
         if is_good:
             good_requests_count += 1
             in_tokens = m.info.request_metrics.text.input_tokens
-            out_tokens = (
-                m.info.response_metrics.output_tokens
-                if m.info.response_metrics and m.info.response_metrics.output_tokens is not None
-                else 0
-            )
+            out_tokens = effective_output_tokens(m.info.response_metrics, use_server_output_tokens)
             good_total_tokens += in_tokens + out_tokens
 
     goodput_percentage = (good_requests_count / total * 100) if total > 0 else 0.0
@@ -563,7 +560,14 @@ def summarize_requests(
 
     # --- Calculate Goodput Metrics ---
     goodput_metrics = calculate_goodput_metrics(
-        all_successful, goodput_config, ttft_values, tpot_values, ntpot_values, request_latency_values, itl_values
+        all_successful,
+        goodput_config,
+        ttft_values,
+        tpot_values,
+        ntpot_values,
+        request_latency_values,
+        itl_values,
+        use_server_output_tokens=use_server_output_tokens,
     )
 
     # --- Filter lists for summarization (remove Nones) ---
@@ -608,10 +612,7 @@ def summarize_requests(
                 else 0.0
             ),
             "output_tokens_per_sec": (
-                sum(
-                    safe_float(x.info.response_metrics.output_tokens) if x.info.response_metrics else 0.0
-                    for x in all_successful
-                )
+                sum(effective_output_tokens(x.info.response_metrics, use_server_output_tokens) for x in all_successful)
                 / total_time
                 if total_time > 0
                 else 0.0
@@ -619,7 +620,7 @@ def summarize_requests(
             "total_tokens_per_sec": (
                 sum(
                     safe_float(x.info.request_metrics.text.input_tokens)
-                    + (safe_float(x.info.response_metrics.output_tokens) if x.info.response_metrics else 0.0)
+                    + effective_output_tokens(x.info.response_metrics, use_server_output_tokens)
                     for x in all_successful
                 )
                 / total_time
@@ -842,7 +843,7 @@ class ReportGenerator:
         # Session-level reports (OTel agentic workloads only)
         if self.session_metrics_collector and report_config.session_lifecycle:
             session_metrics = self.session_metrics_collector.get_metrics()
-            self._enrich_sessions(session_metrics, request_metrics)
+            self._enrich_sessions(session_metrics, request_metrics, use_server_output_tokens)
             session_reports = self.generate_session_reports(
                 session_metrics,
                 report_config.session_lifecycle,
@@ -906,6 +907,7 @@ class ReportGenerator:
         self,
         session_metrics: List[SessionLifecycleMetric],
         request_metrics: List[RequestLifecycleMetric],
+        use_server_output_tokens: bool = False,
     ) -> None:
         """Aggregate per-request token totals and error status onto each session.
 
@@ -921,7 +923,7 @@ class ReportGenerator:
                 inp, out = token_by_session[m.session_id]
                 token_by_session[m.session_id] = (
                     inp + m.info.request_metrics.text.input_tokens,
-                    out + (m.info.response_metrics.output_tokens if m.info.response_metrics else 0),
+                    out + effective_output_tokens(m.info.response_metrics, use_server_output_tokens),
                 )
                 if m.session_id not in error_by_session and m.error is not None:
                     error_by_session[m.session_id] = m.error

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -1,6 +1,12 @@
 import pytest
-from inference_perf.reportgen.base import summarize_requests
-from inference_perf.apis.base import RequestLifecycleMetric, InferenceInfo, StreamedResponseMetrics
+from inference_perf.reportgen.base import summarize_requests, ReportGenerator
+from inference_perf.apis.base import (
+    RequestLifecycleMetric,
+    InferenceInfo,
+    StreamedResponseMetrics,
+    UnaryResponseMetrics,
+    SessionLifecycleMetric,
+)
 from inference_perf.config.reportgen.config import RequestLifecycleMetricsReportConfig
 from inference_perf.payloads import RequestMetrics, Text
 
@@ -332,6 +338,125 @@ def test_use_server_output_tokens_flag_switches_tpot_ntpot_divisor() -> None:
     assert server.successes["output_tokens"] == pytest.approx(
         {"total": 5.0, "mean": 5.0, "min": 5.0, "max": 5.0, "median": 5.0}
     )
+
+
+def test_use_server_output_tokens_switches_output_throughput() -> None:
+    """The aggregate output/total tokens_per_sec honor the flag: server
+    completion_tokens when on, client re-tokenized output_tokens when off."""
+
+    def make_metric() -> RequestLifecycleMetric:
+        info = InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=10,  # client re-tokenized count
+                output_token_times=[1.0, 3.0],
+                server_usage={"completion_tokens": 5},  # exact server count
+            ),
+        )
+        return RequestLifecycleMetric(
+            scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None
+        )
+
+    # total_time = 10.0s (max end - min start).
+    default = summarize_requests([make_metric()], [50])
+    assert default.successes["throughput"]["output_tokens_per_sec"] == pytest.approx(10.0 / 10.0)
+    assert default.successes["throughput"]["total_tokens_per_sec"] == pytest.approx((5.0 + 10.0) / 10.0)
+
+    server = summarize_requests([make_metric()], [50], use_server_output_tokens=True)
+    assert server.successes["throughput"]["output_tokens_per_sec"] == pytest.approx(5.0 / 10.0)
+    assert server.successes["throughput"]["total_tokens_per_sec"] == pytest.approx((5.0 + 5.0) / 10.0)
+
+
+def test_use_server_output_tokens_works_for_non_streaming() -> None:
+    """The flag applies to unary (non-streaming) responses too: NTPOT and the
+    output throughput use the server's completion_tokens when it's available."""
+
+    def make_metric() -> RequestLifecycleMetric:
+        info = InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+            response_metrics=UnaryResponseMetrics(
+                output_tokens=10,  # client re-tokenized count
+                server_usage={"completion_tokens": 5},  # exact server count
+            ),
+        )
+        return RequestLifecycleMetric(
+            scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None
+        )
+
+    # NTPOT = (end - start) / output_tokens over all successful requests.
+    default = summarize_requests([make_metric()], [50])
+    assert default.successes["latency"]["normalized_time_per_output_token"]["mean"] == pytest.approx(10.0 / 10.0)
+    assert default.successes["throughput"]["output_tokens_per_sec"] == pytest.approx(10.0 / 10.0)
+
+    server = summarize_requests([make_metric()], [50], use_server_output_tokens=True)
+    assert server.successes["latency"]["normalized_time_per_output_token"]["mean"] == pytest.approx(10.0 / 5.0)
+    assert server.successes["throughput"]["output_tokens_per_sec"] == pytest.approx(5.0 / 10.0)
+
+
+def test_use_server_output_tokens_switches_goodput_token_total() -> None:
+    """Goodput's token_goodput counts server completion_tokens when the flag is on."""
+    from inference_perf.config.reportgen.config import GoodputConfig
+
+    def make_metric() -> RequestLifecycleMetric:
+        info = InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=10,  # client count
+                output_token_times=[1.0, 3.0],
+                server_usage={"completion_tokens": 5},  # server count
+            ),
+        )
+        return RequestLifecycleMetric(
+            scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="r", info=info, error=None
+        )
+
+    # A lenient latency constraint keeps the single request "good"; benchmark
+    # window is 10s, so token_goodput == good_total_tokens / 10.
+    goodput_config = GoodputConfig(constraints={"request_latency": 100.0})
+
+    default = summarize_requests([make_metric()], [50], goodput_config=goodput_config)
+    assert default.successes["goodput_metrics"]["token_goodput"] == pytest.approx((5.0 + 10.0) / 10.0)
+
+    server = summarize_requests([make_metric()], [50], goodput_config=goodput_config, use_server_output_tokens=True)
+    assert server.successes["goodput_metrics"]["token_goodput"] == pytest.approx((5.0 + 5.0) / 10.0)
+
+
+def test_enrich_sessions_honors_use_server_output_tokens() -> None:
+    """Per-session total_output_tokens uses the server count when the flag is on."""
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+        response_metrics=StreamedResponseMetrics(output_tokens=10, server_usage={"completion_tokens": 5}),
+    )
+    request_metric = RequestLifecycleMetric(
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=10.0,
+        request_data="r",
+        info=info,
+        error=None,
+        session_id="s1",
+    )
+
+    def make_session() -> SessionLifecycleMetric:
+        return SessionLifecycleMetric(
+            session_id="s1",
+            stage_id=0,
+            file_path="s1.json",
+            start_time=0.0,
+            end_time=10.0,
+            duration_sec=10.0,
+            num_events=1,
+            num_events_completed=1,
+        )
+
+    # _enrich_sessions doesn't use `self`, so call it unbound with a dummy self.
+    default_session = make_session()
+    ReportGenerator._enrich_sessions(None, [default_session], [request_metric])  # type: ignore[arg-type]
+    assert default_session.total_output_tokens == 10
+
+    server_session = make_session()
+    ReportGenerator._enrich_sessions(None, [server_session], [request_metric], use_server_output_tokens=True)  # type: ignore[arg-type]
+    assert server_session.total_output_tokens == 5
 
 
 def test_use_server_output_tokens_falls_back_without_usage() -> None:


### PR DESCRIPTION
Extend the config option `use_server_output_tokens` introduced in https://github.com/kubernetes-sigs/inference-perf/pull/577 to apply to non-streaming case + other output metrics (output tok/s, goodput).