### PR TITLE
Add report.request_lifecycle.metrics_only flag for per-request metrics

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -251,6 +251,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--report.request_lifecycle.percentiles` | JSON | Percentiles reported for each metric. |
 | `--report.request_lifecycle.use_server_output_tokens` | boolean | Use the server-reported output token counts in metrics instead of tokenizing the response text. |
 | `--report.request_lifecycle.max_error_messages` | int | Cap on the number of distinct example error messages retained per error label in the failure report, and per substitution entry. |
+| `--report.request_lifecycle.metrics_only` | boolean | Drops raw request/response text and SSE chunk buffers to produce lightweight report. |
 | `--report.prometheus.summary` | boolean | Generate a summary report across the whole run. |
 | `--report.prometheus.per_stage` | boolean | Generate a report for each load stage. |
 | `--report.session_lifecycle.summary` | boolean | Generate a summary report across the whole run. |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -18,6 +18,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--api.response_format.name` | str | Name given to the JSON schema in the request payload. |
 | `--api.response_format.json_schema` | JSON | JSON schema the model output must conform to when type is 'json_schema'. |
 | `--api.session_id_header_key` | str | Header used to send the session ID with each request in multi-turn benchmarks. |
+| `--api.metrics_only` | boolean | Drops raw request/response text and SSE chunk buffers to produce lightweight report. |
 | `--data.type` | Enum (mock, shareGPT, synthetic, random, shared_prefix, cnn_dailymail, infinity_instruct, billsum_conversations, otel_trace_replay, weka_trace_replay, conversation_replay, visionarena) | Dataset or generator used to produce prompts. |
 | `--data.path` | str | Path to the downloaded ShareGPT dataset. Only used by the 'shareGPT' type. |
 | `--data.corpus_file_path` | str | Path to a text file to use as the prompt tokenization corpus instead of the default hardcoded sonnet |

--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -259,11 +259,13 @@ def _build_anthropic_stream_handlers() -> tuple[Callable[[dict[str, Any]], str |
 
 async def parse_anthropic_stream_response(
     response: ClientResponse,
+    metrics_only: bool = False,
 ) -> tuple[str, dict[str, Any], list[float], str, list[str], dict[str, Any] | None]:
     extract_content, build_output_message = _build_anthropic_stream_handlers()
     output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
         response,
         extract_content=extract_content,
+        metrics_only=metrics_only,
     )
     return output_text, build_output_message(output_text), chunk_times, raw_content, response_chunks, server_usage
 
@@ -309,7 +311,7 @@ class AnthropicMessagesAPIData(InferenceAPIData):
                 raw_content,
                 response_chunks,
                 server_usage,
-            ) = await parse_anthropic_stream_response(response)
+            ) = await parse_anthropic_stream_response(response, metrics_only=config.metrics_only)
             input_tokens = (server_usage or {}).get("input_tokens")
             output_tokens = (server_usage or {}).get("output_tokens")
             output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)

--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -311,7 +311,7 @@ class AnthropicMessagesAPIData(InferenceAPIData):
                 raw_content,
                 response_chunks,
                 server_usage,
-            ) = await parse_anthropic_stream_response(response, metrics_only=config.metrics_only)
+            ) = await parse_anthropic_stream_response(response, metrics_only=bool(config.metrics_only))
             input_tokens = (server_usage or {}).get("input_tokens")
             output_tokens = (server_usage or {}).get("output_tokens")
             output_len = int(output_tokens) if output_tokens is not None else tokenizer.count_tokens(output_text)

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -36,6 +36,9 @@ class StreamedResponseMetrics(ResponseMetrics):
     response_chunks: List[str] = []
     chunk_times: List[float] = []
     output_token_times: List[float] = []
+    ttft_sec: Optional[float] = None
+    tpot_sec: Optional[float] = None
+
 
 
 class InferenceInfo(BaseModel):
