### PR TITLE
fix: count generated text without special tokens for output_len

### DIFF
--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -543,7 +543,10 @@ class ChatCompletionAPIData(InferenceAPIData):
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
             prompt_len = self._count_prompt_tokens(tokenizer)
-            output_len = tokenizer.count_tokens(output_text)
+            # Generated text is a continuation, not a sequence start: counting it
+            # with special tokens would add a BOS the server's completion_tokens
+            # never contains.
+            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             return InferenceInfo(
                 request_metrics=self._build_request_metrics(prompt_len, output_len),
                 response_metrics=StreamedResponseMetrics(
@@ -566,7 +569,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                 lora_adapter=lora_adapter,
             )
         output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
-        output_len = tokenizer.count_tokens(output_text)
+        output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
         return InferenceInfo(
             request_metrics=self._build_request_metrics(prompt_len, output_len),
             response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=data.get("usage")),

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -58,7 +58,10 @@ class CompletionAPIData(InferenceAPIData):
             )
 
             prompt_len = tokenizer.count_tokens(self.prompt)
-            output_len = tokenizer.count_tokens(output_text)
+            # Generated text is a continuation, not a sequence start: counting it
+            # with special tokens would add a BOS the server's completion_tokens
+            # never contains.
+            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             self.model_response = output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
@@ -82,7 +85,7 @@ class CompletionAPIData(InferenceAPIData):
                     lora_adapter=lora_adapter,
                 )
             output_text = choices[0].get("text", "")
