### PR TITLE
Add Bslabe123 to inference-perf-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,6 +8,7 @@ aliases:
   - SachinVarghese
   - jjk-g
   - lenadankin
+  - Bslabe123
 
   inference-perf-approvers:
   - alonh


### PR DESCRIPTION
This adds me to the `inference-perf-maintainers` alias, which grants approver rights per the root `OWNERS` file. I'm currently in `inference-perf-reviewers`.

Per the [OWNERS guide](https://git.k8s.io/community/contributors/guide/owners.md), approver promotion is based on sustained contributions and demonstrated review judgment:

- Top contributor to the repo by merged PRs and commits (65 PRs, 177 commits, ~19.9k lines as of Jul 2026), spanning load generation, data generation, metrics/observability, and the e2e test tiers
- 50 reviews to date as a reviewer, including first-pass reviews on external contributions (e.g. IBM's error-reporting work in #601)
- Recent structural ownership: the testing restructure into per-change/at-merge/nightly lanes (#606), the live e2e tier (#529), and the Prometheus observability surface (#501)

Motivation beyond the individual case: the project currently has a review/approval bottleneck (multiple ready PRs waiting weeks for a first pass, and Tide auto-merge is separately broken per #598, so every merge is manual). Widening the approver pool reduces single-point load ahead of the v0.7.0 release.

Requesting sponsorship from current maintainers: @achandrasekar @jjk-g @lenadankin @SachinVarghese
