### PR TITLE
fix: bound tokenizer loading with a configurable deadline

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -272,4 +272,5 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--tokenizer.pretrained_model_name_or_path` | str | Matches tokenizer.pretrained_model_name_or_path in config |
 | `--tokenizer.trust_remote_code` | boolean | Matches tokenizer.trust_remote_code in config |
 | `--tokenizer.token` | str | Matches tokenizer.token in config |
+| `--tokenizer.load_timeout` | float | Matches tokenizer.load_timeout in config |
 | `--circuit_breakers` | JSON | Matches circuit_breakers in config |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -396,5 +396,5 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--tokenizer.pretrained_model_name_or_path` | str | HuggingFace model name or local path of the tokenizer to load. |
 | `--tokenizer.trust_remote_code` | boolean | Allow the tokenizer to execute code from its repository when loading. |
 | `--tokenizer.token` | str | HuggingFace access token used to download the tokenizer. |
-| `--tokenizer.load_timeout` | float | Deadline in seconds for loading the tokenizer, including any download from Hugging Face Hub. None disables the deadline. |
+| `--tokenizer.load_timeout` | float | Deadline in seconds for loading the tokenizer, including any download from Hugging Face Hub. Null disables the deadline. |
 | `--circuit_breakers` | JSON | Circuit breakers that stop the run when observed metrics cross configured thresholds. |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -396,4 +396,5 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--tokenizer.pretrained_model_name_or_path` | str | HuggingFace model name or local path of the tokenizer to load. |
 | `--tokenizer.trust_remote_code` | boolean | Allow the tokenizer to execute code from its repository when loading. |
 | `--tokenizer.token` | str | HuggingFace access token used to download the tokenizer. |
+| `--tokenizer.load_timeout` | float | Deadline in seconds for loading the tokenizer, including any download from Hugging Face Hub. None disables the deadline. |
 | `--circuit_breakers` | JSON | Circuit breakers that stop the run when observed metrics cross configured thresholds. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -284,6 +284,9 @@ tokenizer:
   pretrained_model_name_or_path: "model-id"   # Required model path
   trust_remote_code: true                     # Whether to trust custom tokenizer code
   token: ""                                   # HuggingFace access token for private models
+  load_timeout: 300.0                         # Deadline in seconds for loading the tokenizer,
+                                              # including any download from Hugging Face Hub.
+                                              # Set to null to disable. Default: 300.
 ```
 
 ## Full Configuration Examples

--- a/docs/config.md
+++ b/docs/config.md
@@ -321,6 +321,9 @@ tokenizer:
   pretrained_model_name_or_path: "model-id"   # Required model path
   trust_remote_code: true                     # Whether to trust custom tokenizer code
   token: ""                                   # HuggingFace access token for private models
+  load_timeout: 300.0                         # Deadline in seconds for loading the tokenizer,
+                                              # including any download from Hugging Face Hub.
+                                              # Set to null to disable. Default: 300.
 ```
 
 ## Full Configuration Examples

--- a/docs/config.md
+++ b/docs/config.md
@@ -326,6 +326,8 @@ tokenizer:
                                               # Set to null to disable. Default: 300.
 ```
 
+`load_timeout: null` can only be set in a YAML config file; the `--tokenizer.load_timeout` CLI flag parses a float and rejects `null`. The deadline applies to each tokenizer construction independently; a run constructs a tokenizer in several stages (data generation, the model server client, report generation), so the worst-case total wait is a small multiple of `load_timeout`.
+
 ## Full Configuration Examples
 
 ### Minimal Configuration

--- a/inference_perf/config/utils/config.py
+++ b/inference_perf/config/utils/config.py
@@ -20,3 +20,6 @@ class CustomTokenizerConfig(BaseModel):
     pretrained_model_name_or_path: Optional[str] = None
     trust_remote_code: Optional[bool] = None
     token: Optional[str] = None
+    # Deadline in seconds for loading the tokenizer, including any download from
+    # Hugging Face Hub. None disables the deadline.
+    load_timeout: Optional[float] = 300.0

--- a/inference_perf/config/utils/config.py
+++ b/inference_perf/config/utils/config.py
@@ -25,3 +25,8 @@ class CustomTokenizerConfig(StrictBaseModel):
         default=None, description="Allow the tokenizer to execute code from its repository when loading."
     )
     token: Optional[str] = Field(default=None, description="HuggingFace access token used to download the tokenizer.")
+    load_timeout: Optional[float] = Field(
+        default=300.0,
+        description="Deadline in seconds for loading the tokenizer, including any download from"
+        " Hugging Face Hub. None disables the deadline.",
+    )

