### PR TITLE
Add config-driven registry for runtime Prometheus metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,5 +184,8 @@ reports-*/
 # VSCode settings (keep local configurations)
 .vscode/
 
+# Claude Code local settings and worktrees
+.claude/
+
 # Optional live-test per-case reports
 tests/optional/**/output/

--- a/.gitignore
+++ b/.gitignore
@@ -187,5 +187,8 @@ reports-*/
 # VSCode settings (keep local configurations)
 .vscode/
 
+# Claude Code local settings and worktrees
+.claude/
+
 # Optional live-test per-case reports
 tests/optional/**/output/

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Explore detailed documentation for specific topics:
 | **Configuration** | Full YAML configuration schema and options. | [config.md](./docs/config.md) |
 | **CLI Flags** | All command line flags: global options and configuration overrides. | [cli_flags.md](./docs/cli_flags.md) |
 | **Load Generation** | Detailed explanation of load patterns and multi-worker setup. | [loadgen.md](./docs/loadgen.md) |
-| **Metrics** | Definitions of TTFT, TPOT, ITL, etc. | [metrics.md](./docs/metrics.md) |
+| **Collected Metrics** | Definitions of TTFT, TPOT, ITL, etc. | [metrics.md](./docs/metrics.md) |
+| **Emitted Metrics** | Prometheus metrics inference-perf exports about its own runtime. | [runtime_metrics.md](./inference_perf/observability/metrics/runtime_metrics.md) |
 | **Goodput** | How to measure requests meeting SLOs. | [goodput.md](./docs/goodput.md) |
 | **Reports** | Understanding generated JSON reports. | [reports.md](./docs/reports.md) |
 | **OTel Observability** | Instrument benchmark runs with OpenTelemetry tracing to export to Jaeger, Tempo, etc. | [otel_instrumentation.md](./docs/otel_instrumentation.md) |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Explore detailed documentation for specific topics:
 | **Configuration** | Full YAML configuration schema and options. | [config.md](./docs/config.md) |
 | **CLI Flags** | All command line flags: global options and configuration overrides. | [cli_flags.md](./docs/cli_flags.md) |
 | **Load Generation** | Detailed explanation of load patterns and multi-worker setup. | [loadgen.md](./docs/loadgen.md) |
-| **Metrics** | Definitions of TTFT, TPOT, ITL, etc. | [metrics.md](./docs/metrics.md) |
+| **Collected Metrics** | Definitions of TTFT, TPOT, ITL, etc. | [metrics.md](./docs/metrics.md) |
+| **Emitted Metrics** | Prometheus metrics inference-perf exports about its own runtime. | [runtime_metrics.md](./docs/runtime_metrics.md) |
 | **Comparability** | Configuring runs that are comparable with other benchmarking tools. | [comparability.md](./docs/comparability.md) |
 | **Goodput** | How to measure requests meeting SLOs. | [goodput.md](./docs/goodput.md) |
 | **Reports** | Understanding generated JSON reports. | [reports.md](./docs/reports.md) |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,6 +2,8 @@
 
 This document outlines the key metrics used for evaluating performance, their definition and how they are calculated.
 
+For the Prometheus metrics inference-perf exports about its own runtime (as opposed to the benchmark result metrics defined here), see [runtime_metrics.md](../inference_perf/observability/metrics/runtime_metrics.md).
+
 ## Throughput
 
 | Metric | Formula | Unit | Used For

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,6 +2,8 @@
 
 This document outlines the key metrics used for evaluating performance, their definition and how they are calculated.
 
+For the Prometheus metrics inference-perf exports about its own runtime (as opposed to the benchmark result metrics defined here), see [runtime_metrics.md](./runtime_metrics.md).
+
 ## Throughput
 
 | Metric | Formula | Unit | Used For

--- a/docs/runtime_metrics.md
+++ b/docs/runtime_metrics.md
@@ -1,0 +1,10 @@
+# Inference-Perf Runtime Metrics
+
+These are the Prometheus metrics inference-perf can export about its own runtime over an HTTP `/metrics` endpoint. They are distinct from the metrics inference-perf scrapes from the model server under test and from the benchmark result definitions in [metrics.md](./metrics.md).
+
+This document is automatically generated from the metric specs under `inference_perf/observability/metrics/sets/`. Do not edit it by hand; run `pdm run update:runtime-metrics` after changing the specs.
+
+| Metric | Type | Labels | Exported | Description |
+| --- | --- | --- | --- | --- |
+| `inference_perf_run_elapsed_seconds` | Gauge | none | Always | Wall-clock seconds elapsed since the benchmark run started; 0 until the run starts. |
+| `inference_perf_requests_total` | Counter | `stage`, `status` | Always | Request attempts that have completed, by stage and final status. Incremented when the attempt finishes or fails, not when it is sent. |