@@ -69,11 +72,18 @@ class RequestLifecycleMetric(BaseModel):
     end_time: float
     request_data: str
     response_data: Optional[str] = None
+    request_size_bytes: int = 0
     info: InferenceInfo
     error: Optional[ErrorResponseInfo]
 
     ttft_slo_sec: Optional[float] = None
     tpot_slo_sec: Optional[float] = None
+
+    @property
+    def computed_request_size_bytes(self) -> int:
+        if self.request_size_bytes > 0:
+            return self.request_size_bytes
+        return len(self.request_data.encode("utf-8")) if self.request_data else 0
 
 
 class SessionLifecycleMetric(BaseModel):

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -40,7 +40,6 @@ class StreamedResponseMetrics(ResponseMetrics):
     tpot_sec: Optional[float] = None
 
 
-
 class InferenceInfo(BaseModel):
     request_metrics: RequestMetrics
     response_metrics: Optional[SerializeAsAny[ResponseMetrics]] = None

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -546,7 +546,7 @@ class ChatCompletionAPIData(InferenceAPIData):
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response,
                 extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content"),
-                metrics_only=config.metrics_only,
+                metrics_only=bool(config.metrics_only),
             )
             prompt_len = self._count_prompt_tokens(tokenizer)
             # Generated text is a continuation, not a sequence start: counting it

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -544,7 +544,9 @@ class ChatCompletionAPIData(InferenceAPIData):
     ) -> InferenceInfo:
         if config.streaming:
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
+                response,
+                extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content"),
+                metrics_only=config.metrics_only,
             )
             prompt_len = self._count_prompt_tokens(tokenizer)
             # Generated text is a continuation, not a sequence start: counting it

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -56,7 +56,7 @@ class CompletionAPIData(InferenceAPIData):
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response,
                 extract_content=lambda data: data.get("choices", [{}])[0].get("text"),
-                metrics_only=config.metrics_only,
+                metrics_only=bool(config.metrics_only),
             )
 
             prompt_len = tokenizer.count_tokens(self.prompt)

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -54,7 +54,9 @@ class CompletionAPIData(InferenceAPIData):
         if config.streaming:
             # Use shared streaming parser with completion-specific content extraction
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=lambda data: data.get("choices", [{}])[0].get("text")
+                response,
+                extract_content=lambda data: data.get("choices", [{}])[0].get("text"),
+                metrics_only=config.metrics_only,
             )
 
             prompt_len = tokenizer.count_tokens(self.prompt)

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -43,7 +43,9 @@ class StreamInterruptedError(Exception):
 
 
 async def parse_sse_stream(
-    response: ClientResponse, extract_content: Callable[[dict[str, Any]], Optional[str]]
+    response: ClientResponse,
+    extract_content: Callable[[dict[str, Any]], Optional[str]],
+    metrics_only: bool = False,
 ) -> Tuple[str, List[float], str, List[str], Optional[dict[str, Any]]]:
     """
     Parse Server-Sent Events (SSE) stream and extract content.
@@ -58,22 +60,27 @@ async def parse_sse_stream(
         extract_content: Function to extract text content from parsed JSON data.
                         Should return the text content or None if not found.
                         Example: lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
+        metrics_only: If True, drops raw content and response chunks to conserve memory
+                      and trims chunk_times to at most [first_chunk_time, last_chunk_time].
 
     Returns:
         Tuple of (output_text, chunk_times, raw_content, response_chunks, server_usage):
         - output_text: The concatenated text content from all chunks
         - chunk_times: Timestamps for content-bearing chunks only. Role-only
           deltas, usage-only chunks, [DONE] signals, and unparseable messages
-          are excluded so they don't corrupt downstream TPOT/TTFT/ITL.
-        - raw_content: The raw string content of the stream
+          are excluded so they don't corrupt downstream TPOT/TTFT/ITL. If
+          metrics_only=True, then only include timestamps for first and last chunk.
+        - raw_content: The raw string content of the stream (empty if metrics_only=True)
         - response_chunks: Raw JSON strings of content-bearing chunks, 1:1 with
-          chunk_times.
+          chunk_times (empty if metrics_only=True).
         - server_usage: Merged `usage` fields from chunks that carried one
           (e.g. OpenAI trailing `{"choices":[],"usage":{...}}` or Anthropic
           `message.usage`/`message_delta.usage`). None if the server didn't
           emit usage.
     """
     output_text = ""
