### PR TITLE
perf: add api.use_server_prompt_tokens to skip full-history re-tokenization in session replay

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -14,6 +14,7 @@ These command line flags are automatically generated from the internal `Config` 
 | `--api.response_format.name` | str | Matches api.response_format.name in config |
 | `--api.response_format.json_schema` | JSON | Matches api.response_format.json_schema in config |
 | `--api.session_id_header_key` | str | Matches api.session_id_header_key in config |
+| `--api.use_server_prompt_tokens` | boolean | Matches api.use_server_prompt_tokens in config |
 | `--data.type` | Enum (mock, shareGPT, synthetic, random, shared_prefix, cnn_dailymail, infinity_instruct, billsum_conversations, otel_trace_replay, weka_trace_replay, conversation_replay, visionarena) | Matches data.type in config |
 | `--data.path` | str | Matches data.path in config |
 | `--data.corpus_file_path` | str | Path to a text file to use as the prompt tokenization corpus instead of the default hardcoded sonnet |

--- a/docs/config.md
+++ b/docs/config.md
@@ -38,6 +38,11 @@ api:
   slo_unit: "ms"               # Optional SLO unit (e.g., ms, s), default is ms
   slo_tpot_header: "x-slo-tpot-ms"        # Optional header name for TPOT SLO Header, default is x-slo-tpot-ms
   slo_ttft_header: "x-slo-ttft-ms"        # Optional header name for TTFT SLO Header, default is x-slo-ttft-ms