--- a/inference_perf/client/server_metrics/README.md
+++ b/inference_perf/client/server_metrics/README.md
@@ -2,6 +2,8 @@
 
 This repository provides clients to query performance metrics from various monitoring platforms. Each model server exposes a list of relevant performance metrics, and these clients are designed to retrieve and process that data effectively.
 
+These clients consume metrics from the model server's monitoring stack. For the Prometheus metrics inference-perf itself exports about its own runtime, see [runtime_metrics.md](../../observability/metrics/runtime_metrics.md).
+
 ## Supported Monitoring Platforms
 
 **Available now**:

--- a/inference_perf/client/server_metrics/README.md
+++ b/inference_perf/client/server_metrics/README.md
@@ -2,6 +2,8 @@
 
 This repository provides clients to query performance metrics from various monitoring platforms. Each model server exposes a list of relevant performance metrics, and these clients are designed to retrieve and process that data effectively.
 
+These clients consume metrics from the model server's monitoring stack. For the Prometheus metrics inference-perf itself exports about its own runtime, see [runtime_metrics.md](../../../docs/runtime_metrics.md).
+
 ## Supported Monitoring Platforms
 
 **Available now**:

--- a/inference_perf/observability/metrics/prometheus.py
+++ b/inference_perf/observability/metrics/prometheus.py
@@ -12,68 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Minimal Prometheus exposition surface for inference-perf runtime observability.
+"""Prometheus exposition surface for inference-perf runtime observability.
 
-Seed of kubernetes-sigs/inference-perf#489. Exposes a single gauge,
-``inference_perf_run_elapsed_seconds``, over an HTTP ``/metrics`` endpoint.
-The full metric set and naming conventions are intentionally out of scope here;
-expect this surface to grow once the conventions are agreed upon.
+Serves a caller-provided ``CollectorRegistry`` over an HTTP ``/metrics``
+endpoint. Which metrics exist is decided by
+:func:`inference_perf.observability.metrics.registry.build_metrics`, not here.
 """
 
 from __future__ import annotations
 
-import time
 from threading import Thread
-from typing import Iterator, Optional
+from typing import Optional
 from wsgiref.simple_server import WSGIServer
 
 from prometheus_client import CollectorRegistry, start_http_server
-from prometheus_client.core import GaugeMetricFamily
-from prometheus_client.registry import Collector
 
 DEFAULT_PORT = 9464
 
 
-class _RunElapsedCollector(Collector):
-    def __init__(self) -> None:
-        self._start_time: Optional[float] = None
-
-    def mark_start(self) -> None:
-        self._start_time = time.monotonic()
-
-    def collect(self) -> Iterator[GaugeMetricFamily]:
-        elapsed = 0.0 if self._start_time is None else time.monotonic() - self._start_time
-        yield GaugeMetricFamily(
-            "inference_perf_run_elapsed_seconds",
-            "Wall-clock seconds elapsed since the metrics server started.",
-            value=elapsed,
-        )
-
-
 class PrometheusMetricsServer:
-    """Serves inference-perf's own metrics over an HTTP ``/metrics`` endpoint.
+    """Serves a ``CollectorRegistry`` over an HTTP ``/metrics`` endpoint.
 
