### PR TITLE
test: validate every config YAML in the repo against the schema

### DIFF
--- a/config-weka.yaml
+++ b/config-weka.yaml
@@ -33,4 +33,3 @@ report:
     constraints:
       ttft: 0.3
       itl: 0.018
-    percentile: p90

--- a/demos/kubecon-na-2025/config.yaml
+++ b/demos/kubecon-na-2025/config.yaml
@@ -2,7 +2,7 @@ api:
   type: completion
   streaming: true
 data:
-  type: sharedPrefix
+  type: shared_prefix
   shared_prefix:
     num_unique_system_prompts: 10
     num_users_per_system_prompt: 10

--- a/inference_perf/config/apis/config.py
+++ b/inference_perf/config/apis/config.py
@@ -14,7 +14,7 @@
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel
+from inference_perf.config.common import StrictBaseModel
 
 
 class APIType(Enum):
@@ -28,7 +28,7 @@ class ResponseFormatType(Enum):
     JSON_OBJECT = "json_object"
 
 
-class ResponseFormat(BaseModel):
+class ResponseFormat(StrictBaseModel):
     """Configuration for structured output via response_format parameter.
 
     See vLLM docs: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
@@ -52,7 +52,7 @@ class ResponseFormat(BaseModel):
         }
 
 
-class APIConfig(BaseModel):
+class APIConfig(StrictBaseModel):
     type: APIType = APIType.Completion
     streaming: bool = False
     headers: Optional[dict[str, str]] = None

--- a/inference_perf/config/client/filestorage/config.py
+++ b/inference_perf/config/client/filestorage/config.py
@@ -14,10 +14,10 @@
 from datetime import datetime
 from typing import Literal, Optional
 
-from pydantic import BaseModel
+from inference_perf.config.common import StrictBaseModel
 
 
-class StorageConfigBase(BaseModel):
+class StorageConfigBase(StrictBaseModel):
     path: str = f"reports-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
     report_file_prefix: Optional[str] = None
 
@@ -33,7 +33,7 @@ class SimpleStorageServiceConfig(StorageConfigBase):
     addressing_style: Optional[Literal["auto", "virtual", "path"]] = None
 
 
-class StorageConfig(BaseModel):
+class StorageConfig(StrictBaseModel):
     local_storage: StorageConfigBase = StorageConfigBase()
     google_cloud_storage: Optional[GoogleCloudStorageConfig] = None
     simple_storage_service: Optional[SimpleStorageServiceConfig] = None

--- a/inference_perf/config/client/modelserver/config.py
+++ b/inference_perf/config/client/modelserver/config.py
@@ -14,7 +14,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from inference_perf.config.common import StrictBaseModel
 
 
 class ModelServerType(Enum):
@@ -24,7 +24,7 @@ class ModelServerType(Enum):
     MOCK = "mock"
 
 
-class ModelServerClientConfig(BaseModel):
+class ModelServerClientConfig(StrictBaseModel):
     type: ModelServerType = ModelServerType.VLLM
     model_name: Optional[str] = None
     base_url: str

--- a/inference_perf/config/client/server_metrics/config.py
+++ b/inference_perf/config/client/server_metrics/config.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 from typing import List, Optional
 
-from pydantic import BaseModel, HttpUrl, model_validator
+from inference_perf.config.common import StrictBaseModel
+from pydantic import HttpUrl, model_validator
 
 
-class PrometheusClientConfig(BaseModel):
+class PrometheusClientConfig(StrictBaseModel):
     scrape_interval: int = 15
     url: Optional[HttpUrl] = None
     filters: List[str] = []

--- a/inference_perf/config/common.py
+++ b/inference_perf/config/common.py
@@ -15,7 +15,19 @@ from enum import Enum
 from math import sqrt
 from typing import Optional
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class StrictBaseModel(BaseModel):
+    """Base for every config model: unknown keys are an error, not silently dropped.
+
+    Pydantic's default (`extra="ignore"`) means a renamed or misspelled key is discarded
+    without a word, so a stale config keeps "working" while quietly losing the setting it
+    was meant to apply. Rejecting extras is what lets the example-config CI gate actually
+    detect drift between the YAML in this repo and the schema.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class DistributionType(str, Enum):
@@ -28,7 +40,7 @@ class DistributionType(str, Enum):
 
 
 # Represents the distribution for input prompts and output generations.
-class Distribution(BaseModel):
+class Distribution(StrictBaseModel):
     min: int = 10
     max: int = 1024
     mean: float = 512

--- a/inference_perf/config/config.py
+++ b/inference_perf/config/config.py
@@ -16,7 +16,8 @@ from datetime import datetime
 from typing import Any, List, Optional
 
 import yaml
