### PR TITLE
E2e test: add sim-backed golden accuracy with controlled token counts and chunk timing

### DIFF
--- a/e2e/tests/test_golden_accuracy_sim.py
+++ b/e2e/tests/test_golden_accuracy_sim.py
@@ -1,0 +1,292 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sim-backed golden accuracy e2e (#631).
+
+Ground truth is fully controlled: the golden sim constructs each response
+from a real tokenizer's token ids (known count N, known chunk count K,
+controlled chunk pacing), so token accounting is asserted EXACTLY, zero
+tolerance:
+
+- client-derived output_len == server-reported completion_tokens == N
+- content chunk count == K; reportgen's expanded output_token_times has one
+  entry per token with exactly K-1 nonzero inter-token gaps
+
+The matrix includes a per-chunk BOS-prepending tokenizer (the #564 failure
+mode: Llama-3.1, plus the vendored Gemma-3 so the merge-blocking path needs
+no network) and a mid-token chunk split, so per-chunk re-tokenization bugs
+cannot hide behind polite chunk boundaries.
+
+Timing: sample counts are exact; gap VALUES are asserted against the sim's
+recorded actual send gaps (not the configured interval), because wall-clock
+zero tolerance over a real socket does not exist. A systematic ITL
+distortion (#566 was ~K-fold deflation) fails these bounds; scheduler jitter
+does not.
+
+Expected values are computed with a raw transformers AutoTokenizer, NOT
+inference_perf's CustomTokenizer, so a counting bug in the product cannot
+cancel itself out in the test.
+"""
+
+import statistics
+from collections import Counter
+from typing import List
+
+import pytest
+
+from utils.accuracy import (
+    SUMMARY_REPORT,
+    assert_output_token_accounting,
+    assert_streaming_bookkeeping,
+    assert_successful_run,
+    chunk_gaps,
+    request_body,
+    server_completion_tokens,
+    ttft,
+)
+from utils.benchmark import run_benchmark_minimal
+from utils.golden_sim import GoldenCase, GoldenSimServer
+from utils.net import get_free_port
+from utils.testdata import extract_tarball
+
+GEMMA_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+LLAMA_31 = "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8"  # the #564 tokenizer (public mirror)
+
+TTFT_DELAY = 0.15
+INTERVAL = 0.08
+RATE = 2
+DURATION = 5
+EXPECTED_REQUESTS = RATE * DURATION
+
+# n_tokens doubles as the case id (reported as usage.completion_tokens), so it
+# must be unique. n_chunks == n_tokens is the one-token-per-chunk regime where
+# #564's per-chunk BOS inflation was worst (~2x); the codepoint split places
+# chunk boundaries mid-token so tokenization is deliberately non-compositional
+# across chunks.
+CASES = [
+    GoldenCase(n_tokens=24, n_chunks=1, split="token"),
+    GoldenCase(n_tokens=36, n_chunks=6, split="token"),
+    GoldenCase(n_tokens=48, n_chunks=12, split="codepoint"),
+    GoldenCase(n_tokens=16, n_chunks=16, split="token"),
+]
+
+
+def _load_oracle(pretrained: str):
+    """Independent ground-truth tokenizer (raw transformers, not CustomTokenizer)."""
+    from transformers import AutoTokenizer
+
+    try:
+        return AutoTokenizer.from_pretrained(pretrained)
+    except Exception as e:  # gated/offline hub tokenizers skip instead of erroring
+        pytest.skip(f"tokenizer {pretrained} unavailable: {e}")
+
+
+def _resolve_tokenizer(key: str) -> str:
+    if key == "gemma-3-270m":
+        return str(extract_tarball(GEMMA_TARBALL))
+    if key == "llama-3.1":
+        return LLAMA_31
+    raise ValueError(key)
+
+
+def _prompt_text(body: dict) -> str:
+    if "prompt" in body:
+        return body["prompt"]
+    return "".join(m.get("content", "") for m in body.get("messages", []) if isinstance(m.get("content"), str))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tokenizer_key", "api_type", "streaming", "use_server_output_tokens"),
+    [
+        pytest.param("gemma-3-270m", "completion", True, False, id="gemma-completion-stream"),
+        pytest.param("gemma-3-270m", "chat", True, False, id="gemma-chat-stream"),
+        pytest.param("gemma-3-270m", "completion", False, False, id="gemma-completion-unary"),
+        pytest.param("gemma-3-270m", "completion", True, True, id="gemma-completion-stream-serveroracle"),
+        pytest.param("llama-3.1", "completion", True, False, id="llama31-completion-stream"),
+        pytest.param("llama-3.1", "chat", True, False, id="llama31-chat-stream"),
+    ],
+)
+async def test_golden_accuracy(tokenizer_key: str, api_type: str, streaming: bool, use_server_output_tokens: bool):
+    tokenizer_path = _resolve_tokenizer(tokenizer_key)
+    oracle = _load_oracle(tokenizer_path)
+
+    port = get_free_port()
+    async with GoldenSimServer(
+        oracle,
+        CASES,
+        model="golden-model",
+        ttft_delay=TTFT_DELAY,
+        inter_chunk_interval=INTERVAL,
+        port=port,
+    ) as sim:
+        # Fixture cross-check with the oracle: the served text of each case
+        # must re-encode to exactly n_tokens, and the per-chunk token sums
+        # (what reportgen's timestamp expansion sees) are precomputed here.
+        case_by_n = {c.n_tokens: c for c in CASES}
+        chunk_token_sums = {}
+        for case in CASES:
+            chunks = sim.get_chunks(case.n_tokens)
+            assert len(chunks) == case.n_chunks
+            n = len(oracle("".join(chunks), add_special_tokens=False).input_ids)
+            assert n == case.n_tokens, f"fixture broken: case {case} text re-encodes to {n}"
+            chunk_token_sums[case.n_tokens] = sum(len(oracle(c, add_special_tokens=False).input_ids) for c in chunks)
+
+        result = await run_benchmark_minimal(
+            {
+                "data": {"type": "mock"},
+                "load": {
+                    "type": "constant",
+                    "stages": [{"rate": RATE, "duration": DURATION}],
+                    "num_workers": 2,
+                },
+                "api": {"type": api_type, "streaming": streaming},
+                "server": {
+                    "type": "vllm",
+                    "model_name": "golden-model",
+                    "base_url": f"http://{sim.host}:{sim.port}",
+                    "ignore_eos": True,
+                },
+                "tokenizer": {"pretrained_model_name_or_path": tokenizer_path},
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                        "per_stage": True,
+                        "per_request": True,
+                        "use_server_output_tokens": use_server_output_tokens,
+                    },
+                },
+            },
+            timeout_sec=180,
+        )
+
+    entries = assert_successful_run(result, EXPECTED_REQUESTS)
+    assert len(sim.requests) == EXPECTED_REQUESTS, (
+        f"sim served {len(sim.requests)} requests, expected {EXPECTED_REQUESTS} (client retried or dropped?)"
+    )
+
+    # --- Exact token accounting, per request, zero tolerance ---
+    observed_ns = []
+    client_gap_samples: List[float] = []
+    for entry in entries:
+        n_server = server_completion_tokens(entry)
+        assert n_server in case_by_n, f"server reported unknown case n={n_server}"
+        case = case_by_n[n_server]
+        observed_ns.append(n_server)
+
+        # output_len == completion_tokens == N, no tolerance. This holds for
+        # ALL splits, including mid-token: the client counts the concatenated
+        # text once, so chunking must not affect it.
+        assert_output_token_accounting(entry, expected=case.n_tokens, tolerance=0)
+
+        # Prompt side: recount the exact prompt the client sent. Prompts start
+        # a sequence, so special tokens are included (matches server
+        # prompt_tokens semantics).
+        expected_prompt = len(oracle(_prompt_text(request_body(entry)), add_special_tokens=True).input_ids)
+        got_prompt = entry["info"]["request_metrics"]["text"]["input_tokens"]
+        assert got_prompt == expected_prompt, f"prompt_len {got_prompt} != oracle count {expected_prompt}"
+
+        if streaming:
+            # Chunk/token bookkeeping is exact. output_token_times is chunk
+            # arrival times expanded via per-chunk counts, so its expected
+            # length is the per-chunk sum: equal to N for token-aligned splits,
+            # and whatever the oracle says for mid-token splits.
+            assert_streaming_bookkeeping(
+                entry,
+                expected_chunks=case.n_chunks,
+                expected_token_times=chunk_token_sums[case.n_tokens],
+            )
+            # Timing: TTFT cannot be smaller than the sim's enforced delay, and
+            # no client-observed gap may fall below half the configured
+            # interval (#566-class deflation is a >= 2x effect).
+            assert ttft(entry) >= TTFT_DELAY, f"TTFT {ttft(entry):.4f}s below configured delay {TTFT_DELAY}s"
+            gaps = chunk_gaps(entry)
+            assert len(gaps) == case.n_chunks - 1
+            for g in gaps:
+                assert g >= INTERVAL * 0.5, f"chunk gap {g * 1000:.1f}ms below half the configured {INTERVAL * 1000:.0f}ms"
+            client_gap_samples.extend(gaps)
+
+    # Case cycling is by arrival order, so exactly this multiset was served.
+    expected_ns = [CASES[i % len(CASES)].n_tokens for i in range(EXPECTED_REQUESTS)]
+    assert Counter(observed_ns) == Counter(expected_ns), (
+        f"served case multiset {Counter(observed_ns)} != expected {Counter(expected_ns)}"
+    )
+
+    # --- Timing against what the sim actually did, not what was configured ---
+    if streaming:
+        sim_gap_samples = [
+            t2 - t1 for served in sim.requests for t1, t2 in zip(served.send_times, served.send_times[1:], strict=False)
+        ]
+        assert len(sim_gap_samples) == len(client_gap_samples)
+        client_mean = statistics.mean(client_gap_samples)
+        sim_mean = statistics.mean(sim_gap_samples)
+        assert abs(client_mean - sim_mean) <= 0.02, (
+            f"client mean chunk gap {client_mean * 1000:.1f}ms deviates from sim's actual "
+            f"mean send gap {sim_mean * 1000:.1f}ms by more than 20ms"
+        )
+
+    # --- Summary-level exactness ---
+    summary = result.reports[SUMMARY_REPORT]["successes"]
+    assert summary["output_tokens"]["total"] == float(sum(expected_ns))
+    assert summary["output_len"]["min"] == float(min(expected_ns))
+    assert summary["output_len"]["max"] == float(max(expected_ns))
+    if streaming:
+        # reportgen flags requests whose per-chunk token sums disagree with the
+        # server count; only mid-token splits may legitimately do that.
+        expected_mismatches = sum(1 for n in observed_ns if chunk_token_sums[n] != n)
+        assert summary["token_count_mismatches"] == expected_mismatches
+
+
+# --- Helper self-tests: prove the assertions can actually fail. -------------
+# Guards the helpers against refactors that would make them vacuous (the
+# meta-lesson of #564: green tests that could not have gone red).
+
+
+def _fake_entry(client_n: int, server_n: int, times: List[float], token_times: List[float]) -> dict:
+    return {
+        "start_time": 0.0,
+        "end_time": times[-1] if times else 1.0,
+        "request": '{"prompt": "x"}',
+        "error": None,
+        "info": {
+            "request_metrics": {"text": {"input_tokens": 1}},
+            "response_metrics": {
+                "output_tokens": client_n,
+                "server_usage": {"completion_tokens": server_n},
+                "chunk_times": times,
+                "output_token_times": token_times,
+            },
+        },
+    }
+
+
+def test_token_accounting_helper_rejects_mismatch():
+    entry = _fake_entry(client_n=25, server_n=24, times=[0.1], token_times=[0.1])
+    with pytest.raises(AssertionError, match="exceeds tolerance"):
+        assert_output_token_accounting(entry, expected=24, tolerance=0)
+    # ...but a one-token tolerance (the #630 weak form) accepts it.
+    assert_output_token_accounting(entry, tolerance=1)
+
+
+def test_streaming_bookkeeping_helper_rejects_wrong_counts():
+    entry = _fake_entry(client_n=4, server_n=4, times=[0.1, 0.2], token_times=[0.1, 0.1, 0.2, 0.2])
+    assert_streaming_bookkeeping(entry, expected_chunks=2, expected_token_times=4)
+    with pytest.raises(AssertionError, match="content chunks"):
+        assert_streaming_bookkeeping(entry, expected_chunks=3, expected_token_times=4)
+    with pytest.raises(AssertionError, match="output_token_times"):
+        assert_streaming_bookkeeping(entry, expected_chunks=2, expected_token_times=5)
+    # Inflated timestamp expansion (per-chunk BOS, the #564/#566 signature)
+    # shows up as extra nonzero gaps.
+    entry = _fake_entry(client_n=4, server_n=4, times=[0.1, 0.2], token_times=[0.1, 0.15, 0.2, 0.25])
+    with pytest.raises(AssertionError, match="nonzero inter-token gaps"):
+        assert_streaming_bookkeeping(entry, expected_chunks=2, expected_token_times=4)

--- a/e2e/utils/accuracy.py
+++ b/e2e/utils/accuracy.py
@@ -1,0 +1,154 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared accuracy/consistency assertions over benchmark reports.
+
+Helpers operate on entries of ``per_request_lifecycle_metrics.json`` (dicts,
+as parsed by ``run_benchmark_minimal``). The golden accuracy e2e (#631) calls
+them with ``tolerance=0`` and exact expectations; the universal invariant
+harness (#630) is meant to reuse them with non-zero tolerances on runs where
+ground truth is unknown.
+
+Every helper starts from the same rule: an assertion that can pass on an
+empty or failed run is worthless, so callers go through
+``assert_successful_run`` first, which refuses vacuous reports.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from utils.benchmark import BenchmarkResult
+
+PER_REQUEST_REPORT = "per_request_lifecycle_metrics.json"
+SUMMARY_REPORT = "summary_lifecycle_metrics.json"
+
+
+def assert_successful_run(result: BenchmarkResult, expected_requests: int) -> List[Dict[str, Any]]:
+    """Refuse vacuous runs: the benchmark must have exited cleanly and produced
+    exactly ``expected_requests`` successful, error-free request entries.
+
+    Returns the per-request entries so callers can chain assertions.
+    """
+    assert result.success, f"benchmark process failed (rc={result.return_code}, timed_out={result.timed_out})"
+    assert result.reports, "benchmark produced no reports"
+    assert PER_REQUEST_REPORT in result.reports, f"missing {PER_REQUEST_REPORT} in {sorted(result.reports)}"
+
+    entries = result.reports[PER_REQUEST_REPORT]
+    assert len(entries) == expected_requests, f"expected {expected_requests} requests in report, got {len(entries)}"
+    errored = [e for e in entries if e.get("error")]
+    assert not errored, f"{len(errored)}/{len(entries)} requests errored, first: {errored[0]['error']}"
+
+    summary = result.reports.get(SUMMARY_REPORT)
+    assert summary, f"missing {SUMMARY_REPORT}"
+    assert summary["successes"]["count"] == expected_requests, (
+        f"summary reports {summary['successes']['count']} successes, expected {expected_requests}"
+    )
+    return entries
+
+
+def response_metrics(entry: Dict[str, Any]) -> Dict[str, Any]:
+    metrics = (entry.get("info") or {}).get("response_metrics")
+    assert metrics, f"request entry has no response_metrics: {entry.get('request', '')[:200]}"
+    return metrics
+
+
+def client_output_tokens(entry: Dict[str, Any]) -> int:
+    """Client-derived output length (re-tokenization of the received text)."""
+    tokens = response_metrics(entry).get("output_tokens")
+    assert tokens is not None, "response_metrics has no output_tokens"
+    return int(tokens)
+
+
+def server_completion_tokens(entry: Dict[str, Any]) -> Optional[int]:
+    """Server-reported usage.completion_tokens, None if the server sent none."""
+    usage = response_metrics(entry).get("server_usage")
+    if not usage or usage.get("completion_tokens") is None:
+        return None
+    return int(usage["completion_tokens"])
+
+
+def request_body(entry: Dict[str, Any]) -> Dict[str, Any]:
+    """The JSON request body the client actually sent."""
+    return json.loads(entry["request"])
+
+
+def assert_output_token_accounting(
+    entry: Dict[str, Any],
+    *,
+    expected: Optional[int] = None,
+    tolerance: int = 0,
+) -> None:
+    """Client-derived output_len must agree with the server-reported
+    completion_tokens within ``tolerance`` tokens (0 = exactly), and with
+    ``expected`` (ground truth) when the caller knows it.
+    """
+    client = client_output_tokens(entry)
+    server = server_completion_tokens(entry)
+    assert server is not None, "server reported no completion_tokens; cannot check token accounting"
+    assert abs(client - server) <= tolerance, (
+        f"client output_len {client} vs server completion_tokens {server} exceeds tolerance {tolerance}"
+    )
+    if expected is not None:
+        assert server == expected, f"server completion_tokens {server} != expected {expected}"
+        assert abs(client - expected) <= tolerance, (
+            f"client output_len {client} vs expected {expected} exceeds tolerance {tolerance}"
+        )
+
+
+def chunk_times(entry: Dict[str, Any]) -> List[float]:
+    times = response_metrics(entry).get("chunk_times")
+    assert times is not None, "response_metrics has no chunk_times (not a streamed request?)"
+    return list(times)
+
+
+def chunk_gaps(entry: Dict[str, Any]) -> List[float]:
+    """Client-observed inter-chunk arrival gaps (len == chunks - 1)."""
+    times = chunk_times(entry)
+    return [t2 - t1 for t1, t2 in zip(times, times[1:], strict=False)]
+
+
+def ttft(entry: Dict[str, Any]) -> float:
+    times = chunk_times(entry)
+    assert times, "no content chunks received"
+    return times[0] - entry["start_time"]
+
+
+def assert_streaming_bookkeeping(
+    entry: Dict[str, Any],
+    *,
+    expected_chunks: int,
+    expected_token_times: Optional[int] = None,
+) -> None:
+    """ITL bookkeeping must be internally consistent with what was received:
+
+    - exactly ``expected_chunks`` content-bearing chunks were timestamped
+    - ``output_token_times`` (chunk times expanded per token by reportgen)
+      has exactly ``expected_token_times`` entries when given; its inter-token
+      gaps must contain exactly chunks-1 nonzero values (the real chunk gaps,
+      intra-chunk gaps are 0 by construction)
+    """
+    times = chunk_times(entry)
+    assert len(times) == expected_chunks, f"expected {expected_chunks} content chunks, got {len(times)}"
+    assert times == sorted(times), "chunk_times are not monotonically nondecreasing"
+
+    token_times = response_metrics(entry).get("output_token_times")
+    assert token_times, "response_metrics has no output_token_times"
+    if expected_token_times is not None:
+        assert len(token_times) == expected_token_times, (
+            f"expected {expected_token_times} output_token_times, got {len(token_times)}"
+        )
+    token_gaps = [t2 - t1 for t1, t2 in zip(token_times, token_times[1:], strict=False)]
+    nonzero = [g for g in token_gaps if g != 0.0]
+    assert len(nonzero) == expected_chunks - 1, (
+        f"expected {expected_chunks - 1} nonzero inter-token gaps (one per chunk boundary), got {len(nonzero)}"
+    )

--- a/e2e/utils/golden_sim.py
+++ b/e2e/utils/golden_sim.py
@@ -1,0 +1,353 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenAI-compatible sim server with fully controlled ground truth.
+
+Unlike llm-d-inference-sim, whose chunking follows its own whitespace notion
+of tokens, this sim constructs responses FROM a real tokenizer's token ids, so
+the exact token count of every response is known by construction and chunk
+boundaries can be placed deliberately (token-aligned or mid-token). Chunk
+pacing is controlled and every actual send timestamp is recorded, which lets
+tests assert token accounting at zero tolerance and inter-chunk timing against
+what the sim really did rather than what it was configured to do (#631).
+
+Each response is self-verified at construction: the concatenated chunk text
+must re-encode (add_special_tokens=False) to exactly ``n_tokens`` ids. A case
+that cannot be built exactly fails loudly at setup instead of silently
+testing something weaker.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GoldenCase:
+    """One controlled response: exactly ``n_tokens`` tokens split into
+    ``n_chunks`` SSE deltas.
+
+    ``n_tokens`` must be unique across the cases given to a server: it is
+    reported as ``usage.completion_tokens`` and is how tests map an observed
+    request back to its ground truth.
+
+    ``split`` places chunk boundaries:
+      - "token": boundaries on token boundaries (via offset mapping)
+      - "codepoint": evenly by character, deliberately mid-token/mid-word
+    """
+
+    n_tokens: int
+    n_chunks: int
+    split: str = "token"
+
+
+@dataclass
+class ServedRequest:
+    """What the sim actually did for one request."""
+
+    route: str
+    case: GoldenCase
+    prompt_text: str
+    # perf_counter() stamped immediately after each content chunk was written
+    # and drained. Tests compare client-observed inter-chunk gaps against
+    # diffs of these, so asyncio.sleep overshoot cannot fail the test.
+    send_times: List[float] = field(default_factory=list)
+
+
+class GoldenSimServer:
+    """Serves /v1/completions and /v1/chat/completions, streaming and unary,
+    cycling deterministically through ``cases`` in request-arrival order."""
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        cases: List[GoldenCase],
+        *,
+        model: str,
+        ttft_delay: float = 0.15,
+        inter_chunk_interval: float = 0.08,
+        corpus: Optional[str] = None,
+        host: str = "127.0.0.1",
+        port: int = 8000,
+    ) -> None:
+        ns = [c.n_tokens for c in cases]
+        if len(set(ns)) != len(ns):
+            raise ValueError(f"n_tokens must be unique per case (they key ground truth lookups), got {ns}")
+        self.tokenizer = tokenizer
+        self.cases = cases
+        self.model = model
+        self.ttft_delay = ttft_delay
+        self.inter_chunk_interval = inter_chunk_interval
+        self.host = host
+        self.port = port
+        self.requests: List[ServedRequest] = []
+        self._request_count = 0
+        self._runner: Optional[web.AppRunner] = None
+
+        corpus = corpus or _DEFAULT_CORPUS
+        self._chunks_by_case: Dict[int, List[str]] = {c.n_tokens: self._build_chunks(corpus, c) for c in cases}
+
+    def get_chunks(self, n_tokens: int) -> List[str]:
+        """The exact chunk texts served for the case keyed by ``n_tokens``.
+        Tests use these to derive ground truth with an independent tokenizer."""
+        return list(self._chunks_by_case[n_tokens])
+
+    # -- response construction ------------------------------------------------
+
+    def _build_chunks(self, corpus: str, case: GoldenCase) -> List[str]:
+        if not 1 <= case.n_chunks <= case.n_tokens:
+            raise ValueError(f"need 1 <= n_chunks <= n_tokens, got {case}")
+
+        enc = self.tokenizer(corpus, add_special_tokens=False, return_offsets_mapping=True)
+        ids = enc.input_ids
+        if len(ids) < case.n_tokens:
+            raise ValueError(f"corpus has {len(ids)} tokens, case needs {case.n_tokens}")
+        # Cut the text at the character where token n_tokens starts, so the
+        # response text corresponds to exactly the first n_tokens ids.
+        offsets = enc.offset_mapping
+        end_char = offsets[case.n_tokens - 1][1]
+        full_text = corpus[:end_char]
+
+        if case.split == "token":
+            # Chunk boundaries at token-start character offsets: exact
+            # concatenation is guaranteed because we slice one string.
+            per_chunk, extra = divmod(case.n_tokens, case.n_chunks)
+            boundaries = []
+            t = 0
+            for i in range(case.n_chunks):
+                t += per_chunk + (1 if i < extra else 0)
+                boundaries.append(end_char if t >= case.n_tokens else offsets[t][0])
+            chunks = []
+            start = 0
+            for b in boundaries:
+                chunks.append(full_text[start:b])
+                start = b
+        elif case.split == "codepoint":
+            per_chunk, extra = divmod(len(full_text), case.n_chunks)
+            chunks = []
+            start = 0
+            for i in range(case.n_chunks):
+                end = start + per_chunk + (1 if i < extra else 0)
+                chunks.append(full_text[start:end])
+                start = end
+        else:
+            raise ValueError(f"unknown split mode {case.split!r}")
+
+        # Self-verification: the fixture must actually be golden.
+        if "".join(chunks) != full_text:
+            raise AssertionError(f"chunk concatenation != full text for {case}")
+        if any(not c for c in chunks):
+            raise AssertionError(f"empty chunk built for {case}")
+        recount = len(self.tokenizer(full_text, add_special_tokens=False).input_ids)
+        if recount != case.n_tokens:
+            raise AssertionError(f"constructed text re-encodes to {recount} tokens, case needs {case.n_tokens}")
+        return chunks
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def __aenter__(self) -> "GoldenSimServer":
+        app = web.Application()
+        app.router.add_post("/v1/completions", self._handle_completions)
+        app.router.add_post("/v1/chat/completions", self._handle_chat)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+        logger.debug("golden sim listening on %s:%d", self.host, self.port)
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+
+    # -- request handling -----------------------------------------------------
+
+    def _next_case(self) -> GoldenCase:
+        case = self.cases[self._request_count % len(self.cases)]
+        self._request_count += 1
+        return case
+
+    def _usage(self, prompt_text: str, case: GoldenCase) -> Dict[str, int]:
+        # Like vLLM: prompt_tokens includes the sequence-start special tokens,
+        # completion_tokens counts generated tokens only.
+        prompt_tokens = len(self.tokenizer(prompt_text, add_special_tokens=True).input_ids)
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": case.n_tokens,
+            "total_tokens": prompt_tokens + case.n_tokens,
+        }
+
+    async def _handle_completions(self, request: web.Request) -> web.StreamResponse:
+        body = await request.json()
+        prompt_text = body.get("prompt", "")
+        case = self._next_case()
+        served = ServedRequest(route="/v1/completions", case=case, prompt_text=prompt_text)
+        self.requests.append(served)
+
+        def content_event(text: str, finish: Optional[str]) -> Dict[str, Any]:
+            return {
+                "id": "cmpl-golden",
+                "object": "text_completion",
+                "created": 0,
+                "model": self.model,
+                "choices": [{"index": 0, "text": text, "logprobs": None, "finish_reason": finish}],
+            }
+
+        if body.get("stream"):
+            return await self._stream(
+                request,
+                served,
+                content_events=[
+                    content_event(text, "length" if i == case.n_chunks - 1 else None)
+                    for i, text in enumerate(self._chunks_by_case[case.n_tokens])
+                ],
+                preamble_events=[],
+                usage=self._usage(prompt_text, case),
+            )
+
+        await asyncio.sleep(self.ttft_delay + self.inter_chunk_interval * (case.n_chunks - 1))
+        served.send_times.append(time.perf_counter())
+        return web.json_response(
+            {
+                "id": "cmpl-golden",
+                "object": "text_completion",
+                "created": 0,
+                "model": self.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "text": "".join(self._chunks_by_case[case.n_tokens]),
+                        "logprobs": None,
+                        "finish_reason": "length",
+                    }
+                ],
+                "usage": self._usage(prompt_text, case),
+            }
+        )
+
+    async def _handle_chat(self, request: web.Request) -> web.StreamResponse:
+        body = await request.json()
+        messages = body.get("messages", [])
+        prompt_text = "".join(m.get("content", "") for m in messages if isinstance(m.get("content"), str))
+        case = self._next_case()
+        served = ServedRequest(route="/v1/chat/completions", case=case, prompt_text=prompt_text)
+        self.requests.append(served)
+
+        def delta_event(delta: Dict[str, Any], finish: Optional[str]) -> Dict[str, Any]:
+            return {
+                "id": "chatcmpl-golden",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": self.model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+            }
+
+        if body.get("stream"):
+            chunks = self._chunks_by_case[case.n_tokens]
+            content_events = [{"delta": {"content": text}} for text in chunks]
+            return await self._stream(
+                request,
+                served,
+                content_events=[delta_event(e["delta"], None) for e in content_events],
+                # Realistic vLLM skeleton: a role-only first delta (no content)
+                # and an empty-delta finish event. The client must exclude both
+                # from token and timing accounting.
+                preamble_events=[delta_event({"role": "assistant", "content": ""}, None)],
+                usage=self._usage(prompt_text, case),
+                finish_event=delta_event({}, "length"),
+            )
+
+        await asyncio.sleep(self.ttft_delay + self.inter_chunk_interval * (case.n_chunks - 1))
+        served.send_times.append(time.perf_counter())
+        return web.json_response(
+            {
+                "id": "chatcmpl-golden",
+                "object": "chat.completion",
+                "created": 0,
+                "model": self.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "".join(self._chunks_by_case[case.n_tokens])},
+                        "finish_reason": "length",
+                    }
+                ],
+                "usage": self._usage(prompt_text, case),
+            }
+        )
+
+    async def _stream(
+        self,
+        request: web.Request,
+        served: ServedRequest,
+        *,
+        content_events: List[Dict[str, Any]],
+        preamble_events: List[Dict[str, Any]],
+        usage: Dict[str, int],
+        finish_event: Optional[Dict[str, Any]] = None,
+    ) -> web.StreamResponse:
+        resp = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+        )
+        await resp.prepare(request)
+
+        async def send(event: Dict[str, Any]) -> None:
+            await resp.write(b"data: " + json.dumps(event).encode() + b"\n\n")
+
+        for event in preamble_events:
+            await send(event)
+
+        await asyncio.sleep(self.ttft_delay)
+        for i, event in enumerate(content_events):
+            if i > 0:
+                await asyncio.sleep(self.inter_chunk_interval)
+            await send(event)
+            # Stamp after the write so the recorded time is as close as
+            # possible to when bytes actually left for the client.
+            served.send_times.append(time.perf_counter())
+
+        if finish_event is not None:
+            await send(finish_event)
+        # Trailing usage-only event, as vLLM emits with
+        # stream_options.include_usage=true.
+        await send(
+            {
+                "id": "golden-usage",
+                "object": "chat.completion.chunk",
+                "created": 0,
+                "model": self.model,
+                "choices": [],
+                "usage": usage,
+            }
+        )
+        await resp.write(b"data: [DONE]\n\n")
+        await resp.write_eof()
+        return resp
+
+
+_DEFAULT_CORPUS = (
+    "The quick brown fox jumps over the lazy dog while seventeen curious "
+    "penguins waddle across the frozen harbor, pausing to inspect a bright "
+    "red bucket that someone left beside the pier. Meanwhile the lighthouse "
+    "keeper brews a second pot of coffee and watches the morning ferry carve "
+    "a white line through the gray water, wondering whether the storm the "
+    "radio promised will arrive before the afternoon tide turns."
+)

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -543,7 +543,10 @@ class ChatCompletionAPIData(InferenceAPIData):
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
             prompt_len = self._count_prompt_tokens(tokenizer)
-            output_len = tokenizer.count_tokens(output_text)
+            # Generated text is a continuation, not a sequence start: counting it
+            # with special tokens would add a BOS the server's completion_tokens
+            # never contains.
+            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             return InferenceInfo(
                 request_metrics=self._build_request_metrics(prompt_len, output_len),
                 response_metrics=StreamedResponseMetrics(
@@ -566,7 +569,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                 lora_adapter=lora_adapter,
             )
         output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
-        output_len = tokenizer.count_tokens(output_text)
+        output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
         return InferenceInfo(
             request_metrics=self._build_request_metrics(prompt_len, output_len),
             response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=data.get("usage")),

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -58,7 +58,10 @@ class CompletionAPIData(InferenceAPIData):
             )
 
             prompt_len = tokenizer.count_tokens(self.prompt)
-            output_len = tokenizer.count_tokens(output_text)
+            # Generated text is a continuation, not a sequence start: counting it
+            # with special tokens would add a BOS the server's completion_tokens
+            # never contains.
+            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             self.model_response = output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
@@ -82,7 +85,7 @@ class CompletionAPIData(InferenceAPIData):
                     lora_adapter=lora_adapter,
                 )
             output_text = choices[0].get("text", "")
-            output_len = tokenizer.count_tokens(output_text)
+            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             self.model_response = output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -51,7 +51,7 @@ def test_count_prompt_tokens_includes_prefix_text() -> None:
     tokens — the total reflects the actual prompt sent to the model."""
     tokenizer = MagicMock()
     # One token per whitespace-separated word.
-    tokenizer.count_tokens.side_effect = lambda s: len(s.split())
+    tokenizer.count_tokens.side_effect = lambda s, **kw: len(s.split())
 
     data = ChatCompletionAPIData(
         messages=[ChatMessage(role="user", content="three words here")],
@@ -64,7 +64,7 @@ def test_count_prompt_tokens_includes_prefix_text() -> None:
 def test_count_prompt_tokens_without_prefix_text_unchanged() -> None:
     """Existing behavior holds when prefix_text is unset."""
     tokenizer = MagicMock()
-    tokenizer.count_tokens.side_effect = lambda s: len(s.split())
+    tokenizer.count_tokens.side_effect = lambda s, **kw: len(s.split())
 
     data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="five tokens in this prompt")])
     assert data._count_prompt_tokens(tokenizer) == 5

