### PR TITLE
fix: surface session replay failure causes in reports

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -88,3 +88,57 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
 - **`successes`**: Metrics for successful requests.
 - **`failures`**: Metrics for failed requests, including the per-label error breakdown.
 - **`goodput_metrics`**: (Optional) Goodput statistics if constraints were configured.
+
+## Session Reports
+
+Session replay runs (for example OTel trace replay) additionally produce session
+lifecycle reports, where a session is a graph of dependent requests. Alongside
+`num_sessions_succeeded` and `num_sessions_failed`, the summary carries a
+`failures` section with the same shape as the request-level one:
+
+```json
+{
+  "num_sessions": 100,
+  "num_sessions_succeeded": 94,
+  "num_sessions_failed": 6,
+  "failures": {
+    "count": 6,
+    "by_label": {
+      "predecessor_failed": {
+        "count": 4,
+        "messages": [
+          {
+            "message": "predecessor failed",
+            "session_ids": ["trace1715_066de3655406", "trace2210_1f9b0c4d7e21"]
+          }
+        ]
+      },
+      "recorded_fallback_malformed": {
+        "count": 2,
+        "messages": [
+          {
+            "message": "recorded fallback for evt_7 is also malformed",
+            "session_ids": ["trace42_9f000393d262"]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Unlike request failures, which are bucketed by parsing server error text, session
+failures are bucketed on a stable cause code emitted by the replay runtime. The
+prose in `messages` may embed per-event ids, so the code is what keeps a cause
+from splitting into one bucket per failure.
+
+| Cause code | Meaning |
+| --- | --- |
+| `predecessor_failed` | An event this one awaited failed, so the request was skipped. |
+| `predecessor_wait_failed` | Waiting on a predecessor event timed out. |
+| `session_already_failed` | The session was already failed when this event was reached. |
+| `recorded_fallback_malformed` | `bad_tool_call_handling=use_recorded` fired, but the recorded fallback message was also malformed. |
+| `substitution_tool_call_expected` | The recorded trace expected a tool call at this slot but the live model returned plain text. |
+| `request_failed` | The request to the model server raised; `message` carries the exception type and text. |
+| `unknown` | The session failed without a more specific cause being recorded. |
+| `unreported` | The session was counted as failed but carried no error at all. Should not occur; treat as a bug. |

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -99,3 +99,57 @@ where the two output counts disagree. Alongside it, `client_fallback_requests` s
 requests had no server number at all, per side. See
 [Token Accounting and Provenance](./metrics.md#token-accounting-and-provenance) for what each
 field is derived from and which one normalizes per-token latency.
+
+## Session Reports
+
+Session replay runs (for example OTel trace replay) additionally produce session
+lifecycle reports, where a session is a graph of dependent requests. Alongside
+`num_sessions_succeeded` and `num_sessions_failed`, the summary carries a
+`failures` section with the same shape as the request-level one:
+
+```json
+{
+  "num_sessions": 100,
+  "num_sessions_succeeded": 94,
+  "num_sessions_failed": 6,
+  "failures": {
+    "count": 6,
+    "by_label": {
+      "predecessor_failed": {
+        "count": 4,
+        "messages": [
+          {
+            "message": "predecessor failed",
+            "session_ids": ["trace1715_066de3655406", "trace2210_1f9b0c4d7e21"]
+          }
+        ]
+      },
+      "recorded_fallback_malformed": {
+        "count": 2,
+        "messages": [
+          {
+            "message": "recorded fallback for evt_7 is also malformed",
+            "session_ids": ["trace42_9f000393d262"]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Unlike request failures, which are bucketed by parsing server error text, session
+failures are bucketed on a stable cause code emitted by the replay runtime. The
+prose in `messages` may embed per-event ids, so the code is what keeps a cause
+from splitting into one bucket per failure.
+
+| Cause code | Meaning |
+| --- | --- |
+| `predecessor_failed` | An event this one awaited failed, so the request was skipped. |
+| `predecessor_wait_failed` | Waiting on a predecessor event timed out. |
+| `session_already_failed` | The session was already failed when this event was reached. |
+| `recorded_fallback_malformed` | `bad_tool_call_handling=use_recorded` fired, but the recorded fallback message was also malformed. |
+| `substitution_tool_call_expected` | The recorded trace expected a tool call at this slot but the live model returned plain text. |
+| `request_failed` | The request to the model server raised; `message` carries the exception type and text. |
+| `unknown` | The session failed without a more specific cause being recorded. |
+| `unreported` | The session was counted as failed but carried no error at all. Should not occur; treat as a bug. |

--- a/inference_perf/datagen/replay/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay/replay_graph_session_datagen.py
@@ -30,6 +30,7 @@ import time
 import uuid
 from collections import Counter
 from dataclasses import dataclass, field, replace as dc_replace
+from enum import Enum
 from multiprocessing.managers import SyncManager
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -121,6 +122,27 @@ def _detect_bad_tool_calls(
 # --- end bad_tool_call_handling --------------------------------------------
 
 
+class SessionFailureCause(str, Enum):
+    """Stable cause code for a session replay failure.
+
+    Carried as ``error_type`` on ``SessionLifecycleMetric.error`` and used as the
+    bucket key for the session-level ``failures.by_label`` report. The prose that
+    accompanies a failure goes in ``error_msg`` and is free to embed per-event
+    ids; bucketing on this code rather than on that prose is what keeps a cause
+    like RECORDED_FALLBACK_MALFORMED from producing one singleton bucket per
+    failure. These values are report surface: renaming one changes user-visible
+    output.
+    """
+
+    SESSION_ALREADY_FAILED = "session_already_failed"
+    PREDECESSOR_FAILED = "predecessor_failed"
+    PREDECESSOR_WAIT_FAILED = "predecessor_wait_failed"
+    RECORDED_FALLBACK_MALFORMED = "recorded_fallback_malformed"
+    SUBSTITUTION_TOOL_CALL_EXPECTED = "substitution_tool_call_expected"
+    REQUEST_FAILED = "request_failed"
+    UNKNOWN = "unknown"
+
+
 class EventFailedError(Exception):
     """Raised by EventOutputRegistry.require_async when the awaited event failed."""
 
@@ -156,6 +178,12 @@ class WorkerSessionTracker:
     def __init__(self) -> None:
         self._event_completions: Dict[str, Dict[str, float]] = {}
         self._failed_sessions: Set[str] = set()
+        # Per-session (cause_code, prose) for the FIRST failure observed. Later
+        # failures in the same session are consequences of that root cause
+        # (a failed event cascades to every successor), so first-write-wins is
+        # what keeps the reported cause pointing at the thing that actually
+        # broke rather than at the cascade.
+        self._session_failures: Dict[str, Tuple[str, str]] = {}
         # Per-session set of predecessor event_ids whose live tool_call
         # response was detected malformed at substitution time and replaced
         # with the recorded assistant message. Empty when
@@ -185,6 +213,7 @@ class WorkerSessionTracker:
         """Drop all per-worker tracking for a session (called after eviction)."""
         self._event_completions.pop(session_id, None)
         self._failed_sessions.discard(session_id)
+        self._session_failures.pop(session_id, None)
         self._drained_events.pop(session_id, None)
         self._recorded_substitution_event_ids.pop(session_id, None)
 
@@ -199,11 +228,22 @@ class WorkerSessionTracker:
     def get_event_completion_time(self, session_id: str, event_id: str) -> Optional[float]:
         return self._event_completions.get(session_id, {}).get(event_id)
 
-    def mark_session_failed(self, session_id: str) -> None:
+    def mark_session_failed(
+        self,
+        session_id: str,
+        cause: Optional[SessionFailureCause] = None,
+        reason: Optional[str] = None,
+    ) -> None:
         self._failed_sessions.add(session_id)
+        if cause is not None and session_id not in self._session_failures:
+            self._session_failures[session_id] = (cause.value, reason or cause.value)
 
     def is_session_failed(self, session_id: str) -> bool:
         return session_id in self._failed_sessions
+
+    def get_session_failure(self, session_id: str) -> Optional[Tuple[str, str]]:
+        """Return (cause_code, prose) for a failed session, or None if unrecorded."""
+        return self._session_failures.get(session_id)
 
     def get_session_event_count(self, session_id: str) -> int:
         return len(self._event_completions.get(session_id, {}))
@@ -354,8 +394,10 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     disable_output_substitution: bool = False
     # Set by _build_messages_with_substitution when it calls record_failure
     # early (e.g. recorded fallback also malformed). Lets the caller pass the
-    # right reason string to _fail_and_notify instead of a generic fallback.
+    # right cause code and reason string to _fail_and_notify instead of a
+    # generic fallback.
     _substitution_failure_reason: Optional[str] = None
+    _substitution_failure_cause: Optional[SessionFailureCause] = None
 
     async def to_request_body(
         self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
@@ -399,7 +441,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     def _extract_session_id(self) -> str:
         return self.event_id.split(":")[0] if ":" in self.event_id else self.event_id
 
-    def _fail_and_notify(self, session_id: str, reason: str) -> None:
+    def _fail_and_notify(self, session_id: str, cause: SessionFailureCause, reason: str) -> None:
         """Mark this event and session as failed, notify the completion queue.
 
         Called from wait_for_predecessors_and_substitute when we decide to skip
@@ -410,7 +452,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
         """
         self.skip_request = True
         was_already_failed = self.worker_tracker.is_session_failed(session_id)
-        self.worker_tracker.mark_session_failed(session_id)
+        self.worker_tracker.mark_session_failed(session_id, cause, reason)
         self.registry.record_failure(self.event_id)
         logger.info(f"Event {self.event_id} skipping — {reason}")
 
@@ -422,6 +464,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 "session_id": session_id,
                 "completion_time": completion_time,
                 "failed": True,
+                "failure_cause": cause.value,
                 "failure_reason": reason,
                 "cancelled_events": cancelled,
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
@@ -466,7 +509,9 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
         session_id = self._extract_session_id()
 
         if self.worker_tracker.is_session_failed(session_id):
-            self._fail_and_notify(session_id, "session already failed (pre-wait check)")
+            self._fail_and_notify(
+                session_id, SessionFailureCause.SESSION_ALREADY_FAILED, "session already failed (pre-wait check)"
+            )
             return
 
         if self.predecessor_event_ids:
@@ -479,10 +524,14 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     ]
                 )
             except EventFailedError:
-                self._fail_and_notify(session_id, "predecessor failed")
+                self._fail_and_notify(session_id, SessionFailureCause.PREDECESSOR_FAILED, "predecessor failed")
                 return
             except (TimeoutError, asyncio.TimeoutError) as e:
-                self._fail_and_notify(session_id, f"predecessor wait failed: {type(e).__name__}")
+                self._fail_and_notify(
+                    session_id,
+                    SessionFailureCause.PREDECESSOR_WAIT_FAILED,
+                    f"predecessor wait failed: {type(e).__name__}",
+                )
                 return
             logger.debug(f"Event {self.event_id} all predecessors done")
 
@@ -513,7 +562,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             # live model returned plain text). Detect that and skip the request.
             if self.registry.is_event_failed(self.event_id):
                 reason = self._substitution_failure_reason or "Unknown"
-                self._fail_and_notify(session_id, reason)
+                cause = self._substitution_failure_cause or SessionFailureCause.UNKNOWN
+                self._fail_and_notify(session_id, cause, reason)
                 return
             self.messages = [
                 ChatMessage(
@@ -610,6 +660,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                                 self._substitution_failure_reason = (
                                     f"recorded fallback for {seg.source_event_id} is also malformed"
                                 )
+                                self._substitution_failure_cause = SessionFailureCause.RECORDED_FALLBACK_MALFORMED
                                 self.registry.record_failure(self.event_id)
                                 return result  # partial; caller checks is_event_failed
                             # Tag the predecessor event_id for telemetry. Set
@@ -664,6 +715,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                                 self._substitution_failure_reason = (
                                     "substitution failed (tool call expected but plain text returned)"
                                 )
+                                self._substitution_failure_cause = SessionFailureCause.SUBSTITUTION_TOOL_CALL_EXPECTED
                                 self.registry.record_failure(self.event_id)
                                 return result  # partial result; caller should check skip_request
                             for msg in seg_msgs:
@@ -818,12 +870,21 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
         if completed_count == self.total_events_in_session:
             logger.debug(f"Session {session_id} completed all {self.total_events_in_session} events in worker")
 
-            completion_data = {
+            session_failed = self.worker_tracker.is_session_failed(session_id)
+            completion_data: Dict[str, Any] = {
                 "session_id": session_id,
                 "completion_time": completion_time,
-                "failed": self.worker_tracker.is_session_failed(session_id),
+                "failed": session_failed,
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
             }
+            # A session can reach this all-events-completed path already marked
+            # failed by an earlier event. Carry the recorded cause so the main
+            # process is not left with `failed: True` and no reason.
+            if session_failed:
+                recorded_failure = self.worker_tracker.get_session_failure(session_id)
+                cause, reason = recorded_failure or (SessionFailureCause.UNKNOWN.value, "session marked failed by worker")
+                completion_data["failure_cause"] = cause
+                completion_data["failure_reason"] = reason
             # Telemetry: only emit recorded-substitution keys when at least
             # one substitution fired in this session, so upstream-default runs
             # (handling=none, or handling set but no malformed tool_calls
@@ -1012,7 +1073,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
 
         session_id = self._extract_session_id()
         was_already_failed = self.worker_tracker.is_session_failed(session_id)
-        self.worker_tracker.mark_session_failed(session_id)
+        failure_reason = f"{type(exception).__name__}: {exception}"
+        self.worker_tracker.mark_session_failed(session_id, SessionFailureCause.REQUEST_FAILED, failure_reason)
         self.registry.record_failure(self.event_id)
 
         if not was_already_failed and self.completion_queue is not None:
@@ -1023,6 +1085,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 "session_id": session_id,
                 "completion_time": completion_time,
                 "failed": True,
+                "failure_cause": SessionFailureCause.REQUEST_FAILED.value,
+                "failure_reason": failure_reason,
                 "cancelled_events": cancelled,
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
             }
@@ -1183,6 +1247,7 @@ class ReplaySessionState:
     is_complete: bool = False
     failed: bool = False
     failure_reason: Optional[str] = None
+    failure_cause: Optional[str] = None
     cancelled_events: int = 0
     # Populated from completion_data when the worker finishes the
     # session. None means the worker did not push the keys (i.e.
@@ -1566,9 +1631,18 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
         num_events_completed = len(state.completed_events)
         num_events_cancelled = state.cancelled_events if state.failed else 0
 
+        # `state.failed` alone must produce an error, not just `failure_reason`.
+        # The report's success predicate is derived from `error is None`, so a
+        # session the worker marked failed but for which no reason was recorded
+        # would otherwise be counted as SUCCEEDED whenever all its events
+        # completed. Every producer now carries a cause, making the fallback
+        # below a safety net rather than a routine path.
         error = None
-        if state.failure_reason:
-            error = ErrorResponseInfo(error_type="SessionReplayError", error_msg=state.failure_reason)
+        if state.failed or state.failure_reason:
+            error = ErrorResponseInfo(
+                error_type=state.failure_cause or SessionFailureCause.UNKNOWN.value,
+                error_msg=state.failure_reason or "session marked failed without a recorded reason",
+            )
 
         return SessionLifecycleMetric(
             session_id=session_id,
@@ -1614,8 +1688,17 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                             completed_state.event_completion_times[event_id] = completion_time
 
                     completed_state.is_complete = True
-                    completed_state.failed = completion_data.get("failed", False)
-                    completed_state.failure_reason = completion_data.get("failure_reason")
+                    # Failure is sticky in both directions. A session that any
+                    # worker payload reported as failed stays failed, and the
+                    # first recorded reason wins: a later payload for an
+                    # already-failed session (e.g. the all-events-completed
+                    # push arriving after a skip-failure push) must not blank
+                    # out a real cause by overwriting it with None.
+                    completed_state.failed = completed_state.failed or completion_data.get("failed", False)
+                    incoming_reason = completion_data.get("failure_reason")
+                    if incoming_reason is not None and completed_state.failure_reason is None:
+                        completed_state.failure_reason = incoming_reason
+                        completed_state.failure_cause = completion_data.get("failure_cause")
                     completed_state.cancelled_events = completion_data.get("cancelled_events", 0)
                     # Bad tool-call handling telemetry. The two keys are
                     # gated worker-side behind `len(...) > 0`, so their

--- a/inference_perf/datagen/replay/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay/replay_graph_session_datagen.py
@@ -30,6 +30,7 @@ import time
 import uuid
 from collections import Counter
 from dataclasses import dataclass, field, replace as dc_replace
+from enum import Enum
 from multiprocessing.managers import SyncManager
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -139,6 +140,27 @@ def _detect_bad_tool_calls(
 # --- end bad_tool_call_handling --------------------------------------------
 
 
+class SessionFailureCause(str, Enum):
+    """Stable cause code for a session replay failure.
+
+    Carried as ``error_type`` on ``SessionLifecycleMetric.error`` and used as the
+    bucket key for the session-level ``failures.by_label`` report. The prose that
+    accompanies a failure goes in ``error_msg`` and is free to embed per-event
+    ids; bucketing on this code rather than on that prose is what keeps a cause
+    like RECORDED_FALLBACK_MALFORMED from producing one singleton bucket per
+    failure. These values are report surface: renaming one changes user-visible
+    output.
+    """
+
+    SESSION_ALREADY_FAILED = "session_already_failed"
+    PREDECESSOR_FAILED = "predecessor_failed"
+    PREDECESSOR_WAIT_FAILED = "predecessor_wait_failed"
+    RECORDED_FALLBACK_MALFORMED = "recorded_fallback_malformed"
+    SUBSTITUTION_TOOL_CALL_EXPECTED = "substitution_tool_call_expected"
+    REQUEST_FAILED = "request_failed"
+    UNKNOWN = "unknown"
+
+
 class EventFailedError(Exception):
     """Raised by EventOutputRegistry.require_async when the awaited event failed."""
 
@@ -174,6 +196,12 @@ class WorkerSessionTracker:
     def __init__(self) -> None:
         self._event_completions: Dict[str, Dict[str, float]] = {}
         self._failed_sessions: Set[str] = set()
+        # Per-session (cause_code, prose) for the FIRST failure observed. Later
+        # failures in the same session are consequences of that root cause
+        # (a failed event cascades to every successor), so first-write-wins is
+        # what keeps the reported cause pointing at the thing that actually
+        # broke rather than at the cascade.
+        self._session_failures: Dict[str, Tuple[str, str]] = {}
         # Per-session set of predecessor event_ids whose live tool_call
         # response was detected malformed at substitution time and replaced
         # with the recorded assistant message. Empty when
@@ -203,6 +231,7 @@ class WorkerSessionTracker:
         """Drop all per-worker tracking for a session (called after eviction)."""
         self._event_completions.pop(session_id, None)
         self._failed_sessions.discard(session_id)
+        self._session_failures.pop(session_id, None)
         self._drained_events.pop(session_id, None)
         self._recorded_substitution_event_ids.pop(session_id, None)
 
@@ -217,11 +246,22 @@ class WorkerSessionTracker:
     def get_event_completion_time(self, session_id: str, event_id: str) -> Optional[float]:
         return self._event_completions.get(session_id, {}).get(event_id)
 
-    def mark_session_failed(self, session_id: str) -> None:
+    def mark_session_failed(
+        self,
+        session_id: str,
+        cause: Optional[SessionFailureCause] = None,
+        reason: Optional[str] = None,
+    ) -> None:
         self._failed_sessions.add(session_id)
+        if cause is not None and session_id not in self._session_failures:
+            self._session_failures[session_id] = (cause.value, reason or cause.value)
 
     def is_session_failed(self, session_id: str) -> bool:
         return session_id in self._failed_sessions
+
+    def get_session_failure(self, session_id: str) -> Optional[Tuple[str, str]]:
+        """Return (cause_code, prose) for a failed session, or None if unrecorded."""
+        return self._session_failures.get(session_id)
 
     def get_session_event_count(self, session_id: str) -> int:
         return len(self._event_completions.get(session_id, {}))
@@ -375,8 +415,10 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     disable_output_substitution: bool = False
     # Set by _build_messages_with_substitution when it calls record_failure
     # early (e.g. recorded fallback also malformed). Lets the caller pass the
-    # right reason string to _fail_and_notify instead of a generic fallback.
+    # right cause code and reason string to _fail_and_notify instead of a
+    # generic fallback.
     _substitution_failure_reason: Optional[str] = None
+    _substitution_failure_cause: Optional[SessionFailureCause] = None
 
     async def to_request_body(
         self, effective_model_name: str, max_tokens: int, ignore_eos: bool, streaming: bool
@@ -452,7 +494,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     def _extract_session_id(self) -> str:
         return self.event_id.split(":")[0] if ":" in self.event_id else self.event_id
 
-    def _fail_and_notify(self, session_id: str, reason: str) -> None:
+    def _fail_and_notify(self, session_id: str, cause: SessionFailureCause, reason: str) -> None:
         """Mark this event and session as failed, notify the completion queue.
 
         Called from wait_for_predecessors_and_substitute when we decide to skip
@@ -463,7 +505,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
         """
         self.skip_request = True
         was_already_failed = self.worker_tracker.is_session_failed(session_id)
-        self.worker_tracker.mark_session_failed(session_id)
+        self.worker_tracker.mark_session_failed(session_id, cause, reason)
         self.registry.record_failure(self.event_id)
         logger.info(f"Event {self.event_id} skipping — {reason}")
 
@@ -475,6 +517,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 "session_id": session_id,
                 "completion_time": completion_time,
                 "failed": True,
+                "failure_cause": cause.value,
                 "failure_reason": reason,
                 "cancelled_events": cancelled,
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
@@ -519,7 +562,9 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
         session_id = self._extract_session_id()
 
         if self.worker_tracker.is_session_failed(session_id):
-            self._fail_and_notify(session_id, "session already failed (pre-wait check)")
+            self._fail_and_notify(
+                session_id, SessionFailureCause.SESSION_ALREADY_FAILED, "session already failed (pre-wait check)"
+            )
             return
 
         if self.predecessor_event_ids:
@@ -532,10 +577,14 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     ]
                 )
             except EventFailedError:
-                self._fail_and_notify(session_id, "predecessor failed")
+                self._fail_and_notify(session_id, SessionFailureCause.PREDECESSOR_FAILED, "predecessor failed")
                 return
             except (TimeoutError, asyncio.TimeoutError) as e:
-                self._fail_and_notify(session_id, f"predecessor wait failed: {type(e).__name__}")
+                self._fail_and_notify(
+                    session_id,
+                    SessionFailureCause.PREDECESSOR_WAIT_FAILED,
+                    f"predecessor wait failed: {type(e).__name__}",
+                )
                 return
             logger.debug(f"Event {self.event_id} all predecessors done")
 
@@ -566,7 +615,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             # live model returned plain text). Detect that and skip the request.
             if self.registry.is_event_failed(self.event_id):
                 reason = self._substitution_failure_reason or "Unknown"
-                self._fail_and_notify(session_id, reason)
+                cause = self._substitution_failure_cause or SessionFailureCause.UNKNOWN
+                self._fail_and_notify(session_id, cause, reason)
                 return
             self.messages = [
                 ChatMessage(
@@ -663,6 +713,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                                 self._substitution_failure_reason = (
                                     f"recorded fallback for {seg.source_event_id} is also malformed"
                                 )
+                                self._substitution_failure_cause = SessionFailureCause.RECORDED_FALLBACK_MALFORMED
                                 self.registry.record_failure(self.event_id)
                                 return result  # partial; caller checks is_event_failed
                             # Tag the predecessor event_id for telemetry. Set
@@ -717,6 +768,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                                 self._substitution_failure_reason = (
                                     "substitution failed (tool call expected but plain text returned)"
                                 )
+                                self._substitution_failure_cause = SessionFailureCause.SUBSTITUTION_TOOL_CALL_EXPECTED
                                 self.registry.record_failure(self.event_id)
                                 return result  # partial result; caller should check skip_request
                             for msg in seg_msgs:
@@ -903,12 +955,21 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
         if completed_count == self.total_events_in_session:
             logger.debug(f"Session {session_id} completed all {self.total_events_in_session} events in worker")
 
-            completion_data = {
+            session_failed = self.worker_tracker.is_session_failed(session_id)
+            completion_data: Dict[str, Any] = {
                 "session_id": session_id,
                 "completion_time": completion_time,
-                "failed": self.worker_tracker.is_session_failed(session_id),
+                "failed": session_failed,
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
             }
+            # A session can reach this all-events-completed path already marked
+            # failed by an earlier event. Carry the recorded cause so the main
+            # process is not left with `failed: True` and no reason.
+            if session_failed:
+                recorded_failure = self.worker_tracker.get_session_failure(session_id)
+                cause, reason = recorded_failure or (SessionFailureCause.UNKNOWN.value, "session marked failed by worker")
+                completion_data["failure_cause"] = cause
+                completion_data["failure_reason"] = reason
             # Telemetry: only emit recorded-substitution keys when at least
             # one substitution fired in this session, so upstream-default runs
             # (handling=none, or handling set but no malformed tool_calls
@@ -1097,7 +1158,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
 
         session_id = self._extract_session_id()
         was_already_failed = self.worker_tracker.is_session_failed(session_id)
-        self.worker_tracker.mark_session_failed(session_id)
+        failure_reason = f"{type(exception).__name__}: {exception}"
+        self.worker_tracker.mark_session_failed(session_id, SessionFailureCause.REQUEST_FAILED, failure_reason)
         self.registry.record_failure(self.event_id)
 
         if not was_already_failed and self.completion_queue is not None:
@@ -1108,6 +1170,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 "session_id": session_id,
                 "completion_time": completion_time,
                 "failed": True,
+                "failure_cause": SessionFailureCause.REQUEST_FAILED.value,
+                "failure_reason": failure_reason,
                 "cancelled_events": cancelled,
                 "event_completion_times": self.worker_tracker.get_session_completion_times(session_id),
             }
@@ -1272,6 +1336,7 @@ class ReplaySessionState:
     is_complete: bool = False
     failed: bool = False
     failure_reason: Optional[str] = None
+    failure_cause: Optional[str] = None
     cancelled_events: int = 0
     # Populated from completion_data when the worker finishes the
     # session. None means the worker did not push the keys (i.e.
@@ -1655,9 +1720,18 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
         num_events_completed = len(state.completed_events)
         num_events_cancelled = state.cancelled_events if state.failed else 0
 
+        # `state.failed` alone must produce an error, not just `failure_reason`.
+        # The report's success predicate is derived from `error is None`, so a
+        # session the worker marked failed but for which no reason was recorded
+        # would otherwise be counted as SUCCEEDED whenever all its events
+        # completed. Every producer now carries a cause, making the fallback
+        # below a safety net rather than a routine path.
         error = None
-        if state.failure_reason:
-            error = ErrorResponseInfo(error_type="SessionReplayError", error_msg=state.failure_reason)
+        if state.failed or state.failure_reason:
+            error = ErrorResponseInfo(
+                error_type=state.failure_cause or SessionFailureCause.UNKNOWN.value,
+                error_msg=state.failure_reason or "session marked failed without a recorded reason",
+            )
 
         # Extract user-facing leaf event IDs and confidence from the graph
         user_facing_event_ids = [eid for eid, event in state.graph.events.items() if event.is_user_facing]
@@ -1709,8 +1783,17 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
                             completed_state.event_completion_times[event_id] = completion_time
 
                     completed_state.is_complete = True
-                    completed_state.failed = completion_data.get("failed", False)
-                    completed_state.failure_reason = completion_data.get("failure_reason")
+                    # Failure is sticky in both directions. A session that any
+                    # worker payload reported as failed stays failed, and the
+                    # first recorded reason wins: a later payload for an
+                    # already-failed session (e.g. the all-events-completed
+                    # push arriving after a skip-failure push) must not blank
+                    # out a real cause by overwriting it with None.
+                    completed_state.failed = completed_state.failed or completion_data.get("failed", False)
+                    incoming_reason = completion_data.get("failure_reason")
+                    if incoming_reason is not None and completed_state.failure_reason is None:
+                        completed_state.failure_reason = incoming_reason
+                        completed_state.failure_cause = completion_data.get("failure_cause")
                     completed_state.cancelled_events = completion_data.get("cancelled_events", 0)
                     # Bad tool-call handling telemetry. The two keys are
                     # gated worker-side behind `len(...) > 0`, so their

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -15,7 +15,7 @@ import logging
 import json
 import re
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 if TYPE_CHECKING:
@@ -121,7 +121,23 @@ def make_concise_label(error_type: str, error_msg: str) -> str:
     return error_type.lower().strip()
 
 
-def build_error_counts(metrics_errors: list[tuple[str, str, Optional[str]]], max_error_messages: int) -> dict[str, Any]:
+def use_error_type_as_label(error_type: str, error_msg: str) -> str:
+    """Label function for errors whose ``error_type`` is already a stable code.
+
+    Session replay failures are raised by our own code and arrive pre-classified,
+    so the pattern matching in ``make_concise_label`` is the wrong instrument:
+    those regexes exist to wring structure out of server error text we do not
+    control, and applying them here would collapse distinct causes (any cause
+    whose prose happens to contain "timeout" would land in the same bucket).
+    """
+    return error_type
+
+
+def build_error_counts(
+    metrics_errors: list[tuple[str, str, Optional[str]]],
+    max_error_messages: int,
+    label_fn: Callable[[str, str], str] = make_concise_label,
+) -> dict[str, Any]:
     """Build a {<label>: {count, messages}} dict from (error_type, error_msg, id) triples.
 
     ``count`` reflects the true total number of errors for each label.
@@ -136,7 +152,7 @@ def build_error_counts(metrics_errors: list[tuple[str, str, Optional[str]]], max
     label_messages: dict[str, dict[str, list[str]]] = defaultdict(dict)
     for error_type, error_msg, entity_id in metrics_errors:
         parsed_msg = parse_error_message(error_msg)
-        label = make_concise_label(error_type, parsed_msg)
+        label = label_fn(error_type, parsed_msg)
         label_counts[label] += 1
         merged = label_messages[label]
         if parsed_msg in merged:
@@ -945,6 +961,24 @@ class ReportGenerator:
             if total_span > 0:
                 sessions_per_second = num_sessions / total_span
 
+        # Bucketed on the stable cause code carried as error_type, mirroring the
+        # request-side shape from #601. Sessions counted as failed but carrying
+        # no error are surfaced under an explicit label rather than dropped, so
+        # the by_label counts always reconcile with `num_sessions_failed`.
+        failed_sessions = [m for m in metrics if m.success is False]
+        session_failures = build_error_counts(
+            [
+                (
+                    m.error.error_type if m.error is not None else "unreported",
+                    m.error.error_msg if m.error is not None else "session failed with no error recorded",
+                    m.session_id,
+                )
+                for m in failed_sessions
+            ],
+            max_error_messages,
+            label_fn=use_error_type_as_label,
+        )
+
         # Per-session KV/prefix cache hit rate = cached / total server-reported
         # prompt tokens. Both sides come from the same server usage dicts (see
         # extract_cached_prompt_tokens) rather than pairing the server numerator
@@ -964,6 +998,10 @@ class ReportGenerator:
             "num_sessions": num_sessions,
             "num_sessions_succeeded": num_succeeded,
             "num_sessions_failed": num_failed,
+            "failures": {
+                "count": num_failed,
+                "by_label": session_failures,
+            },
             "total_events": total_events,
             "total_events_completed": total_events_completed,
             "total_events_cancelled": total_events_cancelled,
@@ -1045,7 +1083,10 @@ class ReportGenerator:
             sm.total_cached_tokens = cache_usage[0] if cache_usage else None
             sm.total_cacheable_input_tokens = cache_usage[1] if cache_usage else None
             request_error = error_by_session.get(sm.session_id)
-            if request_error is not None:
+            # The session's own replay error is the more specific diagnosis and
+            # takes precedence; a request-level error only fills the gap when
+            # the session recorded no cause of its own.
+            if request_error is not None and sm.error is None:
                 sm.error = request_error
             sm.success = (sm.num_events_completed == sm.num_events) and (sm.error is None)
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -15,7 +15,7 @@ import logging
 import json
 import re
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 if TYPE_CHECKING:
@@ -122,7 +122,23 @@ def make_concise_label(error_type: str, error_msg: str) -> str:
     return error_type.lower().strip()
 
 
-def build_error_counts(metrics_errors: list[tuple[str, str, Optional[str]]], max_error_messages: int) -> dict[str, Any]:
+def use_error_type_as_label(error_type: str, error_msg: str) -> str:
+    """Label function for errors whose ``error_type`` is already a stable code.
+
+    Session replay failures are raised by our own code and arrive pre-classified,
+    so the pattern matching in ``make_concise_label`` is the wrong instrument:
+    those regexes exist to wring structure out of server error text we do not
+    control, and applying them here would collapse distinct causes (any cause
+    whose prose happens to contain "timeout" would land in the same bucket).
+    """
+    return error_type
+
+
+def build_error_counts(
+    metrics_errors: list[tuple[str, str, Optional[str]]],
+    max_error_messages: int,
+    label_fn: Callable[[str, str], str] = make_concise_label,
+) -> dict[str, Any]:
     """Build a {<label>: {count, messages}} dict from (error_type, error_msg, id) triples.
 
     ``count`` reflects the true total number of errors for each label.
@@ -137,7 +153,7 @@ def build_error_counts(metrics_errors: list[tuple[str, str, Optional[str]]], max
     label_messages: dict[str, dict[str, list[str]]] = defaultdict(dict)
     for error_type, error_msg, entity_id in metrics_errors:
         parsed_msg = parse_error_message(error_msg)
-        label = make_concise_label(error_type, parsed_msg)
+        label = label_fn(error_type, parsed_msg)
         label_counts[label] += 1
         merged = label_messages[label]
         if parsed_msg in merged:
@@ -1168,6 +1184,24 @@ class ReportGenerator:
             if total_span > 0:
                 sessions_per_second = num_sessions / total_span
 
+        # Bucketed on the stable cause code carried as error_type, mirroring the
+        # request-side shape from #601. Sessions counted as failed but carrying
+        # no error are surfaced under an explicit label rather than dropped, so
+        # the by_label counts always reconcile with `num_sessions_failed`.
+        failed_sessions = [m for m in metrics if m.success is False]
+        session_failures = build_error_counts(
+            [
+                (
+                    m.error.error_type if m.error is not None else "unreported",
+                    m.error.error_msg if m.error is not None else "session failed with no error recorded",
+                    m.session_id,
+                )
+                for m in failed_sessions
+            ],
+            max_error_messages,
+            label_fn=use_error_type_as_label,
+        )
+
         # Per-session KV/prefix cache hit rate = cached / total server-reported
         # prompt tokens. Both sides come from the same server usage dicts (see
         # extract_cached_prompt_tokens) rather than pairing the server numerator
@@ -1199,6 +1233,10 @@ class ReportGenerator:
             "num_sessions": num_sessions,
             "num_sessions_succeeded": num_succeeded,
             "num_sessions_failed": num_failed,
+            "failures": {
+                "count": num_failed,
+                "by_label": session_failures,
+            },
             "total_events": total_events,
             "total_events_completed": total_events_completed,
             "total_events_cancelled": total_events_cancelled,
@@ -1300,7 +1338,10 @@ class ReportGenerator:
             sm.total_cacheable_input_tokens = cache_usage[1] if cache_usage else None
             sm.retries_attempted, sm.retries_recovered = retry_by_session.get(sm.session_id, (0, 0))
             request_error = error_by_session.get(sm.session_id)
-            if request_error is not None:
+            # The session's own replay error is the more specific diagnosis and
+            # takes precedence; a request-level error only fills the gap when
+            # the session recorded no cause of its own.
+            if request_error is not None and sm.error is None:
                 sm.error = request_error
             sm.success = (sm.num_events_completed == sm.num_events) and (sm.error is None)
 

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -491,13 +491,15 @@ def _build_error_table(
     successes_by_stage: Dict[int, int],
     failures_by_stage: Dict[int, Dict[str, Any]],
     substitutions_by_stage: Dict[int, int],
+    title: str = "Request Error Summary",
+    successes_label: str = "Successes",
 ) -> Table:
     """Build the per-stage error summary table."""
     labels = _collect_error_labels(failures_by_stage)
     has_substitutions = any(substitutions_by_stage.get(s, 0) > 0 for s in sorted_stages)
-    table = Table(title="[bold magenta]Request Error Summary[/bold magenta]", show_header=True, header_style="bold cyan")
+    table = Table(title=f"[bold magenta]{title}[/bold magenta]", show_header=True, header_style="bold cyan")
     table.add_column("Stage", justify="right")
-    table.add_column("Successes", justify="right")
+    table.add_column(successes_label, justify="right")
     if has_substitutions:
         table.add_column("Bad Tool Calls Substitutions", justify="right")
     for label in labels:
@@ -530,6 +532,8 @@ def print_error_summary_table(reports: List[ReportFile]) -> None:
     successes_by_stage: Dict[int, int] = {}
     failures_by_stage: Dict[int, Dict[str, Any]] = {}
     substitutions_by_stage: Dict[int, int] = {}
+    session_successes_by_stage: Dict[int, int] = {}
+    session_failures_by_stage: Dict[int, Dict[str, Any]] = {}
 
     for report in reports:
         stage_id = extract_stage_id(report.name)
@@ -543,10 +547,29 @@ def print_error_summary_table(reports: List[ReportFile]) -> None:
         if session_stage_id is not None:
             sub_entry = report.contents.get("total_recorded_substitutions", 0)
             substitutions_by_stage[session_stage_id] = sub_entry.get("count", 0) if isinstance(sub_entry, dict) else sub_entry
+            session_successes_by_stage[session_stage_id] = report.contents.get("num_sessions_succeeded", 0)
+            session_failures = report.contents.get("failures", {})
+            session_failures_by_stage[session_stage_id] = (
+                session_failures.get("by_label", {}) if isinstance(session_failures, dict) else {}
+            )
 
-    if not successes_by_stage and not failures_by_stage:
-        return
-
-    sorted_stages = sorted(set(successes_by_stage) | set(failures_by_stage))
     console = Console()
-    console.print(_build_error_table(sorted_stages, successes_by_stage, failures_by_stage, substitutions_by_stage))
+
+    if successes_by_stage or failures_by_stage:
+        sorted_stages = sorted(set(successes_by_stage) | set(failures_by_stage))
+        console.print(_build_error_table(sorted_stages, successes_by_stage, failures_by_stage, substitutions_by_stage))
+
+    # Only worth a table when a session actually failed; a clean replay run would
+    # otherwise print a table whose only column is the success count.
+    if any(session_failures_by_stage.values()):
+        sorted_session_stages = sorted(set(session_successes_by_stage) | set(session_failures_by_stage))
+        console.print(
+            _build_error_table(
+                sorted_session_stages,
+                session_successes_by_stage,
+                session_failures_by_stage,
+                {},
+                title="Session Error Summary",
+                successes_label="Sessions Succeeded",
+            )
+        )

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -632,15 +632,17 @@ def _build_error_table(
     failures_by_stage: Dict[int, Dict[str, Any]],
     substitutions_by_stage: Dict[int, int],
     retries_by_stage: Optional[Dict[int, Dict[str, Any]]] = None,
+    title: str = "Request Error Summary",
+    successes_label: str = "Successes",
 ) -> Table:
     """Build the per-stage error summary table."""
     labels = _collect_error_labels(failures_by_stage)
     has_substitutions = any(substitutions_by_stage.get(s, 0) > 0 for s in sorted_stages)
     retries_by_stage = retries_by_stage or {}
     has_retries = any(retries_by_stage.get(s) for s in sorted_stages)
-    table = Table(title="[bold magenta]Request Error Summary[/bold magenta]", show_header=True, header_style="bold cyan")
+    table = Table(title=f"[bold magenta]{title}[/bold magenta]", show_header=True, header_style="bold cyan")
     table.add_column("Stage", justify="right")
-    table.add_column("Successes", justify="right")
+    table.add_column(successes_label, justify="right")
     if has_substitutions:
         table.add_column("Bad Tool Calls Substitutions", justify="right")
     if has_retries:
@@ -686,6 +688,8 @@ def print_error_summary_table(reports: List[ReportFile]) -> None:
     failures_by_stage: Dict[int, Dict[str, Any]] = {}
     substitutions_by_stage: Dict[int, int] = {}
     retries_by_stage: Dict[int, Dict[str, Any]] = {}
+    session_successes_by_stage: Dict[int, int] = {}
+    session_failures_by_stage: Dict[int, Dict[str, Any]] = {}
 
     for report in reports:
         stage_id = extract_stage_id(report.name)
@@ -703,12 +707,33 @@ def print_error_summary_table(reports: List[ReportFile]) -> None:
         if session_stage_id is not None:
             sub_entry = report.contents.get("total_recorded_substitutions", 0)
             substitutions_by_stage[session_stage_id] = sub_entry.get("count", 0) if isinstance(sub_entry, dict) else sub_entry
+            session_successes_by_stage[session_stage_id] = report.contents.get("num_sessions_succeeded", 0)
+            session_failures = report.contents.get("failures", {})
+            session_failures_by_stage[session_stage_id] = (
+                session_failures.get("by_label", {}) if isinstance(session_failures, dict) else {}
+            )
 
-    if not successes_by_stage and not failures_by_stage:
-        return
-
-    sorted_stages = sorted(set(successes_by_stage) | set(failures_by_stage))
     console = Console()
-    console.print(
-        _build_error_table(sorted_stages, successes_by_stage, failures_by_stage, substitutions_by_stage, retries_by_stage)
-    )
+
+    if successes_by_stage or failures_by_stage:
+        sorted_stages = sorted(set(successes_by_stage) | set(failures_by_stage))
+        console.print(
+            _build_error_table(
+                sorted_stages, successes_by_stage, failures_by_stage, substitutions_by_stage, retries_by_stage
+            )
+        )
+
+    # Only worth a table when a session actually failed; a clean replay run would
+    # otherwise print a table whose only column is the success count.
+    if any(session_failures_by_stage.values()):
+        sorted_session_stages = sorted(set(session_successes_by_stage) | set(session_failures_by_stage))
+        console.print(
+            _build_error_table(
+                sorted_session_stages,
+                session_successes_by_stage,
+                session_failures_by_stage,
+                {},
+                title="Session Error Summary",
+                successes_label="Sessions Succeeded",
+            )
+        )

--- a/tests/required/datagen/test_session_failure_causes.py
+++ b/tests/required/datagen/test_session_failure_causes.py
@@ -1,0 +1,165 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for session failure cause capture and propagation.
+
+The worker records why a session failed; the main process reads those payloads
+off the completion queue. These tests cover the path between the two, where the
+cause was previously either never set or overwritten with None.
+"""
+
+import queue
+from unittest.mock import Mock
+
+from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType
+from inference_perf.datagen.replay.replay_graph_session_datagen import (
+    ReplayGraphSessionGeneratorBase,
+    ReplaySessionState,
+    SessionFailureCause,
+    WorkerSessionTracker,
+)
+from inference_perf.datagen.replay.replay_graph_types import ReplayGraph
+
+
+class TestWorkerSessionTrackerFailureCauses:
+    def test_cause_and_reason_are_recorded(self) -> None:
+        tracker = WorkerSessionTracker()
+        tracker.mark_session_failed("s1", SessionFailureCause.PREDECESSOR_FAILED, "predecessor failed")
+
+        assert tracker.is_session_failed("s1")
+        assert tracker.get_session_failure("s1") == ("predecessor_failed", "predecessor failed")
+
+    def test_first_cause_wins(self) -> None:
+        """A failed event cascades to its successors, so later causes are consequences.
+
+        Keeping the first keeps the reported cause pointing at the thing that
+        actually broke rather than at the resulting cascade.
+        """
+        tracker = WorkerSessionTracker()
+        tracker.mark_session_failed("s1", SessionFailureCause.REQUEST_FAILED, "TimeoutError: boom")
+        tracker.mark_session_failed("s1", SessionFailureCause.SESSION_ALREADY_FAILED, "session already failed")
+
+        assert tracker.get_session_failure("s1") == ("request_failed", "TimeoutError: boom")
+
+    def test_mark_without_cause_still_flags_failure(self) -> None:
+        tracker = WorkerSessionTracker()
+        tracker.mark_session_failed("s1")
+
+        assert tracker.is_session_failed("s1")
+        assert tracker.get_session_failure("s1") is None
+
+    def test_forget_session_clears_recorded_cause(self) -> None:
+        tracker = WorkerSessionTracker()
+        tracker.mark_session_failed("s1", SessionFailureCause.PREDECESSOR_FAILED, "predecessor failed")
+        tracker.forget_session("s1")
+
+        assert not tracker.is_session_failed("s1")
+        assert tracker.get_session_failure("s1") is None
+
+
+class TestCompletionQueueFailurePropagation:
+    """The main process must not degrade a cause it has already been told."""
+
+    def _make_generator(self) -> ReplayGraphSessionGeneratorBase:
+        gen = ReplayGraphSessionGeneratorBase(
+            api_config=APIConfig(type=APIType.Chat),
+            config=DataConfig(type=DataGenType.Random),
+            tokenizer=None,
+        )
+        graph = ReplayGraph(events={"evt_1": Mock()}, root_event_ids=["evt_1"], source_file="t.json")
+        gen.session_graph_state["s1"] = ReplaySessionState(
+            session_id="s1",
+            graph=graph,
+            ready_events=set(),
+            dispatched_events=set(),
+            completed_events=set(),
+            event_completion_times={},
+        )
+        gen.session_completion_queue = queue.Queue()
+        return gen
+
+    def test_cause_and_reason_land_on_state(self) -> None:
+        gen = self._make_generator()
+        gen.session_completion_queue.put(
+            {
+                "session_id": "s1",
+                "completion_time": 1.0,
+                "failed": True,
+                "failure_cause": SessionFailureCause.PREDECESSOR_FAILED.value,
+                "failure_reason": "predecessor failed",
+                "event_completion_times": {},
+            }
+        )
+        gen._process_completion_queue()
+
+        state = gen.session_graph_state["s1"]
+        assert state.failed is True
+        assert state.failure_cause == "predecessor_failed"
+        assert state.failure_reason == "predecessor failed"
+
+    def test_later_payload_without_reason_does_not_blank_it(self) -> None:
+        """The regression: a second payload for an already-failed session.
+
+        The skip-failure push carries the cause; the all-events-completed push
+        that follows it used to assign failure_reason unconditionally, replacing
+        a real cause with None and making the failure unattributable.
+        """
+        gen = self._make_generator()
+        q = gen.session_completion_queue
+        q.put(
+            {
+                "session_id": "s1",
+                "completion_time": 1.0,
+                "failed": True,
+                "failure_cause": SessionFailureCause.RECORDED_FALLBACK_MALFORMED.value,
+                "failure_reason": "recorded fallback for evt_0 is also malformed",
+                "event_completion_times": {},
+            }
+        )
+        q.put({"session_id": "s1", "completion_time": 2.0, "failed": True, "event_completion_times": {}})
+        gen._process_completion_queue()
+
+        state = gen.session_graph_state["s1"]
+        assert state.failure_cause == "recorded_fallback_malformed"
+        assert state.failure_reason == "recorded fallback for evt_0 is also malformed"
+
+    def test_failed_flag_is_sticky(self) -> None:
+        """A later payload reporting failed=False must not clear a recorded failure."""
+        gen = self._make_generator()
+        q = gen.session_completion_queue
+        q.put(
+            {
+                "session_id": "s1",
+                "completion_time": 1.0,
+                "failed": True,
+                "failure_cause": SessionFailureCause.REQUEST_FAILED.value,
+                "failure_reason": "TimeoutError: boom",
+                "event_completion_times": {},
+            }
+        )
+        q.put({"session_id": "s1", "completion_time": 2.0, "failed": False, "event_completion_times": {}})
+        gen._process_completion_queue()
+
+        assert gen.session_graph_state["s1"].failed is True
+
+    def test_clean_completion_records_no_failure(self) -> None:
+        gen = self._make_generator()
+        gen.session_completion_queue.put(
+            {"session_id": "s1", "completion_time": 1.0, "failed": False, "event_completion_times": {"evt_1": 1.0}}
+        )
+        gen._process_completion_queue()
+
+        state = gen.session_graph_state["s1"]
+        assert state.failed is False
+        assert state.failure_reason is None
+        assert state.failure_cause is None

--- a/tests/required/reportgen/test_session_failure_reporting.py
+++ b/tests/required/reportgen/test_session_failure_reporting.py
@@ -1,0 +1,236 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for session-level failure reporting.
+
+Covers the session half of the error reporting that #601 delivered for requests:
+that a session's failure cause survives to the report, that failures bucket on a
+stable cause code, and that a session the worker marked failed is never counted
+as a success.
+"""
+
+from unittest.mock import Mock
+
+from inference_perf.apis.base import (
+    ErrorResponseInfo,
+    InferenceInfo,
+    RequestLifecycleMetric,
+    SessionLifecycleMetric,
+)
+from inference_perf.config.reportgen.config import ReportConfig
+from inference_perf.datagen.replay.replay_graph_session_datagen import SessionFailureCause
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.reportgen.base import ReportGenerator
+
+PERCENTILES = [50.0, 90.0]
+
+
+def _make_generator() -> ReportGenerator:
+    config = Mock()
+    config.report = ReportConfig()
+    return ReportGenerator(metrics_client=None, metrics_collector=Mock(), config=config)
+
+
+def _sess(
+    *,
+    session_id: str = "s1",
+    success: bool | None = None,
+    error: ErrorResponseInfo | None = None,
+    num_events: int = 3,
+    num_events_completed: int = 3,
+) -> SessionLifecycleMetric:
+    return SessionLifecycleMetric(
+        session_id=session_id,
+        stage_id=0,
+        file_path="trace.json",
+        start_time=0.0,
+        end_time=1.0,
+        duration_sec=1.0,
+        num_events=num_events,
+        num_events_completed=num_events_completed,
+        success=success,
+        error=error,
+    )
+
+
+def _req(*, session_id: str, error: ErrorResponseInfo | None = None, input_tokens: int = 10) -> RequestLifecycleMetric:
+    return RequestLifecycleMetric(
+        stage_id=0,
+        session_id=session_id,
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="prompt",
+        info=InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=input_tokens))),
+        error=error,
+    )
+
+
+def _replay_error(cause: SessionFailureCause, msg: str) -> ErrorResponseInfo:
+    return ErrorResponseInfo(error_type=cause.value, error_msg=msg)
+
+
+class TestSessionFailuresByLabel:
+    def test_all_success_empty_by_label(self) -> None:
+        gen = _make_generator()
+        summary = gen.summarize_sessions([_sess(success=True), _sess(session_id="s2", success=True)], PERCENTILES)
+        assert summary["num_sessions_failed"] == 0
+        assert summary["failures"]["count"] == 0
+        assert summary["failures"]["by_label"] == {}
+
+    def test_distinct_prose_still_shares_one_cause_bucket(self) -> None:
+        """The reason for bucketing on the cause code rather than the message.
+
+        RECORDED_FALLBACK_MALFORMED embeds the offending predecessor event id in
+        its prose, so bucketing on raw message text would yield one singleton
+        bucket per failure, which is the flat list #587 was filed to eliminate.
+        """
+        gen = _make_generator()
+        metrics = [
+            _sess(
+                session_id=f"s{i}",
+                success=False,
+                error=_replay_error(
+                    SessionFailureCause.RECORDED_FALLBACK_MALFORMED,
+                    f"recorded fallback for evt_{i} is also malformed",
+                ),
+            )
+            for i in range(3)
+        ]
+        summary = gen.summarize_sessions(metrics, PERCENTILES)
+
+        by_label = summary["failures"]["by_label"]
+        assert list(by_label.keys()) == ["recorded_fallback_malformed"]
+        bucket = by_label["recorded_fallback_malformed"]
+        assert bucket["count"] == 3
+        # Distinct prose is retained as samples under the single bucket.
+        assert len(bucket["messages"]) == 3
+        assert {sid for m in bucket["messages"] for sid in m["session_ids"]} == {"s0", "s1", "s2"}
+
+    def test_cause_code_not_rewritten_by_request_side_regexes(self) -> None:
+        """Session causes must bypass make_concise_label's pattern matching.
+
+        Those regexes exist to parse server error text. `predecessor_wait_failed`
+        carries "TimeoutError" in its prose and would be relabelled the generic
+        "Timeout" bucket if it went through them, silently merging with any
+        unrelated cause whose message also mentions a timeout.
+        """
+        gen = _make_generator()
+        metrics = [
+            _sess(
+                session_id="s1",
+                success=False,
+                error=_replay_error(SessionFailureCause.PREDECESSOR_WAIT_FAILED, "predecessor wait failed: TimeoutError"),
+            ),
+            _sess(
+                session_id="s2",
+                success=False,
+                error=_replay_error(SessionFailureCause.REQUEST_FAILED, "ServerTimeoutError: connection timed out"),
+            ),
+        ]
+        summary = gen.summarize_sessions(metrics, PERCENTILES)
+
+        by_label = summary["failures"]["by_label"]
+        assert set(by_label.keys()) == {"predecessor_wait_failed", "request_failed"}
+        assert "Timeout" not in by_label
+        assert by_label["predecessor_wait_failed"]["count"] == 1
+        assert by_label["request_failed"]["count"] == 1
+
+    def test_labels_sorted_by_descending_count(self) -> None:
+        gen = _make_generator()
+        metrics = [
+            _sess(session_id="a1", success=False, error=_replay_error(SessionFailureCause.PREDECESSOR_FAILED, "pred")),
+            _sess(session_id="a2", success=False, error=_replay_error(SessionFailureCause.PREDECESSOR_FAILED, "pred")),
+            _sess(session_id="b1", success=False, error=_replay_error(SessionFailureCause.REQUEST_FAILED, "boom")),
+        ]
+        summary = gen.summarize_sessions(metrics, PERCENTILES)
+        assert list(summary["failures"]["by_label"].keys())[0] == "predecessor_failed"
+
+    def test_failed_session_without_error_is_surfaced_not_dropped(self) -> None:
+        """by_label totals must reconcile with num_sessions_failed."""
+        gen = _make_generator()
+        metrics = [
+            _sess(session_id="s1", success=False, error=None),
+            _sess(session_id="s2", success=False, error=_replay_error(SessionFailureCause.PREDECESSOR_FAILED, "pred")),
+        ]
+        summary = gen.summarize_sessions(metrics, PERCENTILES)
+
+        by_label = summary["failures"]["by_label"]
+        assert summary["failures"]["count"] == summary["num_sessions_failed"] == 2
+        assert sum(b["count"] for b in by_label.values()) == 2
+        assert "unreported" in by_label
+
+
+class TestSessionErrorPrecedence:
+    def test_session_replay_error_survives_request_error(self) -> None:
+        """The session's own cause is the more specific diagnosis and must win.
+
+        Previously any request-level error for the session overwrote it, which
+        replaced a precise replay cause with an incidental HTTP error.
+        """
+        gen = _make_generator()
+        session = _sess(
+            session_id="s1",
+            error=_replay_error(SessionFailureCause.SUBSTITUTION_TOOL_CALL_EXPECTED, "tool call expected"),
+        )
+        requests = [_req(session_id="s1", error=ErrorResponseInfo(error_type="HTTP Error 400", error_msg="bad request"))]
+
+        gen._enrich_sessions([session], requests)
+
+        assert session.error is not None
+        assert session.error.error_type == SessionFailureCause.SUBSTITUTION_TOOL_CALL_EXPECTED.value
+        assert session.success is False
+
+    def test_request_error_fills_in_when_session_has_no_cause(self) -> None:
+        gen = _make_generator()
+        session = _sess(session_id="s1", error=None)
+        requests = [_req(session_id="s1", error=ErrorResponseInfo(error_type="HTTP Error 500", error_msg="boom"))]
+
+        gen._enrich_sessions([session], requests)
+
+        assert session.error is not None
+        assert session.error.error_type == "HTTP Error 500"
+        assert session.success is False
+
+    def test_clean_session_stays_successful(self) -> None:
+        gen = _make_generator()
+        session = _sess(session_id="s1", error=None)
+        gen._enrich_sessions([session], [_req(session_id="s1")])
+
+        assert session.error is None
+        assert session.success is True
+
+
+class TestFailedSessionNeverCountsAsSuccess:
+    def test_failed_session_with_all_events_completed_is_counted_failed(self) -> None:
+        """Regression for the miscount: `failed` never reached the success predicate.
+
+        A session whose events all completed but which the worker marked failed
+        carries an error built from its cause, so the predicate derived from
+        `error is None` puts it in the failed bucket where it belongs.
+        """
+        gen = _make_generator()
+        session = _sess(
+            session_id="s1",
+            num_events=3,
+            num_events_completed=3,
+            error=_replay_error(SessionFailureCause.UNKNOWN, "session marked failed without a recorded reason"),
+        )
+
+        gen._enrich_sessions([session], [_req(session_id="s1")])
+        summary = gen.summarize_sessions([session], PERCENTILES)
+
+        assert session.success is False
+        assert summary["num_sessions_succeeded"] == 0
+        assert summary["num_sessions_failed"] == 1
+        assert summary["failures"]["by_label"]["unknown"]["count"] == 1

--- a/tests/required/utils/test_cli_summary.py
+++ b/tests/required/utils/test_cli_summary.py
@@ -5,6 +5,7 @@ from inference_perf.utils.cli_summary import (
     extract_session_stage_id,
     print_summary_table,
     print_session_summary_tables,
+    print_error_summary_table,
 )
 from inference_perf.utils.report_file import ReportFile
 
@@ -121,6 +122,40 @@ class TestCliSummary(unittest.TestCase):
         print_summary_table(reports)
         # 5 request tables (including error table) + 3 session tables = 8
         self.assertEqual(mock_console_print.call_count, 8)
+
+    @patch("inference_perf.utils.cli_summary.Console.print")
+    def test_session_error_summary_table_printed_when_sessions_fail(self, mock_console_print: MagicMock) -> None:
+        session_contents = {
+            "num_sessions": 3,
+            "num_sessions_succeeded": 1,
+            "num_sessions_failed": 2,
+            "failures": {
+                "count": 2,
+                "by_label": {
+                    "predecessor_failed": {"count": 2, "messages": [{"message": "predecessor failed"}]},
+                },
+            },
+        }
+        report = ReportFile(name="stage_0_session_lifecycle_metrics", contents=session_contents)
+        print_error_summary_table([report])
+
+        printed = [call.args[0] for call in mock_console_print.call_args_list]
+        titles = [t.title for t in printed]
+        self.assertIn("[bold magenta]Session Error Summary[/bold magenta]", titles)
+
+    @patch("inference_perf.utils.cli_summary.Console.print")
+    def test_session_error_summary_table_omitted_when_no_failures(self, mock_console_print: MagicMock) -> None:
+        """A clean replay run should not print a table whose only column is the success count."""
+        session_contents = {
+            "num_sessions": 3,
+            "num_sessions_succeeded": 3,
+            "num_sessions_failed": 0,
+            "failures": {"count": 0, "by_label": {}},
+        }
+        report = ReportFile(name="stage_0_session_lifecycle_metrics", contents=session_contents)
+        print_error_summary_table([report])
+
+        self.assertEqual(mock_console_print.call_count, 0)
 
 
 if __name__ == "__main__":

--- a/tests/required/utils/test_cli_summary.py
+++ b/tests/required/utils/test_cli_summary.py
@@ -5,6 +5,7 @@ from inference_perf.utils.cli_summary import (
     extract_session_stage_id,
     print_summary_table,
     print_session_summary_tables,
+    print_error_summary_table,
 )
 from inference_perf.utils.report_file import ReportFile
 
@@ -144,6 +145,40 @@ class TestCliSummary(unittest.TestCase):
         print_summary_table(reports)
         # 5 request tables (including error table) + 3 session tables = 8
         self.assertEqual(mock_console_print.call_count, 8)
+
+    @patch("inference_perf.utils.cli_summary.Console.print")
+    def test_session_error_summary_table_printed_when_sessions_fail(self, mock_console_print: MagicMock) -> None:
+        session_contents = {
+            "num_sessions": 3,
+            "num_sessions_succeeded": 1,
+            "num_sessions_failed": 2,
+            "failures": {
+                "count": 2,
+                "by_label": {
+                    "predecessor_failed": {"count": 2, "messages": [{"message": "predecessor failed"}]},
+                },
+            },
+        }
+        report = ReportFile(name="stage_0_session_lifecycle_metrics", contents=session_contents)
+        print_error_summary_table([report])
+
+        printed = [call.args[0] for call in mock_console_print.call_args_list]
+        titles = [t.title for t in printed]
+        self.assertIn("[bold magenta]Session Error Summary[/bold magenta]", titles)
+
+    @patch("inference_perf.utils.cli_summary.Console.print")
+    def test_session_error_summary_table_omitted_when_no_failures(self, mock_console_print: MagicMock) -> None:
+        """A clean replay run should not print a table whose only column is the success count."""
+        session_contents = {
+            "num_sessions": 3,
+            "num_sessions_succeeded": 3,
+            "num_sessions_failed": 0,
+            "failures": {"count": 0, "by_label": {}},
+        }
+        report = ReportFile(name="stage_0_session_lifecycle_metrics", contents=session_contents)
+        print_error_summary_table([report])
+
+        self.assertEqual(mock_console_print.call_count, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -22,6 +22,7 @@ from inference_perf.datagen.replay.replay_graph_session_datagen import (
     ReplayGraphSessionGeneratorBase,
     ReplaySession,
     ReplaySessionState,
+    SessionFailureCause,
 )
 from inference_perf.datagen.replay.replay_graph_types import ReplayGraph
 from inference_perf.config import APIConfig, DataConfig, APIType, TraceFormat, TraceConfig, DataGenType
@@ -126,15 +127,44 @@ class TestBuildSessionMetricFailureReason:
             event_completion_times={},
             failed=True,
             failure_reason="predecessor wait failed: TimeoutError",
+            failure_cause=SessionFailureCause.PREDECESSOR_WAIT_FAILED.value,
             cancelled_events=1,
         )
 
         metric = gen.build_session_metric(session_id="s1", stage_id=0, start_time=100.0, end_time=110.0)
 
         assert metric.error is not None
-        assert metric.error.error_type == "SessionReplayError"
+        # The stable cause code, not the old catch-all "SessionReplayError".
+        assert metric.error.error_type == "predecessor_wait_failed"
         assert metric.error.error_msg == "predecessor wait failed: TimeoutError"
         assert metric.num_events_cancelled == 1
+
+    def test_failed_without_reason_still_produces_error(self) -> None:
+        """A session marked failed with no recorded reason must not read as success.
+
+        The report derives success from `error is None`, so dropping the error here
+        would count this session as SUCCEEDED once all its events completed.
+        """
+        gen = self._make_generator()
+        graph = self._make_graph()
+
+        gen.sessions = [ReplaySession(session_id="s1", source_id="src", session_index=0, graph=graph)]
+        gen.session_graph_state["s1"] = ReplaySessionState(
+            session_id="s1",
+            graph=graph,
+            ready_events=set(),
+            dispatched_events=set(),
+            completed_events={"evt_1"},
+            event_completion_times={"evt_1": 105.0},
+            failed=True,
+            failure_reason=None,
+        )
+
+        metric = gen.build_session_metric(session_id="s1", stage_id=0, start_time=100.0, end_time=110.0)
+
+        assert metric.error is not None
+        assert metric.error.error_type == SessionFailureCause.UNKNOWN.value
+        assert metric.num_events_completed == metric.num_events
 
     def test_no_failure_reason_no_error(self) -> None:
         gen = self._make_generator()


### PR DESCRIPTION
Addresses #656

## Problem

Session failures were miscounted and uninformative:

- **Failed sessions could be reported as succeeded.** `SessionLifecycleMetric` has no `failed` field and `build_session_metric` only built an error from `failure_reason`, so a session the worker marked failed with no recorded reason passed the report's success predicate. `num_sessions_succeeded` / `num_sessions_failed` were wrong, not just uninformative.
- **The `failure_reason` feed was lossy.** Only one of the three completion payload producers set it, and two paths destroyed a cause already recorded: a later payload blanked it to `None`, and `_enrich_sessions` overwrote the session's own error with a request-level one.
- **Every session error used the constant `error_type="SessionReplayError"`**, collapsing all distinct causes into one bucket in `build_error_counts`.

## Change

- New `SessionFailureCause` str-Enum: seven stable cause codes emitted as `error_type`, with the prose kept in `error_msg`. Bucketing on the code matters because some prose embeds per-event ids and would otherwise split into one bucket per failure.
- `WorkerSessionTracker` records the cause per session, first-write-wins; all three completion producers read from it.
- `failed` is sticky and the first recorded reason wins, so a later payload cannot blank a real cause. A session's own replay error takes precedence over a request-level error.
- `build_session_metric` builds an error from `state.failed` alone, closing the miscount.
- `summarize_sessions` gains a `failures.by_label` section matching the request-side shape from #601, bucketed on the cause code (deliberately not through #601's server-error regexes, which would mislabel causes like `predecessor_wait_failed`).
- Symmetric "Session Error Summary" CLI table, printed only when a session actually failed, and a new Session Reports section in `docs/reports.md`.

## New report fields

The session summary now carries a `failures` section alongside the existing counts:

```json
{
  "num_sessions": 100,
  "num_sessions_succeeded": 94,
  "num_sessions_failed": 6,
  "failures": {
    "count": 6,
    "by_label": {
      "predecessor_failed": {
        "count": 4,
        "messages": [
          {
            "message": "predecessor failed",
            "session_ids": ["trace1715_066de3655406", "trace2210_1f9b0c4d7e21"]
          }
        ]
      },
      "recorded_fallback_malformed": {
        "count": 2,
        "messages": [
          {
            "message": "recorded fallback for evt_7 is also malformed",
            "session_ids": ["trace42_9f000393d262"]
          }
        ]
      }
    }
  }
}
```

Cause codes: `predecessor_failed`, `predecessor_wait_failed`, `session_already_failed`, `recorded_fallback_malformed`, `substitution_tool_call_expected`, `request_failed`, `unknown`, plus a synthetic `unreported` label for sessions counted as failed with no error attached, so the buckets always reconcile with `num_sessions_failed`. Each is documented in `docs/reports.md`.

## Testing

25 tests, 17 new, across reportgen, datagen, the CLI summary, and trace replay, including a regression test for the miscount. Full suite: 850 passed / 15 skipped; ruff, format, and `mypy --strict` clean (the one remaining strict error is a pre-existing jmespath stub gap, present on `main`).

## Notes

- **Report surface changed:** `error_type` is no longer the constant `SessionReplayError`, and the session summary gains a `failures` key. The cause codes are user-visible bucket labels, so renaming one is a breaking change to the report.
- **Out of scope:** `cancelled_events` has the same clobber shape, but it is not in #656 and I have not verified it is reachable, so it is left for a follow-up.
- #656's line numbers were written against 4548631 and have shifted by ~127 lines; the structural claims all held.
