### PR TITLE
fix: inject session_id_header for conversation_replay and shared_prefix workloads

### DIFF
--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -336,8 +336,10 @@ class openAIModelServerClientSession(ModelServerClientSession):
         if data.headers:
             _update_headers_case_insensitive(headers, data.headers)
 
-        if data.session_id and self.client.api_config.session_id_header_key:
-            headers[self.client.api_config.session_id_header_key] = data.session_id
+        if self.client.api_config.session_id_header_key:
+            session_id = getattr(data, "session_id", None) or getattr(data, "user_session_id", None)
+            if session_id:
+                headers[self.client.api_config.session_id_header_key] = session_id
 
         request_data = json.dumps(payload)
 

--- a/tests/required/client/modelserver/test_openai_client.py
+++ b/tests/required/client/modelserver/test_openai_client.py
@@ -188,8 +188,49 @@ async def test_session_id_header_injected_when_both_set(mock_client: MagicMock, 
 
 
 @pytest.mark.asyncio
-async def test_session_id_header_not_injected_when_session_id_is_none(mock_client: MagicMock, mock_data: MagicMock) -> None:
+async def test_user_session_id_used_when_session_id_is_none(mock_client: MagicMock, mock_data: MagicMock) -> None:
     mock_data.session_id = None
+    mock_data.user_session_id = "conv_0"
+    mock_client.api_config.session_id_header_key = "x-session-id"
+
+    session = openAIModelServerClientSession(mock_client)
+    session.session = MagicMock()
+
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("force exit"))
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    session.session.post.return_value = mock_post_ctx
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    headers_passed = session.session.post.call_args.kwargs["headers"]
+    assert headers_passed.get("x-session-id") == "conv_0"
+
+
+@pytest.mark.asyncio
+async def test_session_id_takes_precedence_over_user_session_id(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    mock_data.session_id = "trace0_test_session"
+    mock_data.user_session_id = "conv_0"
+    mock_client.api_config.session_id_header_key = "x-session-id"
+
+    session = openAIModelServerClientSession(mock_client)
+    session.session = MagicMock()
+
+    mock_post_ctx = MagicMock()
+    mock_post_ctx.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError("force exit"))
+    mock_post_ctx.__aexit__ = AsyncMock(return_value=None)
+    session.session.post.return_value = mock_post_ctx
+
+    await session.process_request(mock_data, stage_id=1, scheduled_time=0.0)
+
+    headers_passed = session.session.post.call_args.kwargs["headers"]
+    assert headers_passed.get("x-session-id") == "trace0_test_session"
+
+
+@pytest.mark.asyncio
+async def test_session_id_header_not_injected_when_neither_id_is_set(mock_client: MagicMock, mock_data: MagicMock) -> None:
+    mock_data.session_id = None
+    mock_data.user_session_id = None
     mock_client.api_config.session_id_header_key = "x-session-id"
 
     session = openAIModelServerClientSession(mock_client)
@@ -209,6 +250,7 @@ async def test_session_id_header_not_injected_when_session_id_is_none(mock_clien
 @pytest.mark.asyncio
 async def test_session_id_header_not_injected_when_header_key_is_none(mock_client: MagicMock, mock_data: MagicMock) -> None:
     mock_data.session_id = "trace0_test_session"
+    mock_data.user_session_id = "conv_0"
     mock_client.api_config.session_id_header_key = None
 
     session = openAIModelServerClientSession(mock_client)


### PR DESCRIPTION
## Summary

Fixes kubernetes-sigs/inference-perf#574

- Fall back to `user_session_id` when `session_id` is absent in the header injection logic in `openai_client.py`
- `otel_trace_replay` continues using `session_id` as before
- `conversation_replay` and `shared_prefix` now send their `user_session_id` to the gateway
- Generators without either field (`random`, `synthetic`, etc.) are unaffected

## Test plan

- [ ] `test_session_id_header_injected_when_both_set` — `session_id` is used when present
- [ ] `test_user_session_id_used_when_session_id_is_none` — `user_session_id` is the fallback
- [ ] `test_session_id_takes_precedence_over_user_session_id` — `session_id` wins when both are set
- [ ] `test_session_id_header_not_injected_when_neither_id_is_set` — no header when neither field is set
- [ ] `test_session_id_header_not_injected_when_header_key_is_none` — no header when `session_id_header_key` is unset