--- a/inference_perf/config/utils/config.py
+++ b/inference_perf/config/utils/config.py
@@ -27,6 +27,8 @@ class CustomTokenizerConfig(StrictBaseModel):
     token: Optional[str] = Field(default=None, description="HuggingFace access token used to download the tokenizer.")
     load_timeout: Optional[float] = Field(
         default=300.0,
+        gt=0,
+        allow_inf_nan=False,
         description="Deadline in seconds for loading the tokenizer, including any download from"
-        " Hugging Face Hub. None disables the deadline.",
+        " Hugging Face Hub. Null disables the deadline.",
     )

--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -65,6 +65,9 @@ def _load_tokenizer_with_deadline(config: CustomTokenizerConfig) -> PreTrainedTo
     logger.info("Loading tokenizer '%s'", config.pretrained_model_name_or_path)
     thread = threading.Thread(target=load, name="tokenizer-load", daemon=True)
     thread.start()
+    # load_timeout=None must reach join() untouched: join(timeout=None) waits
+    # indefinitely, which is how null disables the deadline. Coercing None to a
+    # number (join(timeout=0) returns immediately) would fail every load.
     thread.join(timeout=config.load_timeout)
     if thread.is_alive():
         raise TimeoutError(

--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+import threading
+
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from transformers.tokenization_utils_base import VERY_LARGE_INTEGER
 from inference_perf.config import CustomTokenizerConfig
 
+logger = logging.getLogger(__name__)
+
 
 class CustomTokenizer:
     def __init__(self, config: CustomTokenizerConfig) -> None:
-        self.tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
-            config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
-        )
+        self.tokenizer: PreTrainedTokenizerBase = _load_tokenizer_with_deadline(config)
 
     def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         if text == "":
@@ -40,3 +43,38 @@ class CustomTokenizer:
 
     def get_tokenizer(self) -> PreTrainedTokenizerBase:
         return self.tokenizer
+
+
+def _load_tokenizer_with_deadline(config: CustomTokenizerConfig) -> PreTrainedTokenizerBase:
+    # AutoTokenizer.from_pretrained downloads tokenizer files from Hugging Face Hub when they
+    # are not cached, and a wedged transfer (e.g. hf_xet hanging on a CDN error instead of
+    # raising) would otherwise block the whole benchmark forever with no visible failure.
+    # Loading in a daemon thread bounds the wait; the stuck thread cannot be cancelled, but it
+    # no longer blocks the process from failing fast or exiting.
+    result: dict[str, PreTrainedTokenizerBase] = {}
+    error: dict[str, BaseException] = {}
+
+    def load() -> None:
+        try:
+            result["tokenizer"] = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
+                config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
+            )
+        except BaseException as e:
+            error["error"] = e
+
+    logger.info("Loading tokenizer '%s'", config.pretrained_model_name_or_path)
+    thread = threading.Thread(target=load, name="tokenizer-load", daemon=True)
+    thread.start()
+    thread.join(timeout=config.load_timeout)
+    if thread.is_alive():
+        raise TimeoutError(
+            f"Loading tokenizer '{config.pretrained_model_name_or_path}' did not finish within "
+            f"{config.load_timeout} seconds. This usually means the download from Hugging Face Hub "
+            "is stuck (network issues or a Hub/CDN outage). Check connectivity to huggingface.co, "
+            "try HF_HUB_DISABLE_XET=1 to surface the underlying download error, pre-populate the "
+            "HF cache, or point 'tokenizer.pretrained_model_name_or_path' at a local directory. "
+            "The deadline is configurable via 'tokenizer.load_timeout' (null disables it)."
+        )
+    if "error" in error:
+        raise error["error"]
+    return result["tokenizer"]

--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -81,6 +81,9 @@ def _load_tokenizer_with_deadline(config: CustomTokenizerConfig) -> PreTrainedTo
     logger.info("Loading tokenizer '%s'", config.pretrained_model_name_or_path)
     thread = threading.Thread(target=load, name="tokenizer-load", daemon=True)
     thread.start()