-from pydantic import BaseModel, model_validator
+from inference_perf.config.common import StrictBaseModel
+from pydantic import model_validator
 
 from inference_perf.circuit_breaker import CircuitBreakerConfig
 from inference_perf.config.apis import APIConfig
@@ -35,7 +36,7 @@ from inference_perf.config.reportgen import ReportConfig
 from inference_perf.config.utils import CustomTokenizerConfig
 
 
-class Config(BaseModel):
+class Config(StrictBaseModel):
     api: APIConfig = APIConfig()
     data: DataConfig = DataConfig()
     load: LoadConfig = LoadConfig()

--- a/inference_perf/config/datagen/config.py
+++ b/inference_perf/config/datagen/config.py
@@ -14,9 +14,9 @@
 from enum import Enum
 from typing import Optional, Union
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, model_validator
+from pydantic import AliasChoices, ConfigDict, Field, model_validator
 
-from inference_perf.config.common import Distribution
+from inference_perf.config.common import Distribution, StrictBaseModel
 from inference_perf.config.datagen.multimodal import SyntheticMultimodalDatagenConfig
 from inference_perf.config.datagen.replay import (
     ConversationReplayConfig,
@@ -43,7 +43,7 @@ class DataGenType(Enum):
 
 
 # Configuration for shared prefix datagen which allows users to specify shared prefixes.
-class SharedPrefix(BaseModel):
+class SharedPrefix(StrictBaseModel):
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
 
     num_groups: int = Field(
@@ -86,7 +86,7 @@ class SharedPrefix(BaseModel):
         return self
 
 
-class DataConfig(BaseModel):
+class DataConfig(StrictBaseModel):
     type: DataGenType = DataGenType.Mock
 
     # Valid only for shareGPT type at this moment

--- a/inference_perf/config/datagen/multimodal.py
+++ b/inference_perf/config/datagen/multimodal.py
@@ -14,9 +14,9 @@
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from inference_perf.config.common import Distribution
+from inference_perf.config.common import Distribution, StrictBaseModel
 from inference_perf.payloads import ImageRepresentation, VideoRepresentation
 
 
@@ -37,7 +37,7 @@ class ResolutionPreset(str, Enum):
     P360 = "360p"
 
 
-class Resolution(BaseModel):
+class Resolution(StrictBaseModel):
     height: int = Field(description="Pixel height (e.g. 1080).")
     width: int = Field(description="Pixel width (e.g. 1920).")
 
@@ -45,28 +45,28 @@ class Resolution(BaseModel):
 AnyResolution = Union[ResolutionPreset, Resolution]
 
 
-class WeightedResolution(BaseModel):
+class WeightedResolution(StrictBaseModel):
     resolution: AnyResolution = Field(description='A ``ResolutionPreset`` (e.g. ``"1080p"``) or explicit ``Resolution``.')
     weight: float = Field(default=1.0, description="Relative frequency of this resolution being selected from the list.")
 
 
-class VideoProfile(BaseModel):
+class VideoProfile(StrictBaseModel):
     resolution: AnyResolution = Field(description="Frame resolution. Preset string or explicit ``Resolution``.")
     frames: int = Field(description="Number of frames in the video. Required.")
 
 
-class WeightedVideoProfile(BaseModel):
+class WeightedVideoProfile(StrictBaseModel):
     profile: VideoProfile
     weight: float = Field(default=1.0, description="Relative frequency of this exact video profile being selected.")
 
 
-class WeightedDuration(BaseModel):
+class WeightedDuration(StrictBaseModel):
     duration: float = Field(description="The length of the audio clip in seconds.")
     weight: float = Field(default=1.0, description="Relative frequency of this duration being selected.")
 
 
 # --- Modality-Specific Request Configs ---
-class MediaDatagenConfig(BaseModel):
+class MediaDatagenConfig(StrictBaseModel):
     count: Optional[Distribution] = Field(
         default=None, description="Distribution of the number of media items to generate per request."
     )
@@ -112,7 +112,7 @@ class AudioDatagenConfig(MediaDatagenConfig):
 
 
 # --- Main Wrapper Models ---
-class SyntheticMultimodalDatagenConfig(BaseModel):
+class SyntheticMultimodalDatagenConfig(StrictBaseModel):
     """Configuration for standard multimodal data generation.
 
     Caveat: resolutions, video profiles, and audio durations specified here are

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -14,9 +14,9 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
-from inference_perf.config.common import Distribution
+from inference_perf.config.common import Distribution, StrictBaseModel
 
 
 class TraceFormat(Enum):
@@ -59,12 +59,12 @@ class BadToolCallHandling(str, Enum):
     USE_RECORDED = "use_recorded"
 
 
-class TraceConfig(BaseModel):
+class TraceConfig(StrictBaseModel):
     file: str
     format: TraceFormat = TraceFormat.AZURE_PUBLIC_DATASET
 
 
-class ConversationReplayConfig(BaseModel):
+class ConversationReplayConfig(StrictBaseModel):
     """Configuration for conversation replay data generator.
 
     Generates synthetic multi-turn conversations in-memory from configurable
@@ -98,7 +98,7 @@ class ConversationReplayConfig(BaseModel):
     max_model_len: Optional[int] = Field(None, description="Maximum model context length in tokens")
 
 
-class SessionReplayConfig(BaseModel):
+class SessionReplayConfig(StrictBaseModel):
     """Base configuration for session replay data generators."""
 
     # Model configuration

--- a/inference_perf/config/datagen/visionarena.py
+++ b/inference_perf/config/datagen/visionarena.py
@@ -15,12 +15,12 @@
 
 from typing import Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from inference_perf.config.common import Distribution
+from inference_perf.config.common import Distribution, StrictBaseModel
 
 
-class VisionArenaConfig(BaseModel):
+class VisionArenaConfig(StrictBaseModel):
     """Configuration for the VisionArena-Chat dataset loader.
 
     Streams real image+prompt pairs from the public

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -16,7 +16,8 @@ from enum import Enum
 from os import cpu_count
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from inference_perf.config.common import StrictBaseModel
+from pydantic import ConfigDict, Field, model_validator
 
 from inference_perf.config.datagen.replay import TraceConfig
 
@@ -29,7 +30,7 @@ class LoadType(Enum):
     TRACE_SESSION_REPLAY = "trace_session_replay"
 
 
-class LoadStage(BaseModel):
+class LoadStage(StrictBaseModel):
     """Base class for load stages. Use specific subclasses for different load types."""
 
     pass
@@ -140,7 +141,7 @@ class StageGenType(Enum):
     LINEAR = "linear"
 
 
-class SweepConfig(BaseModel):
+class SweepConfig(StrictBaseModel):
     type: StageGenType
     num_requests: int = 2000
     timeout: float = 60
@@ -149,12 +150,12 @@ class SweepConfig(BaseModel):
     saturation_percentile: float = 95
 
 
-class MultiLoRAConfig(BaseModel):
+class MultiLoRAConfig(StrictBaseModel):
     name: str
     split: float
 
 
-class LoadConfig(BaseModel):
+class LoadConfig(StrictBaseModel):
     type: LoadType = LoadType.CONSTANT
     interval: float = 1.0
     stages: Union[List[StandardLoadStage], List[ConcurrentLoadStage], List[TraceSessionReplayLoadStage]] = []

--- a/inference_perf/config/metrics/config.py
+++ b/inference_perf/config/metrics/config.py
@@ -14,7 +14,7 @@
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from inference_perf.config.common import StrictBaseModel
 
 from inference_perf.config.client.server_metrics import PrometheusClientConfig
 
@@ -24,6 +24,6 @@ class MetricsClientType(Enum):
     DEFAULT = "default"
 
 
-class MetricsClientConfig(BaseModel):
+class MetricsClientConfig(StrictBaseModel):
     type: MetricsClientType
     prometheus: Optional[PrometheusClientConfig] = None

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from inference_perf.config.common import StrictBaseModel
 
 
-class RequestLifecycleMetricsReportConfig(BaseModel):
+class RequestLifecycleMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = True
     per_stage: Optional[bool] = True
     per_request: Optional[bool] = False
@@ -29,22 +29,22 @@ class RequestLifecycleMetricsReportConfig(BaseModel):
     max_error_messages: int = 100
 
 
-class PrometheusMetricsReportConfig(BaseModel):
+class PrometheusMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = True
     per_stage: Optional[bool] = False
 
 
-class SessionLifecycleReportConfig(BaseModel):
+class SessionLifecycleReportConfig(StrictBaseModel):
     summary: Optional[bool] = True
     per_stage: Optional[bool] = True
     per_session: Optional[bool] = False
 
 
-class GoodputConfig(BaseModel):
+class GoodputConfig(StrictBaseModel):
     constraints: Dict[str, float] = {}
 
 
-class ReportConfig(BaseModel):
+class ReportConfig(StrictBaseModel):
     request_lifecycle: RequestLifecycleMetricsReportConfig = RequestLifecycleMetricsReportConfig()
     prometheus: Optional[PrometheusMetricsReportConfig] = PrometheusMetricsReportConfig()
     session_lifecycle: SessionLifecycleReportConfig = SessionLifecycleReportConfig()

--- a/inference_perf/config/utils/config.py
+++ b/inference_perf/config/utils/config.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 from typing import Optional
 
-from pydantic import BaseModel
+from inference_perf.config.common import StrictBaseModel
 
 
-class CustomTokenizerConfig(BaseModel):
+class CustomTokenizerConfig(StrictBaseModel):
     pretrained_model_name_or_path: Optional[str] = None
     trust_remote_code: Optional[bool] = None
     token: Optional[str] = None

--- a/tests/required/config/test_yaml_configs.py
+++ b/tests/required/config/test_yaml_configs.py
@@ -1,0 +1,130 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Keep the YAML checked into this repo honest.
+
+Two separate properties, because "is this YAML OK" means two different things:
+
+1. Every tracked YAML file parses as YAML (`test_every_tracked_yaml_parses`). Cheap, and it
+   covers workflow files and manifests that nothing else in the unit tier loads.
+2. Every file that is an inference-perf *config* still satisfies the current schema
+   (`test_config_yaml_matches_schema`). This is the anti-staleness gate: as the schema
+   evolves, examples and docs would otherwise desync from the code with no signal.
+
+The third test is the one that keeps this honest over time. Classifying files by directory
+means a new directory of configs would simply never be validated, which is the exact silent
+failure this file exists to prevent, so `test_every_tracked_yaml_is_classified` fails until
+someone puts each new YAML in one bucket or the other.
+
+Note that (2) only has teeth because the config models set `extra="forbid"` (see
+`StrictBaseModel`). With Pydantic's default an obsolete key is discarded silently, so a
+stale config would validate cleanly while quietly losing the setting it meant to apply.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import List
+
+import pytest
+import yaml
+
+from inference_perf.config import read_config
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Directories and files that are inference-perf configs, i.e. loadable by `read_config`.
+CONFIG_DIRS = ("examples", "workload-catalog", "e2e")
+CONFIG_FILES = ("config.yml", "config-weka.yaml", "demos/kubecon-na-2025/config.yaml")
+
+# YAML that is deliberately not an inference-perf config. Each entry is a directory prefix or
+# an exact path, with the reason it cannot be schema-validated.
+NON_CONFIG_PREFIXES = {
+    ".github/": "GitHub Actions workflows",
+    "deploy/": "Helm templates; Go templating is not parseable YAML by design",
+    "tests/": "test fixtures and server manifests, not inference-perf configs",
+    "demos/kubecon-na-2025/vllm": "multi-document Kubernetes manifests",
+}
+NON_CONFIG_FILES = {
+    "cloudbuild.yaml": "Google Cloud Build config",
+    ".pre-push-config.yaml": "pre-commit config",
+    "examples/vllm/docker-compose.yml": "docker-compose service definition",
+    "examples/vllm/prometheus.yml": "Prometheus scrape config",
+    "examples/sglang/docker-compose.yml": "docker-compose service definition",
+    "examples/sglang/prometheus.yml": "Prometheus scrape config",
+    "examples/tgi/docker-compose.yml": "docker-compose service definition",
+    "examples/tgi/prometheus.yml": "Prometheus scrape config",
+}
+
+
+def _tracked_yaml_files() -> List[str]:
+    out = subprocess.check_output(
+        ["git", "ls-files", "*.yaml", "*.yml"],
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    return sorted(p for p in out.split("\n") if p)
+
+
+def _is_config(path: str) -> bool:
+    if path in CONFIG_FILES:
+        return True
+    return any(path.startswith(f"{d}/") for d in CONFIG_DIRS) and path not in NON_CONFIG_FILES
+
+
+def _is_declared_non_config(path: str) -> bool:
+    if path in NON_CONFIG_FILES:
+        return True
+    return any(path.startswith(prefix) for prefix in NON_CONFIG_PREFIXES)
+
+
+ALL_YAML = _tracked_yaml_files()
+CONFIG_YAML = [p for p in ALL_YAML if _is_config(p)]
+
+
+def test_repo_has_tracked_yaml() -> None:
+    """Guard against the discovery itself silently returning nothing."""
+    assert ALL_YAML, "no tracked YAML found; is git ls-files working from the repo root?"
+    assert CONFIG_YAML, "no config YAML discovered; CONFIG_DIRS/CONFIG_FILES are likely stale"
+
+
+@pytest.mark.parametrize("rel_path", ALL_YAML)
+def test_every_tracked_yaml_parses(rel_path: str) -> None:
+    """Every tracked YAML is syntactically valid, including multi-document files."""
+    if rel_path.startswith("deploy/"):
+        pytest.skip("Helm template, not parseable as plain YAML")
+    with open(REPO_ROOT / rel_path) as f:
+        list(yaml.safe_load_all(f))
+
+
+@pytest.mark.parametrize("rel_path", CONFIG_YAML)
+def test_config_yaml_matches_schema(rel_path: str) -> None:
+    """Every config YAML in the repo still satisfies the current schema.
+
+    Uses `read_config` rather than `Config(**data)` so the test exercises the same path the
+    CLI does, including default merging and load-stage type conversion.
+    """
+    read_config(str(REPO_ROOT / rel_path))
+
+
+@pytest.mark.parametrize("rel_path", ALL_YAML)
+def test_every_tracked_yaml_is_classified(rel_path: str) -> None:
+    """Every tracked YAML is either schema-validated or explicitly declared a non-config.
+
+    If this fails for a file you just added, add it to CONFIG_DIRS/CONFIG_FILES if it is an
+    inference-perf config, or to NON_CONFIG_PREFIXES/NON_CONFIG_FILES with a reason if it is
+    not. Silently unvalidated config YAML is what this whole module exists to prevent.
+    """
+    assert _is_config(rel_path) or _is_declared_non_config(rel_path), (
+        f"{rel_path} is neither validated as a config nor declared a non-config. "
+        "Add it to CONFIG_DIRS/CONFIG_FILES or NON_CONFIG_PREFIXES/NON_CONFIG_FILES."
+    )

--- a/tests/required/datagen/test_shared_prefix_datagen.py
+++ b/tests/required/datagen/test_shared_prefix_datagen.py
@@ -181,11 +181,9 @@ class TestMultiTurnChat:
 
 @pytest.fixture
 def api_config() -> APIConfig:
-    return APIConfig(
-        api_type=APIType.Completion,
-        model_name="gpt2",
-        tokenizer_name="gpt2",
-    )
+    # `api_type`/`model_name`/`tokenizer_name` are not APIConfig fields and were silently
+    # dropped before the models rejected extras; the tokenizer comes from its own fixture.
+    return APIConfig(type=APIType.Completion)
 
 
 @pytest.fixture


### PR DESCRIPTION
Addresses: #516

## Problem

The example YAMLs are never loaded in CI, so as the schema evolves they desync from the code with no signal.

The catch is that the obvious version of this test proves nothing. `Config` never set `extra="forbid"`, and Pydantic's default is to ignore unknown keys, so today:

```
>>> read_config("cloudbuild.yaml")     # a Google Cloud Build file
Config(api=APIConfig(type=<APIType.Completion>), data=DataConfig(type=<DataGenType.Mock>), ...)
```

All five of Cloud Build's real keys (`timeout`, `steps`, `substitutions`, `options`, `images`) are silently discarded and it validates cleanly. The staleness this issue is about, a field renamed or removed while old configs keep "working", is precisely what `extra="ignore"` hides.

## Change

Config models now inherit `StrictBaseModel` (`extra="forbid"`). `loadgen` already set this on one model; this generalizes it to all 32.

**This is a user-facing behavior change**: a config with a stray or misspelled key now fails loudly instead of being silently dropped. That is the point, but it is worth a release note.

## Three stale spots that were silently passing

- **`config-weka.yaml`** set `report.goodput.percentile: p90`. `GoodputConfig` has no `percentile` field, so this has never had any effect. Removed. If percentile-based goodput is wanted, that is a feature request, not a config line.
- **`demos/kubecon-na-2025/config.yaml`** set `data.type: sharedPrefix`, which is not a member of the enum (`shared_prefix` is).
- **`tests/required/datagen/test_shared_prefix_datagen.py`** built its `APIConfig` fixture from `api_type`/`model_name`/`tokenizer_name`, none of which are `APIConfig` fields. All three were dropped, so the fixture had been returning a default config and the test was not exercising what it claimed.

## The test

Three properties, in `tests/required/config/test_yaml_configs.py`:

1. Every tracked YAML parses, multi-document aware, skipping Helm templates (Go templating is not parseable YAML by design).
2. Every config YAML satisfies the schema, via `read_config` so it exercises the same path the CLI takes, including default merging and load-stage type conversion.
3. Every tracked YAML is either validated or explicitly declared a non-config, with a reason.

Property 3 is what keeps this honest. Classifying by directory alone means a new directory of configs would simply never be validated, which is the same silent gap in a new costume. `examples/` already contains six files that are not configs (`docker-compose.yml`, `prometheus.yml`), so directory-level inclusion is not sufficient on its own.

96 tracked YAML files: 48 validated as configs, 48 declared non-configs with reasons.