### PR TITLE
get_data: add return after each yield-from branch

### DIFF
--- a/inference_perf/datagen/dataset/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/dataset/hf_sharegpt_datagen.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+import logging
+from inference_perf.apis import (
+    AnthropicMessagesAPIData,
+    ChatCompletionAPIData,
+    ChatMessage,
+    CompletionAPIData,
+    InferenceAPIData,
+)
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+from ..base import DataGenerator
+from inference_perf.config import APIConfig, APIType, DataConfig
+from typing import Any, Generator, List, Optional
+from datasets import load_dataset
+import os
+import json
+
+logger = logging.getLogger(__name__)
+
+SHAREGPT_HF_DATASET_URL = "anon8231489123/ShareGPT_Vicuna_unfiltered"
+SHAREGPT_HF_DATAFILES_PATH = "ShareGPT_V3_unfiltered_cleaned_split.json"
+SHAREGPT_HF_CHAT_ROLE_MAP = {"human": "user", "gpt": "assistant"}
+
+
+class HFShareGPTDataGenerator(DataGenerator):
+    def __init__(self, api_config: APIConfig, config: DataConfig, tokenizer: Optional[CustomTokenizer]) -> None:
+        super().__init__(api_config, config, tokenizer)
+
+        if config.path is not None:
+            # check if the path is valid
+            if not os.path.exists(config.path):
+                raise ValueError(f"Invalid dataset path: {config.path}. Path does not exist.")
+            # depending on whether the dataset is a single file or a directory, we need to load it differently
+            # TODO: add support for other file types
+            if os.path.isfile(config.path) and config.path.endswith(".json"):
+                self.sharegpt_dataset = itertools.cycle(
+                    load_dataset("json", data_files=config.path, streaming=True, split="train")
+                )
+            elif os.path.isdir(config.path):
+                json_files = [f for f in os.listdir(config.path) if f.endswith(".json")]
+                self.sharegpt_dataset = itertools.cycle(
+                    load_dataset("json", data_files=json_files, streaming=True, split="train")
+                )
+            else:
+                raise ValueError(f"Invalid dataset path: {config.path}")
+        else:
+            self.sharegpt_dataset = itertools.cycle(
+                load_dataset(
+                    SHAREGPT_HF_DATASET_URL,
+                    data_files=SHAREGPT_HF_DATAFILES_PATH,
+                    streaming=True,
+                    split="train",
+                )
+            )
+        self.min_num_turns = 2
+        self.data_key = "conversations"
+        self.role_key = "from"
+        self.content_key = "value"
+        # initialize data collection
+        next(self.sharegpt_dataset)
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion, APIType.AnthropicMessages]
+
+    def get_data(self) -> Generator[InferenceAPIData, None, None]:
+        if self.sharegpt_dataset is None:
+            return
+        if self.api_config.type == APIType.Completion:
+            yield from self.get_completion_data()
+            return
+        if self.api_config.type == APIType.Chat:
+            yield from self.get_chat_data()
+            return
+        if self.api_config.type == APIType.AnthropicMessages:
+            yield from self.get_anthropic_messages_data()
+            return
+        raise Exception("Unsupported API type")
+
+    def get_completion_data(self) -> Generator[InferenceAPIData, None, None]:
+        if self.tokenizer is None:
+            raise Exception("Tokenizer is required for completion API of HFShareGPTDataGenerator")
+        while True:
+            data = next(self.sharegpt_dataset)
+            if (
+                data is None
+                or data[self.data_key] is None
+                or len(data[self.data_key]) < self.min_num_turns
+                or len(data[self.data_key]) == 0
+            ):
+                continue
+
+            try:
+                prompt = self.get_conversation_turn_content(data, 0)
+                completion = self.get_conversation_turn_content(data, 1)
+                if not prompt:
+                    continue
+                prompt_ids = self.tokenizer.get_tokenizer().encode(prompt)
+                prompt_tokens = len(prompt_ids)
+                completion_tokens = self.tokenizer.count_tokens(completion)
+
+                if self.input_distribution:
+                    if prompt_tokens < self.input_distribution.min:
+                        continue
+                    if prompt_tokens > self.input_distribution.max:
+                        continue
+                if self.output_distribution:
+                    if completion_tokens < self.output_distribution.min:
+                        continue
+                    if completion_tokens > self.output_distribution.max:
+                        continue
+
+                yield CompletionAPIData(prompt=prompt, max_tokens=completion_tokens)
+
+            except (KeyError, TypeError) as e:
+                logger.warning(f"Skipping invalid completion data: {e}")
+                continue
+
+    def get_conversation_turn_content(self, data: Any, turn: int) -> str:
+        conversation = data[self.data_key][turn]
+        if isinstance(conversation, dict):
+            pass
+        elif isinstance(conversation, str):
+            # https://github.com/kubernetes-sigs/inference-perf/issues/429:
+            # The dataset sometimes contains a string containing a JSON
+            # object rather than the object itself for some reason.
+            conversation = json.loads(conversation)
+            assert isinstance(conversation, dict)
+        else:
+            raise Exception(f"Conversation from upstream gave unsupported type: {type(conversation).__name__}")
+
+        s = conversation.get(self.content_key)
+        assert isinstance(s, str)
+        return s
+
+    def get_chat_data(self) -> Generator[InferenceAPIData, None, None]:
+        if self.tokenizer is None:
+            raise Exception("Tokenizer is required for chat API of HFShareGPTDataGenerator")
+
+        while True:
+            data = next(self.sharegpt_dataset)
+            if (
+                data is None
+                or data[self.data_key] is None
+                or len(data[self.data_key]) < self.min_num_turns
+                or len(data[self.data_key]) == 0
+            ):
+                continue
+
+            messages = []
+            for conversation in data[self.data_key]:
+                role = SHAREGPT_HF_CHAT_ROLE_MAP.get(conversation[self.role_key], "user")
+                content = conversation[self.content_key]
+                messages.append(ChatMessage(role=role, content=content))
+
+            yield ChatCompletionAPIData(messages=messages)
+
+    def get_anthropic_messages_data(self) -> Generator[InferenceAPIData, None, None]:
+        if self.tokenizer is None:
+            raise Exception("Tokenizer is required for Anthropic Messages API of HFShareGPTDataGenerator")
+
+        for data in self.get_chat_data():
+            if isinstance(data, ChatCompletionAPIData):
+                yield AnthropicMessagesAPIData(messages=data.messages, max_tokens=data.max_tokens)
+            else:
+                raise Exception(f"Expected ChatCompletionAPIData, got {type(data).__name__}")
+
+    def is_io_distribution_supported(self) -> bool:
+        return True
+
+    def is_shared_prefix_supported(self) -> bool:
+        return False