-    Currently emits only ``inference_perf_run_elapsed_seconds``. Use a fresh
-    ``CollectorRegistry`` per instance (not the default global one) so multiple
-    runs in the same process do not collide.
+    Pass the registry of a :class:`~inference_perf.observability.metrics.registry.MetricsHub`
+    built by ``build_metrics`` (a fresh registry per run, never the global
+    default one, so multiple runs in the same process do not collide).
 
     Pass ``port=0`` to bind to an ephemeral port; the actual port is then
     available via :attr:`bound_port`.
     """
 
-    def __init__(self, port: int = DEFAULT_PORT, addr: str = "0.0.0.0") -> None:
+    def __init__(self, registry: CollectorRegistry, port: int = DEFAULT_PORT, addr: str = "0.0.0.0") -> None:
+        self.registry = registry
         self.port = port
         self.addr = addr
-        self.registry = CollectorRegistry()
-        self._elapsed = _RunElapsedCollector()
-        self.registry.register(self._elapsed)
         self._server: Optional[WSGIServer] = None
         self._thread: Optional[Thread] = None
 
     def start(self) -> None:
         if self._server is not None:
             raise RuntimeError("PrometheusMetricsServer is already running")
-        self._elapsed.mark_start()
         self._server, self._thread = start_http_server(
             port=self.port,
             addr=self.addr,

--- a/inference_perf/observability/metrics/registry.py
+++ b/inference_perf/observability/metrics/registry.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config-driven registry of inference-perf's own Prometheus metrics.
+
+Each exported metric is declared as a :class:`MetricSpec` whose ``enabled``
+predicate inspects the run :class:`~inference_perf.config.Config`.
+:func:`build_metrics` instantiates only the enabled specs into a fresh
+``CollectorRegistry`` and returns a :class:`MetricsHub` that fans run
+lifecycle events out to them. Disabled metrics are never instantiated, so
+they are absent from the exposition output rather than present at zero.
+
+The metric definitions themselves live under ``sets/``: ``sets/core.py``
+holds the specs exported on every run, and config-conditional sets get
+sibling modules aggregated in ``sets/__init__.py``. The exposition server in
+``prometheus.py`` just serves the registry built here; it does not know which
+metrics exist.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, List, Optional, Sequence, Tuple, TypeVar, Union
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+
+from inference_perf.apis.base import RequestLifecycleMetric
+from inference_perf.config import Config
+
+logger = logging.getLogger(__name__)
+
+PrometheusMetric = Union[Counter, Gauge, Histogram]
+MetricT = TypeVar("MetricT", bound=PrometheusMetric)
+
+
+def always(config: Config) -> bool:
+    """Predicate for core metrics, exported regardless of config."""
+    return True
+
+
+@dataclass(frozen=True)
+class MetricSpec(Generic[MetricT]):
+    """Declares one exported metric and how it reacts to run lifecycle events.
+
+    ``enabled`` decides from the run config whether the metric is exported at
+    all. The lifecycle hooks are the only population path; each hook receives
+    the live ``metric_type`` instance, typed via ``MetricT``, so a spec whose
+    hook expects a different metric type than it declares fails type checking.
+    Anything a hook needs to know about a request must travel on the
+    ``RequestLifecycleMetric`` it is passed.
+    """
+
+    name: str
+    documentation: str
+    metric_type: type[MetricT]
+    labelnames: Tuple[str, ...] = ()
+    buckets: Optional[Tuple[float, ...]] = None  # histograms only
+    enabled: Callable[[Config], bool] = always
+    on_run_start: Optional[Callable[[MetricT], None]] = None
+    on_request: Optional[Callable[[MetricT, RequestLifecycleMetric], None]] = None
+
+    def __post_init__(self) -> None:
+        if self.buckets is not None and self.metric_type is not Histogram:
+            raise ValueError(f"metric {self.name!r}: buckets are only valid for Histogram metrics")
+
+
+class MetricsHub:
+    """Holds the metrics instantiated for one run and fans events out to them.
+
+    Wire :meth:`observe_request` as an observer on the request metric
+    collector and call :meth:`on_run_start` when the benchmark run begins.
+    :attr:`registry` is what a ``PrometheusMetricsServer`` should serve.
+
+    Hook exceptions are logged and swallowed, never propagated: these methods
+    run inside the benchmark's request-recording path, and a buggy metric must
+    not fail the run it is observing.
+    """
+
+    def __init__(self, registry: CollectorRegistry, bindings: Sequence[Tuple[MetricSpec[Any], PrometheusMetric]]) -> None:
+        self.registry = registry
+        self._bindings = tuple(bindings)
+        self._failed_request_hooks: set[str] = set()
+
+    def on_run_start(self) -> None:
+        for spec, prom_metric in self._bindings:
+            if spec.on_run_start is None:
+                continue
+            try:
+                spec.on_run_start(prom_metric)
+            except Exception:
+                logger.exception("on_run_start hook for metric %r failed", spec.name)
+
+    def observe_request(self, metric: RequestLifecycleMetric) -> None:
+        for spec, prom_metric in self._bindings:
+            if spec.on_request is None:
+                continue
+            try:
+                spec.on_request(prom_metric, metric)
+            except Exception:
+                # Log once per spec: this runs per request, and a hook that
+                # fails once will usually fail on every request.
+                if spec.name not in self._failed_request_hooks:
+                    self._failed_request_hooks.add(spec.name)
+                    logger.exception("on_request hook for metric %r failed; suppressing further logs for this hook", spec.name)
+
+
+def build_metrics(config: Config, specs: Optional[Sequence[MetricSpec[Any]]] = None) -> MetricsHub:
+    """Instantiate the specs enabled under ``config`` into a fresh registry.
+
+    Uses a fresh ``CollectorRegistry`` (never the global default one) so
+    multiple runs in the same process do not collide.
+    """
+    if specs is None:
+        # Imported lazily: the sets modules import MetricSpec from here.
+        from inference_perf.observability.metrics.sets import ALL_SPECS
+
+        specs = ALL_SPECS
+
+    names = [spec.name for spec in specs]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise ValueError(f"duplicate metric names in specs: {duplicates}")
+
+    registry = CollectorRegistry()
+    bindings: List[Tuple[MetricSpec[Any], PrometheusMetric]] = []
+    for spec in specs:
+        if spec.enabled(config):
+            bindings.append((spec, _instantiate(spec, registry)))
+    return MetricsHub(registry, bindings)
+
+
+def _instantiate(spec: MetricSpec[Any], registry: CollectorRegistry) -> PrometheusMetric:
+    if spec.metric_type is Histogram and spec.buckets is not None:
+        return Histogram(spec.name, spec.documentation, labelnames=spec.labelnames, registry=registry, buckets=spec.buckets)
+    prom_metric: PrometheusMetric = spec.metric_type(
+        spec.name, spec.documentation, labelnames=spec.labelnames, registry=registry
+    )
+    return prom_metric

--- a/inference_perf/observability/metrics/runtime_metrics.md
+++ b/inference_perf/observability/metrics/runtime_metrics.md
@@ -1,0 +1,10 @@
+# Inference-Perf Runtime Metrics
+
+These are the Prometheus metrics inference-perf can export about its own runtime over an HTTP `/metrics` endpoint. They are distinct from the metrics inference-perf scrapes from the model server under test and from the benchmark result definitions in [metrics.md](../../../docs/metrics.md).
+
+This document is automatically generated from the metric specs under `inference_perf/observability/metrics/sets/`. Do not edit it by hand; run `pdm run update:runtime-metrics` after changing the specs.
+
+| Metric | Type | Labels | Exported | Description |
+| --- | --- | --- | --- | --- |
+| `inference_perf_run_elapsed_seconds` | Gauge | none | Always | Wall-clock seconds elapsed since the benchmark run started; 0 until the run starts. |
+| `inference_perf_requests_total` | Counter | `stage`, `status` | Always | Request attempts that have completed, by stage and final status. Incremented when the attempt finishes or fails, not when it is sent. |

--- a/inference_perf/observability/metrics/sets/__init__.py
+++ b/inference_perf/observability/metrics/sets/__init__.py
@@ -12,9 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Metric exposition surfaces (Prometheus, pushgateway, etc.) for inference-perf."""
+"""Aggregation point for the exported metric sets.
 
-from .prometheus import PrometheusMetricsServer
-from .registry import MetricSpec, MetricsHub, PrometheusMetric, build_metrics
+``core.py`` holds the specs exported on every run. Config-conditional sets
+(streaming latency histograms, per-stage gauges, and so on) should live in
+sibling modules and be appended to ``ALL_SPECS`` here as they are added.
+"""
 
