### PR TITLE
ci: gate tide merges on CI via do-not-merge label

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
       - '**/*.md'
   pull_request:
-    paths-ignore:
-      - '**/*.md'
 
 jobs:
   format-check:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,16 +20,36 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # Important: need full history to checkout 'main'
+      # The workflow runs on every PR (no paths filter) so the Merge Gate
+      # workflow always sees a completed Code Coverage run, but coverage
+      # itself is skipped as a no-op when only markdown files changed.
+      - name: Check for non-markdown changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -qv '\.md$'; then
+              echo "code=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "code=false" >> "$GITHUB_OUTPUT"
+              echo "Only markdown files changed; skipping coverage."
+            fi
+          else
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Set up Python
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up PDM
+        if: steps.changes.outputs.code == 'true'
         uses: pdm-project/setup-pdm@c6081998a653693a457d93c70b8007d979bc6741 # v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        if: steps.changes.outputs.code == 'true'
         run: |
           pdm sync -d -G analysis -G otel
       - name: Run Validation
+        if: steps.changes.outputs.code == 'true'
         run: pdm run check:cov

--- a/.github/workflows/merge_gate.yml
+++ b/.github/workflows/merge_gate.yml
@@ -1,0 +1,104 @@
+name: Merge Gate
+
+# Tide (Prow) merges PRs as soon as they have lgtm + approved, because the
+# only required status check on this repo is EasyCLA. This workflow makes
+# tide wait for CI: it applies the `do-not-merge` label (which tide's query
+# for kubernetes-sigs treats as a merge blocker) whenever a PR is opened or
+# updated, and removes it once the latest run of every CI workflow for the
+# PR's head commit has succeeded.
+#
+# The bare `do-not-merge` label is used (not `do-not-merge/hold`) so this
+# workflow never interferes with a human `/hold`, which Prow manages via the
+# `do-not-merge/hold` label.
+#
+# NOTE: this uses pull_request_target, which runs with write permissions on
+# fork PRs. It must never check out or execute PR code — it only mutates
+# labels via the API.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows:
+      - Unit Tests
+      - Code Coverage
+      - Python Linting and Type Checks
+      - E2E Test on change
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply or clear merge-gate label
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const GATE_LABEL = 'do-not-merge';
+            // Must match the `name:` of every workflow listed under
+            // `on.workflow_run.workflows` above.
+            const REQUIRED_WORKFLOWS = [
+              'Unit Tests',
+              'Code Coverage',
+              'Python Linting and Type Checks',
+              'E2E Test on change',
+            ];
+
+            if (context.eventName === 'pull_request_target') {
+              // New or updated PR: hold it until CI passes.
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [GATE_LABEL],
+              });
+              core.info(`Added ${GATE_LABEL} to #${context.payload.pull_request.number}`);
+              return;
+            }
+
+            // workflow_run completed: check whether every required workflow
+            // succeeded for this head commit.
+            const headSha = context.payload.workflow_run.head_sha;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              ...context.repo,
+              head_sha: headSha,
+              per_page: 100,
+            });
+            for (const name of REQUIRED_WORKFLOWS) {
+              const wfRuns = runs
+                .filter(r => r.name === name && r.event === 'pull_request')
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+              if (wfRuns.length === 0) {
+                core.info(`${name}: no run for ${headSha} yet; keeping label`);
+                return;
+              }
+              const latest = wfRuns[0];
+              if (latest.status !== 'completed' || latest.conclusion !== 'success') {
+                core.info(`${name}: ${latest.status}/${latest.conclusion}; keeping label`);
+                return;
+              }
+            }
+
+            // All required workflows green: unlabel every open PR whose
+            // current head is this commit.
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              ...context.repo,
+              commit_sha: headSha,
+            });
+            for (const pr of prs) {
+              if (pr.state !== 'open' || pr.head.sha !== headSha) continue;
+              if (!pr.labels.some(l => l.name === GATE_LABEL)) continue;
+              try {
+                await github.rest.issues.removeLabel({
+                  ...context.repo,
+                  issue_number: pr.number,
+                  name: GATE_LABEL,
+                });
+                core.info(`Removed ${GATE_LABEL} from #${pr.number}`);
+              } catch (e) {
+                if (e.status !== 404) throw e; // 404: label already gone
+              }
+            }


### PR DESCRIPTION
## Problem

Tide merges PRs as soon as `lgtm` + `approved` land, because the only required status check on this repo is EasyCLA (branch protection is managed centrally in kubernetes/test-infra, and this repo has no entry beyond the org default). None of our GitHub Actions CI gates merging — #651 merged after only EasyCLA + tide ran.

## Approach

Keep everything in-repo (no test-infra changes, no check names referenced externally): a new **Merge Gate** workflow applies/removes the `do-not-merge` label, which tide's kubernetes-sigs query treats as a merge blocker.

- On `pull_request_target` (opened/reopened/synchronize): add `do-not-merge`. This trigger has a write token even on fork PRs; the job never checks out PR code — it only calls the labels API.
- On `workflow_run` completion of any CI workflow (Unit Tests, Code Coverage, Python Linting and Type Checks, E2E Test on change): if the **latest run of all four** for that head SHA succeeded, remove the label from the open PR(s) at that commit. Otherwise the label stays; a new push re-adds and re-evaluates.

The bare `do-not-merge` label is used (already exists in the repo, unmanaged by any Prow plugin) rather than `do-not-merge/hold`, so the gate can never cancel a human `/hold`.

Because the gate requires a completed Code Coverage run, that workflow now triggers on every PR — but it detects markdown-only diffs in-job and skips the actual coverage steps as a no-op, so we don't burn CI on docs changes.

Nice side effect: fork PRs from first-time contributors get labeled immediately, while their CI waits for maintainer run-approval — so they stay held until CI is approved *and* green.

## Test plan

- `workflow_run` triggers only run from the default branch's copy of the workflow, so end-to-end behavior is verifiable after merge: open a trivial PR, confirm the label is applied on open, stays through CI, and is removed once all four workflows pass; confirm an md-only PR gets a green no-op coverage run and is released.