### PR TITLE
fix: reserve request-specific max_tokens during prompt truncation

### DIFF
--- a/inference_perf/apis/user_session.py
+++ b/inference_perf/apis/user_session.py
@@ -141,11 +141,16 @@ class UserSessionCompletionAPIData(CompletionAPIData):
     async def to_request_body(
         self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
     ) -> RequestBody:
+        if self.max_tokens == 0:
+            self.max_tokens = max_tokens
+
         self._session_context = await self.user_session.get_context(self.target_round)
 
         if self.user_session.tokenizer and self.user_session.max_model_len:
+            # Use the request-specific max_tokens (sampled from the output distribution) rather than the
+            # client-wide default so prompt + completion stays within the model's context length.
             # 200 token buffer to ensure we stay under model's context length regardless of any tokenization variations
-            target_len = self.user_session.max_model_len - max_tokens - 200
+            target_len = self.user_session.max_model_len - self.max_tokens - 200
             hf_tokenizer = self.user_session.tokenizer.get_tokenizer()
 
             system_prompt = self.user_session.system_prompt

--- a/tests/required/apis/test_user_session.py
+++ b/tests/required/apis/test_user_session.py
@@ -291,3 +291,35 @@ class TestUserSessionTruncation:
 
         assert session.system_prompt == "tok_10"
         assert payload["prompt"] == "tok_10 tok_10"
+
+    @pytest.mark.parametrize(
+        ("request_max_tokens", "default_max_tokens"),
+        [(10, 2), (0, 10)],
+        ids=["request-specific-value", "client-default-fallback"],
+    )
+    @pytest.mark.asyncio
+    async def test_prompt_truncation_reserves_actual_max_tokens(
+        self, request_max_tokens: int, default_max_tokens: int
+    ) -> None:
+        """Truncation reserves the completion length that the request will send."""
+        tok = _mock_tokenizer()
+        hf = tok.get_tokenizer.return_value
+        hf.encode = MagicMock(side_effect=lambda text: [1] * tok.count_tokens(text))
+
+        session = LocalUserSession(user_session_id="sess_3", system_prompt="tok_5", tokenizer=tok, max_model_len=220)
+        LocalUserSession._instances["sess_3"] = session
+
+        session.history = ["tok_5", "tok_5"]
+        session.context = "tok_5 tok_5 tok_5"
+
+        data = UserSessionCompletionAPIData(
+            user_session_id="sess_3", target_round=1, prompt="tok_10", max_tokens=request_max_tokens
+        )
+
+        payload = await data.to_request_body("model", default_max_tokens, False, False)
+
+        assert payload["max_tokens"] == 10
+        # prompt + completion + 200 token buffer must fit within max_model_len
+        assert tok.count_tokens(payload["prompt"]) + payload["max_tokens"] + 200 <= 220
+        # target_len = 220 - 10 - 200 = 10, so history and system prompt are dropped
+        assert payload["prompt"] == "tok_10"


### PR DESCRIPTION
## Summary

Fixes #617.

- initialize `self.max_tokens` from the client default before truncation when the request does not set it
- calculate the prompt target from the actual completion limit sent in the request
- cover both request-specific and client-default token limits with regression tests

## Test plan

- [x] `pdm run validate`
- [x] `pdm run test` — 493 passed, 10 skipped
- [x] `pdm run check:cov --force` — coverage increased from 69.04% to 69.83%