### PR TITLE
chore: handle null prompt_tokens_details

### DIFF
--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -194,7 +194,7 @@ def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric], percenti
         response_metrics = metric.info.response_metrics
         server_usage = response_metrics.server_usage if response_metrics else None
         prompt_tokens = server_usage.get("prompt_tokens") if server_usage else metric.info.request_metrics.text.input_tokens
-        prompt_tokens_details = server_usage.get("prompt_tokens_details", {}) if server_usage else {}
+        prompt_tokens_details = (server_usage.get("prompt_tokens_details") or {}) if server_usage else {}
 
         prompt_tokens_value = safe_float(prompt_tokens)
         prompt_tokens_total += prompt_tokens_value

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -496,3 +496,29 @@ def test_summarize_requests_surfaces_prompt_cache_usage() -> None:
     for p in DEFAULT_PERCENTILES:
         expected["median" if p == 50 else f"p{p:g}"] = 10.0
     assert result.successes["prompt_tokens"] == pytest.approx(expected)
+
+
+def test_summarize_requests_handles_null_prompt_tokens_details() -> None:
+    """Servers that report `prompt_tokens_details: null` must not crash."""
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=10)),
+        response_metrics=UnaryResponseMetrics(
+            output_tokens=2,
+            server_usage={
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "prompt_tokens_details": None,
+            },
+        ),
+    )
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="test_request", info=info, error=None
+    )
+
+    result = summarize_requests([metric], DEFAULT_PERCENTILES)
+
+    prompt_tokens = result.successes["prompt_tokens"]
+    assert prompt_tokens["total"] == pytest.approx(10.0)
+    assert prompt_tokens["cached"] == pytest.approx(0.0)
+    assert prompt_tokens["uncached"] == pytest.approx(10.0)


### PR DESCRIPTION
as title, handle when the serve returns `"prompt_tokens_details": null` (key present but value is null)