+    # load_timeout=None must reach join() untouched: join(timeout=None) waits
+    # indefinitely, which is how null disables the deadline. Coercing None to a
+    # number (join(timeout=0) returns immediately) would fail every load.
     thread.join(timeout=config.load_timeout)
     if thread.is_alive():
         raise TimeoutError(

--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -66,16 +66,19 @@ def _load_tokenizer_with_deadline(config: CustomTokenizerConfig) -> PreTrainedTo
     # are not cached, and a wedged transfer (e.g. hf_xet hanging on a CDN error instead of
     # raising) would otherwise block the whole benchmark forever with no visible failure.
     # Loading in a daemon thread bounds the wait; the stuck thread cannot be cancelled, but it
-    # no longer blocks the process from failing fast or exiting.
+    # no longer blocks the process from failing fast or exiting. The deadline only bounds loads
+    # blocked in operations that release the GIL (network and file I/O, the hang class this
+    # targets); a loader wedged in pure-Python or GIL-holding native code would also starve the
+    # timer thread.
     result: dict[str, PreTrainedTokenizerBase] = {}
-    error: dict[str, BaseException] = {}
+    error: dict[str, Exception] = {}
 
     def load() -> None:
         try:
-            result["tokenizer"] = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
+            result["tokenizer"] = AutoTokenizer.from_pretrained(
                 config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
             )
-        except BaseException as e:
+        except Exception as e:
             error["error"] = e
 
     logger.info("Loading tokenizer '%s'", config.pretrained_model_name_or_path)
@@ -96,4 +99,9 @@ def _load_tokenizer_with_deadline(config: CustomTokenizerConfig) -> PreTrainedTo
         )
     if "error" in error:
         raise error["error"]
+    if "tokenizer" not in result:
+        raise RuntimeError(
+            f"Tokenizer loader thread for '{config.pretrained_model_name_or_path}' exited without "
+            "producing a tokenizer or an error."
+        )
     return result["tokenizer"]

--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -11,16 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+import threading
+
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from transformers.tokenization_utils_base import VERY_LARGE_INTEGER
 from inference_perf.config import CustomTokenizerConfig
 
+logger = logging.getLogger(__name__)
+
 
 class CustomTokenizer:
     def __init__(self, config: CustomTokenizerConfig) -> None:
-        self.tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
-            config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
-        )
+        self.tokenizer: PreTrainedTokenizerBase = _load_tokenizer_with_deadline(config)
 
     def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
         if text == "":
@@ -56,3 +59,38 @@ class CustomTokenizer:
 
     def get_tokenizer(self) -> PreTrainedTokenizerBase:
         return self.tokenizer
+
+
+def _load_tokenizer_with_deadline(config: CustomTokenizerConfig) -> PreTrainedTokenizerBase:
+    # AutoTokenizer.from_pretrained downloads tokenizer files from Hugging Face Hub when they
+    # are not cached, and a wedged transfer (e.g. hf_xet hanging on a CDN error instead of
+    # raising) would otherwise block the whole benchmark forever with no visible failure.
+    # Loading in a daemon thread bounds the wait; the stuck thread cannot be cancelled, but it
+    # no longer blocks the process from failing fast or exiting.
+    result: dict[str, PreTrainedTokenizerBase] = {}
+    error: dict[str, BaseException] = {}
+
+    def load() -> None:
+        try:
+            result["tokenizer"] = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
+                config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
+            )
+        except BaseException as e:
+            error["error"] = e
+
+    logger.info("Loading tokenizer '%s'", config.pretrained_model_name_or_path)
+    thread = threading.Thread(target=load, name="tokenizer-load", daemon=True)
+    thread.start()
+    thread.join(timeout=config.load_timeout)
+    if thread.is_alive():
+        raise TimeoutError(
+            f"Loading tokenizer '{config.pretrained_model_name_or_path}' did not finish within "
+            f"{config.load_timeout} seconds. This usually means the download from Hugging Face Hub "
+            "is stuck (network issues or a Hub/CDN outage). Check connectivity to huggingface.co, "
+            "try HF_HUB_DISABLE_XET=1 to surface the underlying download error, pre-populate the "
+            "HF cache, or point 'tokenizer.pretrained_model_name_or_path' at a local directory. "
+            "The deadline is configurable via 'tokenizer.load_timeout' (null disables it)."
+        )
+    if "error" in error:
+        raise error["error"]
+    return result["tokenizer"]

--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "analysis", "dev", "lint", "otel", "test", "types"]
 strategy = ["inherit_metadata"]
-lock_version = "4.5.0"
-content_hash = "sha256:e3933d2724dfc873315aabb0ed8d439041fcb9a28a15675d15a5b86f37bbe6cd"
+lock_version = "4.5.1"
+content_hash = "sha256:6f331ad3bcf9e9bc5a0135dabcf2347603ee55ce94b266b81896b87807669cb4"
 
 [[metadata.targets]]
 requires_python = ">=3.12"