-__all__ = ["MetricSpec", "MetricsHub", "PrometheusMetric", "PrometheusMetricsServer", "build_metrics"]
+from typing import Any, Tuple
+
+from inference_perf.observability.metrics.registry import MetricSpec
+
+from .core import CORE_SPECS
+
+ALL_SPECS: Tuple[MetricSpec[Any], ...] = (*CORE_SPECS,)
+
+__all__ = ["ALL_SPECS", "CORE_SPECS"]

--- a/inference_perf/observability/metrics/sets/core.py
+++ b/inference_perf/observability/metrics/sets/core.py
@@ -1,0 +1,59 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Metrics exported on every run, regardless of config.
+
+Metric naming conventions are still being settled in
+kubernetes-sigs/inference-perf#489; keep new names under the
+``inference_perf_`` prefix and consistent with these until then.
+"""
+
+import time
+from typing import Any
+
+from prometheus_client import Counter, Gauge
+
+from inference_perf.apis.base import RequestLifecycleMetric
+from inference_perf.observability.metrics.registry import MetricSpec
+
+
+def _mark_run_start(gauge: Gauge) -> None:
+    start = time.monotonic()
+    gauge.set_function(lambda: time.monotonic() - start)
+
+
+def _count_request(counter: Counter, metric: RequestLifecycleMetric) -> None:
+    stage = "" if metric.stage_id is None else str(metric.stage_id)
+    status = "failure" if metric.error is not None else "success"
+    counter.labels(stage, status).inc()
+
+
+CORE_SPECS: tuple[MetricSpec[Any], ...] = (
+    MetricSpec(
+        name="inference_perf_run_elapsed_seconds",
+        documentation="Wall-clock seconds elapsed since the benchmark run started; 0 until the run starts.",
+        metric_type=Gauge,
+        on_run_start=_mark_run_start,
+    ),
+    MetricSpec(
+        name="inference_perf_requests",
+        documentation=(
+            "Request attempts that have completed, by stage and final status. "
+            "Incremented when the attempt finishes or fails, not when it is sent."
+        ),
+        metric_type=Counter,
+        labelnames=("stage", "status"),
+        on_request=_count_request,
+    ),
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,10 @@ lint = "ruff check"
 type-check = "mypy --strict ./inference_perf ./tests"
 "check:cli-flags" = "python scripts/sync_cli_flags_doc.py --check"
 "update:cli-flags" = "python scripts/sync_cli_flags_doc.py"
+"check:runtime-metrics" = "python scripts/sync_runtime_metrics_doc.py --check"
+"update:runtime-metrics" = "python scripts/sync_runtime_metrics_doc.py"
 check = {composite = ["format", "lint"]}
-validate = {composite = ["format", "lint", "type-check", "check:cli-flags"]}
+validate = {composite = ["format", "lint", "type-check", "check:cli-flags", "check:runtime-metrics"]}
 setup = {shell = "pdm install && pre-commit install --config .pre-push-config.yaml && pre-commit install --config .pre-push-config.yaml --hook-type pre-push"}
 
 "test" = "pytest tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,10 @@ lint = {cmd = "ruff check", help = "Lint code with ruff"}
 type-check = {cmd = "mypy --strict ./inference_perf ./tests", help = "Strict mypy over inference_perf and tests"}
 "check:cli-flags" = {cmd = "python scripts/sync_cli_flags_doc.py --check", help = "Verify docs/cli_flags.md is in sync with the CLI"}
 "update:cli-flags" = {cmd = "python scripts/sync_cli_flags_doc.py", help = "Regenerate docs/cli_flags.md from the CLI"}
+"check:runtime-metrics" = {cmd = "python scripts/sync_runtime_metrics_doc.py --check", help = "Verify the runtime metrics doc is in sync with the registry"}
+"update:runtime-metrics" = {cmd = "python scripts/sync_runtime_metrics_doc.py", help = "Regenerate the runtime metrics doc from the registry"}
 check = {composite = ["format", "lint"], help = "Fast check: format + lint"}
-validate = {composite = ["format", "lint", "type-check", "check:cli-flags"], help = "Full check: format, lint, type-check, cli-flags doc sync"}
+validate = {composite = ["format", "lint", "type-check", "check:cli-flags", "check:runtime-metrics"], help = "Full check: format, lint, type-check, cli-flags and runtime-metrics doc sync"}
 setup = {shell = "pdm install && pre-commit install --config .pre-push-config.yaml && pre-commit install --config .pre-push-config.yaml --hook-type pre-push", help = "Install dependencies and git hooks"}
 
 "test" = {cmd = "pytest tests", help = "Run unit tests"}

--- a/scripts/sync_runtime_metrics_doc.py
+++ b/scripts/sync_runtime_metrics_doc.py
@@ -1,0 +1,93 @@
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+from prometheus_client import Counter
+
+from inference_perf.observability.metrics.registry import MetricSpec, always
+from inference_perf.observability.metrics.sets import ALL_SPECS
+
+HEADER = """# Inference-Perf Runtime Metrics
+
+These are the Prometheus metrics inference-perf can export about its own runtime over an HTTP `/metrics` endpoint. They are distinct from the metrics inference-perf scrapes from the model server under test and from the benchmark result definitions in [metrics.md](../../../docs/metrics.md).
+
+This document is automatically generated from the metric specs under `inference_perf/observability/metrics/sets/`. Do not edit it by hand; run `pdm run update:runtime-metrics` after changing the specs.
+
+| Metric | Type | Labels | Exported | Description |
+| --- | --- | --- | --- | --- |
+"""
+
+
+def exposition_name(spec: MetricSpec[Any]) -> str:
+    # prometheus_client appends _total to Counter sample names.
+    if spec.metric_type is Counter:
+        return f"{spec.name}_total"
+    return spec.name
+
+
+def exported_when(spec: MetricSpec[Any]) -> str:
+    if spec.enabled is always:
+        return "Always"
+    doc = spec.enabled.__doc__
+    if not doc:
+        print(
+            f"Error: the enabled predicate for metric {spec.name!r} has no docstring. "
+            "Conditional specs in ALL_SPECS must use a named predicate whose docstring "
+            "describes the condition, so this doc can be generated."
+        )
+        sys.exit(1)
+    return doc.strip().splitlines()[0]
+
+
+def generate_doc() -> str:
+    rows = []
+    for spec in ALL_SPECS:
+        labels = ", ".join(f"`{label}`" for label in spec.labelnames) or "none"
+        rows.append(
+            f"| `{exposition_name(spec)}` | {spec.metric_type.__name__} | {labels} "
+            f"| {exported_when(spec)} | {spec.documentation} |"
+        )
+    return HEADER + "\n".join(rows) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sync runtime metrics documentation.")
+    parser.add_argument("--check", action="store_true", help="Fail if doc is out of sync.")
+    args = parser.parse_args()
+
+    doc_path = Path("inference_perf/observability/metrics/runtime_metrics.md")
+
+    expected_content = generate_doc()
+
+    if args.check:
+        if not doc_path.exists():
+            print(f"Error: {doc_path} does not exist. Run `pdm run update:runtime-metrics` to create it.")
+            sys.exit(1)
+
+        with open(doc_path, "r") as f:
+            current_content = f.read()
+
+        if current_content != expected_content:
+            print(f"Error: {doc_path} is out of sync with the metric specs.")
+            import difflib
+
+            diff = difflib.unified_diff(
+                current_content.splitlines(keepends=True),
+                expected_content.splitlines(keepends=True),
+                fromfile="current",
+                tofile="expected",
+            )
+            sys.stdout.writelines(diff)
+            print("Run `pdm run update:runtime-metrics` to update it.")
+            sys.exit(1)
+        else:
+            print(f"{doc_path} is in sync.")
+    else:
+        with open(doc_path, "w") as f:
+            f.write(expected_content)
+        print(f"Updated {doc_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_runtime_metrics_doc.py
+++ b/scripts/sync_runtime_metrics_doc.py
@@ -1,0 +1,93 @@
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+from prometheus_client import Counter
+
+from inference_perf.observability.metrics.registry import MetricSpec, always
+from inference_perf.observability.metrics.sets import ALL_SPECS
+
+HEADER = """# Inference-Perf Runtime Metrics
+
+These are the Prometheus metrics inference-perf can export about its own runtime over an HTTP `/metrics` endpoint. They are distinct from the metrics inference-perf scrapes from the model server under test and from the benchmark result definitions in [metrics.md](./metrics.md).
+
+This document is automatically generated from the metric specs under `inference_perf/observability/metrics/sets/`. Do not edit it by hand; run `pdm run update:runtime-metrics` after changing the specs.
+
+| Metric | Type | Labels | Exported | Description |
+| --- | --- | --- | --- | --- |
+"""
+
+
+def exposition_name(spec: MetricSpec[Any]) -> str:
+    # prometheus_client appends _total to Counter sample names.
+    if spec.metric_type is Counter:
+        return f"{spec.name}_total"
+    return spec.name
+
+
+def exported_when(spec: MetricSpec[Any]) -> str:
+    if spec.enabled is always:
+        return "Always"
+    doc = spec.enabled.__doc__
+    if not doc:
+        print(
+            f"Error: the enabled predicate for metric {spec.name!r} has no docstring. "
+            "Conditional specs in ALL_SPECS must use a named predicate whose docstring "
+            "describes the condition, so this doc can be generated."
+        )
+        sys.exit(1)
+    return doc.strip().splitlines()[0]
+
+
+def generate_doc() -> str:
+    rows = []
+    for spec in ALL_SPECS:
+        labels = ", ".join(f"`{label}`" for label in spec.labelnames) or "none"
+        rows.append(
+            f"| `{exposition_name(spec)}` | {spec.metric_type.__name__} | {labels} "
+            f"| {exported_when(spec)} | {spec.documentation} |"
+        )
+    return HEADER + "\n".join(rows) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Sync runtime metrics documentation.")
+    parser.add_argument("--check", action="store_true", help="Fail if doc is out of sync.")
+    args = parser.parse_args()
+
+    doc_path = Path("docs/runtime_metrics.md")
+
+    expected_content = generate_doc()
+
+    if args.check:
+        if not doc_path.exists():
+            print(f"Error: {doc_path} does not exist. Run `pdm run update:runtime-metrics` to create it.")
+            sys.exit(1)
+
+        with open(doc_path, "r") as f:
+            current_content = f.read()
+
+        if current_content != expected_content:
+            print(f"Error: {doc_path} is out of sync with the metric specs.")
+            import difflib
+
+            diff = difflib.unified_diff(
+                current_content.splitlines(keepends=True),
+                expected_content.splitlines(keepends=True),
+                fromfile="current",
+                tofile="expected",
+            )
+            sys.stdout.writelines(diff)
+            print("Run `pdm run update:runtime-metrics` to update it.")
+            sys.exit(1)
+        else:
+            print(f"{doc_path} is in sync.")
+    else:
+        with open(doc_path, "w") as f:
+            f.write(expected_content)
+        print(f"Updated {doc_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/required/observability/test_prometheus.py
+++ b/tests/required/observability/test_prometheus.py
@@ -12,19 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import urllib.request
 from typing import Iterator
 
 import pytest
+from prometheus_client import CollectorRegistry, Counter
 
 from inference_perf.observability.metrics import PrometheusMetricsServer
 from inference_perf.observability.metrics.prometheus import DEFAULT_PORT
 
 
+def _registry_with_counter() -> CollectorRegistry:
+    registry = CollectorRegistry()
+    Counter("test_scrapeable", "A counter the server should expose.", registry=registry)
+    return registry
+
+
 @pytest.fixture
 def server() -> Iterator[PrometheusMetricsServer]:
-    s = PrometheusMetricsServer(port=0)
+    s = PrometheusMetricsServer(_registry_with_counter(), port=0)
     s.start()
     yield s
     s.stop()
@@ -36,30 +42,15 @@ def _scrape(port: int) -> str:
     return body.decode()
 
 
-def _parse_elapsed(body: str) -> float:
-    for line in body.splitlines():
-        if line.startswith("inference_perf_run_elapsed_seconds "):
-            return float(line.split()[1])
-    raise AssertionError(f"inference_perf_run_elapsed_seconds not found in:\n{body}")
-
-
 def test_default_port_constant() -> None:
     assert DEFAULT_PORT == 9464
+    assert PrometheusMetricsServer(_registry_with_counter()).port == DEFAULT_PORT
 
 
-def test_server_starts_and_exposes_elapsed_gauge(server: PrometheusMetricsServer) -> None:
+def test_server_exposes_given_registry(server: PrometheusMetricsServer) -> None:
     assert server.bound_port is not None
     body = _scrape(server.bound_port)
-    assert "inference_perf_run_elapsed_seconds" in body
-    assert _parse_elapsed(body) >= 0.0
-
-
-def test_elapsed_gauge_advances_between_scrapes(server: PrometheusMetricsServer) -> None:
-    assert server.bound_port is not None
-    first = _parse_elapsed(_scrape(server.bound_port))
-    time.sleep(0.1)
-    second = _parse_elapsed(_scrape(server.bound_port))
-    assert second > first
+    assert "test_scrapeable_total 0.0" in body
 
 
 def test_double_start_raises(server: PrometheusMetricsServer) -> None:
@@ -68,7 +59,7 @@ def test_double_start_raises(server: PrometheusMetricsServer) -> None:
 
 
 def test_stop_is_idempotent() -> None:
-    s = PrometheusMetricsServer(port=0)
+    s = PrometheusMetricsServer(_registry_with_counter(), port=0)
     s.start()
     s.stop()
     s.stop()

--- a/tests/required/observability/test_registry.py
+++ b/tests/required/observability/test_registry.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+from typing import Optional
+
+import pytest
+from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client.exposition import generate_latest
+
+from inference_perf.apis.base import ErrorResponseInfo, InferenceInfo, RequestLifecycleMetric
+from inference_perf.config import APIConfig, Config
+from inference_perf.observability.metrics import MetricSpec, MetricsHub, PrometheusMetricsServer, build_metrics
+from inference_perf.payloads import RequestMetrics, Text
+
+
+def _metric(stage_id: Optional[int], failed: bool = False) -> RequestLifecycleMetric:
+    return RequestLifecycleMetric(
+        stage_id=stage_id,
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="r",
+        info=InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=1))),
+        error=ErrorResponseInfo(error_type="Timeout", error_msg="boom") if failed else None,
+    )
+
+
+def _exposition(hub: MetricsHub) -> str:
+    return generate_latest(hub.registry).decode()
+
+
+def test_core_metrics_exported_on_default_config() -> None:
+    hub = build_metrics(Config())
+    body = _exposition(hub)
+    assert "inference_perf_run_elapsed_seconds" in body
+    assert "inference_perf_requests_total" in body
+
+
+def test_disabled_spec_is_absent_not_zero() -> None:
+    specs = (
+        MetricSpec(name="test_on", documentation="enabled", metric_type=Gauge),
+        MetricSpec(name="test_off", documentation="disabled", metric_type=Gauge, enabled=lambda config: False),
+    )
+    hub = build_metrics(Config(), specs=specs)
+    body = _exposition(hub)
+    assert "test_on" in body
+    assert "test_off" not in body
+
+
+def test_enabled_predicate_reads_config() -> None:
+    specs = (
+        MetricSpec(
+            name="test_streaming_only",
+            documentation="only exported for streaming runs",
+            metric_type=Histogram,
+            buckets=(0.1, 1.0),
+            enabled=lambda config: config.api.streaming,
+        ),
+    )
+    off = build_metrics(Config(api=APIConfig(streaming=False)), specs=specs)
+    on = build_metrics(Config(api=APIConfig(streaming=True)), specs=specs)
+    assert "test_streaming_only" not in _exposition(off)
+    assert "test_streaming_only" in _exposition(on)
+
+
+def test_requests_counted_at_completion_by_stage_and_status() -> None:
+    hub = build_metrics(Config())
+    hub.observe_request(_metric(stage_id=0))
+    hub.observe_request(_metric(stage_id=0))
+    hub.observe_request(_metric(stage_id=0, failed=True))
+    hub.observe_request(_metric(stage_id=None))
+
+    counter = "inference_perf_requests_total"
+    assert hub.registry.get_sample_value(counter, {"stage": "0", "status": "success"}) == 2.0
+    assert hub.registry.get_sample_value(counter, {"stage": "0", "status": "failure"}) == 1.0
+    assert hub.registry.get_sample_value(counter, {"stage": "", "status": "success"}) == 1.0
+
+
+def test_run_elapsed_zero_until_run_start_then_advances() -> None:
+    hub = build_metrics(Config())
+    gauge = "inference_perf_run_elapsed_seconds"
+    assert hub.registry.get_sample_value(gauge) == 0.0
+
+    hub.on_run_start()
+    time.sleep(0.01)
+    first = hub.registry.get_sample_value(gauge)
+    assert first is not None and first > 0.0
+    time.sleep(0.01)
+    second = hub.registry.get_sample_value(gauge)
+    assert second is not None and second > first
+
+
+def test_failing_hook_is_isolated_and_logged_once(caplog: pytest.LogCaptureFixture) -> None:
+    def _boom(counter: Counter, metric: RequestLifecycleMetric) -> None:
+        raise RuntimeError("boom")
+
+    def _count(counter: Counter, metric: RequestLifecycleMetric) -> None:
+        counter.inc()
+
+    # The failing spec comes first to prove the fan-out continues past it.
+    specs = (
+        MetricSpec(name="test_boom", documentation="always fails", metric_type=Counter, on_request=_boom),
+        MetricSpec(name="test_ok", documentation="counts requests", metric_type=Counter, on_request=_count),
+    )
+    hub = build_metrics(Config(), specs=specs)
+    with caplog.at_level(logging.ERROR):
+        hub.observe_request(_metric(stage_id=0))
+        hub.observe_request(_metric(stage_id=0))
+
+    assert hub.registry.get_sample_value("test_ok_total") == 2.0
+    boom_logs = [r for r in caplog.records if "test_boom" in r.getMessage()]
+    assert len(boom_logs) == 1
+
+
+def test_duplicate_metric_names_rejected() -> None:
+    spec = MetricSpec(name="test_dupe", documentation="duplicated", metric_type=Gauge)
+    with pytest.raises(ValueError, match="duplicate metric names"):
+        build_metrics(Config(), specs=(spec, spec))
+
+
+def test_buckets_rejected_for_non_histograms() -> None:
+    with pytest.raises(ValueError, match="buckets"):
+        MetricSpec(name="test_bad", documentation="bad", metric_type=Counter, buckets=(1.0,))
+
+
+def test_hub_registry_served_over_http() -> None:
+    hub = build_metrics(Config())
+    hub.observe_request(_metric(stage_id=1))
+    server = PrometheusMetricsServer(hub.registry, port=0)
+    server.start()
+    try:
+        import urllib.request
+
+        assert server.bound_port is not None
+        with urllib.request.urlopen(f"http://127.0.0.1:{server.bound_port}/metrics", timeout=2) as resp:
+            body = resp.read().decode()
+        assert 'inference_perf_requests_total{stage="1",status="success"} 1.0' in body
+    finally:
+        server.stop()


### PR DESCRIPTION
Rel: #489

**tldr: derive emitted prometheus metrics set from incoming config**

## Summary

Adds an extensible, config-driven registry for the Prometheus metrics inference-perf exports about its own runtime (as opposed to metrics scraped from the model server under test):

- `MetricSpec`: a frozen dataclass declaring one exported metric (name, docs, type, labels, buckets) plus an `enabled` predicate over the run `Config` and typed lifecycle hooks (`on_run_start`, `on_request`). `MetricSpec` is generic over the Prometheus metric type, so a spec whose hook expects a different metric class than it declares fails `mypy --strict`.
- `build_metrics(config)`: instantiates only the enabled specs into a fresh `CollectorRegistry` (never the global default), so disabled metrics are absent from exposition rather than present at zero.
- `MetricsHub`: holds the instantiated metrics for one run and fans lifecycle events out to the spec hooks. Hook exceptions are logged and swallowed (once per spec on the per-request path) so a buggy metric can never fail the run it is observing.
- Metric definitions live under `observability/metrics/sets/`; `sets/core.py` holds the always-on specs and future config-conditional sets get sibling modules aggregated in `sets/__init__.py`.
- `PrometheusMetricsServer` now serves a caller-provided registry instead of the global default.
- `docs/runtime_metrics.md` is generated from the specs by `scripts/sync_runtime_metrics_doc.py`, with `pdm run update:runtime-metrics` / `check:runtime-metrics` to keep it in sync.

Initial metrics:

| Metric | Type | Labels |
| --- | --- | --- |
| `inference_perf_run_elapsed_seconds` | Gauge | none |
| `inference_perf_requests_total` | Counter | `stage`, `status` |

`inference_perf_requests_total` is incremented when a request attempt completes or fails, not when it is sent.

## Deliberately out of scope (follow-up wiring PR)

- Wiring `MetricsHub.observe_request` into the request metric collectors (its signature matches `RequestMetricCollector.record_metric`; the plan is a proper subscription/fan-out at `record_metric`, migrating the hardcoded `feed_breakers` call onto it).
- Calling `build_metrics` / `on_run_start` / `PrometheusMetricsServer` from `main.py`.
