### PR TITLE
fix: use pulls.list to find open PRs by head SHA in merge gate

### DIFF
--- a/.github/workflows/merge_gate.yml
+++ b/.github/workflows/merge_gate.yml
@@ -84,12 +84,16 @@ jobs:
 
             // All required workflows green: unlabel every open PR whose
             // current head is this commit.
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            // `listPullRequestsAssociatedWithCommit` does not reliably resolve an
+            // upstream PR when the head commit exists only in a contributor's fork.
+            // List open PRs and match their current head SHA instead.
+            const prs = await github.paginate(github.rest.pulls.list, {
               ...context.repo,
-              commit_sha: headSha,
+              state: 'open',
+              per_page: 100,
             });
             for (const pr of prs) {
-              if (pr.state !== 'open' || pr.head.sha !== headSha) continue;
+              if (pr.head.sha !== headSha) continue;
               if (!pr.labels.some(l => l.name === GATE_LABEL)) continue;
               try {
                 await github.rest.issues.removeLabel({


### PR DESCRIPTION
The merge gate workflow has two parts: it adds `do-not-merge` when a PR is opened or updated, and removes the label once all required CI workflows pass. The removal path was broken for PRs originating from forks.

`listPullRequestsAssociatedWithCommit` does not reliably resolve an upstream PR when the head commit exists only in a contributor’s fork. It returns an empty list, so the unlabel loop never runs and do-not-merge remains on the PR even after CI passes.

Fix this by paginating open PRs with `pulls.list` and matching each PR’s current `head.sha` against the completed workflow’s SHA.

Fixes #668