+  use_server_prompt_tokens: false # Opt-in: record usage.prompt_tokens from the server as input tokens for replay-graph
+                                  # session workloads instead of re-tokenizing the full conversation client-side.
+                                  # Client-side re-tokenization costs O(conversation) CPU on the loadgen event loop per
+                                  # event and can bottleneck long-context replay (issue #648). Falls back to client-side
+                                  # counting when the server does not report usage.
 ```  
 
 ### Data Generation

--- a/docs/weka_trace_replay.md
+++ b/docs/weka_trace_replay.md
@@ -30,6 +30,10 @@ load:
 api:
   type: chat
   streaming: true
+  use_server_prompt_tokens: true # Recommended for long-context traces: records the server's
+                                 # usage.prompt_tokens instead of re-tokenizing the full
+                                 # conversation client-side on every event, which is CPU-intensive
+                                 # and can cap the achievable send rate (issue #648).
 
 server:
   type: mock # or openai/vllm/sglang/tgi

--- a/inference_perf/config/apis/config.py
+++ b/inference_perf/config/apis/config.py
@@ -60,3 +60,11 @@ class APIConfig(BaseModel):
     slo_ttft_header: Optional[str] = None
     response_format: Optional[ResponseFormat] = None
     session_id_header_key: Optional[str] = None
+    # Opt-in: record the server-reported usage.prompt_tokens as the request's
+    # input token count instead of re-tokenizing the full conversation
+    # client-side (replay-graph session workloads). Client-side re-tokenization
+    # is O(conversation) CPU on the loadgen event loop per event and can
+    # bottleneck long-context replay; see
+    # https://github.com/kubernetes-sigs/inference-perf/issues/648. Falls back
+    # to client-side counting when the server does not report usage.
+    use_server_prompt_tokens: bool = False

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -113,6 +113,25 @@ def _detect_bad_tool_calls(
 # --- end bad_tool_call_handling --------------------------------------------
 
 
+_warned_missing_server_prompt_tokens = False
+
+
+def _warn_missing_server_prompt_tokens(event_id: str) -> None:
+    """Warn once per process when `use_server_prompt_tokens` is enabled but the
+    server response carried no usage.prompt_tokens, forcing the CPU-intensive
+    client-side re-tokenization of the full conversation history."""
+    global _warned_missing_server_prompt_tokens
+    if _warned_missing_server_prompt_tokens:
+        return
+    _warned_missing_server_prompt_tokens = True
+    logger.warning(
+        f"api.use_server_prompt_tokens is enabled but the server response for event {event_id} "
+        "did not include usage.prompt_tokens; falling back to client-side tokenization of the "
+        "full conversation history. This is CPU-intensive for long histories and can bottleneck "
+        "the load generator (https://github.com/kubernetes-sigs/inference-perf/issues/648)."
+    )
+
+
 class EventFailedError(Exception):
     """Raised by EventOutputRegistry.require_async when the awaited event failed."""
 
@@ -877,8 +896,19 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             if reasoning_text:
                 streaming_output_message["reasoning_content"] = reasoning_text
 
-            prompt_text = "".join([_get_text(msg.content) for msg in self.messages if msg.content])
-            prompt_len = tokenizer.count_tokens(prompt_text)
+            # With api.use_server_prompt_tokens, prefer the server-reported
+            # usage.prompt_tokens: re-tokenizing the full conversation here is
+            # O(history) CPU that blocks the worker's event loop on every event
+            # (quadratic per session), throttling long-context replay. See
+            # https://github.com/kubernetes-sigs/inference-perf/issues/648.
+            server_prompt_tokens = server_usage.get("prompt_tokens") if server_usage else None
+            if config.use_server_prompt_tokens and server_prompt_tokens is not None:
+                prompt_len = int(server_prompt_tokens)
+            else:
+                if config.use_server_prompt_tokens:
+                    _warn_missing_server_prompt_tokens(self.event_id)
+                prompt_text = "".join([_get_text(msg.content) for msg in self.messages if msg.content])
+                prompt_len = tokenizer.count_tokens(prompt_text)
             server_completion_tokens = server_usage.get("completion_tokens") if server_usage else None
             if server_completion_tokens is not None:
                 output_len = int(server_completion_tokens)
@@ -903,7 +933,16 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             )
         else:
             data = await response.json()
-            prompt_len = tokenizer.count_tokens("".join([_get_text(m.content) for m in self.messages]))
+            usage = data.get("usage") or {}
+            # Prefer server-reported prompt tokens when opted in; see the
+            # streaming branch above for why.
+            server_prompt_tokens = usage.get("prompt_tokens")
+            if config.use_server_prompt_tokens and server_prompt_tokens is not None:
+                prompt_len = int(server_prompt_tokens)
+            else:
+                if config.use_server_prompt_tokens:
+                    _warn_missing_server_prompt_tokens(self.event_id)
+                prompt_len = tokenizer.count_tokens("".join([_get_text(m.content) for m in self.messages]))
             choices = data.get("choices", [])
             output_message: Optional[Dict[str, Any]] = None
             tool_calls = None
@@ -928,7 +967,6 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
 
                 if reasoning_content:
                     output_message["reasoning_content"] = reasoning_content
-            usage = data.get("usage") or {}
             server_completion_tokens = usage.get("completion_tokens")
             if server_completion_tokens is not None:
                 output_len = int(server_completion_tokens)
@@ -939,7 +977,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 output_len = tokenizer.count_tokens(output_text + tc_text)
             info = SessionInferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
-                response_metrics=UnaryResponseMetrics(output_tokens=output_len),
+                response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=data.get("usage")),
                 lora_adapter=lora_adapter,
                 output_text=output_text or None,
                 output_message=output_message,

--- a/tests/test_server_prompt_tokens.py
+++ b/tests/test_server_prompt_tokens.py
@@ -1,0 +1,239 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `api.use_server_prompt_tokens` fast path in
+SessionChatCompletionAPIData.process_response (issue #648).
+
+When the flag is enabled and the server reports usage.prompt_tokens, the
+client records the server count and skips re-tokenizing the full conversation
+history (an O(history) CPU cost on the loadgen event loop per event). When the
+flag is disabled (the default), behavior is unchanged: the client tokenizes
+the joined conversation text.
+"""
+
+import json
+import logging
+from typing import Any, AsyncGenerator, Dict, List, Optional, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import ClientResponse
+
+import inference_perf.datagen.replay_graph_session_datagen as replay_mod
+from inference_perf.apis.chat import ChatMessage
+from inference_perf.config import APIConfig, APIType
+from inference_perf.datagen.replay_graph_session_datagen import (
+    EventOutputRegistry,
+    SessionChatCompletionAPIData,
+    WorkerSessionTracker,
+)
+
+
+# The fallback tokenizer below counts whitespace-split words, so this prompt
+# counts as 3 client-side tokens; the server-reported count is deliberately
+# different so the two paths are distinguishable.
+PROMPT_TEXT = "alpha beta gamma"
+SERVER_USAGE: Dict[str, Any] = {"prompt_tokens": 4242, "completion_tokens": 7, "total_tokens": 4249}
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(replay_mod, "_warned_missing_server_prompt_tokens", False)
+
+
+def _make_tokenizer() -> MagicMock:
+    tok = MagicMock()
+    tok.count_tokens = MagicMock(side_effect=lambda text: max(1, len((text or "").split())))
+    return tok
+
+
+def _make_config(streaming: bool, use_server_prompt_tokens: bool) -> APIConfig:
+    return APIConfig(type=APIType.Chat, streaming=streaming, use_server_prompt_tokens=use_server_prompt_tokens)
+
+
+class FakeStreamingResponse:
+    """Minimal aiohttp ClientResponse stand-in that yields preset SSE bytes."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        self.status = 200
+        self.headers = {"content-type": "text/event-stream"}
+        self._chunks = chunks
+        self.content = self._make_content()
+
+    def _make_content(self) -> MagicMock:
+        content = MagicMock()
+
+        async def iter_any() -> AsyncGenerator[bytes, None]:
+            for chunk in self._chunks:
+                yield chunk
+
+        content.iter_any = iter_any
+        return content
+
+
+def _make_streaming_response(deltas: List[Dict[str, Any]], usage: Optional[Dict[str, Any]] = None) -> ClientResponse:
+    parts: List[bytes] = []
+    for delta in deltas:
+        parts.append(f"data: {json.dumps({'choices': [{'delta': delta}]})}\n\n".encode())
+    if usage is not None:
+        parts.append(f"data: {json.dumps({'choices': [], 'usage': usage})}\n\n".encode())
+    parts.append(b"data: [DONE]\n\n")
+    return cast(ClientResponse, FakeStreamingResponse([b"".join(parts)]))
+
+
+def _make_non_streaming_response(usage: Optional[Dict[str, Any]] = None) -> ClientResponse:
+    body: Dict[str, Any] = {"choices": [{"message": {"role": "assistant", "content": "The answer"}}]}
+    if usage is not None:
+        body["usage"] = usage
+    response = MagicMock()
+    response.json = AsyncMock(return_value=body)
+    return cast(ClientResponse, response)
+
+
+def _make_session_api_data() -> SessionChatCompletionAPIData:
+    return SessionChatCompletionAPIData(
+        messages=[ChatMessage(role="user", content=PROMPT_TEXT)],
+        max_tokens=500,
+        event_id="session_1:event_0",
+        registry=EventOutputRegistry(),
+        worker_tracker=WorkerSessionTracker(),
+        completion_queue=None,
+        total_events_in_session=1,
+        predecessor_event_ids=[],
+    )
+
+
+class TestStreamingServerPromptTokens:
+    @pytest.mark.asyncio
+    async def test_enabled_uses_server_count_and_skips_tokenizer(self) -> None:
+        api_data = _make_session_api_data()
+        tokenizer = _make_tokenizer()
+        response = _make_streaming_response([{"content": "Hi"}], usage=SERVER_USAGE)
+
+        info = await api_data.process_response(response, _make_config(True, True), tokenizer)
+
+        assert info.request_metrics is not None
+        assert info.request_metrics.text.input_tokens == 4242
+        assert info.response_metrics is not None
+        assert info.response_metrics.output_tokens == 7
+        # The whole point: no client-side tokenization at all.
+        assert tokenizer.count_tokens.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_enabled_falls_back_when_usage_absent(self) -> None:
+        api_data = _make_session_api_data()
+        tokenizer = _make_tokenizer()
+        response = _make_streaming_response([{"content": "Hi"}], usage=None)
+
+        info = await api_data.process_response(response, _make_config(True, True), tokenizer)
+
+        assert info.request_metrics is not None
+        assert info.request_metrics.text.input_tokens == 3  # client-side word count of PROMPT_TEXT
+        assert tokenizer.count_tokens.call_count > 0
+
+    @pytest.mark.asyncio
+    async def test_enabled_falls_back_when_prompt_tokens_missing(self) -> None:
+        api_data = _make_session_api_data()
+        tokenizer = _make_tokenizer()
+        response = _make_streaming_response([{"content": "Hi"}], usage={"completion_tokens": 7})
+
+        info = await api_data.process_response(response, _make_config(True, True), tokenizer)
+
+        assert info.request_metrics is not None
+        assert info.request_metrics.text.input_tokens == 3  # prompt falls back to the client count
+        assert info.response_metrics is not None
+        assert info.response_metrics.output_tokens == 7  # output still honors server usage
+        assert tokenizer.count_tokens.call_count == 1  # prompt only; output came from the server
+
+    @pytest.mark.asyncio
+    async def test_disabled_keeps_client_side_count(self) -> None:
+        api_data = _make_session_api_data()
+        tokenizer = _make_tokenizer()
+        response = _make_streaming_response([{"content": "Hi"}], usage=SERVER_USAGE)
+
+        info = await api_data.process_response(response, _make_config(True, False), tokenizer)
+
+        assert info.request_metrics is not None
+        assert info.request_metrics.text.input_tokens == 3  # default behavior is unchanged
+        assert info.response_metrics is not None
+        assert info.response_metrics.output_tokens == 7
+        assert tokenizer.count_tokens.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_warns_once_per_process_when_usage_absent(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING, logger=replay_mod.__name__)
+        config = _make_config(True, True)
+        for _ in range(2):
+            api_data = _make_session_api_data()
+            response = _make_streaming_response([{"content": "Hi"}], usage=None)
+            await api_data.process_response(response, config, _make_tokenizer())
+
+        warnings = [r for r in caplog.records if "usage.prompt_tokens" in r.getMessage()]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_disabled_never_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING, logger=replay_mod.__name__)
+        api_data = _make_session_api_data()
+        response = _make_streaming_response([{"content": "Hi"}], usage=None)
+
+        await api_data.process_response(response, _make_config(True, False), _make_tokenizer())
+
+        assert not [r for r in caplog.records if "usage.prompt_tokens" in r.getMessage()]
+
+
+class TestNonStreamingServerPromptTokens:
+    @pytest.mark.asyncio
+    async def test_enabled_uses_server_count_and_propagates_usage(self) -> None:
+        api_data = _make_session_api_data()
+        tokenizer = _make_tokenizer()
+        response = _make_non_streaming_response(usage=SERVER_USAGE)
+
+        info = await api_data.process_response(response, _make_config(False, True), tokenizer)
+
+        assert info.request_metrics is not None
+        assert info.request_metrics.text.input_tokens == 4242
+        assert info.response_metrics is not None
+        assert info.response_metrics.output_tokens == 7
+        assert info.response_metrics.server_usage == SERVER_USAGE
+        assert tokenizer.count_tokens.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_enabled_falls_back_when_usage_absent(self) -> None:
+        api_data = _make_session_api_data()
+        tokenizer = _make_tokenizer()
+        response = _make_non_streaming_response(usage=None)
+
+        info = await api_data.process_response(response, _make_config(False, True), tokenizer)
+
+        assert info.request_metrics is not None
+        assert info.request_metrics.text.input_tokens == 3
+        assert info.response_metrics is not None
+        assert info.response_metrics.output_tokens == 2  # client-side count of "The answer"
+        assert info.response_metrics.server_usage is None
+
+    @pytest.mark.asyncio
+    async def test_disabled_keeps_client_side_count_but_propagates_usage(self) -> None:
+        api_data = _make_session_api_data()
+        tokenizer = _make_tokenizer()
+        response = _make_non_streaming_response(usage=SERVER_USAGE)
+
+        info = await api_data.process_response(response, _make_config(False, False), tokenizer)
+
+        assert info.request_metrics is not None
+        assert info.request_metrics.text.input_tokens == 3  # default behavior is unchanged
+        assert info.response_metrics is not None
+        assert info.response_metrics.output_tokens == 7  # output-side server preference predates the flag
+        # usage propagation into metrics is unconditional, matching chat.py/completion.py
+        assert info.response_metrics.server_usage == SERVER_USAGE


### PR DESCRIPTION
Fixes #648.

Session replay (`weka_trace_replay` / `otel_trace_replay`) re-tokenizes the entire accumulated conversation on every completed event to compute `input_tokens`. The call runs synchronously on the loadgen worker's event loop, costs O(history) CPU per event (quadratic per session), and caps the achievable send rate for long-context agentic traces while distorting latency metrics of concurrent in-flight streams. In our runs this worked out to ~4 client CPU-seconds per request, plateauing achieved concurrency at ~15-20 regardless of the configured stage concurrency (details and stack samples in the issue).

## What this PR does

Adds an opt-in `api.use_server_prompt_tokens` flag (default `false`, preserving existing behavior byte-for-byte):

- When enabled and the server reports `usage.prompt_tokens`, record the server count and skip client-side tokenization entirely. This removes the hot path for OpenAI-compatible servers and is also more accurate: the server count includes chat-template tokens, tool definitions, and tool_call JSON, and is not truncated at `tokenizer.model_max_length`.
- When enabled but the server does not report usage, fall back to the existing client-side count with a once-per-process warning.
- Also propagates server usage into `UnaryResponseMetrics` for the non-streaming session path, matching what `chat.py`/`completion.py` already do since #607.

This mirrors what the output side already does: the session path prefers `usage.completion_tokens` unconditionally, and reports already prefer server `prompt_tokens` over the client-side count whenever available - so today the expensive client-side prompt count is computed per event and then ignored by the primary prompt-token report.

The flag is deliberately opt-in rather than default-on, so operators explicitly choose to trust server-reported `usage.prompt_tokens`; happy to flip the default if maintainers prefer.

## Testing

New `tests/test_server_prompt_tokens.py` (9 tests) covers streaming and non-streaming session paths: enabled + server usage present (no tokenizer call), enabled + usage missing (fallback + one-time warning), disabled (identical behavior to today, tokenizer still used), and usage propagation into `UnaryResponseMetrics`.

Full suite passes locally (`pytest`, `ruff check`, `ruff format --check`, `mypy --strict`).