@@ -2926,6 +2926,20 @@ dependencies = [
 files = [
     {file = "pytest_picked-0.5.1-py3-none-any.whl", hash = "sha256:af65c4763b51dc095ae4bc5073a962406902422ad9629c26d8b01122b677d998"},
     {file = "pytest_picked-0.5.1.tar.gz", hash = "sha256:6634c4356a560a5dc3dba35471865e6eb06bbd356b56b69c540593e9d5620ded"},
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+requires_python = ">=3.7"
+summary = "pytest plugin to abort hanging tests"
+groups = ["dev", "test"]
+dependencies = [
+    "pytest>=7.0.0",
+]
+files = [
+    {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
+    {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "hypothesis>=6.146.0",
     "pytest-asyncio>=1.3.0",
     "pytest-picked",
+    "pytest-timeout>=2.3.0",
     "types-PyYAML>=6.0.0",
 ]
 otel = [
@@ -65,6 +66,7 @@ test = [
     "ipykernel>=6.29.5",
     "pytest-cov>=7.0.0",
     "pytest-xdist>=3.6.0",
+    "pytest-timeout>=2.3.0",
 ]
 types = [
     "types-PyYAML>=6.0.12.20241230",

--- a/tests/required/utils/test_custom_tokenizer.py
+++ b/tests/required/utils/test_custom_tokenizer.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import threading
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from inference_perf.config import CustomTokenizerConfig
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+
+class TestCustomTokenizerLoadDeadline(unittest.TestCase):
+    @patch("inference_perf.utils.custom_tokenizer.AutoTokenizer")
+    def test_load_success(self, mock_auto_tokenizer: MagicMock) -> None:
+        fake_tokenizer = MagicMock()
+        mock_auto_tokenizer.from_pretrained.return_value = fake_tokenizer
+
+        tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="some/model", load_timeout=5.0))
+
+        self.assertIs(tokenizer.get_tokenizer(), fake_tokenizer)
+        mock_auto_tokenizer.from_pretrained.assert_called_once_with("some/model", token=None, trust_remote_code=None)
+
+    @patch("inference_perf.utils.custom_tokenizer.AutoTokenizer")
+    def test_load_error_propagates(self, mock_auto_tokenizer: MagicMock) -> None:
+        mock_auto_tokenizer.from_pretrained.side_effect = OSError("repo not found")
+
+        with self.assertRaises(OSError):
+            CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="some/model", load_timeout=5.0))
+
+    @patch("inference_perf.utils.custom_tokenizer.AutoTokenizer")
+    def test_hung_download_raises_timeout(self, mock_auto_tokenizer: MagicMock) -> None:
+        # Simulate hf_xet wedging mid-download: from_pretrained never returns.
+        release = threading.Event()
+
+        def hang(*args: Any, **kwargs: Any) -> MagicMock:
+            release.wait()
+            return MagicMock()
+
+        mock_auto_tokenizer.from_pretrained.side_effect = hang
+        try:
+            with self.assertRaises(TimeoutError) as ctx:
+                CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="some/model", load_timeout=0.1))
+            self.assertIn("did not finish within 0.1 seconds", str(ctx.exception))
+        finally:
+            release.set()
+
+    def test_default_load_timeout(self) -> None:
+        self.assertEqual(CustomTokenizerConfig().load_timeout, 300.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/utils/test_custom_tokenizer.py
+++ b/tests/required/utils/test_custom_tokenizer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import threading
+import time
 import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -54,6 +55,26 @@ class TestCustomTokenizerLoadDeadline(unittest.TestCase):
             self.assertIn("did not finish within 0.1 seconds", str(ctx.exception))
         finally:
             release.set()
+
+    @patch("inference_perf.utils.custom_tokenizer.AutoTokenizer")
+    def test_null_load_timeout_disables_deadline(self, mock_auto_tokenizer: MagicMock) -> None:
+        # load_timeout=null must mean "no deadline": the load is waited on until
+        # it completes, however long it takes. A regression that coerces None to
+        # a number (e.g. thread.join(timeout=0)) would return with the loader
+        # thread still alive and raise a spurious TimeoutError on every load, so
+        # the slow load below must still succeed.
+        fake_tokenizer = MagicMock()
+
+        def slow_load(*args: Any, **kwargs: Any) -> MagicMock:
+            time.sleep(0.2)
+            return fake_tokenizer
+
+        mock_auto_tokenizer.from_pretrained.side_effect = slow_load
+
+        tokenizer = CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="some/model", load_timeout=None))
+
+        self.assertIs(tokenizer.get_tokenizer(), fake_tokenizer)
+        mock_auto_tokenizer.from_pretrained.assert_called_once_with("some/model", token=None, trust_remote_code=None)
 
     def test_default_load_timeout(self) -> None:
         self.assertEqual(CustomTokenizerConfig().load_timeout, 300.0)