+    first_time: Optional[float] = None
+    last_time: Optional[float] = None
     chunk_times: List[float] = []
     buffer = b""
     raw_content = b""
@@ -82,7 +89,8 @@ async def parse_sse_stream(
 
     try:
         async for chunk in response.content.iter_any():
-            raw_content += chunk
+            if not metrics_only:
+                raw_content += chunk
             buffer += chunk
             while b"\n\n" in buffer:
                 message, buffer = buffer.split(b"\n\n", 1)
@@ -105,8 +113,12 @@ async def parse_sse_stream(
                                 server_usage = {**(server_usage or {}), **usage}
                             if content := extract_content(data):
                                 output_text += content
-                                chunk_times.append(message_time)
-                                response_chunks.append(data_str.decode("utf-8", errors="ignore"))
+                                if first_time is None:
+                                    first_time = message_time
+                                last_time = message_time
+                                if not metrics_only:
+                                    chunk_times.append(message_time)
+                                    response_chunks.append(data_str.decode("utf-8", errors="ignore"))
                         except (json.JSONDecodeError, IndexError):
                             continue
                 if done:
@@ -118,4 +130,12 @@ async def parse_sse_stream(
         # what the server actually sent instead of an empty response body.
         raise StreamInterruptedError(e, raw_content.decode("utf-8", errors="ignore")) from e
 
-    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage
+    if metrics_only:
+        chunk_times = (
+            [first_time, last_time]
+            if (first_time is not None and last_time is not None and first_time != last_time)
+            else ([first_time] if first_time is not None else [])
+        )
+
+    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore") if not metrics_only else "", response_chunks, server_usage
+

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -137,5 +137,10 @@ async def parse_sse_stream(
             else ([first_time] if first_time is not None else [])
         )
 
-    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore") if not metrics_only else "", response_chunks, server_usage
-
+    return (
+        output_text,
+        chunk_times,
+        raw_content.decode("utf-8", errors="ignore") if not metrics_only else "",
+        response_chunks,
+        server_usage,
+    )

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -514,11 +514,14 @@ class openAIModelServerClientSession(ModelServerClientSession):
         if data.labels:
             info.labels = data.labels
 
+        metrics_only = getattr(self.client.api_config, "metrics_only", False)
+        request_bytes = len(request_data.encode("utf-8")) if request_data else 0
         metric = RequestLifecycleMetric(
             stage_id=stage_id,
             session_id=data.session_id if isinstance(data.session_id, str) else None,
-            request_data=request_data,
-            response_data=response_content,
+            request_data="" if metrics_only else request_data,
+            response_data="" if metrics_only else response_content,
+            request_size_bytes=request_bytes,
             info=info,
             error=error,
             start_time=start,

--- a/inference_perf/config/apis/config.py
+++ b/inference_perf/config/apis/config.py
@@ -82,3 +82,6 @@ class APIConfig(StrictBaseModel):
     session_id_header_key: Optional[str] = Field(
         default=None, description="Header used to send the session ID with each request in multi-turn benchmarks."
     )
+    metrics_only: Optional[bool] = Field(
+        default=False, description="Drops raw request/response text and SSE chunk buffers to produce lightweight report."
+    )

--- a/inference_perf/config/config.py
+++ b/inference_perf/config/config.py
@@ -71,7 +71,7 @@ class Config(StrictBaseModel):
                 )
         if self.report and self.report.request_lifecycle:
             # metrics_only is only allowed with per_request, otherwise it's a no-op
-            self.api.metrics_only = (
+            self.api.metrics_only = bool(
                 self.report.request_lifecycle.metrics_only and self.report.request_lifecycle.per_request
             )
         return self

--- a/inference_perf/config/config.py
+++ b/inference_perf/config/config.py
@@ -69,6 +69,11 @@ class Config(StrictBaseModel):
                     f"but got '{self.load.type.value}'. Trace replay with dependencies requires "
                     f"session-based load dispatch to properly handle event dependencies and timing."
                 )
+        if self.report and self.report.request_lifecycle:
+            # metrics_only is only allowed with per_request, otherwise it's a no-op
+            self.api.metrics_only = (
+                self.report.request_lifecycle.metrics_only and self.report.request_lifecycle.per_request
+            )
         return self
 
 

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -37,7 +37,9 @@ class RequestLifecycleMetricsReportConfig(StrictBaseModel):
         description="Cap on the number of distinct example error messages retained per error label in the failure "
         "report, and per substitution entry.",
     )
-
+    metrics_only: Optional[bool] = Field(
+        default=False, description="Drops raw request/response text and SSE chunk buffers to produce lightweight report."
+    )
 
 class PrometheusMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = Field(default=True, description="Generate a summary report across the whole run.")

--- a/inference_perf/config/reportgen/config.py
+++ b/inference_perf/config/reportgen/config.py
@@ -41,6 +41,7 @@ class RequestLifecycleMetricsReportConfig(StrictBaseModel):
         default=False, description="Drops raw request/response text and SSE chunk buffers to produce lightweight report."
     )
 
+
 class PrometheusMetricsReportConfig(StrictBaseModel):
     summary: Optional[bool] = Field(default=True, description="Generate a summary report across the whole run.")
     per_stage: Optional[bool] = Field(default=False, description="Generate a report for each load stage.")

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -138,7 +138,7 @@ def main_cli() -> None:
 
     config = read_config(args.config_file, cli_overrides)
     # metrics_only is only allowed with per_request, otherwise it's a no-op
-    config.api.metrics_only = (
+    config.api.metrics_only = bool(
         config.report.request_lifecycle.metrics_only and config.report.request_lifecycle.per_request
     )
 

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -142,7 +142,6 @@ def main_cli() -> None:
         config.report.request_lifecycle.metrics_only and config.report.request_lifecycle.per_request
     )
 
-
     # Set stage rates to high values if using concurrent load type
     if config.load.type == LoadType.CONCURRENT:
         # The validation is now handled by Pydantic in the config classes

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -137,6 +137,11 @@ def main_cli() -> None:
     cli_overrides = unflatten_dict(cli_overrides_flat)
 
     config = read_config(args.config_file, cli_overrides)
+    # metrics_only is only allowed with per_request, otherwise it's a no-op
+    config.api.metrics_only = (
+        config.report.request_lifecycle.metrics_only and config.report.request_lifecycle.per_request
+    )
+
 
     # Set stage rates to high values if using concurrent load type
     if config.load.type == LoadType.CONCURRENT:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -663,7 +663,6 @@ def summarize_requests(
                 else:
                     ttft = None
                     tpot = None
-
                 response_metrics.ttft_sec = ttft
                 response_metrics.tpot_sec = tpot
             ttft_values.append(ttft)

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -642,30 +642,43 @@ def summarize_requests(
         else:
             ntpot_values.append(0.0)
 
-        # Check if streamable: Must have more than 1 output token timestamp
+        # Check if streamable: Must have output token timestamps or trimmed chunk_times
         response_metrics = m.info.response_metrics
-        if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
-            # TTFT: First Token Time - Start Time
-            ttft = response_metrics.output_token_times[0] - m.start_time
-            ttft_values.append(ttft)
-
-            # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
-            duration = response_metrics.output_token_times[-1] - response_metrics.output_token_times[0]
-            tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
-            if tpot_output_tokens > 1:
-                tpot = duration / (tpot_output_tokens - 1)
+        if isinstance(response_metrics, StreamedResponseMetrics):
+            if response_metrics.ttft_sec is not None:
+                ttft = response_metrics.ttft_sec
+                tpot = response_metrics.tpot_sec
             else:
-                tpot = None
+                token_times = response_metrics.output_token_times or response_metrics.chunk_times
+                if token_times:
+                    # TTFT: First Token Time - Start Time
+                    ttft = token_times[0] - m.start_time
+                    # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
+                    duration = token_times[-1] - token_times[0]
+                    tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
+                    if tpot_output_tokens > 1 and len(token_times) > 1:
+                        tpot = duration / (tpot_output_tokens - 1)
+                    else:
+                        tpot = None
+                else:
+                    ttft = None
+                    tpot = None
+
+                response_metrics.ttft_sec = ttft
+                response_metrics.tpot_sec = tpot
+            ttft_values.append(ttft)
             tpot_values.append(tpot)
 
             # Add inter-token deltas
             request_itl = []
-            for t1, t2 in zip(response_metrics.output_token_times, response_metrics.output_token_times[1:], strict=False):
-                inter_token_latencies.append(t2 - t1)
-                request_itl.append(t2 - t1)
-
-            if request_itl:
+            if len(response_metrics.output_token_times) > 1:
+                for t1, t2 in zip(response_metrics.output_token_times, response_metrics.output_token_times[1:], strict=False):
+                    inter_token_latencies.append(t2 - t1)
+                    request_itl.append(t2 - t1)
                 itl_values.append(sum(request_itl) / len(request_itl))
+            elif tpot is not None:
+                inter_token_latencies.append(tpot)
+                itl_values.append(tpot)
             else:
                 itl_values.append(None)
         else:
@@ -690,7 +703,7 @@ def summarize_requests(
     valid_tpot = [v for v in tpot_values if v is not None]
     valid_ttft = [v for v in ttft_values if v is not None]
 
-    request_sizes = [len(x.request_data.encode("utf-8")) for x in all_successful]
+    request_sizes = [x.computed_request_size_bytes for x in all_successful]
     all_images = []
     all_videos = []
     all_audios = []
@@ -906,19 +919,26 @@ class ReportGenerator:
                 lifecycle_reports.append(report_file)
 
         if report_config.request_lifecycle.per_request:
-            report_file = ReportFile(
-                name="per_request_lifecycle_metrics",
-                contents=[
+            contents = []
+            is_metrics_only = report_config.request_lifecycle.metrics_only
+            for metric in request_metrics:
+                if is_metrics_only and isinstance(metric.info.response_metrics, StreamedResponseMetrics):
+                    metric.info.response_metrics.chunk_times = []
+                    metric.info.response_metrics.output_token_times = []
+                contents.append(
                     {
                         "start_time": metric.start_time,
                         "end_time": metric.end_time,
                         "request": metric.request_data,
                         "response": metric.response_data,
+                        "request_size_bytes": metric.request_size_bytes,
                         "info": metric.info.model_dump() if metric.info else None,
                         "error": metric.error.model_dump() if metric.error else None,
                     }
-                    for metric in request_metrics
-                ],
+                )
+            report_file = ReportFile(
+                name="per_request_lifecycle_metrics",
+                contents=contents,
             )
             lifecycle_reports.append(report_file)
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -760,7 +760,7 @@ def summarize_requests(
             "videos_per_sec": (sum(video_counts) / total_time if total_time > 0 else 0.0),
             "audios_per_sec": (sum(audio_counts) / total_time if total_time > 0 else 0.0),
         },
-        "request_size_bytes": summarize([float(x) for x in request_sizes], percentiles),
+        "request_size_bytes": summarize([safe_float(x) for x in request_sizes], percentiles),
         "prompt_len": summarize(
             [safe_float(success.info.request_metrics.text.input_tokens) for success in all_successful], percentiles
         ),

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -170,4 +170,3 @@ async def test_parse_sse_stream_metrics_only() -> None:
     assert len(chunk_times) == 2
     assert raw_content == ""
     assert response_chunks == []
-

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -136,3 +136,38 @@ async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
     # The bytes received before the break are retained, not discarded.
     assert "Hello" in err.raw_content
     assert "world" in err.raw_content
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_metrics_only() -> None:
+    """Verifies that parse_sse_stream when metrics_only=True drops response_chunks and
+    raw_content, while keeping chunk_times trimmed to [first_chunk_time, last_chunk_time]."""
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    chunks = [
+        b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": " "}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": "world"}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+
+    mock_content.iter_any = mock_iter_any
+
+    def extract_content(data: dict[str, Any]) -> Optional[str]:
+        return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
+
+    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+        mock_response, extract_content, metrics_only=True
+    )
+
+    assert output_text == "Hello world"
+    assert len(chunk_times) == 2
+    assert raw_content == ""
+    assert response_chunks == []
+

--- a/tests/required/reportgen/test_multimodal_metrics.py
+++ b/tests/required/reportgen/test_multimodal_metrics.py
@@ -36,6 +36,7 @@ def test_summarize_requests_multimodal_metrics() -> None:
     metric1.ttft_slo_sec = None
     metric1.tpot_slo_sec = None
     metric1.request_data = "short request"
+    metric1.computed_request_size_bytes = len(metric1.request_data.encode("utf-8"))
     metric1.info = Mock(spec=InferenceInfo)
     metric1.info.request_metrics = RequestMetrics(
         text=Text(input_tokens=10),
@@ -63,6 +64,7 @@ def test_summarize_requests_multimodal_metrics() -> None:
     metric2.ttft_slo_sec = None
     metric2.tpot_slo_sec = None
     metric2.request_data = "a much longer request with more data"
+    metric2.computed_request_size_bytes = len(metric2.request_data.encode("utf-8"))
     metric2.info = Mock(spec=InferenceInfo)
     metric2.info.request_metrics = RequestMetrics(
         text=Text(input_tokens=15),

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -522,3 +522,53 @@ def test_summarize_requests_handles_null_prompt_tokens_details() -> None:
     assert prompt_tokens["total"] == pytest.approx(10.0)
     assert prompt_tokens["cached"] == pytest.approx(0.0)
     assert prompt_tokens["uncached"] == pytest.approx(10.0)
+
+
+def test_summarize_requests_metrics_only_mode() -> None:
+    """Verifies that summarize_requests correctly calculates TTFT, TPOT, and request sizes when metrics_only=True."""
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=10)),
+        response_metrics=StreamedResponseMetrics(
+            response_chunks=[],
+            chunk_times=[1.5, 3.5],
+            output_tokens=11,
+            output_token_times=[],
+        ),
+    )
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=0.0,
+        start_time=1.0,
+        end_time=3.5,
+        request_data="",
+        response_data="",
+        request_size_bytes=256,
+        info=info,
+        error=None,
+    )
+
+    result = summarize_requests([metric], DEFAULT_PERCENTILES)
+    successes = result.successes
+
+    # TTFT = chunk_times[0] (1.5) - start_time (1.0) = 0.5
+    assert successes["latency"]["time_to_first_token"]["mean"] == pytest.approx(0.5)
+    # TPOT = (chunk_times[1] (3.5) - chunk_times[0] (1.5)) / (11 - 1) = 2.0 / 10 = 0.2
+    assert successes["latency"]["time_per_output_token"]["mean"] == pytest.approx(0.2)
+    # Request size bytes uses metric.request_size_bytes (256)
+    assert successes["request_size_bytes"]["mean"] == pytest.approx(256.0)
+
+
+def test_metrics_only_config_gating() -> None:
+    """Verifies that api.metrics_only is True ONLY when both metrics_only and per_request are True."""
+    from inference_perf.config import Config, ReportConfig
+    from inference_perf.config.reportgen import RequestLifecycleMetricsReportConfig
+
+    # Case 1: metrics_only=True, per_request=False -> api.metrics_only=False
+    cfg1 = Config(report=ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(metrics_only=True, per_request=False)))
+    assert cfg1.api.metrics_only is False
+
+    # Case 2: metrics_only=True, per_request=True -> api.metrics_only=True
+    cfg2 = Config(report=ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(metrics_only=True, per_request=True)))
+    assert cfg2.api.metrics_only is True
+
+

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -564,11 +564,13 @@ def test_metrics_only_config_gating() -> None:
     from inference_perf.config.reportgen import RequestLifecycleMetricsReportConfig
 
     # Case 1: metrics_only=True, per_request=False -> api.metrics_only=False
