### PR TITLE
docs: unify global and Config CLI flag documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Explore detailed documentation for specific topics:
 | Topic | Description | Link |
 | :--- | :--- | :--- |
 | **Configuration** | Full YAML configuration schema and options. | [config.md](./docs/config.md) |
-| **CLI Flags** | Overriding configuration via command line flags. | [cli_flags.md](./docs/cli_flags.md) |
+| **CLI Flags** | All command line flags: global options and configuration overrides. | [cli_flags.md](./docs/cli_flags.md) |
 | **Load Generation** | Detailed explanation of load patterns and multi-worker setup. | [loadgen.md](./docs/loadgen.md) |
 | **Metrics** | Definitions of TTFT, TPOT, ITL, etc. | [metrics.md](./docs/metrics.md) |
 | **Goodput** | How to measure requests meeting SLOs. | [goodput.md](./docs/goodput.md) |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -1,9 +1,13 @@
 # Inference-Perf CLI Flags
 
-These command line flags are automatically generated from the internal `Config` schema. You can override any configuration directly from the CLI without using a yaml configuration file.
+These command line flags are automatically generated from the CLI parser. The global flags at the top of the table control the tool itself; every other flag is generated from the internal `Config` schema and overrides that configuration directly from the CLI without using a yaml configuration file.
 
 | Flag | Type | Description |
 | --- | --- | --- |
+| `-c`, `--config_file` | str | Config File |
+| `-a`, `--analyze` | list of str | Path to a report directories to analyze |
+| `-u`, `--unified_analysis_dir` | str | Unified analysis directory path |
+| `--log-level` | Enum (DEBUG, INFO, WARNING, ERROR, CRITICAL) | Logging level (default: INFO) |
 | `--api.type` | Enum (completion, chat, anthropic_messages) | API endpoint to benchmark: text completion or chat completion. |
 | `--api.streaming` | boolean | Stream responses instead of waiting for the full response. Enables TTFT and TPOT metrics. |
 | `--api.headers` | JSON | Additional HTTP headers to send with every request. |

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -70,7 +70,7 @@ from inference_perf.metrics.request_collector import (
 )
 from inference_perf.circuit_breaker import init_circuit_breakers
 from inference_perf.reportgen import ReportGenerator
-from inference_perf.utils import CustomTokenizer, ReportFile, add_pydantic_args, unflatten_dict
+from inference_perf.utils import CustomTokenizer, ReportFile, add_global_args, add_pydantic_args, unflatten_dict
 from inference_perf.utils.cli_summary import print_summary_table
 from inference_perf.observability.logging import setup_logging
 import asyncio
@@ -122,13 +122,7 @@ def main_cli() -> None:
 
     # Parse command line arguments
     parser = ArgumentParser()
