### PR TITLE
fix: bound stage teardown so timed-out stages always produce reports

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -232,6 +232,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--load.trace.format` | Enum (AzurePublicDataset) | Matches load.trace.format in config |
 | `--load.circuit_breakers` | JSON | Matches load.circuit_breakers in config |
 | `--load.request_timeout` | float | Matches load.request_timeout in config |
+| `--load.stage_teardown_grace_seconds` | float | How long to let in-flight requests finish after a stage ends or times out, before they are cancelled. Teardown is bounded: once the grace (plus a fixed margin) expires, remaining work is force-cancelled and unresponsive workers are terminated and respawned, so report generation always runs. Set to 0 to cancel in-flight requests immediately at stage end. |
 | `--load.lora_traffic_split` | JSON | Matches load.lora_traffic_split in config |
 | `--load.base_seed` | int | Matches load.base_seed in config |
 | `--metrics.type` | Enum (prometheus, default) | Matches metrics.type in config |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -349,6 +349,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--load.trace.format` | Enum (AzurePublicDataset) | Format of the trace file. |
 | `--load.circuit_breakers` | JSON | Names of configured circuit breakers to enable for the run. |
 | `--load.request_timeout` | float | Per-request timeout in seconds. |
+| `--load.stage_teardown_grace_seconds` | float | How long to let in-flight requests finish after a stage ends or times out, before they are cancelled. Teardown is bounded: once the grace (plus a fixed margin) expires, remaining work is force-cancelled and unresponsive workers are terminated and respawned, so report generation always runs. Set to 0 to cancel in-flight requests immediately at stage end. |
 | `--load.lora_traffic_split` | JSON | Traffic split across LoRA adapters. Splits must sum to 1.0. |
 | `--load.base_seed` | int | Base random seed for load generation. Defaults to the current time. |
 | `--metrics.type` | Enum (prometheus, default) | Metrics client used to collect server-side metrics. |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -349,7 +349,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--load.trace.format` | Enum (AzurePublicDataset) | Format of the trace file. |
 | `--load.circuit_breakers` | JSON | Names of configured circuit breakers to enable for the run. |
 | `--load.request_timeout` | float | Per-request timeout in seconds. |
-| `--load.stage_teardown_grace_seconds` | float | How long to let in-flight requests finish after a stage ends or times out, before they are cancelled. Teardown is bounded: once the grace (plus a fixed margin) expires, remaining work is force-cancelled and unresponsive workers are terminated and respawned, so report generation always runs. Set to 0 to cancel in-flight requests immediately at stage end. |
+| `--load.stage_teardown_grace_seconds` | float | How long to let in-flight requests finish after a stage ends or times out, before they are cancelled. Teardown is bounded: once the grace (plus a fixed margin) expires, remaining work is force-cancelled and unresponsive workers are terminated and respawned, so report generation always runs. Set to 0 to cancel in-flight requests immediately at stage end. The teardown window is excluded from the stage's reported end_time and metrics windows; it is reported separately as teardown_duration. |
 | `--load.lora_traffic_split` | JSON | Traffic split across LoRA adapters. Splits must sum to 1.0. |
 | `--load.base_seed` | int | Base random seed for load generation. Defaults to the current time. |
 | `--metrics.type` | Enum (prometheus, default) | Metrics client used to collect server-side metrics. |

--- a/inference_perf/client/server_metrics/base.py
+++ b/inference_perf/client/server_metrics/base.py
@@ -34,11 +34,18 @@ class StageStatus(Enum):
 class StageRuntimeInfo(BaseModel):
     stage_id: int
     rate: float
+    # End of the load window. Stage teardown (draining or cancelling in-flight
+    # requests) happens after end_time and is reported in teardown_duration,
+    # so metrics windows derived from [start_time, end_time] exclude it.
     end_time: float
     start_time: float
     status: StageStatus
     concurrency_level: Optional[int] = None
     timeout: Optional[float] = None
+    teardown_duration: Optional[float] = None
+    # Requests generated for the stage but never dispatched to the model
+    # server because the stage ended first; > 0 marks a truncated stage.
+    dropped_requests: Optional[int] = None
 
 
 class PerfRuntimeParameters:

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -165,6 +165,17 @@ class LoadConfig(BaseModel):
     trace: Optional[TraceConfig] = None
     circuit_breakers: List[str] = []
     request_timeout: Optional[float] = None
+    stage_teardown_grace_seconds: float = Field(
+        default=120.0,
+        ge=0,
+        description=(
+            "How long to let in-flight requests finish after a stage ends or times out, "
+            "before they are cancelled. Teardown is bounded: once the grace (plus a fixed "
+            "margin) expires, remaining work is force-cancelled and unresponsive workers "
+            "are terminated and respawned, so report generation always runs. Set to 0 to "
+            "cancel in-flight requests immediately at stage end."
+        ),
+    )
     lora_traffic_split: Optional[List[MultiLoRAConfig]] = None
     base_seed: int = Field(default_factory=lambda: int(time.time() * 1000))
 

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -181,6 +181,17 @@ class LoadConfig(StrictBaseModel):
     )
     circuit_breakers: List[str] = Field(default=[], description="Names of configured circuit breakers to enable for the run.")
     request_timeout: Optional[float] = Field(default=None, description="Per-request timeout in seconds.")
+    stage_teardown_grace_seconds: float = Field(
+        default=120.0,
+        ge=0,
+        description=(
+            "How long to let in-flight requests finish after a stage ends or times out, "
+            "before they are cancelled. Teardown is bounded: once the grace (plus a fixed "
+            "margin) expires, remaining work is force-cancelled and unresponsive workers "
+            "are terminated and respawned, so report generation always runs. Set to 0 to "
+            "cancel in-flight requests immediately at stage end."
+        ),
+    )
     lora_traffic_split: Optional[List[MultiLoRAConfig]] = Field(
         default=None, description="Traffic split across LoRA adapters. Splits must sum to 1.0."
     )

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -189,7 +189,9 @@ class LoadConfig(StrictBaseModel):
             "before they are cancelled. Teardown is bounded: once the grace (plus a fixed "
             "margin) expires, remaining work is force-cancelled and unresponsive workers "
             "are terminated and respawned, so report generation always runs. Set to 0 to "
-            "cancel in-flight requests immediately at stage end."
+            "cancel in-flight requests immediately at stage end. The teardown window is "
+            "excluded from the stage's reported end_time and metrics windows; it is "
+            "reported separately as teardown_duration."
         ),
     )
     lora_traffic_split: Optional[List[MultiLoRAConfig]] = Field(

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -36,12 +36,15 @@ from inference_perf.config import (
 from asyncio import (
     CancelledError,
     Semaphore,
+    Task,
+    TimeoutError as AsyncioTimeoutError,
     create_task,
     gather,
     run,
     sleep,
     set_event_loop_policy,
     get_event_loop,
+    wait_for,
 )
 import sys
 
@@ -58,7 +61,7 @@ from types import FrameType
 import time
 import multiprocessing as mp
 from queue import Empty
-from multiprocessing.synchronize import Barrier as SyncBarrier, Event as SyncEvent
+from multiprocessing.synchronize import Event as SyncEvent
 from multiprocessing.sharedctypes import Synchronized
 from concurrent.futures import TimeoutError
 from functools import partial
@@ -79,6 +82,17 @@ import signal
 from inference_perf.observability.logging import get_console
 
 logger = logging.getLogger(__name__)
+
+# Stage-teardown tuning. The teardown protocol is bounded end to end: workers
+# give in-flight requests `stage_teardown_grace_seconds` (LoadConfig) to finish
+# naturally, then cancel and reap the remainder within _WIND_DOWN_REAP_SECONDS.
+# The main process allows the worker grace plus _TEARDOWN_MARGIN_SECONDS before
+# broadcasting the force-stop signal, then _FORCE_REAP_SECONDS more before
+# terminating (and respawning) workers that still have not reached the stage
+# rendezvous. Report generation therefore always runs.
+_WIND_DOWN_REAP_SECONDS = 10.0
+_TEARDOWN_MARGIN_SECONDS = 15.0
+_FORCE_REAP_SECONDS = 20.0
 
 
 class RequestQueueData(NamedTuple):
@@ -103,7 +117,9 @@ class Worker(mp.Process):
         active_requests_counter: "Synchronized[int]",
         shared_max_concurrency: Optional["Synchronized[int]"],
         base_seed: int,
-        stage_barrier: Optional[SyncBarrier] = None,
+        force_stop_signal: Optional[SyncEvent] = None,
+        stage_done_counter: Optional["Synchronized[int]"] = None,
+        teardown_grace_seconds: float = 120.0,
     ):
         super().__init__(daemon=True)  # kill worker process if main process exit unexpected
         self.id = id
@@ -119,7 +135,12 @@ class Worker(mp.Process):
         self.shared_max_concurrency = shared_max_concurrency
         self.skip = False
         self.base_seed = base_seed
-        self.stage_barrier = stage_barrier
+        self.force_stop_signal = force_stop_signal
+        self.stage_done_counter = stage_done_counter
+        self.teardown_grace_seconds = teardown_grace_seconds
+        # True while the stage is winding down: in-flight requests may finish,
+        # but no new requests are dispatched to the model server.
+        self.draining = False
         # Snapshot the parent's effective root log level so the worker
         # interpreter (which under forkserver/spawn does not inherit the
         # parent's basicConfig) can configure its own handler to surface
@@ -157,7 +178,12 @@ class Worker(mp.Process):
                 await sleep(0)
 
             # Process requests in loop
-            while self.request_phase.is_set() and not self.cancel_signal.is_set() and not self.skip:
+            while (
+                self.request_phase.is_set()
+                and not self.cancel_signal.is_set()
+                and not self.skip
+                and not self.stop_signal.is_set()
+            ):
                 await semaphore.acquire()
                 try:
                     # Use partial to pass named arg
@@ -204,6 +230,15 @@ class Worker(mp.Process):
                             )
                             return  # Exit this task, finally block will clean up
 
+                        # Stage is winding down: in-flight requests may finish,
+                        # but nothing new is sent to the model server. This also
+                        # unwinds session-replay dependency chains quickly - a
+                        # successor woken by its predecessor exits here instead
+                        # of dispatching.
+                        if self.draining:
+                            logger.debug(f"[Worker {self.id}] stage tearing down, not dispatching new request")
+                            return
+
                         with self.active_requests_counter.get_lock():
                             self.active_requests_counter.value += 1
                             inflight = True
@@ -246,23 +281,66 @@ class Worker(mp.Process):
             # Reset skip
             self.skip = False
 
-            if self.cancel_signal.is_set():
-                logger.debug(f"[Worker {self.id}] cancelling tasks with {self.active_requests_counter.value} active requests")
-                for task in tasks:
-                    task.cancel()
-                while self.request_phase.is_set():
-                    await sleep(0)
-                logger.debug(f"[Worker {self.id}] done cancelling")
-            if not self.request_phase.is_set():
-                await gather(*tasks)
+            if self.cancel_signal.is_set() or not self.request_phase.is_set():
+                await self._wind_down_stage(tasks)
                 tasks = []
                 LocalUserSession.clear_instances()
-                if self.stage_barrier:
-                    self.stage_barrier.wait()
+                if self.stage_done_counter is not None:
+                    with self.stage_done_counter.get_lock():
+                        self.stage_done_counter.value += 1
+                # Hold until the main process acknowledges the stage boundary by
+                # clearing cancel_signal, so one stage cannot be reported done
+                # twice by the same worker.
+                while self.cancel_signal.is_set() and not self.stop_signal.is_set():
+                    await sleep(0.05)
                 logger.debug(f"[Worker {self.id}] waiting for next phase")
-                self.request_phase.wait()
+                while not self.request_phase.is_set() and not self.stop_signal.is_set():
+                    self.request_phase.wait(timeout=0.5)
 
         logger.debug(f"[Worker {self.id}] stopped")
+
+    async def _wind_down_stage(self, tasks: List["Task[None]"]) -> None:
+        """Bounded end-of-stage wind-down; always returns.
+
+        In-flight requests get up to teardown_grace_seconds to finish naturally
+        (recording their metrics). Tasks still parked on session predecessors
+        unwind quickly because new dispatches are gated off by self.draining.
+        Whatever remains after the grace is cancelled and reaped within a fixed
+        bound, so the worker always reaches the stage rendezvous.
+        """
+        self.draining = True
+        try:
+            pending = [t for t in tasks if not t.done()]
+            if pending:
+                logger.debug(
+                    f"[Worker {self.id}] stage teardown: waiting up to {self.teardown_grace_seconds:.0f}s "
+                    f"for {len(pending)} in-flight tasks"
+                )
+                deadline = time.perf_counter() + self.teardown_grace_seconds
+                while pending and time.perf_counter() < deadline:
+                    if self.force_stop_signal is not None and self.force_stop_signal.is_set():
+                        break
+                    await sleep(0.25)
+                    pending = [t for t in pending if not t.done()]
+            if pending:
+                logger.warning(f"[Worker {self.id}] cancelling {len(pending)} tasks still running at stage teardown")
+                for task in pending:
+                    task.cancel()
+                try:
+                    await wait_for(gather(*pending, return_exceptions=True), timeout=_WIND_DOWN_REAP_SECONDS)
+                except (AsyncioTimeoutError, TimeoutError):
+                    stuck = sum(1 for t in pending if not t.done())
+                    logger.error(f"[Worker {self.id}] abandoning {stuck} tasks that did not respond to cancellation")
+            # Surface real task failures. Before this rework they were re-raised
+            # by an unguarded gather at teardown, killing the worker process and
+            # stranding the main process at the stage rendezvous.
+            for task in tasks:
+                if task.done() and not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        logger.error(f"[Worker {self.id}] task failed during stage: {type(exc).__name__}: {exc}")
+        finally:
+            self.draining = False
 
     def run(self) -> None:
         # forkserver/spawn workers start from a fresh interpreter without the
@@ -308,6 +386,13 @@ class LoadGenerator:
         self.sweep_config = load_config.sweep
         self.interrupt_sig = False
         self.session_metrics_collector = session_metrics_collector
+        self.teardown_grace_seconds = load_config.stage_teardown_grace_seconds
+        # Set by mp_run; broadcast to workers when the teardown grace expires
+        # so they cancel whatever is still in flight.
+        self._force_stop_signal: Optional[SyncEvent] = None
+        # Number of stage teardowns completed so far; each worker's
+        # stage_done_counter must reach this value at the stage rendezvous.
+        self._expected_stage_done = 0
         signal.signal(signal.SIGINT, self._sigint_handler)
 
         # Validate that datagen type matches load_type
@@ -619,6 +704,19 @@ class LoadGenerator:
                     del session_spans[sid]
                 break
 
+            # Fail fast on worker death instead of waiting out the stage
+            # timeout: sessions assigned to a dead worker can never complete.
+            if self.workers and any(not w.is_alive() for w in self.workers):
+                if progress_ctx and stage_task:
+                    progress_ctx.remove_task(stage_task)
+                    stage_task = None
+                logger.error(f"Stage {stage_id}: a worker process died unexpectedly; failing stage")
+                stage_status = StageStatus.FAILED
+                for sid in list(session_spans.keys()):
+                    otel_instr.end_session_span(session_spans[sid], "Worker process died")
+                    del session_spans[sid]
+                break
+
             # Check for completed sessions
             newly_completed = []
             for session_idx in list(active_session_indices):
@@ -699,22 +797,11 @@ class LoadGenerator:
         if stage_status == StageStatus.RUNNING:
             stage_status = StageStatus.COMPLETED
 
-        # Cancel in-flight tasks and drain stranded queue items.
-        # In the happy path this is a no-op (all items already processed).
-        # In the failure path, process_failure sends a completion notification
-        # immediately — before the worker picks up all items from the queue.
-        # Without this, request_queue.join() hangs on items that never got task_done().
-        if cancel_signal is not None:
-            cancel_signal.set()
-            await sleep(1)
-            while active_requests_counter.value > 0:
-                await sleep(1)
-            request_queue.drain()
-            cancel_signal.clear()
-
-        # Clear the request_phase event to force worker gather
-        request_phase.clear()
-        request_queue.join()
+        # Bounded teardown: stop dispatching, give in-flight requests the
+        # configured grace to complete (their metrics are kept), then force
+        # the stage boundary. Guaranteed to return, so reports always generate.
+        if not await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal):
+            stage_status = StageStatus.FAILED
 
         # End stage-level span if trace_per_stage is enabled
         if stage_span is not None:
@@ -733,6 +820,110 @@ class LoadGenerator:
         )
         logger.info(
             "Stage %d - session-based run %s", stage_id, "completed" if stage_status == StageStatus.COMPLETED else "failed"
+        )
+
+    async def _teardown_stage(
+        self,
+        stage_id: int,
+        request_queue: RequestQueue[RequestQueueData],
+        request_phase: SyncEvent,
+        cancel_signal: Optional[SyncEvent],
+    ) -> bool:
+        """Bounded stage teardown; always returns, so reports always generate.
+
+        Stops dispatch immediately, gives in-flight requests the configured
+        grace to finish (their metrics are kept), then forces the boundary:
+        the force-stop signal makes workers cancel whatever is left, and any
+        worker that still fails to reach the stage rendezvous (died, or its
+        event loop is wedged) is terminated and respawned so subsequent stages
+        run at full capacity. Returns True when every worker wound down
+        cleanly, False when the stage had to be forced.
+        """
+        if cancel_signal is not None:
+            cancel_signal.set()
+        request_phase.clear()
+
+        clean = True
+        if self.workers:
+            self._expected_stage_done += 1
+            expected = self._expected_stage_done
+            grace_deadline = time.perf_counter() + self.teardown_grace_seconds + _TEARDOWN_MARGIN_SECONDS
+            force_deadline: Optional[float] = None
+            while True:
+                pending = [
+                    w
+                    for w in self.workers
+                    if w.is_alive() and (w.stage_done_counter is None or w.stage_done_counter.value < expected)
+                ]
+                if not pending:
+                    break
+                now = time.perf_counter()
+                if force_deadline is None and now >= grace_deadline:
+                    logger.warning(
+                        "Stage %d: teardown grace expired; forcing cancellation of in-flight work on %d worker(s)",
+                        stage_id,
+                        len(pending),
+                    )
+                    if self._force_stop_signal is not None:
+                        self._force_stop_signal.set()
+                    force_deadline = now + _FORCE_REAP_SECONDS
+                elif force_deadline is not None and now >= force_deadline:
+                    for worker in pending:
+                        logger.error("Stage %d: terminating worker %d stuck in teardown", stage_id, worker.id)
+                        worker.terminate()
+                    clean = False
+                    break
+                await sleep(0.25)
+
+        # Nobody is pulling anymore: remove undispatched items left in the queue.
+        request_queue.drain()
+        if self._force_stop_signal is not None:
+            self._force_stop_signal.clear()
+        if cancel_signal is not None:
+            cancel_signal.clear()
+
+        # Replace workers that did not survive the stage (terminated above, or
+        # died earlier e.g. from an OOM kill) so later stages keep full capacity.
+        for idx, worker in enumerate(self.workers):
+            if not worker.is_alive() and worker.exitcode is None:
+                continue  # never started; leave to caller
+            if not worker.is_alive() or (
+                worker.stage_done_counter is not None and worker.stage_done_counter.value < self._expected_stage_done
+            ):
+                clean = False
+                worker.join(timeout=5.0)
+                if worker.is_alive():
+                    worker.kill()
+                    worker.join(timeout=5.0)
+                logger.warning("Stage %d: worker %d did not survive the stage; respawning", stage_id, worker.id)
+                self.workers[idx] = self._respawn_worker(worker)
+                self.workers[idx].start()
+        return clean
+
+    def _respawn_worker(self, dead: Worker) -> Worker:
+        """Build a replacement for a dead worker, sharing the same IPC objects.
+
+        The replacement forks from the main process' current state, and its
+        stage-done counter starts at the current expected value so it is
+        considered up to date at the next rendezvous.
+        """
+        stage_done_counter: "Synchronized[int]" = mp.Value("i", self._expected_stage_done)
+        return Worker(
+            dead.id,
+            dead.client,
+            dead.request_queue,
+            dead.datagen,
+            dead.max_concurrency,
+            dead.stop_signal,
+            dead.cancel_signal,
+            dead.request_phase,
+            dead.finished_requests_counter,
+            dead.active_requests_counter,
+            dead.shared_max_concurrency,
+            dead.base_seed,
+            force_stop_signal=dead.force_stop_signal,
+            stage_done_counter=stage_done_counter,
+            teardown_grace_seconds=dead.teardown_grace_seconds,
         )
 
     async def run_stage(
@@ -822,22 +1013,11 @@ class LoadGenerator:
         if progress_ctx and stage_task:
             progress_ctx.remove_task(stage_task)
 
-        # Trigger cleanup if timed out or received SIGINT
-        if (timed_out or self.interrupt_sig) and cancel_signal:
-            # Cancel signal must be set before request_phase
-            # Allow time for workers to process the signal
-            cancel_signal.set()
-            await sleep(1)
-            while active_requests_counter.value > 0:
-                await sleep(1)
-            request_queue.drain()
-            cancel_signal.clear()
+        stage_status = StageStatus.FAILED if (timed_out or self.interrupt_sig) else StageStatus.COMPLETED
+        # Bounded teardown: stop dispatching, give in-flight requests the
+        # configured grace to complete, then force the stage boundary.
+        if not await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal):
             stage_status = StageStatus.FAILED
-        else:
-            stage_status = StageStatus.COMPLETED
-        # Clear the request_phase event to force worker gather
-        request_phase.clear()
-        request_queue.join()
 
         self.stage_runtime_info[stage_id] = StageRuntimeInfo(
             stage_id=stage_id,
@@ -943,9 +1123,10 @@ class LoadGenerator:
         request_phase: SyncEvent = mp.Event()
         stop_signal: SyncEvent = mp.Event()
         cancel_signal: SyncEvent = mp.Event()
-        # Synchronize workers and main at stage boundaries so workers finish
-        # in-flight requests and clear session state before the next stage begins.
-        stage_barrier: SyncBarrier = mp.Barrier(self.num_workers + 1)
+        # Broadcast when the teardown grace expires so workers cancel whatever
+        # is still in flight (see _teardown_stage).
+        force_stop_signal: SyncEvent = mp.Event()
+        self._force_stop_signal = force_stop_signal
         # start workers in the request phase
         request_phase.set()
 
@@ -956,6 +1137,10 @@ class LoadGenerator:
                 shared_max_concurrency = mp.Value("i", self.worker_max_concurrency)
             else:
                 shared_max_concurrency = None
+
+            # Per-worker stage-done counter for the stage rendezvous: the worker
+            # increments it after winding down each stage (see _teardown_stage).
+            stage_done_counter: "Synchronized[int]" = mp.Value("i", 0)
 
             self.workers.append(
                 Worker(
@@ -971,7 +1156,9 @@ class LoadGenerator:
                     active_requests_counter,
                     shared_max_concurrency,
                     self.base_seed,
-                    stage_barrier,
+                    force_stop_signal=force_stop_signal,
+                    stage_done_counter=stage_done_counter,
+                    teardown_grace_seconds=self.teardown_grace_seconds,
                 )
             )
             self.workers[-1].start()
@@ -1071,7 +1258,8 @@ class LoadGenerator:
                 else:
                     raise Exception(f"Stage {stage_id} has the wrong load type")
 
-                stage_barrier.wait()
+                # Stage rendezvous already happened inside _teardown_stage
+                # (bounded, liveness-aware), so no barrier is needed here.
 
                 # If we encountered a SIGINT, we can break out of run stages loop
                 if self.interrupt_sig:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -36,12 +36,15 @@ from inference_perf.config import (
 from asyncio import (
     CancelledError,
     Semaphore,
+    Task,
+    TimeoutError as AsyncioTimeoutError,
     create_task,
     gather,
     run,
     sleep,
     set_event_loop_policy,
     get_event_loop,
+    wait_for,
 )
 import sys
 
@@ -58,7 +61,7 @@ from types import FrameType
 import time
 import multiprocessing as mp
 from queue import Empty
-from multiprocessing.synchronize import Barrier as SyncBarrier, Event as SyncEvent
+from multiprocessing.synchronize import Event as SyncEvent
 from multiprocessing.sharedctypes import Synchronized
 from concurrent.futures import TimeoutError
 from functools import partial
@@ -79,6 +82,17 @@ import signal
 from inference_perf.observability.logging import get_console
 
 logger = logging.getLogger(__name__)
+
+# Stage-teardown tuning. The teardown protocol is bounded end to end: workers
+# give in-flight requests `stage_teardown_grace_seconds` (LoadConfig) to finish
+# naturally, then cancel and reap the remainder within _WIND_DOWN_REAP_SECONDS.
+# The main process allows the worker grace plus _TEARDOWN_MARGIN_SECONDS before
+# broadcasting the force-stop signal, then _FORCE_REAP_SECONDS more before
+# terminating (and respawning) workers that still have not reached the stage
+# rendezvous. Report generation therefore always runs.
+_WIND_DOWN_REAP_SECONDS = 10.0
+_TEARDOWN_MARGIN_SECONDS = 15.0
+_FORCE_REAP_SECONDS = 20.0
 
 
 class RequestQueueData(NamedTuple):
@@ -103,7 +117,9 @@ class Worker(mp.Process):
         active_requests_counter: "Synchronized[int]",
         shared_max_concurrency: Optional["Synchronized[int]"],
         base_seed: int,
-        stage_barrier: Optional[SyncBarrier] = None,
+        force_stop_signal: Optional[SyncEvent] = None,
+        stage_done_counter: Optional["Synchronized[int]"] = None,
+        teardown_grace_seconds: float = 120.0,
     ):
         super().__init__(daemon=True)  # kill worker process if main process exit unexpected
         self.id = id
@@ -119,7 +135,12 @@ class Worker(mp.Process):
         self.shared_max_concurrency = shared_max_concurrency
         self.skip = False
         self.base_seed = base_seed
-        self.stage_barrier = stage_barrier
+        self.force_stop_signal = force_stop_signal
+        self.stage_done_counter = stage_done_counter
+        self.teardown_grace_seconds = teardown_grace_seconds
+        # True while the stage is winding down: in-flight requests may finish,
+        # but no new requests are dispatched to the model server.
+        self.draining = False
         # Snapshot the parent's effective root log level so the worker
         # interpreter (which under forkserver/spawn does not inherit the
         # parent's basicConfig) can configure its own handler to surface
@@ -157,7 +178,12 @@ class Worker(mp.Process):
                 await sleep(0)
 
             # Process requests in loop
-            while self.request_phase.is_set() and not self.cancel_signal.is_set() and not self.skip:
+            while (
+                self.request_phase.is_set()
+                and not self.cancel_signal.is_set()
+                and not self.skip
+                and not self.stop_signal.is_set()
+            ):
                 await semaphore.acquire()
                 try:
                     # Use partial to pass named arg
@@ -205,6 +231,15 @@ class Worker(mp.Process):
                             )
                             return  # Exit this task, finally block will clean up
 
+                        # Stage is winding down: in-flight requests may finish,
+                        # but nothing new is sent to the model server. This also
+                        # unwinds session-replay dependency chains quickly - a
+                        # successor woken by its predecessor exits here instead
+                        # of dispatching.
+                        if self.draining:
+                            logger.debug(f"[Worker {self.id}] stage tearing down, not dispatching new request")
+                            return
+
                         with self.active_requests_counter.get_lock():
                             self.active_requests_counter.value += 1
                             inflight = True
@@ -247,23 +282,66 @@ class Worker(mp.Process):
             # Reset skip
             self.skip = False
 
-            if self.cancel_signal.is_set():
-                logger.debug(f"[Worker {self.id}] cancelling tasks with {self.active_requests_counter.value} active requests")
-                for task in tasks:
-                    task.cancel()
-                while self.request_phase.is_set():
-                    await sleep(0)
-                logger.debug(f"[Worker {self.id}] done cancelling")
-            if not self.request_phase.is_set():
-                await gather(*tasks)
+            if self.cancel_signal.is_set() or not self.request_phase.is_set():
+                await self._wind_down_stage(tasks)
                 tasks = []
                 LocalUserSession.clear_instances()
-                if self.stage_barrier:
-                    self.stage_barrier.wait()
+                if self.stage_done_counter is not None:
+                    with self.stage_done_counter.get_lock():
+                        self.stage_done_counter.value += 1
+                # Hold until the main process acknowledges the stage boundary by
+                # clearing cancel_signal, so one stage cannot be reported done
+                # twice by the same worker.
+                while self.cancel_signal.is_set() and not self.stop_signal.is_set():
+                    await sleep(0.05)
                 logger.debug(f"[Worker {self.id}] waiting for next phase")
-                self.request_phase.wait()
+                while not self.request_phase.is_set() and not self.stop_signal.is_set():
+                    self.request_phase.wait(timeout=0.5)
 
         logger.debug(f"[Worker {self.id}] stopped")
+
+    async def _wind_down_stage(self, tasks: List["Task[None]"]) -> None:
+        """Bounded end-of-stage wind-down; always returns.
+
+        In-flight requests get up to teardown_grace_seconds to finish naturally
+        (recording their metrics). Tasks still parked on session predecessors
+        unwind quickly because new dispatches are gated off by self.draining.
+        Whatever remains after the grace is cancelled and reaped within a fixed
+        bound, so the worker always reaches the stage rendezvous.
+        """
+        self.draining = True
+        try:
+            pending = [t for t in tasks if not t.done()]
+            if pending:
+                logger.debug(
+                    f"[Worker {self.id}] stage teardown: waiting up to {self.teardown_grace_seconds:.0f}s "
+                    f"for {len(pending)} in-flight tasks"
+                )
+                deadline = time.perf_counter() + self.teardown_grace_seconds
+                while pending and time.perf_counter() < deadline:
+                    if self.force_stop_signal is not None and self.force_stop_signal.is_set():
+                        break
+                    await sleep(0.25)
+                    pending = [t for t in pending if not t.done()]
+            if pending:
+                logger.warning(f"[Worker {self.id}] cancelling {len(pending)} tasks still running at stage teardown")
+                for task in pending:
+                    task.cancel()
+                try:
+                    await wait_for(gather(*pending, return_exceptions=True), timeout=_WIND_DOWN_REAP_SECONDS)
+                except (AsyncioTimeoutError, TimeoutError):
+                    stuck = sum(1 for t in pending if not t.done())
+                    logger.error(f"[Worker {self.id}] abandoning {stuck} tasks that did not respond to cancellation")
+            # Surface real task failures. Before this rework they were re-raised
+            # by an unguarded gather at teardown, killing the worker process and
+            # stranding the main process at the stage rendezvous.
+            for task in tasks:
+                if task.done() and not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        logger.error(f"[Worker {self.id}] task failed during stage: {type(exc).__name__}: {exc}")
+        finally:
+            self.draining = False
 
     def run(self) -> None:
         # forkserver/spawn workers start from a fresh interpreter without the
@@ -309,6 +387,13 @@ class LoadGenerator:
         self.sweep_config = load_config.sweep
         self.interrupt_sig = False
         self.session_metrics_collector = session_metrics_collector
+        self.teardown_grace_seconds = load_config.stage_teardown_grace_seconds
+        # Set by mp_run; broadcast to workers when the teardown grace expires
+        # so they cancel whatever is still in flight.
+        self._force_stop_signal: Optional[SyncEvent] = None
+        # Number of stage teardowns completed so far; each worker's
+        # stage_done_counter must reach this value at the stage rendezvous.
+        self._expected_stage_done = 0
         signal.signal(signal.SIGINT, self._sigint_handler)
 
         # Validate that datagen type matches load_type
@@ -398,7 +483,6 @@ class LoadGenerator:
         request_phase: SyncEvent,
         cancel_signal: Optional[SyncEvent] = None,
         progress_ctx: Optional[Progress] = None,
-        stage_barrier: Optional[SyncBarrier] = None,
     ) -> None:
         """Run a session-based trace replay stage.
 
@@ -623,6 +707,19 @@ class LoadGenerator:
                     del session_spans[sid]
                 break
 
+            # Fail fast on worker death instead of waiting out the stage
+            # timeout: sessions assigned to a dead worker can never complete.
+            if self.workers and any(not w.is_alive() for w in self.workers):
+                if progress_ctx and stage_task:
+                    progress_ctx.remove_task(stage_task)
+                    stage_task = None
+                logger.error(f"Stage {stage_id}: a worker process died unexpectedly; failing stage")
+                stage_status = StageStatus.FAILED
+                for sid in list(session_spans.keys()):
+                    otel_instr.end_session_span(session_spans[sid], "Worker process died")
+                    del session_spans[sid]
+                break
+
             # Check for completed sessions
             newly_completed = []
             for session_idx in list(active_session_indices):
@@ -710,20 +807,11 @@ class LoadGenerator:
         if stage_status == StageStatus.RUNNING:
             stage_status = StageStatus.COMPLETED
 
-        # Cancel in-flight tasks so process_failure completions don't strand queued
-        # items with no task_done(), which would hang request_queue.join().
-        if cancel_signal is not None:
-            cancel_signal.set()
-
-        # Stop workers consuming, then rendezvous so every worker has run task_done()
-        # on all items it pulled before we drain/join (avoids orphaned untasked items).
-        request_phase.clear()
-        if stage_barrier:
-            stage_barrier.wait()
-        if cancel_signal is not None:
-            request_queue.drain()
-            cancel_signal.clear()
-        request_queue.join()
+        # Bounded teardown: stop dispatching, give in-flight requests the
+        # configured grace to complete (their metrics are kept), then force
+        # the stage boundary. Guaranteed to return, so reports always generate.
+        if not await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal):
+            stage_status = StageStatus.FAILED
 
         # End stage-level span if trace_per_stage is enabled
         if stage_span is not None:
@@ -744,6 +832,110 @@ class LoadGenerator:
             "Stage %d - session-based run %s", stage_id, "completed" if stage_status == StageStatus.COMPLETED else "failed"
         )
 
+    async def _teardown_stage(
+        self,
+        stage_id: int,
+        request_queue: RequestQueue[RequestQueueData],
+        request_phase: SyncEvent,
+        cancel_signal: Optional[SyncEvent],
+    ) -> bool:
+        """Bounded stage teardown; always returns, so reports always generate.
+
+        Stops dispatch immediately, gives in-flight requests the configured
+        grace to finish (their metrics are kept), then forces the boundary:
+        the force-stop signal makes workers cancel whatever is left, and any
+        worker that still fails to reach the stage rendezvous (died, or its
+        event loop is wedged) is terminated and respawned so subsequent stages
+        run at full capacity. Returns True when every worker wound down
+        cleanly, False when the stage had to be forced.
+        """
+        if cancel_signal is not None:
+            cancel_signal.set()
+        request_phase.clear()
+
+        clean = True
+        if self.workers:
+            self._expected_stage_done += 1
+            expected = self._expected_stage_done
+            grace_deadline = time.perf_counter() + self.teardown_grace_seconds + _TEARDOWN_MARGIN_SECONDS
+            force_deadline: Optional[float] = None
+            while True:
+                pending = [
+                    w
+                    for w in self.workers
+                    if w.is_alive() and (w.stage_done_counter is None or w.stage_done_counter.value < expected)
+                ]
+                if not pending:
+                    break
+                now = time.perf_counter()
+                if force_deadline is None and now >= grace_deadline:
+                    logger.warning(
+                        "Stage %d: teardown grace expired; forcing cancellation of in-flight work on %d worker(s)",
+                        stage_id,
+                        len(pending),
+                    )
+                    if self._force_stop_signal is not None:
+                        self._force_stop_signal.set()
+                    force_deadline = now + _FORCE_REAP_SECONDS
+                elif force_deadline is not None and now >= force_deadline:
+                    for worker in pending:
+                        logger.error("Stage %d: terminating worker %d stuck in teardown", stage_id, worker.id)
+                        worker.terminate()
+                    clean = False
+                    break
+                await sleep(0.25)
+
+        # Nobody is pulling anymore: remove undispatched items left in the queue.
+        request_queue.drain()
+        if self._force_stop_signal is not None:
+            self._force_stop_signal.clear()
+        if cancel_signal is not None:
+            cancel_signal.clear()
+
+        # Replace workers that did not survive the stage (terminated above, or
+        # died earlier e.g. from an OOM kill) so later stages keep full capacity.
+        for idx, worker in enumerate(self.workers):
+            if not worker.is_alive() and worker.exitcode is None:
+                continue  # never started; leave to caller
+            if not worker.is_alive() or (
+                worker.stage_done_counter is not None and worker.stage_done_counter.value < self._expected_stage_done
+            ):
+                clean = False
+                worker.join(timeout=5.0)
+                if worker.is_alive():
+                    worker.kill()
+                    worker.join(timeout=5.0)
+                logger.warning("Stage %d: worker %d did not survive the stage; respawning", stage_id, worker.id)
+                self.workers[idx] = self._respawn_worker(worker)
+                self.workers[idx].start()
+        return clean
+
+    def _respawn_worker(self, dead: Worker) -> Worker:
+        """Build a replacement for a dead worker, sharing the same IPC objects.
+
+        The replacement forks from the main process' current state, and its
+        stage-done counter starts at the current expected value so it is
+        considered up to date at the next rendezvous.
+        """
+        stage_done_counter: "Synchronized[int]" = mp.Value("i", self._expected_stage_done)
+        return Worker(
+            dead.id,
+            dead.client,
+            dead.request_queue,
+            dead.datagen,
+            dead.max_concurrency,
+            dead.stop_signal,
+            dead.cancel_signal,
+            dead.request_phase,
+            dead.finished_requests_counter,
+            dead.active_requests_counter,
+            dead.shared_max_concurrency,
+            dead.base_seed,
+            force_stop_signal=dead.force_stop_signal,
+            stage_done_counter=stage_done_counter,
+            teardown_grace_seconds=dead.teardown_grace_seconds,
+        )
+
     async def run_stage(
         self,
         stage_id: int,
@@ -757,7 +949,6 @@ class LoadGenerator:
         timeout: Optional[float] = None,
         concurrency_level: Optional[int] = None,
         progress_ctx: Optional[Progress] = None,
-        stage_barrier: Optional[SyncBarrier] = None,
     ) -> None:
         logger.info("Stage %d - run started", stage_id)
 
@@ -832,22 +1023,11 @@ class LoadGenerator:
         if progress_ctx and stage_task:
             progress_ctx.remove_task(stage_task)
 
-        # Trigger cleanup if timed out or received SIGINT
-        if (timed_out or self.interrupt_sig) and cancel_signal:
-            cancel_signal.set()
+        stage_status = StageStatus.FAILED if (timed_out or self.interrupt_sig) else StageStatus.COMPLETED
+        # Bounded teardown: stop dispatching, give in-flight requests the
+        # configured grace to complete, then force the stage boundary.
+        if not await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal):
             stage_status = StageStatus.FAILED
-        else:
-            stage_status = StageStatus.COMPLETED
-
-        # Stop workers consuming, then rendezvous so every worker has run task_done()
-        # on all items it pulled before we drain/join (avoids orphaned untasked items).
-        request_phase.clear()
-        if stage_barrier:
-            stage_barrier.wait()
-        if stage_status == StageStatus.FAILED and cancel_signal:
-            request_queue.drain()
-            cancel_signal.clear()
-        request_queue.join()
 
         self.stage_runtime_info[stage_id] = StageRuntimeInfo(
             stage_id=stage_id,
@@ -867,7 +1047,6 @@ class LoadGenerator:
         finished_requests_counter: "Synchronized[int]",
         request_phase: SyncEvent,
         cancel_signal: SyncEvent,
-        stage_barrier: Optional[SyncBarrier] = None,
     ) -> None:
         """
         Runs a preliminary load test to automatically determine the server's saturation point
@@ -906,7 +1085,6 @@ class LoadGenerator:
             request_phase,
             timeout=timeout,
             cancel_signal=cancel_signal,
-            stage_barrier=stage_barrier,
         )
 
         aggregator_task.cancel()
@@ -955,9 +1133,10 @@ class LoadGenerator:
         request_phase: SyncEvent = mp.Event()
         stop_signal: SyncEvent = mp.Event()
         cancel_signal: SyncEvent = mp.Event()
-        # Synchronize workers and main at stage boundaries so workers finish
-        # in-flight requests and clear session state before the next stage begins.
-        stage_barrier: SyncBarrier = mp.Barrier(self.num_workers + 1)
+        # Broadcast when the teardown grace expires so workers cancel whatever
+        # is still in flight (see _teardown_stage).
+        force_stop_signal: SyncEvent = mp.Event()
+        self._force_stop_signal = force_stop_signal
         # start workers in the request phase
         request_phase.set()
 
@@ -968,6 +1147,10 @@ class LoadGenerator:
                 shared_max_concurrency = mp.Value("i", self.worker_max_concurrency)
             else:
                 shared_max_concurrency = None
+
+            # Per-worker stage-done counter for the stage rendezvous: the worker
+            # increments it after winding down each stage (see _teardown_stage).
+            stage_done_counter: "Synchronized[int]" = mp.Value("i", 0)
 
             self.workers.append(
                 Worker(
@@ -983,7 +1166,9 @@ class LoadGenerator:
                     active_requests_counter,
                     shared_max_concurrency,
                     self.base_seed,
-                    stage_barrier,
+                    force_stop_signal=force_stop_signal,
+                    stage_done_counter=stage_done_counter,
+                    teardown_grace_seconds=self.teardown_grace_seconds,
                 )
             )
             self.workers[-1].start()
@@ -997,7 +1182,6 @@ class LoadGenerator:
                     finished_requests_counter,
                     request_phase,
                     cancel_signal,
-                    stage_barrier=stage_barrier,
                 )
             except Exception as e:
                 logger.error(f"Preprocessing exception: {e}")
@@ -1048,7 +1232,6 @@ class LoadGenerator:
                         request_phase,
                         cancel_signal,
                         progress_ctx=progress,
-                        stage_barrier=stage_barrier,
                     )
                 # Update worker concurrency for concurrent load type
                 elif self.load_type == LoadType.CONCURRENT and isinstance(stage, ConcurrentLoadStage):
@@ -1070,7 +1253,6 @@ class LoadGenerator:
                         cancel_signal,
                         concurrency_level=concurrency_level,
                         progress_ctx=progress,
-                        stage_barrier=stage_barrier,
                     )
                 elif self.load_type != LoadType.CONCURRENT and isinstance(stage, StandardLoadStage):
                     rate = stage.rate
@@ -1087,10 +1269,12 @@ class LoadGenerator:
                         cancel_signal,
                         concurrency_level=concurrency_level,
                         progress_ctx=progress,
-                        stage_barrier=stage_barrier,
                     )
                 else:
                     raise Exception(f"Stage {stage_id} has the wrong load type")
+
+                # Stage rendezvous already happened inside _teardown_stage
+                # (bounded, liveness-aware), so no barrier is needed here.
 
                 # If we encountered a SIGINT, we can break out of run stages loop
                 if self.interrupt_sig:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -56,8 +56,9 @@ else:
     # Runtime usage will still require Python 3.11+.
     TaskGroup = object
 
-from typing import List, Tuple, Optional, NamedTuple, Union, Set, Dict
+from typing import List, Tuple, Optional, NamedTuple, Union, Set, Dict, cast
 from types import FrameType
+import ctypes
 import time
 import multiprocessing as mp
 from queue import Empty
@@ -95,6 +96,22 @@ _TEARDOWN_MARGIN_SECONDS = 15.0
 _FORCE_REAP_SECONDS = 20.0
 
 
+def _counter_value_nolock(counter: "Synchronized[int]") -> int:
+    """Read a shared counter without acquiring its lock.
+
+    `Synchronized.value` acquires the mutex, so a worker terminated while
+    holding it would strand the lock and hang any later locked access. The
+    main process must only read worker-owned counters through this helper so
+    that teardown always returns.
+    """
+    return int(cast("ctypes.c_int", counter.get_obj()).value)
+
+
+class TeardownResult(NamedTuple):
+    clean: bool
+    dropped_requests: int
+
+
 class RequestQueueData(NamedTuple):
     stage_id: int
     request_data: InferenceAPIData
@@ -107,7 +124,7 @@ class Worker(mp.Process):
         self,
         id: int,
         client: ModelServerClient,
-        request_queue: "mp.JoinableQueue[RequestQueueData]",
+        request_queue: "mp.Queue[RequestQueueData]",
         datagen: BaseGenerator,
         max_concurrency: int,
         stop_signal: SyncEvent,
@@ -119,6 +136,7 @@ class Worker(mp.Process):
         base_seed: int,
         force_stop_signal: Optional[SyncEvent] = None,
         stage_done_counter: Optional["Synchronized[int]"] = None,
+        stage_boundary_seq: Optional["Synchronized[int]"] = None,
         teardown_grace_seconds: float = 120.0,
     ):
         super().__init__(daemon=True)  # kill worker process if main process exit unexpected
@@ -137,6 +155,7 @@ class Worker(mp.Process):
         self.base_seed = base_seed
         self.force_stop_signal = force_stop_signal
         self.stage_done_counter = stage_done_counter
+        self.stage_boundary_seq = stage_boundary_seq
         self.teardown_grace_seconds = teardown_grace_seconds
         # True while the stage is winding down: in-flight requests may finish,
         # but no new requests are dispatched to the model server.
@@ -184,13 +203,23 @@ class Worker(mp.Process):
                 and not self.skip
                 and not self.stop_signal.is_set()
             ):
-                await semaphore.acquire()
+                # Bounded acquire so a worker saturated with hung in-flight
+                # requests (all permits held) still re-checks the loop
+                # condition and reaches the stage boundary, where those
+                # requests get the teardown grace and are then cancelled.
                 try:
-                    # Use partial to pass named arg
-                    get = partial(self.request_queue.get, timeout=timeout)
-                    item = await event_loop.run_in_executor(None, get)
+                    await wait_for(semaphore.acquire(), timeout=timeout)
+                except (AsyncioTimeoutError, TimeoutError):
+                    continue
+                try:
+                    # Non-blocking get: a blocking get(timeout=...) holds the
+                    # queue's shared reader lock across the poll, so a worker
+                    # killed abruptly (OOM, terminate) mid-poll would strand
+                    # the lock and starve every consumer of this channel,
+                    # including its own respawned replacement. get_nowait
+                    # holds the lock only while actually transferring an item.
+                    item = await event_loop.run_in_executor(None, self.request_queue.get_nowait)
                     if item is None:
-                        self.request_queue.task_done()
                         semaphore.release()
                         continue
                 except TimeoutError:
@@ -199,6 +228,7 @@ class Worker(mp.Process):
                     continue
                 except Empty:
                     semaphore.release()
+                    await sleep(0.02)
                     continue
                 except Exception as e:
                     logger.info(f"[Worker {self.id}] hit exception {e}")
@@ -206,7 +236,6 @@ class Worker(mp.Process):
                     continue
 
                 async def schedule_client(
-                    queue: "mp.JoinableQueue[RequestQueueData]",
                     request_data: InferenceAPIData,
                     request_time: float,
                     stage_id: int,
@@ -256,7 +285,6 @@ class Worker(mp.Process):
                                 self.active_requests_counter.value -= 1
                         with self.finished_requests_counter.get_lock():
                             self.finished_requests_counter.value += 1
-                        queue.task_done()
                         semaphore.release()
 
                 try:
@@ -266,13 +294,10 @@ class Worker(mp.Process):
                     logger.error(f"[Worker {self.id}] Failed to get request: {e}", exc_info=True)
                     with self.finished_requests_counter.get_lock():
                         self.finished_requests_counter.value += 1
-                    self.request_queue.task_done()
                     semaphore.release()
                     continue
 
-                task = create_task(
-                    schedule_client(self.request_queue, request_data, request_time, stage_id, semaphore, lora_adapter)
-                )
+                task = create_task(schedule_client(request_data, request_time, stage_id, semaphore, lora_adapter))
                 logging.debug(
                     f"creating inference task with request data {request_data}", extra={"request_data": request_data}
                 )
@@ -286,17 +311,34 @@ class Worker(mp.Process):
                 await self._wind_down_stage(tasks)
                 tasks = []
                 LocalUserSession.clear_instances()
-                if self.stage_done_counter is not None:
+                if self.stage_done_counter is not None and self.stage_boundary_seq is not None:
+                    # Assign the main-published boundary sequence rather than
+                    # incrementing: a worker that enters this block without
+                    # having served the stage (e.g. respawned between stages)
+                    # then converges on the current boundary instead of
+                    # running permanently ahead of the rendezvous.
                     with self.stage_done_counter.get_lock():
-                        self.stage_done_counter.value += 1
-                # Hold until the main process acknowledges the stage boundary by
-                # clearing cancel_signal, so one stage cannot be reported done
-                # twice by the same worker.
-                while self.cancel_signal.is_set() and not self.stop_signal.is_set():
-                    await sleep(0.05)
-                logger.debug(f"[Worker {self.id}] waiting for next phase")
-                while not self.request_phase.is_set() and not self.stop_signal.is_set():
-                    self.request_phase.wait(timeout=0.5)
+                        self.stage_done_counter.value = _counter_value_nolock(self.stage_boundary_seq)
+                    logger.debug(f"[Worker {self.id}] waiting for next phase")
+                    # Hold until the next stage is running, or until a newer
+                    # boundary is published. The latter covers a stage that
+                    # started and finished entirely between two samples of
+                    # these events (e.g. zero requests, or a circuit breaker
+                    # opening immediately): the worker then re-enters the
+                    # boundary block and acknowledges the new sequence instead
+                    # of waiting out a signal edge it never observed.
+                    while not self.stop_signal.is_set():
+                        if self.request_phase.is_set() and not self.cancel_signal.is_set():
+                            break
+                        if _counter_value_nolock(self.stage_boundary_seq) > _counter_value_nolock(self.stage_done_counter):
+                            break
+                        self.request_phase.wait(timeout=0.05)
+                else:
+                    while self.cancel_signal.is_set() and not self.stop_signal.is_set():
+                        await sleep(0.05)
+                    logger.debug(f"[Worker {self.id}] waiting for next phase")
+                    while not self.request_phase.is_set() and not self.stop_signal.is_set():
+                        self.request_phase.wait(timeout=0.5)
 
         logger.debug(f"[Worker {self.id}] stopped")
 
@@ -391,9 +433,12 @@ class LoadGenerator:
         # Set by mp_run; broadcast to workers when the teardown grace expires
         # so they cancel whatever is still in flight.
         self._force_stop_signal: Optional[SyncEvent] = None
-        # Number of stage teardowns completed so far; each worker's
+        # Number of stage teardowns initiated so far; each worker's
         # stage_done_counter must reach this value at the stage rendezvous.
+        # Published to workers through _stage_boundary_seq so they assign
+        # (not increment) their counter at the boundary.
         self._expected_stage_done = 0
+        self._stage_boundary_seq: Optional["Synchronized[int]"] = None
         signal.signal(signal.SIGINT, self._sigint_handler)
 
         # Validate that datagen type matches load_type
@@ -461,17 +506,6 @@ class LoadGenerator:
             return TraceReplayLoadTimer(trace_reader=self.trace_reader, trace_file=Path(self.trace.file))
         # For concurrent and constant load types (rate is adjusted in main.py for concurrent load type)
         return ConstantLoadTimer(rate=rate, duration=duration)
-
-    async def drain(self, queue: "mp.JoinableQueue[RequestQueueData]") -> None:
-        while True:
-            try:
-                _ = queue.get_nowait()
-                queue.task_done()
-            except Empty:
-                # No qsize() check: it raises NotImplementedError on macOS.
-                # Empty from get_nowait() is sufficient since producers are stopped before drain.
-                logger.debug("Drain finished")
-                return
 
     async def run_session_stage(
         self,
@@ -807,10 +841,17 @@ class LoadGenerator:
         if stage_status == StageStatus.RUNNING:
             stage_status = StageStatus.COMPLETED
 
+        # The metrics window ends here: the teardown tail carries no offered
+        # load, so including it would stretch every server-side rate average.
+        end_time_epoch = time.time()
+
         # Bounded teardown: stop dispatching, give in-flight requests the
         # configured grace to complete (their metrics are kept), then force
         # the stage boundary. Guaranteed to return, so reports always generate.
-        if not await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal):
+        teardown_start = time.perf_counter()
+        teardown = await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal)
+        teardown_duration = time.perf_counter() - teardown_start
+        if not teardown.clean:
             stage_status = StageStatus.FAILED
 
         # End stage-level span if trace_per_stage is enabled
@@ -823,10 +864,12 @@ class LoadGenerator:
             stage_id=stage_id,
             rate=session_rate if session_rate else 0.0,
             start_time=start_time_epoch,
-            end_time=time.time(),
+            end_time=end_time_epoch,
             status=stage_status,
             concurrency_level=concurrent_sessions,
             timeout=timeout,
+            teardown_duration=teardown_duration,
+            dropped_requests=teardown.dropped_requests,
         )
         logger.info(
             "Stage %d - session-based run %s", stage_id, "completed" if stage_status == StageStatus.COMPLETED else "failed"
@@ -838,7 +881,7 @@ class LoadGenerator:
         request_queue: RequestQueue[RequestQueueData],
         request_phase: SyncEvent,
         cancel_signal: Optional[SyncEvent],
-    ) -> bool:
+    ) -> TeardownResult:
         """Bounded stage teardown; always returns, so reports always generate.
 
         Stops dispatch immediately, gives in-flight requests the configured
@@ -846,24 +889,34 @@ class LoadGenerator:
         the force-stop signal makes workers cancel whatever is left, and any
         worker that still fails to reach the stage rendezvous (died, or its
         event loop is wedged) is terminated and respawned so subsequent stages
-        run at full capacity. Returns True when every worker wound down
-        cleanly, False when the stage had to be forced.
+        run at full capacity. Returns clean=True when every worker wound down
+        cleanly, clean=False when the stage had to be forced, plus the number
+        of never-dispatched requests dropped from the queue.
         """
+        event_loop = get_event_loop()
+        forced: Set[int] = set()
+
+        clean = True
+        if self.workers:
+            # Publish the boundary sequence before signalling so any worker
+            # observing the boundary reads the current value.
+            self._expected_stage_done += 1
+            expected = self._expected_stage_done
+            if self._stage_boundary_seq is not None:
+                self._stage_boundary_seq.value = expected
         if cancel_signal is not None:
             cancel_signal.set()
         request_phase.clear()
 
-        clean = True
         if self.workers:
-            self._expected_stage_done += 1
-            expected = self._expected_stage_done
             grace_deadline = time.perf_counter() + self.teardown_grace_seconds + _TEARDOWN_MARGIN_SECONDS
             force_deadline: Optional[float] = None
             while True:
                 pending = [
                     w
                     for w in self.workers
-                    if w.is_alive() and (w.stage_done_counter is None or w.stage_done_counter.value < expected)
+                    if w.is_alive()
+                    and (w.stage_done_counter is None or _counter_value_nolock(w.stage_done_counter) < expected)
                 ]
                 if not pending:
                     break
@@ -881,12 +934,15 @@ class LoadGenerator:
                     for worker in pending:
                         logger.error("Stage %d: terminating worker %d stuck in teardown", stage_id, worker.id)
                         worker.terminate()
+                        forced.add(worker.id)
                     clean = False
                     break
                 await sleep(0.25)
 
         # Nobody is pulling anymore: remove undispatched items left in the queue.
-        request_queue.drain()
+        dropped = request_queue.drain()
+        if dropped:
+            logger.warning("Stage %d: dropped %d request(s) that were never dispatched to the model server", stage_id, dropped)
         if self._force_stop_signal is not None:
             self._force_stop_signal.clear()
         if cancel_signal is not None:
@@ -894,34 +950,47 @@ class LoadGenerator:
 
         # Replace workers that did not survive the stage (terminated above, or
         # died earlier e.g. from an OOM kill) so later stages keep full capacity.
+        # A terminated worker may have died holding its counter's lock, so its
+        # counter is never re-read here: forced membership already implies the
+        # worker missed the rendezvous.
         for idx, worker in enumerate(self.workers):
             if not worker.is_alive() and worker.exitcode is None:
                 continue  # never started; leave to caller
-            if not worker.is_alive() or (
-                worker.stage_done_counter is not None and worker.stage_done_counter.value < self._expected_stage_done
+            if (
+                worker.id in forced
+                or not worker.is_alive()
+                or (
+                    worker.stage_done_counter is not None
+                    and _counter_value_nolock(worker.stage_done_counter) < self._expected_stage_done
+                )
             ):
                 clean = False
-                worker.join(timeout=5.0)
+                await event_loop.run_in_executor(None, partial(worker.join, 5.0))
                 if worker.is_alive():
                     worker.kill()
-                    worker.join(timeout=5.0)
+                    await event_loop.run_in_executor(None, partial(worker.join, 5.0))
                 logger.warning("Stage %d: worker %d did not survive the stage; respawning", stage_id, worker.id)
-                self.workers[idx] = self._respawn_worker(worker)
+                # A per-worker channel has no other consumers, so swap it out
+                # in case the dead worker stranded the old queue's locks. A
+                # shared channel is kept: surviving workers still hold it.
+                fresh_channel = request_queue.replace_channel(worker.id) if request_queue.num_channels > 1 else None
+                self.workers[idx] = self._respawn_worker(worker, request_channel=fresh_channel)
                 self.workers[idx].start()
-        return clean
+        return TeardownResult(clean=clean, dropped_requests=dropped)
 
-    def _respawn_worker(self, dead: Worker) -> Worker:
+    def _respawn_worker(self, dead: Worker, request_channel: Optional["mp.Queue[RequestQueueData]"] = None) -> Worker:
         """Build a replacement for a dead worker, sharing the same IPC objects.
 
         The replacement forks from the main process' current state, and its
         stage-done counter starts at the current expected value so it is
-        considered up to date at the next rendezvous.
+        considered up to date at the next rendezvous. request_channel, when
+        given, replaces the dead worker's queue channel (see _teardown_stage).
         """
         stage_done_counter: "Synchronized[int]" = mp.Value("i", self._expected_stage_done)
         return Worker(
             dead.id,
             dead.client,
-            dead.request_queue,
+            request_channel if request_channel is not None else dead.request_queue,
             dead.datagen,
             dead.max_concurrency,
             dead.stop_signal,
@@ -933,6 +1002,7 @@ class LoadGenerator:
             dead.base_seed,
             force_stop_signal=dead.force_stop_signal,
             stage_done_counter=stage_done_counter,
+            stage_boundary_seq=dead.stage_boundary_seq,
             teardown_grace_seconds=dead.teardown_grace_seconds,
         )
 
@@ -1024,18 +1094,29 @@ class LoadGenerator:
             progress_ctx.remove_task(stage_task)
 
         stage_status = StageStatus.FAILED if (timed_out or self.interrupt_sig) else StageStatus.COMPLETED
+
+        # The metrics window ends here: the teardown tail carries no offered
+        # load, so including it would stretch every server-side rate average.
+        end_time_epoch = time.time()
+
         # Bounded teardown: stop dispatching, give in-flight requests the
         # configured grace to complete, then force the stage boundary.
-        if not await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal):
+        teardown_start = time.perf_counter()
+        teardown = await self._teardown_stage(stage_id, request_queue, request_phase, cancel_signal)
+        teardown_duration = time.perf_counter() - teardown_start
+        if not teardown.clean:
             stage_status = StageStatus.FAILED
 
         self.stage_runtime_info[stage_id] = StageRuntimeInfo(
             stage_id=stage_id,
             rate=rate,
             start_time=start_time_epoch,
-            end_time=time.time(),
+            end_time=end_time_epoch,
             status=stage_status,
             concurrency_level=concurrency_level,
+            timeout=timeout,
+            teardown_duration=teardown_duration,
+            dropped_requests=teardown.dropped_requests,
         )
         logger.info("Stage %d - run completed" if stage_status == StageStatus.COMPLETED else "Stage %d - run failed", stage_id)
 
@@ -1137,6 +1218,11 @@ class LoadGenerator:
         # is still in flight (see _teardown_stage).
         force_stop_signal: SyncEvent = mp.Event()
         self._force_stop_signal = force_stop_signal
+        # Stage-boundary sequence number, written only by the main process.
+        # Workers assign it to their stage_done_counter at each rendezvous
+        # (see _teardown_stage).
+        stage_boundary_seq: "Synchronized[int]" = mp.Value("i", 0)
+        self._stage_boundary_seq = stage_boundary_seq
         # start workers in the request phase
         request_phase.set()
 
@@ -1149,7 +1235,8 @@ class LoadGenerator:
                 shared_max_concurrency = None
 
             # Per-worker stage-done counter for the stage rendezvous: the worker
-            # increments it after winding down each stage (see _teardown_stage).
+            # sets it to the published boundary sequence after winding down each
+            # stage (see _teardown_stage).
             stage_done_counter: "Synchronized[int]" = mp.Value("i", 0)
 
             self.workers.append(
@@ -1168,6 +1255,7 @@ class LoadGenerator:
                     self.base_seed,
                     force_stop_signal=force_stop_signal,
                     stage_done_counter=stage_done_counter,
+                    stage_boundary_seq=stage_boundary_seq,
                     teardown_grace_seconds=self.teardown_grace_seconds,
                 )
             )

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -1330,6 +1330,8 @@ class ReportGenerator:
                         "status": status_str,
                         "timeout_configured": stage_info.timeout,
                         "actual_duration": stage_info.end_time - stage_info.start_time,
+                        "teardown_duration": stage_info.teardown_duration,
+                        "dropped_requests": stage_info.dropped_requests,
                         "concurrent_sessions": stage_info.concurrency_level,
                         "session_rate": stage_info.rate if stage_info.rate > 0 else None,
                     }

--- a/inference_perf/utils/request_queue.py
+++ b/inference_perf/utils/request_queue.py
@@ -22,6 +22,15 @@ T = TypeVar("T")
 
 
 class RequestQueue(Generic[T]):
+    """Multi-channel request queue between the main process and workers.
+
+    Plain mp.Queue channels, deliberately without JoinableQueue's
+    task_done/join accounting: stage completion is tracked through counters
+    and the stage rendezvous in the load generator, and task_done acquires a
+    shared condition lock that a worker killed mid-call would strand,
+    hanging every other process that touches it.
+    """
+
     def __init__(self, num_channels: int = 1):
         """
         initialize request queue based on number of channels, when num_channels is 1, there is only one global channel for all consumers.
@@ -30,29 +39,46 @@ class RequestQueue(Generic[T]):
             num_channels (int, optional): number of channels. Defaults to 1.
         """
         self.num_channels: int = num_channels
-        self.queues: List[mp.JoinableQueue[T]] = [mp.JoinableQueue() for _ in range(num_channels)]
+        self.queues: List[mp.Queue[T]] = [mp.Queue() for _ in range(num_channels)]
 
-    def get_channel(self, channel_id: int) -> "mp.JoinableQueue[T]":
+    def get_channel(self, channel_id: int) -> "mp.Queue[T]":
         return self.queues[channel_id % self.num_channels]
 
-    def drain(self, channel_id: int = -1) -> None:
+    def replace_channel(self, channel_id: int) -> "mp.Queue[T]":
+        """Replace a channel with a fresh queue and return it.
+
+        Used when the channel's sole consumer died abruptly: the dead process
+        may have stranded the queue's internal locks, which would starve any
+        replacement consumer. Only valid for per-consumer channels; a shared
+        channel must not be replaced while other consumers hold the old one.
+        """
+        queue: "mp.Queue[T]" = mp.Queue()
+        self.queues[channel_id % self.num_channels] = queue
+        return queue
+
+    def drain(self, channel_id: int = -1) -> int:
         """
         drain the specific queue by giving channel id, when id is -1, drain all queues.
 
         Args:
             channel_id (int, optional): the id of the queue to drain. Defaults to -1 (all queues).
+
+        Returns:
+            int: number of items removed.
         """
+        drained = 0
         queues_to_drain = self.queues if channel_id == -1 else [self.get_channel(channel_id)]
         for queue in queues_to_drain:
             while True:
                 try:
                     _ = queue.get_nowait()
-                    queue.task_done()
+                    drained += 1
                 except Empty:
                     # No qsize() check: it raises NotImplementedError on macOS.
                     # Empty from get_nowait() is sufficient since producers are stopped before drain.
                     logger.debug("Drain finished")
                     break
+        return drained
 
     def put(self, item: T, channel_id: int = -1) -> None:
         """
@@ -65,14 +91,3 @@ class RequestQueue(Generic[T]):
         queues_to_put = self.queues if channel_id == -1 else [self.get_channel(channel_id)]
         for queue in queues_to_put:
             queue.put(item)
-
-    def join(self, channel_id: int = -1) -> None:
-        """
-        join the queue by giving channel id, when channel id is -1, join all queues.
-
-        Args:
-            channel_id (int, optional): the id of the queue to join. Defaults to -1 (all queues).
-        """
-        queues_to_join = self.queues if channel_id == -1 else [self.get_channel(channel_id)]
-        for queue in queues_to_join:
-            queue.join()

--- a/tests/required/loadgen/test_load_generator.py
+++ b/tests/required/loadgen/test_load_generator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-from itertools import repeat
+from itertools import count, repeat
 from unittest.mock import MagicMock, AsyncMock, patch
 import multiprocessing as mp
 import asyncio
@@ -170,10 +170,10 @@ class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
     @patch("inference_perf.loadgen.load_generator.time")
     async def test_run_stage_timeout(self, mock_time: MagicMock, mock_sleep: AsyncMock) -> None:
         mock_time.time.return_value = 1000
-        mock_time.perf_counter.side_effect = [0, 10, 20]  # simulate time passing
+        mock_time.perf_counter.side_effect = count(0, 10)  # simulate time passing
 
         request_queue = MagicMock(spec=RequestQueue)
-        request_queue.drain = MagicMock()
+        request_queue.drain = MagicMock(return_value=0)
         active_counter = MagicMock()
         active_counter.value = 0
         finished_counter = MagicMock()
@@ -240,16 +240,20 @@ class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(self.load_generator.stage_runtime_info[0].status.name, "COMPLETED")
 
     async def test_drain(self) -> None:
+        from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+
         q: RequestQueue[RequestQueueData] = RequestQueue(1)
-        dummy_data = MagicMock(spec=InferenceAPIData)
+        # Payload must be picklable: the queue's feeder thread silently drops
+        # anything it cannot serialize (e.g. MagicMock).
+        dummy_data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="drain me")])
         q.put(RequestQueueData(0, dummy_data, 0.0, None), 0)
         q.put(RequestQueueData(0, dummy_data, 0.0, None), 0)
 
         # Small sleep to let queue populate
         await asyncio.sleep(0.1)
 
-        # Add tasks to queue so task_done doesn't fail
-        await self.load_generator.drain(q.get_channel(0))
+        drained = q.drain(0)
+        self.assertEqual(drained, 2)
         self.assertTrue(q.get_channel(0).empty())
 
     def test_sigint_handler(self) -> None:

--- a/tests/required/loadgen/test_stage_teardown.py
+++ b/tests/required/loadgen/test_stage_teardown.py
@@ -1,0 +1,260 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for bounded stage teardown.
+
+A stage that times out with work still in flight must never hang the run:
+in-flight requests get the configured grace to finish, whatever remains is
+cancelled, and a worker whose event loop is wedged (never observes the
+cancellation) is terminated and respawned so later stages still run.
+"""
+
+import asyncio
+import multiprocessing as mp
+import sys
+import time
+from typing import Generator, List, Optional, Tuple
+
+import pytest
+
+import inference_perf.loadgen.load_generator as lg_module
+from inference_perf.apis.base import InferenceAPIData
+from inference_perf.client.modelserver.base import ModelServerClient, PrometheusMetricMetadata
+from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType, LoadConfig, LoadType, StandardLoadStage
+from inference_perf.datagen import MockDataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator, RequestQueueData, Worker
+from inference_perf.utils.request_queue import RequestQueue
+
+
+class _TestClientBase(ModelServerClient):
+    def __init__(self) -> None:
+        super().__init__(APIConfig(type=APIType.Chat))
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat]
+
+    def get_prometheus_metric_metadata(self) -> PrometheusMetricMetadata:
+        raise NotImplementedError("not used in teardown tests")
+
+
+class SlowClient(_TestClientBase):
+    """Requests take a fixed time, longer than the stage timeout but shorter
+    than the teardown grace: they should complete during teardown."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        await asyncio.sleep(2.0)
+
+
+class HangingAsyncClient(_TestClientBase):
+    """Requests hang forever but respond to cancellation."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        await asyncio.sleep(3600)
+
+
+class WedgedSyncClient(_TestClientBase):
+    """Blocks the worker's event loop synchronously: cancellation is never
+    delivered, so only terminate-and-respawn can end the stage."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        time.sleep(3600)
+
+
+@pytest.fixture(autouse=True)
+def _fork_start_method() -> Generator[None, None, None]:
+    # Workers must fork (matching production: Linux default, forced on macOS in
+    # main_cli) so unpicklable test state is inherited rather than pickled.
+    old = mp.get_start_method(allow_none=True)
+    if old != "fork":
+        if "fork" not in mp.get_all_start_methods():
+            pytest.skip("fork start method unavailable on this platform")
+        mp.set_start_method("fork", force=True)
+    yield
+    if old is not None and old != "fork":
+        mp.set_start_method(old, force=True)
+
+
+class _Harness:
+    def __init__(self, client: ModelServerClient, teardown_grace_seconds: float) -> None:
+        api_config = APIConfig(type=APIType.Chat)
+        self.datagen = MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+        load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            stages=[StandardLoadStage(rate=2, duration=1)],
+            num_workers=1,
+            worker_max_concurrency=4,
+            stage_teardown_grace_seconds=teardown_grace_seconds,
+        )
+        self.loadgen = LoadGenerator(self.datagen, load_config)
+        self.request_queue: RequestQueue[RequestQueueData] = RequestQueue(1)
+        self.finished_counter = mp.Value("i", 0)
+        self.active_counter = mp.Value("i", 0)
+        self.request_phase = mp.Event()
+        self.stop_signal = mp.Event()
+        self.cancel_signal = mp.Event()
+        self.force_stop_signal = mp.Event()
+        self.loadgen._force_stop_signal = self.force_stop_signal
+        self.request_phase.set()
+
+        worker = Worker(
+            0,
+            client,
+            self.request_queue.get_channel(0),
+            self.datagen,
+            load_config.worker_max_concurrency,
+            self.stop_signal,
+            self.cancel_signal,
+            self.request_phase,
+            self.finished_counter,
+            self.active_counter,
+            None,
+            base_seed=42,
+            force_stop_signal=self.force_stop_signal,
+            stage_done_counter=mp.Value("i", 0),
+            teardown_grace_seconds=teardown_grace_seconds,
+        )
+        worker.start()
+        self.loadgen.workers = [worker]
+
+    async def run_stage(self, stage_id: int, timeout: float) -> float:
+        start = time.perf_counter()
+        await self.loadgen.run_stage(
+            stage_id,
+            rate=2,
+            duration=1,
+            request_queue=self.request_queue,
+            active_requests_counter=self.active_counter,
+            finished_requests_counter=self.finished_counter,
+            request_phase=self.request_phase,
+            cancel_signal=self.cancel_signal,
+            timeout=timeout,
+        )
+        return time.perf_counter() - start
+
+    def worker_pids(self) -> Tuple[Optional[int], ...]:
+        return tuple(w.pid for w in self.loadgen.workers)
+
+    def shutdown(self) -> None:
+        self.stop_signal.set()
+        self.request_phase.set()
+        for worker in self.loadgen.workers:
+            worker.join(timeout=3.0)
+            if worker.is_alive():
+                worker.terminate()
+                worker.join(timeout=3.0)
+
+
+async def test_grace_lets_inflight_requests_complete() -> None:
+    """Requests in flight at stage timeout finish during the teardown grace
+    and their completions are counted; the worker survives untouched."""
+    harness = _Harness(SlowClient(), teardown_grace_seconds=15.0)
+    try:
+        pids_before = harness.worker_pids()
+        elapsed = await harness.run_stage(0, timeout=1.0)
+
+        assert elapsed < 30, f"teardown not bounded: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"  # timed out
+        # Both requests (rate*duration = 2) completed during the grace window.
+        assert harness.finished_counter.value == 2
+        assert harness.worker_pids() == pids_before, "worker should not be respawned"
+        assert harness.loadgen.workers[0].is_alive()
+    finally:
+        harness.shutdown()
+
+
+async def test_stuck_requests_cancelled_at_grace_expiry() -> None:
+    """Requests that never finish are cancelled once the grace expires; the
+    worker survives and the next stage still runs."""
+    harness = _Harness(HangingAsyncClient(), teardown_grace_seconds=1.0)
+    try:
+        pids_before = harness.worker_pids()
+
+        elapsed = await harness.run_stage(0, timeout=1.0)
+        assert elapsed < 30, f"teardown not bounded: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
+        assert harness.worker_pids() == pids_before, "cancellable tasks must not force a respawn"
+
+        # Multi-stage: the next stage must run through the same worker.
+        elapsed = await harness.run_stage(1, timeout=1.0)
+        assert elapsed < 30, f"second stage teardown not bounded: {elapsed:.1f}s"
+        assert 1 in harness.loadgen.stage_runtime_info
+    finally:
+        harness.shutdown()
+
+
+async def test_wedged_worker_terminated_and_respawned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A worker whose event loop is blocked never observes cancellation: it
+    must be terminated at the force deadline and respawned so subsequent
+    stages run at full capacity."""
+    monkeypatch.setattr(lg_module, "_TEARDOWN_MARGIN_SECONDS", 2.0)
+    monkeypatch.setattr(lg_module, "_FORCE_REAP_SECONDS", 2.0)
+
+    harness = _Harness(WedgedSyncClient(), teardown_grace_seconds=0.5)
+    try:
+        pids_before = harness.worker_pids()
+
+        elapsed = await harness.run_stage(0, timeout=1.0)
+        assert elapsed < 45, f"teardown not bounded: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
+        assert harness.worker_pids() != pids_before, "wedged worker should be respawned"
+        assert harness.loadgen.workers[0].is_alive(), "replacement worker should be running"
+
+        # Multi-stage: the respawned worker serves the next stage, which wedges
+        # and is bounded again.
+        elapsed = await harness.run_stage(1, timeout=1.0)
+        assert elapsed < 45, f"second stage teardown not bounded: {elapsed:.1f}s"
+        assert 1 in harness.loadgen.stage_runtime_info
+    finally:
+        harness.shutdown()
+
+
+async def test_multi_stage_happy_path_through_mp_run() -> None:
+    """Normal multi-stage runs must be unaffected by the teardown rework: both
+    stages complete cleanly through the real mp_run worker lifecycle."""
+    from inference_perf.client.modelserver import MockModelServerClient
+    from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+
+    api_config = APIConfig(type=APIType.Chat)
+    datagen = MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+    load_config = LoadConfig(
+        type=LoadType.CONSTANT,
+        interval=0.1,
+        stages=[StandardLoadStage(rate=4, duration=1), StandardLoadStage(rate=4, duration=1)],
+        num_workers=2,
+        worker_max_concurrency=4,
+        stage_teardown_grace_seconds=10.0,
+    )
+    loadgen = LoadGenerator(datagen, load_config)
+    client = MockModelServerClient(LocalRequestMetricCollector(), api_config, mock_latency=0.05)
+
+    start = time.perf_counter()
+    await loadgen.run(client)
+    elapsed = time.perf_counter() - start
+
+    try:
+        assert elapsed < 60, f"multi-stage run not bounded: {elapsed:.1f}s"
+        assert loadgen.stage_runtime_info[0].status.name == "COMPLETED"
+        assert loadgen.stage_runtime_info[1].status.name == "COMPLETED"
+    finally:
+        await loadgen.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/required/loadgen/test_stage_teardown.py
+++ b/tests/required/loadgen/test_stage_teardown.py
@@ -18,10 +18,19 @@ A stage that times out with work still in flight must never hang the run:
 in-flight requests get the configured grace to finish, whatever remains is
 cancelled, and a worker whose event loop is wedged (never observes the
 cancellation) is terminated and respawned so later stages still run.
+
+Timing assertions are two-sided on purpose. The lower bound pins that the
+grace was actually waited for; the upper bound pins that teardown returned as
+soon as the work was done instead of exhausting the grace, force, or reap
+windows. Deterministic components per stage (with the default constants and
+the per-test grace G): ~2s of stage run (1s scheduling offset + 1s stage
+timeout), then G of wind-down when tasks are still pending, then sub-second
+cancellation/rendezvous overhead.
 """
 
 import asyncio
 import multiprocessing as mp
+import os
 import sys
 import time
 from typing import Generator, List, Optional, Tuple
@@ -30,9 +39,20 @@ import pytest
 
 import inference_perf.loadgen.load_generator as lg_module
 from inference_perf.apis.base import InferenceAPIData
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
 from inference_perf.client.modelserver.base import ModelServerClient
 from inference_perf.client.modelserver.metrics import BaseMetrics
-from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType, LoadConfig, LoadType, StandardLoadStage
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    DataConfig,
+    DataGenType,
+    LoadConfig,
+    LoadType,
+    StageGenType,
+    StandardLoadStage,
+    SweepConfig,
+)
 from inference_perf.datagen import MockDataGenerator
 from inference_perf.loadgen.load_generator import LoadGenerator, RequestQueueData, Worker
 from inference_perf.utils.request_queue import RequestQueue
@@ -49,14 +69,22 @@ class _TestClientBase(ModelServerClient):
         raise NotImplementedError("not used in teardown tests")
 
 
-class SlowClient(_TestClientBase):
+class CompletingSlowClient(_TestClientBase):
     """Requests take a fixed time, longer than the stage timeout but shorter
-    than the teardown grace: they should complete during teardown."""
+    than the teardown grace: they should complete during teardown. A completion
+    line is appended only when the request actually ran to the end, so a
+    teardown that cancels instead of waiting is detected."""
+
+    def __init__(self, completion_log: str) -> None:
+        super().__init__()
+        self.completion_log = completion_log
 
     async def process_request(
         self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
     ) -> None:
         await asyncio.sleep(2.0)
+        with open(self.completion_log, "a") as f:
+            f.write("completed\n")
 
 
 class HangingAsyncClient(_TestClientBase):
@@ -68,6 +96,29 @@ class HangingAsyncClient(_TestClientBase):
         await asyncio.sleep(3600)
 
 
+class QuickClient(_TestClientBase):
+    """Requests complete almost immediately."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        await asyncio.sleep(0.05)
+
+
+class CancelHostileClient(_TestClientBase):
+    """Requests hang forever and raise a non-cancellation error when
+    cancelled. The wind-down gather must absorb the error (return_exceptions)
+    instead of letting it kill the worker process."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise RuntimeError("client failure during cancellation") from None
+
+
 class WedgedSyncClient(_TestClientBase):
     """Blocks the worker's event loop synchronously: cancellation is never
     delivered, so only terminate-and-respawn can end the stage."""
@@ -76,6 +127,84 @@ class WedgedSyncClient(_TestClientBase):
         self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
     ) -> None:
         time.sleep(3600)
+
+
+class DieOnceClient(_TestClientBase):
+    """The first request ever dispatched kills the worker process abruptly
+    (simulating an OOM kill). Requests served by the respawned worker behave
+    like CompletingSlowClient."""
+
+    def __init__(self, death_marker: str, completion_log: str) -> None:
+        super().__init__()
+        self.death_marker = death_marker
+        self.completion_log = completion_log
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        if not os.path.exists(self.death_marker):
+            with open(self.death_marker, "w") as f:
+                f.write("died\n")
+            os._exit(1)
+        await asyncio.sleep(2.0)
+        with open(self.completion_log, "a") as f:
+            f.write("completed\n")
+
+
+class ChainedChatData(ChatCompletionAPIData):
+    """Chat data that optionally waits for a flag file before dispatch,
+    modeling a session-replay successor parked on its predecessor."""
+
+    wait_flag_path: Optional[str] = None
+
+    async def wait_for_predecessors_and_substitute(self) -> None:
+        if self.wait_flag_path is None:
+            return
+        while not os.path.exists(self.wait_flag_path):
+            await asyncio.sleep(0.05)
+
+
+class ChainDataGenerator(MockDataGenerator):
+    """Yields alternating plain / predecessor-gated requests."""
+
+    def __init__(self, api_config: APIConfig, config: DataConfig, wait_flag_path: str) -> None:
+        super().__init__(api_config, config, None)
+        self.wait_flag_path = wait_flag_path
+
+    def get_data(self) -> Generator[InferenceAPIData, None, None]:
+        i = 0
+        while True:
+            i += 1
+            yield ChainedChatData(
+                messages=[ChatMessage(role="user", content=f"chained prompt {i}")],
+                wait_flag_path=self.wait_flag_path if i % 2 == 0 else None,
+            )
+
+
+class ChainClient(_TestClientBase):
+    """Logs each dispatch, then completes after a delay and raises the flag
+    the gated request is waiting on."""
+
+    def __init__(self, dispatch_log: str, done_flag: str) -> None:
+        super().__init__()
+        self.dispatch_log = dispatch_log
+        self.done_flag = done_flag
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        with open(self.dispatch_log, "a") as f:
+            f.write("dispatched\n")
+        await asyncio.sleep(3.0)
+        with open(self.done_flag, "w") as f:
+            f.write("done\n")
+
+
+def _line_count(path: str) -> int:
+    if not os.path.exists(path):
+        return 0
+    with open(path) as f:
+        return len(f.readlines())
 
 
 @pytest.fixture(autouse=True)
@@ -93,14 +222,22 @@ def _fork_start_method() -> Generator[None, None, None]:
 
 
 class _Harness:
-    def __init__(self, client: ModelServerClient, teardown_grace_seconds: float) -> None:
+    def __init__(
+        self,
+        client: ModelServerClient,
+        teardown_grace_seconds: float,
+        datagen: Optional[MockDataGenerator] = None,
+        worker_max_concurrency: int = 4,
+    ) -> None:
         api_config = APIConfig(type=APIType.Chat)
-        self.datagen = MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+        self.datagen = (
+            datagen if datagen is not None else MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+        )
         load_config = LoadConfig(
             type=LoadType.CONSTANT,
             stages=[StandardLoadStage(rate=2, duration=1)],
             num_workers=1,
-            worker_max_concurrency=4,
+            worker_max_concurrency=worker_max_concurrency,
             stage_teardown_grace_seconds=teardown_grace_seconds,
         )
         self.loadgen = LoadGenerator(self.datagen, load_config)
@@ -111,7 +248,9 @@ class _Harness:
         self.stop_signal = mp.Event()
         self.cancel_signal = mp.Event()
         self.force_stop_signal = mp.Event()
+        self.stage_boundary_seq = mp.Value("i", 0)
         self.loadgen._force_stop_signal = self.force_stop_signal
+        self.loadgen._stage_boundary_seq = self.stage_boundary_seq
         self.request_phase.set()
 
         worker = Worker(
@@ -119,7 +258,7 @@ class _Harness:
             client,
             self.request_queue.get_channel(0),
             self.datagen,
-            load_config.worker_max_concurrency,
+            worker_max_concurrency,
             self.stop_signal,
             self.cancel_signal,
             self.request_phase,
@@ -129,16 +268,17 @@ class _Harness:
             base_seed=42,
             force_stop_signal=self.force_stop_signal,
             stage_done_counter=mp.Value("i", 0),
+            stage_boundary_seq=self.stage_boundary_seq,
             teardown_grace_seconds=teardown_grace_seconds,
         )
         worker.start()
         self.loadgen.workers = [worker]
 
-    async def run_stage(self, stage_id: int, timeout: float) -> float:
+    async def run_stage(self, stage_id: int, timeout: float, rate: float = 2) -> float:
         start = time.perf_counter()
         await self.loadgen.run_stage(
             stage_id,
-            rate=2,
+            rate=rate,
             duration=1,
             request_queue=self.request_queue,
             active_requests_counter=self.active_counter,
@@ -162,18 +302,25 @@ class _Harness:
                 worker.join(timeout=3.0)
 
 
-async def test_grace_lets_inflight_requests_complete() -> None:
+async def test_grace_lets_inflight_requests_complete(tmp_path: object) -> None:
     """Requests in flight at stage timeout finish during the teardown grace
-    and their completions are counted; the worker survives untouched."""
-    harness = _Harness(SlowClient(), teardown_grace_seconds=15.0)
+    (proven by completion markers written at request end, which cancellation
+    would skip); teardown returns at completion, far below the grace bound."""
+    completion_log = os.path.join(str(tmp_path), "completions.log")
+    harness = _Harness(CompletingSlowClient(completion_log), teardown_grace_seconds=15.0)
     try:
         pids_before = harness.worker_pids()
         elapsed = await harness.run_stage(0, timeout=1.0)
 
-        assert elapsed < 30, f"teardown not bounded: {elapsed:.1f}s"
+        # Lower bound: requests dispatch at >= 1s and take 2s, so a teardown
+        # that really waits cannot return before ~3s. Upper bound: it must
+        # return at completion (~4s), not at grace + margin (30s).
+        assert 3.0 <= elapsed < 12.0, f"teardown window violated: {elapsed:.1f}s"
         assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"  # timed out
-        # Both requests (rate*duration = 2) completed during the grace window.
+        # Both requests (rate*duration = 2) ran to completion during the grace.
+        assert _line_count(completion_log) == 2
         assert harness.finished_counter.value == 2
+        assert harness.loadgen.stage_runtime_info[0].dropped_requests == 0
         assert harness.worker_pids() == pids_before, "worker should not be respawned"
         assert harness.loadgen.workers[0].is_alive()
     finally:
@@ -188,13 +335,62 @@ async def test_stuck_requests_cancelled_at_grace_expiry() -> None:
         pids_before = harness.worker_pids()
 
         elapsed = await harness.run_stage(0, timeout=1.0)
-        assert elapsed < 30, f"teardown not bounded: {elapsed:.1f}s"
+        # Lower bound: ~2s of stage run plus the full 1s grace (the tasks
+        # never finish, so the grace cannot be cut short). Upper bound:
+        # cancellation must end the wind-down promptly; a reap that waits out
+        # _WIND_DOWN_REAP_SECONDS (10s) because tasks were not cancelled would
+        # exceed it.
+        assert 3.0 <= elapsed < 8.0, f"teardown window violated: {elapsed:.1f}s"
         assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
         assert harness.worker_pids() == pids_before, "cancellable tasks must not force a respawn"
 
         # Multi-stage: the next stage must run through the same worker.
         elapsed = await harness.run_stage(1, timeout=1.0)
-        assert elapsed < 30, f"second stage teardown not bounded: {elapsed:.1f}s"
+        assert 3.0 <= elapsed < 8.0, f"second stage teardown window violated: {elapsed:.1f}s"
+        assert 1 in harness.loadgen.stage_runtime_info
+    finally:
+        harness.shutdown()
+
+
+async def test_saturated_worker_reaches_boundary_and_drops_backlog() -> None:
+    """A worker whose concurrency permits are all held by hung requests must
+    still observe the stage boundary (bounded semaphore acquire), cancel at
+    grace expiry without being terminated, and the undispatched backlog must
+    be counted as dropped."""
+    harness = _Harness(HangingAsyncClient(), teardown_grace_seconds=1.0, worker_max_concurrency=4)
+    try:
+        pids_before = harness.worker_pids()
+
+        # 20 requests, 4 permits: 4 hang in flight, 16 never leave the queue.
+        elapsed = await harness.run_stage(0, timeout=1.0, rate=20)
+
+        # Same window as the unsaturated hang case: the boundary must be
+        # reached within the 0.5s acquire timeout, not via the force path
+        # (grace + 15s margin + terminate).
+        assert 3.0 <= elapsed < 9.0, f"teardown window violated: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
+        assert harness.loadgen.stage_runtime_info[0].dropped_requests == 16
+        assert harness.finished_counter.value == 4  # the cancelled in-flight tasks
+        assert harness.worker_pids() == pids_before, "saturated worker must drain gracefully, not be terminated"
+        assert harness.loadgen.workers[0].is_alive()
+    finally:
+        harness.shutdown()
+
+
+async def test_cancel_hostile_task_failure_does_not_kill_worker() -> None:
+    """A task that raises a non-cancellation error while being cancelled must
+    be absorbed by the wind-down gather; the worker survives and serves the
+    next stage."""
+    harness = _Harness(CancelHostileClient(), teardown_grace_seconds=1.0)
+    try:
+        pids_before = harness.worker_pids()
+
+        elapsed = await harness.run_stage(0, timeout=1.0)
+        assert 3.0 <= elapsed < 8.0, f"teardown window violated: {elapsed:.1f}s"
+        assert harness.worker_pids() == pids_before, "task failure at cancellation must not kill the worker"
+        assert harness.loadgen.workers[0].is_alive()
+
+        elapsed = await harness.run_stage(1, timeout=1.0)
         assert 1 in harness.loadgen.stage_runtime_info
     finally:
         harness.shutdown()
@@ -212,7 +408,11 @@ async def test_wedged_worker_terminated_and_respawned(monkeypatch: pytest.Monkey
         pids_before = harness.worker_pids()
 
         elapsed = await harness.run_stage(0, timeout=1.0)
-        assert elapsed < 45, f"teardown not bounded: {elapsed:.1f}s"
+        # Lower bound: ~2s run + 0.5s grace + 2s margin + 2s force reap = 6.5s
+        # of deterministic waiting before terminate. Upper bound: terminate
+        # must kill the worker promptly; skipping terminate and relying on the
+        # join(5s)-then-kill fallback would add ~5s and exceed it.
+        assert 6.0 <= elapsed < 11.0, f"teardown window violated: {elapsed:.1f}s"
         assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
         assert harness.worker_pids() != pids_before, "wedged worker should be respawned"
         assert harness.loadgen.workers[0].is_alive(), "replacement worker should be running"
@@ -220,8 +420,102 @@ async def test_wedged_worker_terminated_and_respawned(monkeypatch: pytest.Monkey
         # Multi-stage: the respawned worker serves the next stage, which wedges
         # and is bounded again.
         elapsed = await harness.run_stage(1, timeout=1.0)
-        assert elapsed < 45, f"second stage teardown not bounded: {elapsed:.1f}s"
+        assert 6.0 <= elapsed < 15.0, f"second stage teardown window violated: {elapsed:.1f}s"
         assert 1 in harness.loadgen.stage_runtime_info
+    finally:
+        harness.shutdown()
+
+
+async def test_respawned_worker_resyncs_stage_rendezvous(tmp_path: object) -> None:
+    """A worker respawned after dying mid-stage may pass a stage boundary it
+    never served (it starts while request_phase is cleared). Its stage-done
+    counter must converge on the published boundary sequence instead of
+    running ahead, so the next stage's teardown still waits for real work."""
+    death_marker = os.path.join(str(tmp_path), "death.marker")
+    completion_log = os.path.join(str(tmp_path), "completions.log")
+    harness = _Harness(DieOnceClient(death_marker, completion_log), teardown_grace_seconds=15.0)
+    try:
+        pids_before = harness.worker_pids()
+
+        # Stage 0: the first dispatched request kills the worker; the stage
+        # fails and the worker is respawned during teardown.
+        await harness.run_stage(0, timeout=5.0)
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
+        assert harness.worker_pids() != pids_before, "dead worker should be respawned"
+        assert harness.loadgen.workers[0].is_alive()
+        pids_after_respawn = harness.worker_pids()
+
+        # Gap between stages: the respawned worker passes the idle stage
+        # boundary here. With a relative counter this desynchronized the
+        # rendezvous permanently; the published sequence keeps it aligned.
+        await asyncio.sleep(3.0)
+
+        # Stage 1: two 2s requests against a 1s timeout. The teardown must
+        # wait for both to complete during the grace; a desynchronized
+        # rendezvous returns immediately with nothing completed.
+        elapsed = await harness.run_stage(1, timeout=1.0)
+        assert 3.0 <= elapsed < 12.0, f"teardown window violated: {elapsed:.1f}s"
+        assert _line_count(completion_log) == 2, "in-flight requests must complete during the grace"
+        assert harness.finished_counter.value == 2
+        assert harness.worker_pids() == pids_after_respawn, "respawned worker must survive the next stage"
+    finally:
+        harness.shutdown()
+
+
+async def test_draining_gate_blocks_dependent_dispatch(tmp_path: object) -> None:
+    """Session-replay dependency chains: a request parked on its predecessor
+    that wakes up during teardown must exit without dispatching (draining
+    gate), so the chain unwinds well before the grace expires."""
+    dispatch_log = os.path.join(str(tmp_path), "dispatch.log")
+    done_flag = os.path.join(str(tmp_path), "done.flag")
+    api_config = APIConfig(type=APIType.Chat)
+    datagen = ChainDataGenerator(api_config, DataConfig(type=DataGenType.Mock), done_flag)
+    harness = _Harness(ChainClient(dispatch_log, done_flag), teardown_grace_seconds=15.0, datagen=datagen)
+    try:
+        pids_before = harness.worker_pids()
+
+        # Request A dispatches (~1.5s) and completes at ~4.5s, raising the
+        # flag. Request B waits on the flag; teardown starts at ~2s, so B
+        # wakes while draining and must not dispatch.
+        elapsed = await harness.run_stage(0, timeout=1.0)
+
+        # Lower bound: teardown cannot end before A completes (~4.5s). Upper
+        # bound: the chain must unwind at A's completion, not at grace +
+        # margin (30s), and without B's extra 3s dispatch.
+        assert 3.5 <= elapsed < 10.0, f"teardown window violated: {elapsed:.1f}s"
+        assert _line_count(dispatch_log) == 1, "dependent request must not dispatch during teardown"
+        assert harness.finished_counter.value == 2  # A completed, B exited via the gate
+        assert harness.worker_pids() == pids_before
+    finally:
+        harness.shutdown()
+
+
+async def test_zero_request_stage_boundary_is_not_missed() -> None:
+    """A stage with zero requests sets and tears down its signals within
+    milliseconds, faster than a parked worker samples them. The worker must
+    still acknowledge that boundary (via the published sequence) instead of
+    waiting out the grace and being killed as unresponsive."""
+    harness = _Harness(QuickClient(), teardown_grace_seconds=1.0)
+    try:
+        pids_before = harness.worker_pids()
+
+        # Stage 0: normal, completes.
+        elapsed = await harness.run_stage(0, timeout=10.0)
+        assert harness.loadgen.stage_runtime_info[0].status.name == "COMPLETED"
+
+        # Stage 1: rate*duration < 1 -> zero requests -> immediate teardown.
+        elapsed = await harness.run_stage(1, timeout=10.0, rate=0.5)
+        # A missed boundary parks the worker until the grace + margin (16s)
+        # expires and then respawns it; an acknowledged boundary returns fast.
+        assert elapsed < 5.0, f"zero-request stage teardown not acknowledged: {elapsed:.1f}s"
+        assert harness.worker_pids() == pids_before, "healthy worker must not be killed at an empty boundary"
+
+        # Stage 2: normal again, must run through the same worker.
+        elapsed = await harness.run_stage(2, timeout=10.0)
+        assert elapsed < 10.0, f"stage after empty boundary not bounded: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[2].status.name == "COMPLETED"
+        assert harness.finished_counter.value == 2
+        assert harness.worker_pids() == pids_before
     finally:
         harness.shutdown()
 
@@ -253,6 +547,38 @@ async def test_multi_stage_happy_path_through_mp_run() -> None:
         assert elapsed < 60, f"multi-stage run not bounded: {elapsed:.1f}s"
         assert loadgen.stage_runtime_info[0].status.name == "COMPLETED"
         assert loadgen.stage_runtime_info[1].status.name == "COMPLETED"
+        assert loadgen.stage_runtime_info[0].dropped_requests == 0
+        assert loadgen.stage_runtime_info[1].dropped_requests == 0
+    finally:
+        await loadgen.stop()
+
+
+async def test_sweep_preprocess_timeout_is_bounded() -> None:
+    """The sweep preprocess stage is designed to time out through the
+    teardown machinery (#608 regression surface). With a hanging server it
+    must still return promptly and record runtime info for the probe stage
+    instead of deadlocking."""
+    api_config = APIConfig(type=APIType.Chat)
+    datagen = MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+    load_config = LoadConfig(
+        type=LoadType.CONSTANT,
+        stages=[],
+        sweep=SweepConfig(type=StageGenType.GEOM, num_requests=8, timeout=2.0, num_stages=2, stage_duration=1),
+        num_workers=1,
+        worker_max_concurrency=4,
+        stage_teardown_grace_seconds=1.0,
+    )
+    loadgen = LoadGenerator(datagen, load_config)
+
+    start = time.perf_counter()
+    await loadgen.run(HangingAsyncClient())
+    elapsed = time.perf_counter() - start
+
+    try:
+        assert elapsed < 25, f"sweep preprocess not bounded: {elapsed:.1f}s"
+        # The probe stage (stage_id=-1) timed out but still produced runtime info.
+        assert -1 in loadgen.stage_runtime_info
+        assert loadgen.stage_runtime_info[-1].status.name == "FAILED"
     finally:
         await loadgen.stop()
 

--- a/tests/required/loadgen/test_stage_teardown.py
+++ b/tests/required/loadgen/test_stage_teardown.py
@@ -1,0 +1,261 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for bounded stage teardown.
+
+A stage that times out with work still in flight must never hang the run:
+in-flight requests get the configured grace to finish, whatever remains is
+cancelled, and a worker whose event loop is wedged (never observes the
+cancellation) is terminated and respawned so later stages still run.
+"""
+
+import asyncio
+import multiprocessing as mp
+import sys
+import time
+from typing import Generator, List, Optional, Tuple
+
+import pytest
+
+import inference_perf.loadgen.load_generator as lg_module
+from inference_perf.apis.base import InferenceAPIData
+from inference_perf.client.modelserver.base import ModelServerClient
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType, LoadConfig, LoadType, StandardLoadStage
+from inference_perf.datagen import MockDataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator, RequestQueueData, Worker
+from inference_perf.utils.request_queue import RequestQueue
+
+
+class _TestClientBase(ModelServerClient):
+    def __init__(self) -> None:
+        super().__init__(APIConfig(type=APIType.Chat))
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat]
+
+    def get_prometheus_metric_metadata(self) -> BaseMetrics:
+        raise NotImplementedError("not used in teardown tests")
+
+
+class SlowClient(_TestClientBase):
+    """Requests take a fixed time, longer than the stage timeout but shorter
+    than the teardown grace: they should complete during teardown."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        await asyncio.sleep(2.0)
+
+
+class HangingAsyncClient(_TestClientBase):
+    """Requests hang forever but respond to cancellation."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        await asyncio.sleep(3600)
+
+
+class WedgedSyncClient(_TestClientBase):
+    """Blocks the worker's event loop synchronously: cancellation is never
+    delivered, so only terminate-and-respawn can end the stage."""
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        time.sleep(3600)
+
+
+@pytest.fixture(autouse=True)
+def _fork_start_method() -> Generator[None, None, None]:
+    # Workers must fork (matching production: Linux default, forced on macOS in
+    # main_cli) so unpicklable test state is inherited rather than pickled.
+    old = mp.get_start_method(allow_none=True)
+    if old != "fork":
+        if "fork" not in mp.get_all_start_methods():
+            pytest.skip("fork start method unavailable on this platform")
+        mp.set_start_method("fork", force=True)
+    yield
+    if old is not None and old != "fork":
+        mp.set_start_method(old, force=True)
+
+
+class _Harness:
+    def __init__(self, client: ModelServerClient, teardown_grace_seconds: float) -> None:
+        api_config = APIConfig(type=APIType.Chat)
+        self.datagen = MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+        load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            stages=[StandardLoadStage(rate=2, duration=1)],
+            num_workers=1,
+            worker_max_concurrency=4,
+            stage_teardown_grace_seconds=teardown_grace_seconds,
+        )
+        self.loadgen = LoadGenerator(self.datagen, load_config)
+        self.request_queue: RequestQueue[RequestQueueData] = RequestQueue(1)
+        self.finished_counter = mp.Value("i", 0)
+        self.active_counter = mp.Value("i", 0)
+        self.request_phase = mp.Event()
+        self.stop_signal = mp.Event()
+        self.cancel_signal = mp.Event()
+        self.force_stop_signal = mp.Event()
+        self.loadgen._force_stop_signal = self.force_stop_signal
+        self.request_phase.set()
+
+        worker = Worker(
+            0,
+            client,
+            self.request_queue.get_channel(0),
+            self.datagen,
+            load_config.worker_max_concurrency,
+            self.stop_signal,
+            self.cancel_signal,
+            self.request_phase,
+            self.finished_counter,
+            self.active_counter,
+            None,
+            base_seed=42,
+            force_stop_signal=self.force_stop_signal,
+            stage_done_counter=mp.Value("i", 0),
+            teardown_grace_seconds=teardown_grace_seconds,
+        )
+        worker.start()
+        self.loadgen.workers = [worker]
+
+    async def run_stage(self, stage_id: int, timeout: float) -> float:
+        start = time.perf_counter()
+        await self.loadgen.run_stage(
+            stage_id,
+            rate=2,
+            duration=1,
+            request_queue=self.request_queue,
+            active_requests_counter=self.active_counter,
+            finished_requests_counter=self.finished_counter,
+            request_phase=self.request_phase,
+            cancel_signal=self.cancel_signal,
+            timeout=timeout,
+        )
+        return time.perf_counter() - start
+
+    def worker_pids(self) -> Tuple[Optional[int], ...]:
+        return tuple(w.pid for w in self.loadgen.workers)
+
+    def shutdown(self) -> None:
+        self.stop_signal.set()
+        self.request_phase.set()
+        for worker in self.loadgen.workers:
+            worker.join(timeout=3.0)
+            if worker.is_alive():
+                worker.terminate()
+                worker.join(timeout=3.0)
+
+
+async def test_grace_lets_inflight_requests_complete() -> None:
+    """Requests in flight at stage timeout finish during the teardown grace
+    and their completions are counted; the worker survives untouched."""
+    harness = _Harness(SlowClient(), teardown_grace_seconds=15.0)
+    try:
+        pids_before = harness.worker_pids()
+        elapsed = await harness.run_stage(0, timeout=1.0)
+
+        assert elapsed < 30, f"teardown not bounded: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"  # timed out
+        # Both requests (rate*duration = 2) completed during the grace window.
+        assert harness.finished_counter.value == 2
+        assert harness.worker_pids() == pids_before, "worker should not be respawned"
+        assert harness.loadgen.workers[0].is_alive()
+    finally:
+        harness.shutdown()
+
+
+async def test_stuck_requests_cancelled_at_grace_expiry() -> None:
+    """Requests that never finish are cancelled once the grace expires; the
+    worker survives and the next stage still runs."""
+    harness = _Harness(HangingAsyncClient(), teardown_grace_seconds=1.0)
+    try:
+        pids_before = harness.worker_pids()
+
+        elapsed = await harness.run_stage(0, timeout=1.0)
+        assert elapsed < 30, f"teardown not bounded: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
+        assert harness.worker_pids() == pids_before, "cancellable tasks must not force a respawn"
+
+        # Multi-stage: the next stage must run through the same worker.
+        elapsed = await harness.run_stage(1, timeout=1.0)
+        assert elapsed < 30, f"second stage teardown not bounded: {elapsed:.1f}s"
+        assert 1 in harness.loadgen.stage_runtime_info
+    finally:
+        harness.shutdown()
+
+
+async def test_wedged_worker_terminated_and_respawned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A worker whose event loop is blocked never observes cancellation: it
+    must be terminated at the force deadline and respawned so subsequent
+    stages run at full capacity."""
+    monkeypatch.setattr(lg_module, "_TEARDOWN_MARGIN_SECONDS", 2.0)
+    monkeypatch.setattr(lg_module, "_FORCE_REAP_SECONDS", 2.0)
+
+    harness = _Harness(WedgedSyncClient(), teardown_grace_seconds=0.5)
+    try:
+        pids_before = harness.worker_pids()
+
+        elapsed = await harness.run_stage(0, timeout=1.0)
+        assert elapsed < 45, f"teardown not bounded: {elapsed:.1f}s"
+        assert harness.loadgen.stage_runtime_info[0].status.name == "FAILED"
+        assert harness.worker_pids() != pids_before, "wedged worker should be respawned"
+        assert harness.loadgen.workers[0].is_alive(), "replacement worker should be running"
+
+        # Multi-stage: the respawned worker serves the next stage, which wedges
+        # and is bounded again.
+        elapsed = await harness.run_stage(1, timeout=1.0)
+        assert elapsed < 45, f"second stage teardown not bounded: {elapsed:.1f}s"
+        assert 1 in harness.loadgen.stage_runtime_info
+    finally:
+        harness.shutdown()
+
+
+async def test_multi_stage_happy_path_through_mp_run() -> None:
+    """Normal multi-stage runs must be unaffected by the teardown rework: both
+    stages complete cleanly through the real mp_run worker lifecycle."""
+    from inference_perf.client.modelserver import MockModelServerClient
+    from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+
+    api_config = APIConfig(type=APIType.Chat)
+    datagen = MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+    load_config = LoadConfig(
+        type=LoadType.CONSTANT,
+        interval=0.1,
+        stages=[StandardLoadStage(rate=4, duration=1), StandardLoadStage(rate=4, duration=1)],
+        num_workers=2,
+        worker_max_concurrency=4,
+        stage_teardown_grace_seconds=10.0,
+    )
+    loadgen = LoadGenerator(datagen, load_config)
+    client = MockModelServerClient(LocalRequestMetricCollector(), api_config, mock_latency=0.05)
+
+    start = time.perf_counter()
+    await loadgen.run(client)
+    elapsed = time.perf_counter() - start
+
+    try:
+        assert elapsed < 60, f"multi-stage run not bounded: {elapsed:.1f}s"
+        assert loadgen.stage_runtime_info[0].status.name == "COMPLETED"
+        assert loadgen.stage_runtime_info[1].status.name == "COMPLETED"
+    finally:
+        await loadgen.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/required/reportgen/test_session_and_prometheus_reports.py
+++ b/tests/required/reportgen/test_session_and_prometheus_reports.py
@@ -298,6 +298,8 @@ class TestGenerateSessionReports:
             "status": "COMPLETED",
             "timeout_configured": 30.0,
             "actual_duration": 6.0,
+            "teardown_duration": None,
+            "dropped_requests": None,
             "concurrent_sessions": 4,
             "session_rate": 2.0,
         }


### PR DESCRIPTION
Fixes #647.

A stage that times out with many sessions in flight can hang the run indefinitely and never produce a report. As detailed in the issue, post-timeout teardown chains four unbounded waits, each of which deadlocks permanently if a single worker process dies (e.g. OOM kill, realistic with many 256k-token sessions in flight) or a task never observes cancellation:

1. the active-request drain loops in `run_session_stage` / `run_stage` (a dead worker's in-flight increments are never undone)
2. `request_queue.join()`, called synchronously on the main event loop
3. the worker-side `gather` without `return_exceptions`, which re-raises stored task exceptions at teardown and kills the worker at exactly the wrong moment
4. the stage barrier (`mp.Barrier` has no recovery when a party dies)

## What this PR does

Teardown is now bounded end to end and liveness-aware:

- **Grace period**: workers give in-flight requests `stage_teardown_grace_seconds` (new `LoadConfig` field, default 120s) to finish naturally after stage end; completions during the grace keep their metrics. New dispatches are gated off during wind-down, which also unwinds session-replay dependency chains quickly (successors woken by predecessors exit instead of sending).
- **Bounded cancel/reap**: whatever remains after the grace is cancelled and reaped within a fixed bound, and real task exceptions are logged instead of killing the worker.
- **Liveness-aware rendezvous**: the barrier, queue join, and drain spins are replaced by a per-worker stage-done rendezvous polled together with worker liveness. The main process publishes a stage-boundary sequence number; workers assign it (rather than increment a counter) at each boundary, so respawned workers and stages that start and end between two signal samples stay synchronized. Dead workers never extend the wait; workers that miss the force deadline are terminated.
- **Worker respawn**: terminated or dead workers are respawned after teardown so multi-stage runs keep full capacity; `run_session_stage` also fails fast when a worker dies mid-stage instead of waiting out the stage timeout.
- **Stranded-lock hardening**: the main process reads worker-owned counters lock-free, workers poll the request queue non-blocking (the old blocking `get(timeout=...)` held the queue's reader lock across the poll, so an abruptly killed worker starved every later consumer of the channel), the unused `task_done`/`join` accounting is retired (`RequestQueue` wraps plain `mp.Queue`), and per-worker channels are swapped for fresh queues on respawn. A worker saturated with hung requests uses a bounded semaphore acquire so it still reaches the stage boundary and drains gracefully.
- **Metrics window accuracy**: stage `end_time` is captured before teardown, so server-side metrics windows and `actual_duration` exclude the zero-load drain tail. The drain is reported separately as `teardown_duration`, and never-dispatched requests are counted as `dropped_requests`; both appear in `StageRuntimeInfo` and the per-stage session metadata.

With this, report generation becomes a structural guarantee: teardown completes within grace + fixed margins in every failure mode.

## Testing

Regression tests in `tests/required/loadgen/test_stage_teardown.py` spawn real forked workers, with two-sided timing bounds (lower bound: the grace was actually waited for; upper bound: teardown returned as soon as work finished) and side-effect markers (completion/dispatch log files) instead of liveness-only asserts. Covered:

- in-flight requests completing within the grace (completion markers kept, metrics window intact)
- stuck-but-cancellable requests cancelled at grace expiry, across two stages
- a saturated worker (all permits held by hung requests) reaching the boundary without being terminated, with the queue backlog counted as dropped
- a task raising a non-cancellation error during cancellation, absorbed without killing the worker
- a wedged worker (blocked event loop) terminated at the force deadline and respawned, with the next stage still running
- a worker killed mid-stage (`os._exit`), respawned, and the rendezvous staying synchronized through the next stage
- a session-replay style dependency chain unwinding through the draining gate without dispatching the successor
- a zero-request stage whose boundary signals flip faster than the worker sampling interval
- a normal two-stage `mp_run` happy path
- the sweep preprocess stage timing out against a hanging server and returning bounded (#608 regression surface)

Full suite passes locally (`pytest`, `ruff check`, `ruff format --check`, `mypy --strict`).

```release-note
Stage teardown is now bounded: timed-out stages always produce reports. Stage `end_time` in reports no longer includes the post-stage drain window, which changes server-side rate averages for stages that hit their timeout; the drain is reported separately as `teardown_duration`, and requests dropped at stage end are reported as `dropped_requests`. Added `load.stage_teardown_grace_seconds` (default 120) to control how long in-flight requests may finish after stage end.
```
