### PR TITLE
Let the finite timer stop zero-worker load generation

### DIFF
--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -1121,7 +1121,7 @@ class LoadGenerator:
 
                 async with TaskGroup() as tg:
                     time_generator = timer.start_timer(start_time)
-                    for count, (data, time_index) in enumerate(zip(self.datagen.get_data(), time_generator, strict=True)):
+                    for count, (data, time_index) in enumerate(zip(self.datagen.get_data(), time_generator, strict=False)):
                         if progress and stage_task:
                             progress.update(stage_task, completed=count + 1)
                         data.stage_id = stage_id

--- a/tests/required/loadgen/test_load_generator.py
+++ b/tests/required/loadgen/test_load_generator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+from itertools import repeat
 from unittest.mock import MagicMock, AsyncMock, patch
 import multiprocessing as mp
 import asyncio
@@ -212,7 +213,7 @@ class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
 
         mock_data = MagicMock(spec=InferenceAPIData)
         mock_data.preferred_worker_id = -1
-        self.mock_datagen.get_data.return_value = iter([mock_data, mock_data])
+        self.mock_datagen.get_data.return_value = repeat(mock_data)
 
         # Patch LazyLoadDataMixin to just return the object
         with (


### PR DESCRIPTION
## What changed

Use the finite stage timer as the limiting iterator in the `num_workers=0`
load-generation path. The data iterator may be unbounded, so requiring both
iterators to end together caused `zip(..., strict=True)` to raise after the
final scheduled request time.

The existing single-worker regression test now uses an unbounded data iterator
and verifies that only the two timer-scheduled tasks are created and that the
stage completes.

Fixes #590.

## Validation

- Negative control on unchanged `main` reproduced
  `ValueError: zip() argument 2 is shorter than argument 1`.
- Focused regression test passed.
- `pdm run check` passed.
- `pdm run validate` passed, including formatting, lint, strict mypy, and CLI
  documentation synchronization.
- Full suite passed: 435 passed, 9 skipped.
- Coverage comparison passed; total coverage changed from 67.43% to 67.47%,
  and `load_generator.py` from 39.04% to 39.52%.
- `git diff --check` passed.

## AI assistance

This PR was written in part with the assistance of generative AI. I reviewed
and understand the complete change, personally wrote the commit message, and
verified the implementation and test evidence before submission.