-    parser.add_argument("-c", "--config_file", help="Config File", required=False)
-    parser.add_argument("-a", "--analyze", nargs="*", help="Path to a report directories to analyze", required=False)
-    parser.add_argument("-u", "--unified_analysis_dir", help="Unified analysis directory path", required=False)
-    parser.add_argument(
-        "--log-level", help="Logging level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-    )
-
+    base_args = add_global_args(parser)
     add_pydantic_args(parser, Config)
 
     args = parser.parse_args()
@@ -139,7 +133,6 @@ def main_cli() -> None:
         analyze_reports(args.analyze, args.unified_analysis_dir)
         return
 
-    base_args = {"config_file", "analyze", "unified_analysis_dir", "log_level"}
     cli_overrides_flat = {k: v for k, v in vars(args).items() if k not in base_args}
     cli_overrides = unflatten_dict(cli_overrides_flat)
 

--- a/inference_perf/utils/__init__.py
+++ b/inference_perf/utils/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 from .custom_tokenizer import CustomTokenizer
 from .report_file import ReportFile
-from .cli_parser import add_pydantic_args, unflatten_dict
+from .cli_parser import add_global_args, add_pydantic_args, unflatten_dict
 
-__all__ = ["CustomTokenizer", "ReportFile", "add_pydantic_args", "unflatten_dict"]
+__all__ = ["CustomTokenizer", "ReportFile", "add_global_args", "add_pydantic_args", "unflatten_dict"]

--- a/inference_perf/utils/cli_parser.py
+++ b/inference_perf/utils/cli_parser.py
@@ -16,6 +16,45 @@ def unwrap_type(annotation: typing.Any) -> typing.Tuple[typing.Any, bool]:
     return annotation, False
 
 
+def add_global_args(
+    parser: argparse.ArgumentParser,
+    docs: typing.Optional[typing.List[str]] = None,
+) -> typing.Set[str]:
+    """
+    Adds the global (non-Config) CLI arguments. Both the runtime parser and the docs
+    generator build these from this single definition so the two cannot drift apart.
+
+    Appends a markdown doc row for each argument to `docs` and returns the set of
+    argparse dests so callers can separate global args from Config overrides.
+    """
+    if docs is None:
+        docs = []
+
+    actions = [
+        parser.add_argument("-c", "--config_file", help="Config File", required=False),
+        parser.add_argument("-a", "--analyze", nargs="*", help="Path to a report directories to analyze", required=False),
+        parser.add_argument("-u", "--unified_analysis_dir", help="Unified analysis directory path", required=False),
+        parser.add_argument(
+            "--log-level", help="Logging level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+        ),
+    ]
+
+    for action in actions:
+        flags = ", ".join(f"`{opt}`" for opt in action.option_strings)
+        if action.choices is not None:
+            arg_type = f"Enum ({', '.join(str(choice) for choice in action.choices)})"
+        elif action.nargs == "*":
+            arg_type = "list of str"
+        else:
+            arg_type = "str"
+        help_text = action.help or ""
+        if action.default is not None:
+            help_text = f"{help_text} (default: {action.default})"
+        docs.append(f"| {flags} | {arg_type} | {help_text} |")
+
+    return {action.dest for action in actions}
+
+
 def add_pydantic_args(
     parser: argparse.ArgumentParser | argparse._ArgumentGroup,
     model_cls: type[BaseModel],

--- a/scripts/sync_cli_flags_doc.py
+++ b/scripts/sync_cli_flags_doc.py
@@ -4,12 +4,12 @@ import sys
 import typing
 from pathlib import Path
 from pydantic import BaseModel
-from inference_perf.utils.cli_parser import add_pydantic_args
+from inference_perf.utils.cli_parser import add_global_args, add_pydantic_args
 from inference_perf.config import Config
 
 HEADER = """# Inference-Perf CLI Flags
 
-These command line flags are automatically generated from the internal `Config` schema. You can override any configuration directly from the CLI without using a yaml configuration file.
+These command line flags are automatically generated from the CLI parser. The global flags at the top of the table control the tool itself; every other flag is generated from the internal `Config` schema and overrides that configuration directly from the CLI without using a yaml configuration file.
 
 | Flag | Type | Description |
 | --- | --- | --- |
@@ -18,7 +18,8 @@ These command line flags are automatically generated from the internal `Config` 
 
 def generate_doc() -> str:
     parser = argparse.ArgumentParser()
-    docs = []
+    docs: list[str] = []
+    add_global_args(parser, docs=docs)
     add_pydantic_args(parser, Config, docs=docs)
     return HEADER + "\n".join(docs) + "\n"
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,0 +1,54 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+from inference_perf.config import Config
+from inference_perf.utils.cli_parser import add_global_args, add_pydantic_args
+
+
+def test_add_global_args_documents_every_flag() -> None:
+    parser = argparse.ArgumentParser()
+    docs: list[str] = []
+    base_args = add_global_args(parser, docs=docs)
+
+    assert base_args == {"config_file", "analyze", "unified_analysis_dir", "log_level"}
+    # One doc row per global flag, so a flag added through this helper cannot go undocumented.
+    assert len(docs) == len(base_args)
+    for dest in base_args:
+        assert any(dest in row or dest.replace("_", "-") in row for row in docs)
+
+
+def test_global_doc_rows_precede_config_rows() -> None:
+    parser = argparse.ArgumentParser()
+    docs: list[str] = []
+    add_global_args(parser, docs=docs)
+    global_rows = list(docs)
+    add_pydantic_args(parser, Config, docs=docs)
+
+    assert len(docs) > len(global_rows)
+    # Config rows are appended after the global rows, which survive as an unchanged prefix.
+    assert docs[: len(global_rows)] == global_rows
+
+
+def test_base_args_filter_separates_config_overrides() -> None:
+    parser = argparse.ArgumentParser()
+    base_args = add_global_args(parser)
+    add_pydantic_args(parser, Config)
+
+    args = parser.parse_args(["-c", "cfg.yaml", "--log-level", "DEBUG", "--api.streaming", "true"])
+    overrides = {k: v for k, v in vars(args).items() if k not in base_args}
+
+    assert overrides == {"api.streaming": True}
+    assert args.config_file == "cfg.yaml"
+    assert args.log_level == "DEBUG"


### PR DESCRIPTION
Fixes #515

Global flags (`-c/--config_file`, `-a/--analyze`, `-u/--unified_analysis_dir`, `--log-level`) were defined inline in `main_cli()` and documented nowhere, while Config-derived flags were auto-generated into `docs/cli_flags.md` behind the `check:cli-flags` CI gate.

This PR makes the argparse parser the single source of truth for all flags:

- New `add_global_args()` in `inference_perf/utils/cli_parser.py` defines the global flags once, emits a doc row per flag (same `docs=` pattern as `add_pydantic_args`), and returns the set of argparse dests.
- `main_cli()` builds its parser from the helper and derives the `base_args` filter from the returned dests instead of a hardcoded set.
- `scripts/sync_cli_flags_doc.py` prepends the global flag rows to the generated table; `docs/cli_flags.md` regenerated.
- A future global flag added through the helper is covered by the existing `check:cli-flags` gate; one added outside the helper would leak into `cli_overrides` and break config parsing immediately, so flags cannot quietly go undocumented.
- Unit tests in `tests/test_cli_parser.py` cover the dest set, doc-row emission, ordering, and the override filter.