### PR TITLE
fix: restore mypy --strict clean on main

### DIFF
--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -298,6 +298,9 @@ class AnthropicMessagesAPIData(InferenceAPIData):
     async def process_response(
         self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: str | None = None
     ) -> InferenceInfo:
+        # The streaming branch always builds a message dict; the unary branch gets None back from
+        # parse_anthropic_content when the response carries no content blocks.
+        output_message: dict[str, Any] | None
         if config.streaming:
             (
                 output_text,

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -1056,6 +1056,9 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
     ) -> SessionInferenceInfo:
         logger.debug(f"process_response called for event {self.event_id}")
 
+        # The streaming branch always builds a message dict; the unary branch gets None back from
+        # parse_anthropic_content when the response carries no content blocks.
+        output_message: Optional[Dict[str, Any]]
         if config.streaming:
             (
                 output_text,

--- a/tests/required/datagen/test_hf_sharegpt_datagen.py
+++ b/tests/required/datagen/test_hf_sharegpt_datagen.py
@@ -56,8 +56,11 @@ def test_get_conversation_turn_content_unsupported_type() -> None:
 
 def test_get_anthropic_messages_data_rejects_unexpected_chat_data() -> None:
     generator = HFShareGPTDataGenerator.__new__(HFShareGPTDataGenerator)
-    generator.tokenizer = object()
-    generator.get_chat_data = lambda: iter([CompletionAPIData(prompt="hello")])
+    # Deliberately stub the instance past its real types: the test only needs
+    # get_anthropic_messages_data to reject a non-chat payload, so the tokenizer is never used
+    # and get_chat_data is replaced with a generator of the wrong element type on purpose.
+    generator.tokenizer = object()  # type: ignore[assignment]
+    generator.get_chat_data = lambda: iter([CompletionAPIData(prompt="hello")])  # type: ignore[method-assign,assignment,return-value]
 
     with pytest.raises(Exception, match="Expected ChatCompletionAPIData, got CompletionAPIData"):
         next(generator.get_anthropic_messages_data())

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -1764,6 +1764,7 @@ class TestWorkerSessionEviction:
         assert len(events) == 2
         datas = [gen.load_lazy_data(e) for e in events]
         for d in datas:
+            assert isinstance(d, SessionChatCompletionAPIData)
             assert d.generator is gen  # back-reference wired
 
         info = SessionInferenceInfo(output_text="x", request_metrics=RequestMetrics(text=Text(input_tokens=1)))
@@ -1791,6 +1792,7 @@ class TestWorkerSessionEviction:
 
         # The two successors are dequeued and skip via the session-already-failed path.
         for d in datas[1:]:
+            assert isinstance(d, SessionChatCompletionAPIData)
             asyncio.run(d.wait_for_predecessors_and_substitute())
             assert d.skip_request is True
 
@@ -1907,6 +1909,7 @@ class TestUnbuildableSessionSlot:
         assert len(scheduled) == 1, f"expected 1 scheduled event, got {len(scheduled)}"
 
         data = gen.load_lazy_data(scheduled[0])
+        assert isinstance(data, SessionChatCompletionAPIData)
         assert data.generator is gen
 
         # total_events_in_session must equal the scheduled count (1), not len(graph.events) (2).


### PR DESCRIPTION
## Problem

`pdm run validate` has been failing on `main` since 80bf53a (#575). The **Python Linting and Type Checks** workflow has been red on every commit since:

```
failure  307e09c  [P1] Unit tests: config (#520)
failure  a40897e  ci: gate tide merges on CI via do-not-merge label (#653)
failure  57595ed  Add /ok-to-test command to approve held PR workflow runs (#657)
failure  80bf53a  Add Anthropic Messages API support (#575)
success  7b2046f  chore: handle null prompt_tokens_details (#664)
```

This is now merge-blocking rather than cosmetic. #653's Merge Gate applies `do-not-merge` on every push and only clears it once *all four* CI workflows succeed for the head commit, and Python Linting and Type Checks is one of the four. So any PR that is pushed to or rebased inherits a failure it did not cause and can no longer clear the gate. Three PRs are sitting in that state today.

12 errors in 4 files, all fallout from #575.

## Fix

**`apis/anthropic_messages.py`, `datagen/replay_graph_session_datagen.py`** - declare `output_message` as optional. The streaming branch always builds a message dict, so mypy bound the variable to that type, but the unary branch gets `None` back from `parse_anthropic_content` when the response carries no content blocks. Both files carry the same shape of this code.

**`tests/test_otel_replay_datagen.py`** - narrow with `isinstance`. #575 widened `ReplayGraphSessionGeneratorBase.load_lazy_data` from `SessionChatCompletionAPIData` to `InferenceAPIData` so it could also return the new `SessionAnthropicMessagesAPIData`. That widening is correct; the test reads `generator`, `skip_request`, `wait_for_predecessors_and_substitute`, and `total_events_in_session`, which only exist on the session subclass. Asserting the concrete type is what the test already assumed.

**`tests/required/datagen/test_hf_sharegpt_datagen.py`** - targeted ignores for the deliberate instance stubbing in the negative test #575 added, which constructs via `__new__` and replaces `get_chat_data` with a wrong-element-type generator on purpose.

## Notes

No behavior change.