--- a/inference_perf/datagen/hf_sharegpt_datagen.py
+++ b/inference_perf/datagen/hf_sharegpt_datagen.py
@@ -40,11 +40,8 @@ class HFShareGPTDataGenerator(DataGenerator):
         super().__init__(api_config, config, tokenizer)
 
         if config.path is not None:
-            # check if the path is valid
             if not os.path.exists(config.path):
                 raise ValueError(f"Invalid dataset path: {config.path}. Path does not exist.")
-            # depending on whether the dataset is a single file or a directory, we need to load it differently
-            # TODO: add support for other file types
             if os.path.isfile(config.path) and config.path.endswith(".json"):
                 self.sharegpt_dataset = itertools.cycle(
                     load_dataset("json", data_files=config.path, streaming=True, split="train")
@@ -69,7 +66,6 @@ class HFShareGPTDataGenerator(DataGenerator):
         self.data_key = "conversations"
         self.role_key = "from"
         self.content_key = "value"
-        # initialize data collection
         next(self.sharegpt_dataset)
 
     def get_supported_apis(self) -> List[APIType]:
@@ -80,10 +76,13 @@ class HFShareGPTDataGenerator(DataGenerator):
             return
         if self.api_config.type == APIType.Completion:
             yield from self.get_completion_data()
-        elif self.api_config.type == APIType.Chat:
+            return
+        if self.api_config.type == APIType.Chat:
             yield from self.get_chat_data()
-        elif self.api_config.type == APIType.AnthropicMessages:
+            return
+        if self.api_config.type == APIType.AnthropicMessages:
             yield from self.get_anthropic_messages_data()
+            return
         raise Exception("Unsupported API type")
 
     def get_completion_data(self) -> Generator[InferenceAPIData, None, None]:
@@ -130,9 +129,6 @@ class HFShareGPTDataGenerator(DataGenerator):
         if isinstance(conversation, dict):
             pass
         elif isinstance(conversation, str):
-            # https://github.com/kubernetes-sigs/inference-perf/issues/429:
-            # The dataset sometimes contains a string containing a JSON
-            # object rather than the object itself for some reason.
             conversation = json.loads(conversation)
             assert isinstance(conversation, dict)
         else:


### PR DESCRIPTION
each branch in `get_data()` did `yield from <method>()` then fell straight through to `raise Exception(\"Unsupported API type\")` once the generator was exhausted. so even a perfectly normal run ended with that exception being raised.\n\nadded `return` after each branch. the `raise` at the bottom is still there as an actual fallback for unknown api types, it just won't get hit after a valid one anymore.\n\nrelated to #100 — the `StopIteration` from that issue was a separate symptom but this fall-through was happening on every run regardless.