### PR TITLE
fix: correct stale table print-count assertions in test_cli_summary

### DIFF
--- a/tests/required/utils/test_cli_summary.py
+++ b/tests/required/utils/test_cli_summary.py
@@ -46,7 +46,7 @@ class TestCliSummary(unittest.TestCase):
         report = ReportFile(name="stage_0_lifecycle_metrics", contents=contents)
         print_summary_table([report])
 
-        self.assertEqual(mock_console_print.call_count, 4)
+        self.assertEqual(mock_console_print.call_count, 5)
 
     def test_extract_session_stage_id(self) -> None:
         self.assertEqual(extract_session_stage_id("stage_0_session_lifecycle_metrics"), 0)
@@ -119,8 +119,8 @@ class TestCliSummary(unittest.TestCase):
             ReportFile(name="stage_0_session_lifecycle_metrics", contents=session_contents),
         ]
         print_summary_table(reports)
-        # 4 request tables + 3 session tables = 7
-        self.assertEqual(mock_console_print.call_count, 7)
+        # 5 request tables (including error table) + 3 session tables = 8
+        self.assertEqual(mock_console_print.call_count, 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Fixes [#650](https://github.com/kubernetes-sigs/inference-perf/issues/650).

[#601](https://github.com/kubernetes-sigs/inference-perf/pull/601) added `print_error_summary_table`, called from `print_summary_table`, adding one more `console.print` call per invocation for the new error summary table. The hardcoded expected call counts in two tests in `tests/required/utils/test_cli_summary.py` were never updated to account for it:

- `test_print_summary_table_with_reports`: 4 -> 5
- `test_print_summary_table_includes_session_tables`: 7 -> 8 (5 request tables including the error table + 3 session tables)

## Test plan

- [x] `pdm run python -m pytest tests/required/utils/test_cli_summary.py -v` — all 7 tests pass