### PR TITLE
ci: give CI jobs distinct names so they can be required status checks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,11 +8,9 @@ on:
     paths-ignore:
       - '**/*.md'
   pull_request:
-    paths-ignore:
-      - '**/*.md'
 
 jobs:
-  format-check:
+  coverage:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,7 +11,7 @@ on:
       - 'feature/**'
 
 jobs:
-  format-check:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  format-check:
+  unit-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## What this does

The unit test, coverage, and lint workflows all use the same job id (`format-check`), so their GitHub check contexts collide as `format-check (3.13)`. This renames them so each produces a distinct, stable context:

| Workflow | Old context | New context |
|---|---|---|
| unit_test.yml | format-check (3.13) | unit-test (3.13) |
| coverage.yml | format-check (3.13) | coverage (3.13) |
| format.yml | format-check (3.13) | lint (3.13) |

It also drops the `pull_request` `paths-ignore` filter on the coverage workflow: once coverage becomes a required status check, a docs-only PR that skips the workflow would block forever on "Expected — waiting for status".

## Why

#651 was merged by tide after only EasyCLA + tide passed — the repo's branch protection (managed by branchprotector in kubernetes/test-infra) requires only `EasyCLA`, so none of the CI workflows gate merges. A follow-up PR to kubernetes/test-infra will add these contexts (plus `e2e-tests`) as required status checks and set `from-branch-protection: true` in tide's `context_options`, so Prow waits for CI to pass before merging.

This PR must merge first so the new context names exist.