--- a/tests/required/loadgen/test_multi_turn_hang.py
+++ b/tests/required/loadgen/test_multi_turn_hang.py
@@ -27,7 +27,7 @@ def _make_mock_tokenizer(vocab_size: int = 1000) -> MagicMock:
     # Match the decode mock's "text_N" format so count_tokens returns a real int
     # (the new exact-length datagen path compares this against target_len).
     mock_tokenizer.count_tokens = MagicMock(
-        side_effect=lambda text: sum(int(n) for n in re.findall(r"text_(\d+)", text)) if isinstance(text, str) else 0
+        side_effect=lambda text, **kw: sum(int(n) for n in re.findall(r"text_(\d+)", text)) if isinstance(text, str) else 0
     )
     return mock_tokenizer
 

--- a/tests/test_conversation_replay_datagen.py
+++ b/tests/test_conversation_replay_datagen.py
@@ -47,7 +47,7 @@ def _clear_user_session_registry() -> Generator[None, None, None]:
 def _make_mock_tokenizer(vocab_size: int = 32000) -> MagicMock:
     """Create a mock tokenizer with the expected interface."""
     mock_tokenizer = MagicMock()
-    mock_tokenizer.count_tokens.side_effect = lambda text: len(text.split()) * 10 if text.strip() else 0
+    mock_tokenizer.count_tokens.side_effect = lambda text, **kw: len(text.split()) * 10 if text.strip() else 0
     hf_tok = MagicMock()
     hf_tok.vocab_size = vocab_size
     hf_tok.decode.side_effect = lambda ids, **kwargs: f"decoded_{ids}"