--- a/tests/required/utils/test_custom_tokenizer.py
+++ b/tests/required/utils/test_custom_tokenizer.py
@@ -11,14 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 import threading
 import time
 import unittest
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+from pydantic import ValidationError
+
 from inference_perf.config import CustomTokenizerConfig
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+# If the deadline mechanism is disarmed (e.g. a bare thread.join()), the hung-download
+# test blocks forever; fail the file instead of hanging CI.
+pytestmark = pytest.mark.timeout(30)
 
 
 class TestCustomTokenizerLoadDeadline(unittest.TestCase):
@@ -50,9 +58,13 @@ class TestCustomTokenizerLoadDeadline(unittest.TestCase):
 
         mock_auto_tokenizer.from_pretrained.side_effect = hang
         try:
+            start = time.monotonic()
             with self.assertRaises(TimeoutError) as ctx:
                 CustomTokenizer(CustomTokenizerConfig(pretrained_model_name_or_path="some/model", load_timeout=0.1))
+            elapsed = time.monotonic() - start
             self.assertIn("did not finish within 0.1 seconds", str(ctx.exception))
+            # The timeout must fire near the configured deadline, not merely eventually.
+            self.assertLess(elapsed, 5.0)
         finally:
             release.set()
 
@@ -78,6 +90,22 @@ class TestCustomTokenizerLoadDeadline(unittest.TestCase):
 
     def test_default_load_timeout(self) -> None:
         self.assertEqual(CustomTokenizerConfig().load_timeout, 300.0)
+
+
+class TestLoadTimeoutValidation(unittest.TestCase):
+    def test_accepts_positive_and_null(self) -> None:
+        self.assertEqual(CustomTokenizerConfig(load_timeout=300.0).load_timeout, 300.0)
+        self.assertEqual(CustomTokenizerConfig(load_timeout=0.001).load_timeout, 0.001)
+        self.assertIsNone(CustomTokenizerConfig(load_timeout=None).load_timeout)
+
+    def test_rejects_non_positive_and_non_finite(self) -> None:
+        # 0 and negatives would make thread.join() return immediately, so every
+        # load would surface as a Hub outage; inf and nan raise from
+        # threading internals, bypassing the TimeoutError path. All four must
+        # fail config validation instead.
+        for value in (0, -5, math.inf, math.nan):
+            with self.assertRaises(ValidationError, msg=f"load_timeout={value}"):
+                CustomTokenizerConfig(load_timeout=value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #609

## Problem

`CustomTokenizer` calls `AutoTokenizer.from_pretrained` with no bound on how long it may take. When the tokenizer is not in the local HF cache, this downloads from Hugging Face Hub, and a wedged transfer hangs the whole benchmark forever with no visible failure. We hit this in production when HF's GCP CDN bridge started rejecting signed URLs with 403 and `hf_xet` went silent instead of raising: the bench pod logged "Report files will be stored at ..." and then sat idle for 25+ minutes while the target server received zero traffic.

Every tokenizer path funnels through `CustomTokenizer.__init__`, both the explicit `tokenizer:` config and the tokenizer inferred from the model name by the vLLM/SGLang/TGI clients, so any run with a cold HF cache is exposed.

## Fix

Load the tokenizer in a daemon thread joined with a deadline. On expiry, raise a `TimeoutError` with actionable guidance (check connectivity, try `HF_HUB_DISABLE_XET=1` to surface the underlying download error, pre-populate the HF cache, or point the tokenizer at a local directory). The stuck downloader thread cannot be cancelled, but as a daemon it no longer prevents the process from failing fast and exiting. A log line before loading makes any remaining stall visible in the logs.

The deadline is configurable as `tokenizer.load_timeout` (seconds, default 300, `null` disables it). Tokenizer files are small, so 5 minutes is generous for healthy networks while still converting an indefinite silent hang into a fast, visible error.

## Changes

- `inference_perf/utils/custom_tokenizer.py`: deadline-bounded tokenizer loading
- `inference_perf/config/utils/config.py`: new `load_timeout` field on `CustomTokenizerConfig`
- `docs/config.md`, `docs/cli_flags.md`: document the new field (the latter regenerated via `scripts/sync_cli_flags_doc.py`)
- `tests/required/utils/test_custom_tokenizer.py`: tests for success, error propagation, hung-download-raises-`TimeoutError`, and the default value

## Testing

- New unit tests pass, including one that simulates a never-returning `from_pretrained` and asserts a `TimeoutError` within the deadline
- Full `tests/required` suite passes
- `mypy --strict` clean on the touched files
- `scripts/sync_cli_flags_doc.py --check` passes