### PR TITLE
fix: restore mypy --strict clean after the transformers 5.13 bump

### DIFF
--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -18,7 +18,7 @@ from inference_perf.config import CustomTokenizerConfig
 
 class CustomTokenizer:
     def __init__(self, config: CustomTokenizerConfig) -> None:
-        self.tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
+        self.tokenizer: PreTrainedTokenizerBase = AutoTokenizer.from_pretrained(
             config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
         )
 

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 from inference_perf.reportgen.base import summarize_requests, ReportGenerator
 from inference_perf.apis.base import (
@@ -137,7 +139,9 @@ def test_itl_not_inflated_by_per_chunk_bos() -> None:
     # Build a one-token-per-chunk stream by decoding each real token id back to text.
     text = "The quick brown fox jumps over the lazy dog"
     ids = hf.encode(text, add_special_tokens=False)
-    chunk_texts = [hf.decode([i]) for i in ids]
+    # transformers>=5.13 types decode() as str | list[str] because it also accepts batched
+    # ids; a flat list[int] is the single-sequence form and always decodes to one str.
+    chunk_texts = [cast(str, hf.decode([i])) for i in ids]
     n = len(ids)
 
     # Sanity: with the BOS the per-chunk sum is inflated by exactly one token per


### PR DESCRIPTION
## What

`mypy --strict` fails on `main` with 5 errors, so the Python Linting and Type
Checks job is red on every open PR. This restores it.

## Why

#597 bumped `transformers` to 5.13.0, which tightened two annotations:

- `AutoTokenizer.from_pretrained` is now typed, so the existing
  `# type: ignore[no-untyped-call]` is unused and `warn_unused_ignores` fires.
- `PreTrainedTokenizerBase.decode` is now `str | list[str]` because it also
  accepts batched ids, so `hf.decode([i])` no longer narrows to `str`. That
  breaks the `count_tokens` call in the ITL regression test and cascades into
  two spurious `sum()` overload errors.

`main` has been red since b997897. It is not caused by any individual PR.

## How

Drop the stale ignore and cast the single-sequence decode back to `str`.
No runtime behavior changes: the flat `list[int]` form has always returned
one `str`.

## Verification

`pdm run validate` is green (ruff format, ruff check, `mypy --strict` across
226 files, `docs/cli_flags.md` in sync), and
`tests/required/reportgen/test_summarize_requests.py` passes 18/18.
