### PR TITLE
test: cover multi-turn session turn serialization and transcript semantics

### DIFF
--- a/tests/required/apis/test_user_session.py
+++ b/tests/required/apis/test_user_session.py
@@ -14,12 +14,13 @@
 
 """Tests for LocalUserSession lifecycle."""
 
+import asyncio
 import multiprocessing as mp
 import re
 import pytest
 from collections import defaultdict
 from queue import Empty
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 from unittest.mock import MagicMock
 
 from inference_perf.apis.user_session import LocalUserSession, UserSessionCompletionAPIData
@@ -49,8 +50,9 @@ def _mock_tokenizer() -> MagicMock:
     tok.get_tokenizer.return_value = hf
     # Match the decode mock's "tok_N" format so count_tokens returns a real int
     # (the exact-length datagen path compares this against target_len).
+    # **kw absorbs add_special_tokens, which the response path passes explicitly.
     tok.count_tokens = MagicMock(
-        side_effect=lambda text: sum(int(n) for n in re.findall(r"tok_(\d+)", text)) if isinstance(text, str) else 0
+        side_effect=lambda text, **kw: sum(int(n) for n in re.findall(r"tok_(\d+)", text)) if isinstance(text, str) else 0
     )
     return tok
 
@@ -248,6 +250,201 @@ class TestLocalUserSessionLifecycle:
             )
 
 