@@ -504,7 +504,7 @@ class TestSlidingWindowTruncation:
 
         mock_tokenizer = MagicMock()
         # count_tokens returns 100 for system prompt and 100 for each turn
-        mock_tokenizer.count_tokens.side_effect = lambda text: len(text.split()) * 10
+        mock_tokenizer.count_tokens.side_effect = lambda text, **kw: len(text.split()) * 10
 
         system_prompt = "System Instruction"  # length in words = 2 -> 20 tokens
         session = LocalUserSession(

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -82,7 +82,7 @@ def make_api_config() -> APIConfig:
 def make_mock_tokenizer() -> MagicMock:
     """Return a mock tokenizer that counts words as tokens."""
     tok = MagicMock()
-    tok.count_tokens = lambda text: max(1, len((text or "").split()))
+    tok.count_tokens = lambda text, **kw: max(1, len((text or "").split()))
     return tok
 
 

--- a/tests/test_output_len_special_tokens.py
+++ b/tests/test_output_len_special_tokens.py
@@ -1,0 +1,163 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for special-token handling in client-derived output_len.
+
+The server's completion_tokens counts generated tokens only; it never
+includes a client-side BOS. Counting the generated text with
+add_special_tokens=True adds one BOS per request for BOS-prepending
+tokenizers (e.g. Llama-3.1), so client output_len would sit at N+1 against
+the server's N and the two could never agree exactly.
+
+This pins the asymmetric policy:
+- output text is a continuation -> counted WITHOUT special tokens
+- prompt text starts a sequence -> counted WITH special tokens (matching
+  the server's prompt_tokens, which includes BOS)
+
+The fake tokenizer mimics a BOS-prepending tokenizer: one token per
+whitespace-separated word, plus one BOS when add_special_tokens=True.
+"""
+
+from typing import Any, AsyncGenerator, Dict, List, cast
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import ClientResponse
+
+from inference_perf.apis.base import StreamedResponseMetrics, UnaryResponseMetrics
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.config import APIConfig, APIType
+
+
+class FakeStreamingResponse:
+    """Minimal aiohttp ClientResponse stand-in that yields preset SSE bytes."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        self.status = 200
+        self.headers = {"content-type": "text/event-stream"}
+        self._chunks = chunks
+        self.content = self._make_content()
+
+    def _make_content(self) -> MagicMock:
+        content = MagicMock()
+
+        async def iter_any() -> AsyncGenerator[bytes, None]:
+            for chunk in self._chunks:
+                yield chunk
+
+        content.iter_any = iter_any
+        return content
+
+
+class FakeUnaryResponse:
+    """Minimal aiohttp ClientResponse stand-in for non-streaming JSON."""
+
+    def __init__(self, payload: Dict[str, Any]) -> None:
+        self.status = 200
+        self.headers = {"content-type": "application/json"}
+        self._payload = payload
+
+    async def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+def _bos_tokenizer() -> MagicMock:
+    """One token per word; add_special_tokens=True prepends one BOS."""
+
+    def count(text: str, add_special_tokens: bool = True) -> int:
+        if text == "":
+            return 0
+        return len(text.split()) + (1 if add_special_tokens else 0)
+
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=count)
+    return tokenizer
+
+
+def _chat_sse(chunk_texts: List[str]) -> bytes:
+    parts = [f'data: {{"choices":[{{"delta":{{"content":"{text}"}}}}]}}\n\n'.encode() for text in chunk_texts]
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+def _completion_sse(chunk_texts: List[str]) -> bytes:
+    parts = [f'data: {{"choices":[{{"text":"{text}"}}]}}\n\n'.encode() for text in chunk_texts]
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_output_len_excludes_special_tokens() -> None:
+    chunk_texts = ["aa bb", "cc dd", "ee"]
+    response = FakeStreamingResponse([_chat_sse(chunk_texts)])
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Chat, streaming=True)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="p1 p2 p3")], max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, StreamedResponseMetrics)
+    # "aa bbcc ddee" -> 3 words, and no BOS for generated text.
+    assert info.response_metrics.output_tokens == 3
+    # Prompt-side counting keeps special tokens: 3 words + BOS.
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4
+
+
+@pytest.mark.asyncio
+async def test_chat_unary_output_len_excludes_special_tokens() -> None:
+    payload = {"choices": [{"message": {"content": "aa bb cc"}}]}
+    response = FakeUnaryResponse(payload)
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Chat, streaming=False)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="p1 p2 p3")], max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, UnaryResponseMetrics)
+    assert info.response_metrics.output_tokens == 3
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4
+
+
+@pytest.mark.asyncio
+async def test_completion_streaming_output_len_excludes_special_tokens() -> None:
+    chunk_texts = ["aa bb", "cc dd", "ee"]
+    response = FakeStreamingResponse([_completion_sse(chunk_texts)])
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Completion, streaming=True)
+    data = CompletionAPIData(prompt="p1 p2 p3", max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, StreamedResponseMetrics)
+    assert info.response_metrics.output_tokens == 3
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4
+
+
+@pytest.mark.asyncio
+async def test_completion_unary_output_len_excludes_special_tokens() -> None:
+    payload = {"choices": [{"text": "aa bb cc"}]}
+    response = FakeUnaryResponse(payload)
+    tokenizer = _bos_tokenizer()
+    config = APIConfig(type=APIType.Completion, streaming=False)
+    data = CompletionAPIData(prompt="p1 p2 p3", max_tokens=100)
+
+    info = await data.process_response(cast(ClientResponse, response), config, tokenizer)
+
+    assert isinstance(info.response_metrics, UnaryResponseMetrics)
+    assert info.response_metrics.output_tokens == 3
+    assert info.request_metrics.text is not None
+    assert info.request_metrics.text.input_tokens == 4