-            output_len = tokenizer.count_tokens(output_text)
+            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             self.model_response = output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -51,7 +51,7 @@ def test_count_prompt_tokens_includes_prefix_text() -> None:
     tokens — the total reflects the actual prompt sent to the model."""
     tokenizer = MagicMock()
     # One token per whitespace-separated word.
-    tokenizer.count_tokens.side_effect = lambda s: len(s.split())
+    tokenizer.count_tokens.side_effect = lambda s, **kw: len(s.split())
 
     data = ChatCompletionAPIData(
         messages=[ChatMessage(role="user", content="three words here")],
@@ -64,7 +64,7 @@ def test_count_prompt_tokens_includes_prefix_text() -> None:
 def test_count_prompt_tokens_without_prefix_text_unchanged() -> None:
     """Existing behavior holds when prefix_text is unset."""
     tokenizer = MagicMock()
-    tokenizer.count_tokens.side_effect = lambda s: len(s.split())
+    tokenizer.count_tokens.side_effect = lambda s, **kw: len(s.split())
 
     data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="five tokens in this prompt")])
     assert data._count_prompt_tokens(tokenizer) == 5

--- a/tests/required/loadgen/test_multi_turn_hang.py
+++ b/tests/required/loadgen/test_multi_turn_hang.py
@@ -27,7 +27,7 @@ def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
     # Match the decode mock's "text_N" format so count_tokens returns a real int
     # (the new exact-length datagen path compares this against target_len).
     mock_tokenizer.count_tokens = MagicMock(
-        side_effect=lambda text: sum(int(n) for n in re.findall(r"text_(\d+)", text)) if isinstance(text, str) else 0
+        side_effect=lambda text, **kw: sum(int(n) for n in re.findall(r"text_(\d+)", text)) if isinstance(text, str) else 0
     )
     return mock_tokenizer
 

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -47,7 +47,7 @@ def _clear_user_session_registry() -> Generator[None, None, None]:
 def _make_mock_tokenizer(vocab_size: int = 32000) -> MagicMock:
     """Create a mock tokenizer with the expected interface."""
     mock_tokenizer = MagicMock()
-    mock_tokenizer.count_tokens.side_effect = lambda text: len(text.split()) * 10 if text.strip() else 0
+    mock_tokenizer.count_tokens.side_effect = lambda text, **kw: len(text.split()) * 10 if text.strip() else 0
     hf_tok = MagicMock()
     hf_tok.vocab_size = vocab_size
     hf_tok.decode.side_effect = lambda ids, **kwargs: f"decoded_{ids}"
@@ -504,7 +504,7 @@ class TestSlidingWindowTruncation:
 
         mock_tokenizer = MagicMock()
         # count_tokens returns 100 for system prompt and 100 for each turn
-        mock_tokenizer.count_tokens.side_effect = lambda text: len(text.split()) * 10
+        mock_tokenizer.count_tokens.side_effect = lambda text, **kw: len(text.split()) * 10
 
         system_prompt = "System Instruction"  # length in words = 2 -> 20 tokens
         session = LocalUserSession(

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -82,7 +82,7 @@ def make_api_config() -> APIConfig:
 def make_mock_tokenizer() -> MagicMock:
     """Return a mock tokenizer that counts words as tokens."""
     tok = MagicMock()
-    tok.count_tokens = lambda text: max(1, len((text or "").split()))
+    tok.count_tokens = lambda text, **kw: max(1, len((text or "").split()))
     return tok
 
 

--- a/tests/test_output_len_special_tokens.py
+++ b/tests/test_output_len_special_tokens.py
@@ -1,0 +1,163 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for special-token handling in client-derived output_len.
+
+The server's completion_tokens counts generated tokens only; it never
+includes a client-side BOS. Counting the generated text with
+add_special_tokens=True adds one BOS per request for BOS-prepending
+tokenizers (e.g. Llama-3.1), so client output_len would sit at N+1 against
+the server's N and the two could never agree exactly.
+
+This pins the asymmetric policy:
+- output text is a continuation -> counted WITHOUT special tokens
+- prompt text starts a sequence -> counted WITH special tokens (matching
+  the server's prompt_tokens, which includes BOS)
+
+The fake tokenizer mimics a BOS-prepending tokenizer: one token per
+whitespace-separated word, plus one BOS when add_special_tokens=True.
+"""
+
+from typing import Any, AsyncGenerator, Dict, List, cast
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import ClientResponse
+
+from inference_perf.apis.base import StreamedResponseMetrics, UnaryResponseMetrics
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.config import APIConfig, APIType
+
+
+class FakeStreamingResponse:
+    """Minimal aiohttp ClientResponse stand-in that yields preset SSE bytes."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        self.status = 200
+        self.headers = {"content-type": "text/event-stream"}
+        self._chunks = chunks
+        self.content = self._make_content()
+
+    def _make_content(self) -> MagicMock:
+        content = MagicMock()
+
+        async def iter_any() -> AsyncGenerator[bytes, None]:
+            for chunk in self._chunks:
+                yield chunk
+
+        content.iter_any = iter_any
+        return content
+
+
+class FakeUnaryResponse:
+    """Minimal aiohttp ClientResponse stand-in for non-streaming JSON."""
+
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self.status = 200
+        self.headers = {"content-type": "application/json"}
+        self._payload = payload
+
+    async def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+def _bos_tokenizer() -> MagicMock:
+    """One token per word; add_special_tokens=True prepends one BOS."""
+
+    def count(text: str, add_special_tokens: bool = True) -> int:
+        if text == "":
+            return 0
+        return len(text.split()) + (1 if add_special_tokens else 0)
+
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=count)
+    return tokenizer
+
+
+def _chat_sse(chunk_texts: List[str]) -> bytes:
+    parts = [f'data: {{"choices":[{{"delta":{{"content":"{text}"}}}}]}}\n\n'.encode() for text in chunk_texts]
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+def _completion_sse(chunk_texts: List[str]) -> bytes:
+    parts = [f'data: {{"choices":[{{"text":"{text}"}}]}}\n\n'.encode() for text in chunk_texts]
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_output_len_excludes_special_tokens() -> None:
+    chunk_texts = ["aa bb", "cc dd", "ee"]
+    response = FakeStreamingResponse([_chat_sse(chunk_texts)])
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Chat, streaming=True)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="p1 p2 p3")], max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, StreamedResponseMetrics)
+    # "aa bbcc ddee" -> 3 words, and no BOS for generated text.
+    assert info.response_metrics.output_tokens == 3
+    # Prompt-side counting keeps special tokens: 3 words + BOS.
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4
+
+
+@pytest.mark.asyncio
+async def test_chat_unary_output_len_excludes_special_tokens() -> None:
+    payload = {"choices": [{"message": {"content": "aa bb cc"}}]}
+    response = FakeUnaryResponse(payload)
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Chat, streaming=False)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="p1 p2 p3")], max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, UnaryResponseMetrics)
+    assert info.response_metrics.output_tokens == 3
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4
+
+
+@pytest.mark.asyncio
+async def test_completion_streaming_output_len_excludes_special_tokens() -> None:
+    chunk_texts = ["aa bb", "cc dd", "ee"]
+    response = FakeStreamingResponse([_completion_sse(chunk_texts)])
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Completion, streaming=True)
+    data = CompletionAPIData(prompt="p1 p2 p3", max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, StreamedResponseMetrics)
+    assert info.response_metrics.output_tokens == 3
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4
+
+
+@pytest.mark.asyncio
+async def test_completion_unary_output_len_excludes_special_tokens() -> None:
+    payload = {"choices": [{"text": "aa bb cc"}]}
+    response = FakeUnaryResponse(payload)
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Completion, streaming=False)
+    data = CompletionAPIData(prompt="p1 p2 p3", max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, UnaryResponseMetrics)
+    assert info.response_metrics.output_tokens == 3
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4

--- a/tests/test_reasoning_output_support.py
+++ b/tests/test_reasoning_output_support.py
@@ -46,7 +46,7 @@ from inference_perf.datagen.replay_graph_session_datagen import (
 
 def _make_tokenizer() -> MagicMock:
     tok = MagicMock()
-    tok.count_tokens = lambda text: max(1, len((text or "").split()))
+    tok.count_tokens = lambda text, **kw: max(1, len((text or "").split()))
     return tok
 
 

--- a/tests/test_streaming_response_order.py
+++ b/tests/test_streaming_response_order.py
@@ -57,7 +57,7 @@ async def test_streaming_parser_receives_content() -> None:
     config = APIConfig(type=APIType.Chat, streaming=True)
 
     tokenizer = MagicMock()
-    tokenizer.count_tokens = MagicMock(side_effect=lambda text: len(text.split()))
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kw: len(text.split()))
 
     data = ChatCompletionAPIData(
         messages=[ChatMessage(role="user", content="test")],

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -60,7 +60,7 @@ class TestTraceReplay:
             mock_tokenizer_obj.vocab_size = 1000
             mock_tokenizer_obj.all_special_ids = []
             mock_tokenizer.get_tokenizer.return_value = mock_tokenizer_obj
-            mock_tokenizer.count_tokens.side_effect = lambda text: len(text.split())
+            mock_tokenizer.count_tokens.side_effect = lambda text, **kw: len(text.split())
 
             api_config = APIConfig(type=APIType.Completion)
             trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.AZURE_PUBLIC_DATASET)


### PR DESCRIPTION
## Summary

All four output-side call sites (`completion.py` and `chat.py`, streaming and unary) compute `output_len` with `tokenizer.count_tokens(output_text)`, which defaults to `add_special_tokens=True`. For BOS-prepending tokenizers (Llama 3, Gemma), this inflates the client-side output token count by exactly 1 per request.

Generated text is a continuation, not a sequence start, so it should be counted without special tokens. This also matches the server's own semantics: `usage.completion_tokens` does not include special tokens, while `usage.prompt_tokens` does. Prompt-side counting is deliberately left on the default (`add_special_tokens=True`) for the same reason.

## Context

This is the last residual of the #564 lineage:

- #565 stopped overwriting `output_tokens` with the per-chunk sum
- #566 made the per-chunk timestamp expansion in reportgen count with `add_special_tokens=False`
- This PR fixes the remaining whole-text count, which still added the BOS

The bug is invisible to existing tests because none of them run a BOS-prepending tokenizer against a known-token-count response. #645 adds a sim-backed golden accuracy e2e that asserts client-side counts exactly and turns red without this fix.

## Impact on reported numbers

Benchmarks using a BOS tokenizer with client-side counting (`use_server_output_tokens: false`, the default) will report exactly 1 fewer output token per request than before. That is the inflation being removed, not a regression; runs with `use_server_output_tokens: true` are unaffected.

With the bug live, the error is +1 output token per request: `output_len` and `output_tokens_per_sec` are inflated and TPOT/NTPOT deflated by roughly 1/N for N-token outputs. That is under 1% for typical output lengths but reaches ~12% on short-output latency probes (N=8).

## Severity and workaround (P1)

Until this merges, the recommended mitigation is server-side counting:

```yaml
report:
  request_lifecycle:
    use_server_output_tokens: true
```

This makes TPOT, NTPOT, throughput, and the `output_tokens` summary use `usage.completion_tokens` instead of the client-side recount. It is primarily a vLLM and llm-d oriented workaround, which covers the overwhelming majority of deployments: both report usage on unary responses and on streaming responses via `stream_options: {"include_usage": true}`, which the client already sends. Two caveats:

- Other OpenAI-compatible backends that do not report usage fall back silently to the client-side count, reintroducing the error even with the flag set.
- `output_len` in the summary is always client-derived and remains +1 per request for BOS tokenizers regardless of the flag.

Since the headline metrics have this workaround in the dominant deployments, this is P1 rather than P0.

## Changes

- `inference_perf/apis/completion.py`, `inference_perf/apis/chat.py`: pass `add_special_tokens=False` at the four output-side sites
- `tests/test_output_len_special_tokens.py`: new unit tests (chat/completion x streaming/unary) with a BOS-simulating mock tokenizer, asserting output counts exclude the BOS while prompt counts keep it
- Seven test files: existing `count_tokens` mock lambdas gain `**kw` so they accept the new keyword argument