-    cfg1 = Config(report=ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(metrics_only=True, per_request=False)))
+    cfg1 = Config(
+        report=ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(metrics_only=True, per_request=False))
+    )
     assert cfg1.api.metrics_only is False
 
     # Case 2: metrics_only=True, per_request=True -> api.metrics_only=True
-    cfg2 = Config(report=ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(metrics_only=True, per_request=True)))
+    cfg2 = Config(
+        report=ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(metrics_only=True, per_request=True))
+    )
     assert cfg2.api.metrics_only is True
-
-


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it:**

Performance debugging often requires granular per-request metrics (specifically TTFT, TPOT, and latency distributions). Enabling `--report.request_lifecycle.per_request=True` currently dumps all raw request payload strings (`request_data`), response text (`response_data`), SSE chunk strings (`response_chunks`), and full timestamp arrays (`chunk_times`). This generates bloated, unneeded text data in report artifacts (e.g., 38.87 MB for a 300-request run).

This PR ntroduces `--report.request_lifecycle.metrics_only` to allow emitting per-request lifecycle metrics (spcifically TTFT and TPOT) while suppressing raw payload text and intermediate chunk arrays.
1. **Gated Execution**: Active only when `metrics_only == True` AND `per_request == True`.
2. **Payload Suppression**: Skips building `request_data`, `response_data`, and streaming `response_chunks` buffers inside `parse_sse_stream()`.
3. **Timestamp Trimming**: Trims `chunk_times` to `[first_chunk_time, last_chunk_time]` during stream parsing, clearing to `[]` prior to final JSON serialization.
4. **Latency Computation**: Calculates `ttft_sec` and `tpot_sec` directly inside `summarize_requests()` and populates `StreamedResponseMetrics`.
5. **Request Size**: Report the request payload byte count as `request_size_bytes`. Needed so the payload size metrics remain available when `request_data` text string is suppressed.
6. **Schema Compatibility**: Maintains 100% schema backward compatibility for `per_request_lifecycle_metrics.json`.

We ran it on a small benchmark (300-request workload) and the size of `per_request_lifecycle_metrics.json` dropped from **38.87 MB to 274.7 KB** (**141.5x reduction**).

**Which issue(s) this PR fixes:**
Fixes #522 

**Does this PR introduce a user-facing change?**

1. Adds `--report.request_lifecycle.metrics_only` (bool, default `False`).
2. When both `--report.request_lifecycle.per_request=True` and `--report.request_lifecycle.metrics_only=True` are set, `per_request_lifecycle_metrics.json` outputs empty strings (`""`) for request and response text, and empty lists (`[]`) for response_chunks and chunk_times.
3. Adds explicit `ttft_sec`, `tpot_sec`, and `request_size_bytes` numeric fields to each request entry in `per_request_lifecycle_metrics.json`.
4. Default behavior stays unchanged; default is `metrics_only=False`, retaining existing logging behavior.