--- a/tests/test_reasoning_output_support.py
+++ b/tests/test_reasoning_output_support.py
@@ -46,7 +46,7 @@ from inference_perf.datagen.replay_graph_session_datagen import (
 
 def _make_tokenizer() -> MagicMock:
     tok = MagicMock()
-    tok.count_tokens = lambda text: max(1, len((text or "").split()))
+    tok.count_tokens = lambda text, **kw: max(1, len((text or "").split()))
     return tok
 
 

--- a/tests/test_streaming_response_order.py
+++ b/tests/test_streaming_response_order.py
@@ -57,7 +57,7 @@ async def test_streaming_parser_receives_content() -> None:
     config = APIConfig(type=APIType.Chat, streaming=True)
 
     tokenizer = MagicMock()
-    tokenizer.count_tokens = MagicMock(side_effect=lambda text: len(text.split()))
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kw: len(text.split()))
 
     data = ChatCompletionAPIData(
         messages=[ChatMessage(role="user", content="test")],

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -60,7 +60,7 @@ class TestTraceReplay:
             mock_tokenizer_obj.vocab_size = 1000
             mock_tokenizer_obj.all_special_ids = []
             mock_tokenizer.get_tokenizer.return_value = mock_tokenizer_obj
-            mock_tokenizer.count_tokens.side_effect = lambda text: len(text.split())
+            mock_tokenizer.count_tokens.side_effect = lambda text, **kw: len(text.split())
 
             api_config = APIConfig(type=APIType.Completion)
             trace_config = TraceConfig(file=str(temp_path), format=TraceFormat.AZURE_PUBLIC_DATASET)


### PR DESCRIPTION
Fixes #631

Stacked on #644 (its commit is the first of the two in this PR); Will rebase once that merges. The test asserts client-side token counts exactly, so it is red without #644.

## Motivation

The metrics fidelity e2e (#614) uses llm-d-inference-sim, whose streamed chunks are words from its own bank. The client tokenizer's count of that text is unpredictable, so the test has to route token assertions through `use_server_output_tokens: true` and cannot check client-side counting at all. That is exactly where the #564 lineage of bugs lived. This PR closes that gap per the plan in #631.

## What it adds

**`e2e/utils/golden_sim.py`**: an aiohttp OpenAI-compatible sim whose responses are constructed *from* real tokenizer ids. For each golden case it decodes a fixed number of tokens, splits the text on exact token boundaries via `offset_mapping` (or deliberately mid-token for codepoint-split cases), self-verifies the fixtures (chunks concatenate to the full text and re-encode to the intended count), and streams them with a fixed TTFT and inter-chunk interval, recording actual send timestamps. Every quantity the client reports has a known exact expected value.

**`e2e/utils/accuracy.py`**: shared assertion helpers (non-vacuous run success, per-entry output token accounting with zero default tolerance, chunk/token-time bookkeeping, gap extraction) reusable by future accuracy tests, plus self-tests proving the helpers reject wrong values.

**`e2e/tests/test_golden_accuracy_sim.py`**: a 6-way matrix over two BOS-prepending tokenizers (vendored gemma-3-270m, offline; and the Llama 3.1 8B FP8 tokenizer from #564), completion and chat, streaming and unary, plus a `use_server_output_tokens` variant. Golden cases cover single-chunk, multi-chunk token-aligned, mid-token (codepoint) splits, and one-token-per-chunk. Assertions are exact where the value is deterministic: per-request output tokens, chunk counts, token-time expansion counts (K-1 nonzero gaps, N-K zeros), summary totals and `token_count_mismatches`, and the multiset of cases served. Timing is bounded against the sim's recorded actual send gaps rather than nominal config, keeping it flake-resistant under loaded CI runners.

## Validation

- Mutation-tested: reintroducing the #564-class bugs (whole-text BOS count, per-chunk BOS in the reportgen expansion) each turn the matrix red with the expected failure messages
- Full unit suite, ruff, and mypy --strict clean; e2e matrix passes locally under pytest-xdist