+# A dropped handoff between turns deadlocks rather than erroring, so the
+# contention tests are bounded: a stalled conversation must fail the run, not hang it.
+_TURN_TIMEOUT = 5.0
+
+
+def _unary_response(text: str) -> MagicMock:
+    """Minimal non-streaming completion response carrying ``text``."""
+    response = MagicMock()
+    body: asyncio.Future[Any] = asyncio.Future()
+    body.set_result({"choices": [{"text": text}]})
+    response.json = MagicMock(return_value=body)
+    response.status = 200
+    response.headers = {"content-type": "application/json"}
+    return response
+
+
+def _new_session(session_id: str, context: str = "") -> LocalUserSession:
+    """Register a session the way a datagen does, so ``user_session`` resolves to it."""
+    session = LocalUserSession(user_session_id=session_id, context=context)
+    LocalUserSession._instances[session_id] = session
+    return session
+
+
+class TestUserSessionTurnSerialization:
+    """A session serves one turn at a time.
+
+    Every other multi-turn test drives a session sequentially (acquire, release,
+    acquire), so the waiter queue in ``get_context`` is never entered. These
+    tests put turns in genuine contention, which is the invariant multi-turn
+    rests on: a conversation is only coherent if turn N+1 observes the context
+    turn N produced. Losing it does not raise, it silently degrades the
+    benchmark into concurrent single-turn requests that happen to share an id.
+    """
+
+    def setup_method(self) -> None:
+        LocalUserSession.clear_instances()
+
+    def teardown_method(self) -> None:
+        LocalUserSession.clear_instances()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_turns_never_overlap(self) -> None:
+        session = _new_session("sess_excl")
+        in_flight = 0
+        peak = 0
+
+        async def turn(n: int) -> None:
+            nonlocal in_flight, peak
+            await session.get_context(n)
+            in_flight += 1
+            peak = max(peak, in_flight)
+            # Yield while holding the slot so an unserialized turn would enter here.
+            await asyncio.sleep(0)
+            in_flight -= 1
+            session.update_context(f"resp{n}")
+
+        await asyncio.wait_for(asyncio.gather(*(turn(i) for i in range(5))), timeout=_TURN_TIMEOUT)
+
+        assert peak == 1, f"{peak} turns held the same session at once; turns are not serialized"
+        assert session._current_round == 5
+
+    @pytest.mark.asyncio
+    async def test_queued_turns_are_served_in_arrival_order(self) -> None:
+        session = _new_session("sess_fifo")
+        served: List[int] = []
+
+        async def turn(n: int) -> None:
+            await session.get_context(n)
+            served.append(n)
+            await asyncio.sleep(0)
+            session.update_context(f"resp{n}")
+
+        # gather schedules in argument order, so turns 1..4 queue behind turn 0.
+        await asyncio.wait_for(asyncio.gather(*(turn(i) for i in range(5))), timeout=_TURN_TIMEOUT)
+
+        assert served == [0, 1, 2, 3, 4], f"queued turns were reordered: {served}"
+
+    @pytest.mark.asyncio
+    async def test_sessions_do_not_block_each_other(self) -> None:
+        """Serialization is per session. A slow conversation must not stall the rest
+        of the load, or reported latency would fold in queueing that no server saw."""
+        slow = _new_session("sess_slow")
+        fast = _new_session("sess_fast")
+        events: List[str] = []
+
+        async def slow_turn() -> None:
+            await slow.get_context(0)
+            events.append("slow_start")
+            await asyncio.sleep(0.05)
+            events.append("slow_end")
+            slow.update_context("slow_resp")
+
+        async def fast_turn() -> None:
+            await fast.get_context(0)
+            events.append("fast_start")
+            events.append("fast_end")
+            fast.update_context("fast_resp")
+
+        await asyncio.wait_for(asyncio.gather(slow_turn(), fast_turn()), timeout=_TURN_TIMEOUT)
+
+        assert events == ["slow_start", "fast_start", "fast_end", "slow_end"], (
+            f"the fast session waited on the slow one: {events}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_turns_build_one_ordered_transcript(self) -> None:
+        """Dispatch turns concurrently through the real request path and check the
+        conversation still reads as a single ordered transcript."""
+        session = _new_session("sess_transcript", context="SYSTEM")
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        tokenizer = _mock_tokenizer()
+
+        async def turn(n: int) -> None:
+            data = UserSessionCompletionAPIData(
+                user_session_id="sess_transcript", target_round=n, prompt=f"Q{n}", max_tokens=8
+            )
+            await data.to_request_body("model", 8, False, False)
+            # Stand in for the request being in flight. Without a suspension here
+            # the turns would run to completion one after another on their own and
+            # the session's serialization would never be exercised.
+            await asyncio.sleep(0)
+            await data.process_response(_unary_response(f"A{n}"), api_config, tokenizer)
+
+        await asyncio.wait_for(asyncio.gather(*(turn(i) for i in range(4))), timeout=_TURN_TIMEOUT)
+
+        assert session.context == "SYSTEM Q0 A0 Q1 A1 Q2 A2 Q3 A3"
+
+
+class TestMultiTurnConversationSemantics:
+    """Each turn sends the accumulated conversation, not just its own question."""
+
+    def setup_method(self) -> None:
+        LocalUserSession.clear_instances()
+
+    def teardown_method(self) -> None:
+        LocalUserSession.clear_instances()
+
+    @pytest.mark.asyncio
+    async def test_each_turn_carries_the_prior_transcript(self) -> None:
+        _new_session("sess_grow", context="SYSTEM")
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        tokenizer = _mock_tokenizer()
+        prompts: List[str] = []
+
+        for n in range(3):
+            data = UserSessionCompletionAPIData(user_session_id="sess_grow", target_round=n, prompt=f"Q{n}", max_tokens=8)
+            body = await data.to_request_body("model", 8, False, False)
+            prompts.append(body["prompt"])
+            await data.process_response(_unary_response(f"A{n}"), api_config, tokenizer)
+
+        # The growing prefix is the whole point of the workload: each turn is a
+        # longer prefill than the last, and a cached prefix the server can reuse.
+        assert prompts == ["SYSTEM Q0", "SYSTEM Q0 A0 Q1", "SYSTEM Q0 A0 Q1 A1 Q2"]
+
+    @pytest.mark.asyncio
+    async def test_turns_are_tagged_with_session_and_round(self) -> None:
+        """Reporting splits latency by turn index, so these tags must advance."""
+        _new_session("sess_tags", context="SYSTEM")
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        tokenizer = _mock_tokenizer()
+        rounds: List[int] = []
+
+        for n in range(3):
+            data = UserSessionCompletionAPIData(user_session_id="sess_tags", target_round=n, prompt=f"Q{n}", max_tokens=8)
+            await data.to_request_body("model", 8, False, False)
+            info = await data.process_response(_unary_response(f"A{n}"), api_config, tokenizer)
+            assert info.extra_info["user_session"] == "sess_tags"
+            rounds.append(info.extra_info["chat_round"])
+
+        assert rounds == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_failed_turn_rolls_back_context_and_frees_the_slot(self) -> None:
+        """A failed turn must leave no trace in the transcript: the model never saw
+        it, so replaying it as context would fabricate history the server never had."""
+        session = _new_session("sess_fail", context="SYSTEM")
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        tokenizer = _mock_tokenizer()
+
+        ok = UserSessionCompletionAPIData(user_session_id="sess_fail", target_round=0, prompt="Q0", max_tokens=8)
+        await ok.to_request_body("model", 8, False, False)
+        await ok.process_response(_unary_response("A0"), api_config, tokenizer)
+        assert session.context == "SYSTEM Q0 A0"
+
+        failed = UserSessionCompletionAPIData(user_session_id="sess_fail", target_round=1, prompt="Q1", max_tokens=8)
+        await failed.to_request_body("model", 8, False, False)
+        await failed.process_failure(None, api_config, tokenizer, Exception("connection reset"))
+        assert session.context == "SYSTEM Q0 A0"
+
+        # The slot must be free, otherwise the conversation stalls for the run.
+        nxt = UserSessionCompletionAPIData(user_session_id="sess_fail", target_round=2, prompt="Q2", max_tokens=8)
+        body = await asyncio.wait_for(nxt.to_request_body("model", 8, False, False), timeout=2.0)
+        assert body["prompt"] == "SYSTEM Q0 A0 Q2"
+
+
 class TestUserSessionTruncation:
     def setup_method(self) -> None:
         LocalUserSession.clear_instances()
@@ -292,3 +489,24 @@ class TestUserSessionTruncation:
 
         assert session.system_prompt == "tok_10"
         assert payload["prompt"] == "tok_10 tok_10"
+
+    @pytest.mark.asyncio
+    async def test_question_alone_over_budget_drops_system_prompt(self) -> None:
+        """When the current question alone exceeds the context budget there is no
+        room left for the system prompt, so it is dropped and the question clipped.
+        Sending it anyway would overflow the model and fail the request instead of
+        measuring it."""
+        tok = _mock_tokenizer()
+        hf = tok.get_tokenizer.return_value
+        hf.encode = MagicMock(side_effect=lambda text: [1] * tok.count_tokens(text))
+
+        # target_len = max_model_len - max_tokens - 200 = 20
+        session = LocalUserSession(user_session_id="sess_3", system_prompt="tok_5", tokenizer=tok, max_model_len=220)
+        LocalUserSession._instances["sess_3"] = session
+
+        data = UserSessionCompletionAPIData(user_session_id="sess_3", target_round=0, prompt="tok_25", max_tokens=0)
+
+        payload = await data.to_request_body("model", 0, False, False)
+
+        assert session.system_prompt == ""
+        assert payload["prompt"] == "tok_20"


### PR DESCRIPTION
Addresses: #332

## Problem

The multi-turn path has no test that puts two turns in contention on the same
session, so the waiter queue in `LocalUserSession.get_context` is never entered.
The existing tests drive a session sequentially (acquire, release, acquire),
which exercises the lock but not the handoff.

That gap matters because losing the handoff does not raise. A conversation whose
turns stop serializing degrades into concurrent single-turn requests that happen
to share a session id, and the run still reports clean numbers. There is no
failure to notice.

## Change

Test-only: 220 lines added to `tests/required/apis/test_user_session.py` in three
new classes.

**`TestUserSessionTurnSerialization`** puts turns in genuine contention:

- `test_concurrent_turns_never_overlap`: five turns gathered on one session, each
  yielding while holding the slot so an unserialized turn would interleave.
  Asserts the peak number of concurrent holders is 1.
- `test_queued_turns_are_served_in_arrival_order`: queued turns are FIFO, not
  reordered.
- `test_sessions_do_not_block_each_other`: serialization is per session. A slow
  conversation must not stall unrelated load, or reported latency folds in
  queueing that no server ever saw.
- `test_concurrent_turns_build_one_ordered_transcript`: four turns dispatched
  concurrently through the real `to_request_body` / `process_response` path still
  produce `"SYSTEM Q0 A0 Q1 A1 Q2 A2 Q3 A3"`.

**`TestMultiTurnConversationSemantics`** covers what the workload is for:

- `test_each_turn_carries_the_prior_transcript`: asserts the exact growing prefix
  (`"SYSTEM Q0"`, `"SYSTEM Q0 A0 Q1"`, ...). Each turn being a longer prefill than
  the last, and a cached prefix the server can reuse, is the point of the workload.
- `test_turns_are_tagged_with_session_and_round`: `extra_info["user_session"]` and
  `extra_info["chat_round"]` advance 1, 2, 3. Reporting splits latency by turn
  index, so stale tags would silently mislabel it.
- `test_failed_turn_rolls_back_context_and_frees_the_slot`: a failed turn leaves no
  trace in the transcript, since the model never saw it and replaying it as context
  would fabricate history the server never had. It also must not hold the slot for
  the rest of the run.

**`TestUserSessionTruncation`** gains `test_question_alone_over_budget_drops_system_prompt`,
the one uncovered branch: when the question alone exceeds the context budget there
is no room left for the system prompt, so it is dropped and the question clipped.

This takes `inference_perf/apis/user_session.py` from 93% to 100% statement coverage.

## Why the contention tests carry an explicit timeout

A dropped handoff deadlocks rather than erroring, so a regression here would hang
CI instead of failing it. Every contention test is bounded by
`asyncio.wait_for(..., timeout=5.0)`.

## Notes for reviewers

- The `_new_session` helper registers sessions by assigning `LocalUserSession._instances`
  directly, because `get_instance` does not accept the constructor kwargs (`context`,
  `system_prompt`, `max_model_len`) these tests need. Happy to add a public seam for
  that instead if reviewers prefer.
- One assertion reads `session._current_round`, the counter the public `chat_round`
  tag is derived from.
- The mock tokenizer's `count_tokens` now absorbs `**kw` because the response path
  passes `add_special_tokens` explicitly. Existing callers are unaffected.
