### PR TITLE
test: in-process unit tests for the load generator execution core

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,32 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repo-wide pytest setup (rootdir conftest, loaded for every test tier)."""
+
+import multiprocessing as mp
+import sys
+
+import pytest
+
+
+# Match the multiprocessing start method used in production (main.py): on
+# macOS force "fork" so tokenizer and datagen objects are inherited by worker
+# processes instead of pickled. Linux already defaults to fork, so this is a
+# no-op there. Set once here, before any test module is imported, instead of
+# at import time in individual test modules.
+def pytest_configure(config: pytest.Config) -> None:
+    if sys.platform == "darwin":
+        try:
+            mp.set_start_method("fork", force=True)
+        except RuntimeError:
+            pass

--- a/tests/required/loadgen/test_load_timer.py
+++ b/tests/required/loadgen/test_load_timer.py
@@ -1,0 +1,78 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Contract tests for the load timers.
+
+These pin the dispatch-schedule contract run_stage relies on (request count,
+monotonicity, span), not the timers' internal interval distributions.
+"""
+
+import itertools
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from inference_perf.loadgen.load_timer import ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
+
+
+class TestConstantLoadTimer(unittest.TestCase):
+    def test_emits_exactly_rate_times_duration_requests(self) -> None:
+        timer = ConstantLoadTimer(rate=10, duration=5)
+        times = list(timer.start_timer(initial=100.0))
+        self.assertEqual(len(times), 50)
+
+    def test_truncates_fractional_request_count(self) -> None:
+        timer = ConstantLoadTimer(rate=2.5, duration=1)
+        self.assertEqual(len(list(timer.start_timer(initial=0.0))), 2)
+
+    def test_zero_requests_yields_nothing(self) -> None:
+        timer = ConstantLoadTimer(rate=0.5, duration=1)
+        self.assertEqual(list(timer.start_timer(initial=0.0)), [])
+
+    def test_times_are_strictly_increasing_after_initial(self) -> None:
+        initial = 1000.0
+        timer = ConstantLoadTimer(rate=100, duration=2)
+        times = list(timer.start_timer(initial=initial))
+        self.assertTrue(all(t > initial for t in times))
+        self.assertTrue(all(b > a for a, b in zip(times, times[1:], strict=False)))
+
+    def test_schedule_spans_exactly_the_duration(self) -> None:
+        # Intervals are normalized so the last dispatch lands at initial + duration.
+        initial, duration = 50.0, 3.0
+        timer = ConstantLoadTimer(rate=20, duration=duration)
+        times = list(timer.start_timer(initial=initial))
+        self.assertAlmostEqual(times[-1], initial + duration, places=6)
+
+
+class TestPoissonLoadTimer(unittest.TestCase):
+    def test_generator_is_unbounded_and_monotonic(self) -> None:
+        initial = 10.0
+        timer = PoissonLoadTimer(rate=10, duration=1)
+        times = list(itertools.islice(timer.start_timer(initial=initial), 50))
+        self.assertEqual(len(times), 50)
+        self.assertTrue(all(t > initial for t in times))
+        self.assertTrue(all(b > a for a, b in zip(times, times[1:], strict=False)))
+
+
+class TestTraceReplayLoadTimer(unittest.TestCase):
+    def test_offsets_trace_timestamps_from_initial(self) -> None:
+        trace_reader = MagicMock()
+        trace_reader.load_traces.return_value = iter([(0.0, 1, 2), (1.5, 3, 4), (4.0, 5, 6)])
+        timer = TraceReplayLoadTimer(trace_reader=trace_reader, trace_file=Path("dummy.csv"))
+        times = list(timer.start_timer(initial=100.0))
+        self.assertEqual(times, [100.0, 101.5, 104.0])
+        trace_reader.load_traces.assert_called_once_with(Path("dummy.csv"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/test_mp_run_stages.py
+++ b/tests/required/loadgen/test_mp_run_stages.py
@@ -1,0 +1,124 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-stage mp_run integration test with real worker processes.
+
+Locks the stage-boundary protocol invariant: every stage end pairs one
+main-side stage_barrier.wait() with one arrival from each worker, so a
+multi-stage run completes without deadlock and every stage's requests are
+accounted. Any stage-driving code path that runs a stage outside the
+mp_run stage loop (as the sweep pre-pass does) breaks this pairing and
+hangs the run — asyncio.wait_for turns that hang into a test failure.
+"""
+
+import asyncio
+import multiprocessing as mp
+import sys
+import unittest
+from typing import Any
+
+from inference_perf.client.modelserver.mock_client import MockModelServerClient
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    DataConfig,
+    DataGenType,
+    Distribution,
+    LoadConfig,
+    LoadType,
+    StandardLoadStage,
+)
+from inference_perf.datagen.synthetic.random_datagen import RandomDataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+# Match the start method used in production (main.py) so the tokenizer and
+# datagen objects are inherited rather than pickled into worker processes.
+if sys.platform == "darwin":
+    try:
+        mp.set_start_method("fork", force=True)
+    except RuntimeError:
+        pass
+
+
+class _DummyHFTokenizer:
+    """Minimal HuggingFace-shaped tokenizer backed by space-delimited integers."""
+
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def decode(self, tokens: list[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+    def encode(self, text: str) -> list[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return list(range(10, 10010))
+
+
+class _DummyCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return _DummyHFTokenizer()
+
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
+        # Each space-separated integer is one token.
+        return len(text.split()) if text else 0
+
+
+class TestMpRunMultiStage(unittest.IsolatedAsyncioTestCase):
+    async def test_two_stages_complete_with_paired_barriers(self) -> None:
+        requests_per_stage = 3
+        num_stages = 2
+
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        data_config = DataConfig(
+            type=DataGenType.Random,
+            input_distribution=Distribution(min=10, max=10, mean=10.0, std_dev=0.0, total_count=requests_per_stage),
+            output_distribution=Distribution(min=5, max=5, mean=5.0, std_dev=0.0, total_count=requests_per_stage),
+        )
+        datagen = RandomDataGenerator(api_config, data_config, _DummyCustomTokenizer())
+
+        collector = MultiprocessRequestMetricCollector()
+        client = MockModelServerClient(collector, api_config, mock_latency=0)
+
+        load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            num_workers=1,
+            worker_max_concurrency=10,
+            interval=0,
+            stages=[StandardLoadStage(rate=requests_per_stage, duration=1) for _ in range(num_stages)],
+            base_seed=42,
+        )
+        load_gen = LoadGenerator(datagen, load_config)
+
+        async with collector.start():
+            # A broken barrier pairing deadlocks instead of failing, so bound
+            # the whole run.
+            await asyncio.wait_for(load_gen.mp_run(client), timeout=120)
+        await load_gen.stop()
+
+        metrics = collector.get_metrics()
+        self.assertEqual(len(metrics), requests_per_stage * num_stages, "every stage's requests must be accounted")
+        for stage_id in range(num_stages):
+            stage_metrics = [m for m in metrics if m.stage_id == stage_id]
+            self.assertEqual(len(stage_metrics), requests_per_stage, f"stage {stage_id} must process its own requests")
+            self.assertEqual(load_gen.stage_runtime_info[stage_id].status.name, "COMPLETED")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/test_mp_run_stages.py
+++ b/tests/required/loadgen/test_mp_run_stages.py
@@ -22,8 +22,6 @@ hangs the run — asyncio.wait_for turns that hang into a test failure.
 """
 
 import asyncio
-import multiprocessing as mp
-import sys
 import unittest
 from typing import Any
 
@@ -42,14 +40,6 @@ from inference_perf.datagen.synthetic.random_datagen import RandomDataGenerator
 from inference_perf.loadgen.load_generator import LoadGenerator
 from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-
-# Match the start method used in production (main.py) so the tokenizer and
-# datagen objects are inherited rather than pickled into worker processes.
-if sys.platform == "darwin":
-    try:
-        mp.set_start_method("fork", force=True)
-    except RuntimeError:
-        pass
 
 
 class _DummyHFTokenizer:

--- a/tests/required/loadgen/test_run_session_stage.py
+++ b/tests/required/loadgen/test_run_session_stage.py
@@ -1,0 +1,249 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for run_session_stage: session pool management, the cross-stage
+session cursor, rate limiting, timeout, and dispatch stamping — driven by a
+scripted SessionGenerator, no worker processes."""
+
+import multiprocessing as mp
+import unittest
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from inference_perf.apis import LazyLoadInferenceAPIData
+from inference_perf.config import APIType, LoadConfig, LoadType, TraceSessionReplayLoadStage
+from inference_perf.datagen.base import SessionGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.metrics import SessionMetricsCollector
+from inference_perf.utils.request_queue import RequestQueue
+
+
+class FakeSessionGenerator(SessionGenerator):
+    """Scripted in-memory session corpus.
+
+    A session reports completed on its ``completes_after_checks``-th
+    check_session_completed poll after activation, which lets tests drive the
+    pool through deterministic refill cycles without running workers.
+    """
+
+    def __init__(
+        self,
+        num_sessions: int,
+        events_per_session: int = 2,
+        completes_after_checks: int = 1,
+        preferred_worker_ids: Optional[List[int]] = None,
+        unbuildable_indices: Optional[List[int]] = None,
+    ) -> None:
+        # Deliberately no super().__init__: the base requires api/data configs
+        # that session-pool management never touches.
+        self._session_ids = [f"s{i}" for i in range(num_sessions)]
+        self.events_per_session = events_per_session
+        self.completes_after_checks = completes_after_checks
+        self.preferred_worker_ids = preferred_worker_ids
+        self.unbuildable = set(unbuildable_indices or [])
+        self.activated: List[str] = []
+        self.cleaned: List[str] = []
+        self.events: Dict[str, List[LazyLoadInferenceAPIData]] = {}
+        self._check_counts: Dict[str, int] = {}
+        self._live: set[str] = set()
+        self.max_live = 0
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Completion]
+
+    def get_session_count(self) -> int:
+        return len(self._session_ids)
+
+    def get_session_info(self, session_index: int) -> Dict[str, Any]:
+        return {"session_id": self._session_ids[session_index]}
+
+    def get_session_event_indices(self, session_index: int) -> List[int]:
+        return list(range(self.events_per_session))
+
+    def is_session_buildable(self, session_index: int) -> bool:
+        return session_index not in self.unbuildable
+
+    def get_session_events(self, session_index: int) -> List[LazyLoadInferenceAPIData]:
+        session_id = self._session_ids[session_index]
+        events = []
+        for event_index in range(self.events_per_session):
+            preferred = self.preferred_worker_ids[event_index] if self.preferred_worker_ids else -1
+            events.append(
+                LazyLoadInferenceAPIData(data_index=session_index * 100 + event_index, preferred_worker_id=preferred)
+            )
+        self.events[session_id] = events
+        return events
+
+    def activate_session(self, session_id: str) -> None:
+        self.activated.append(session_id)
+        self._live.add(session_id)
+        self.max_live = max(self.max_live, len(self._live))
+
+    def check_session_completed(self, session_id: str) -> bool:
+        if session_id not in self._live:
+            return False
+        self._check_counts[session_id] = self._check_counts.get(session_id, 0) + 1
+        if self._check_counts[session_id] >= self.completes_after_checks:
+            self._live.discard(session_id)
+            return True
+        return False
+
+    def build_session_metric(self, session_id: str, stage_id: int, start_time: float, end_time: float) -> Any:
+        return {"session_id": session_id, "stage_id": stage_id}
+
+    def cleanup_session(self, session_id: str) -> None:
+        self.cleaned.append(session_id)
+
+    def get_session_state(self, session_id: str) -> Any:
+        return None
+
+
+def _make_load_generator(
+    datagen: FakeSessionGenerator, stages: List[TraceSessionReplayLoadStage], num_workers: int = 2
+) -> LoadGenerator:
+    load_config = LoadConfig(
+        type=LoadType.TRACE_SESSION_REPLAY,
+        num_workers=num_workers,
+        stages=stages,
+        base_seed=42,
+    )
+    with patch("inference_perf.loadgen.load_generator.get_circuit_breaker"):
+        return LoadGenerator(datagen, load_config)
+
+
+class TestRunSessionStage(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.collector = MagicMock(spec=SessionMetricsCollector)
+        self.active_counter = mp.Value("i", 0)
+        self.finished_counter = mp.Value("i", 0)
+        self.request_phase = mp.Event()
+        self.cancel_signal = mp.Event()
+
+    async def _run(
+        self,
+        load_generator: LoadGenerator,
+        stage: TraceSessionReplayLoadStage,
+        stage_id: int = 0,
+        request_queue: Optional[Any] = None,
+    ) -> None:
+        if request_queue is None:
+            # No worker consumes the queue in these tests, so a real
+            # JoinableQueue would hang in the teardown join(): items put()
+            # reach the pipe through a feeder thread, and with sleep patched
+            # the drain can run before the feeder flushes them.
+            request_queue = MagicMock(spec=RequestQueue)
+        with patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock):
+            await load_generator.run_session_stage(
+                stage_id,
+                stage,
+                request_queue,
+                self.active_counter,
+                self.finished_counter,
+                self.request_phase,
+                self.cancel_signal,
+            )
+
+    async def test_pool_refills_up_to_concurrent_sessions(self) -> None:
+        datagen = FakeSessionGenerator(num_sessions=4, completes_after_checks=2)
+        stage = TraceSessionReplayLoadStage(concurrent_sessions=2)
+        load_generator = _make_load_generator(datagen, [stage])
+        load_generator.session_metrics_collector = self.collector
+
+        await self._run(load_generator, stage)
+
+        self.assertEqual(datagen.activated, ["s0", "s1", "s2", "s3"], "pool refills in corpus order")
+        self.assertLessEqual(datagen.max_live, 2, "active sessions must never exceed concurrent_sessions")
+        self.assertEqual(self.collector.record_metric.call_count, 4)
+        self.assertEqual(sorted(datagen.cleaned), ["s0", "s1", "s2", "s3"])
+        info = load_generator.stage_runtime_info[0]
+        self.assertEqual(info.status.name, "COMPLETED")
+        self.assertEqual(info.concurrency_level, 2)
+
+    async def test_session_cursor_slices_corpus_across_stages(self) -> None:
+        datagen = FakeSessionGenerator(num_sessions=5)
+        stages = [TraceSessionReplayLoadStage(concurrent_sessions=0, num_sessions=2) for _ in range(4)]
+        load_generator = _make_load_generator(datagen, stages)
+        load_generator.session_metrics_collector = self.collector
+
+        await self._run(load_generator, stages[0], stage_id=0)
+        self.assertEqual(datagen.activated, ["s0", "s1"])
+
+        await self._run(load_generator, stages[1], stage_id=1)
+        self.assertEqual(datagen.activated, ["s0", "s1", "s2", "s3"])
+
+        # Only one session remains; num_sessions=2 must clamp to it.
+        await self._run(load_generator, stages[2], stage_id=2)
+        self.assertEqual(datagen.activated, ["s0", "s1", "s2", "s3", "s4"])
+        self.assertEqual(load_generator._session_cursor, 5)
+
+        # Corpus exhausted: the stage skips without recording runtime info.
+        await self._run(load_generator, stages[3], stage_id=3)
+        self.assertEqual(len(datagen.activated), 5)
+        self.assertNotIn(3, load_generator.stage_runtime_info)
+
+    async def test_stage_timeout_fails_stage_and_respects_rate_limit(self) -> None:
+        # A rate limit far below 1/timeout means only the first session is
+        # ever dispatched; the stage must exit FAILED at the timeout instead
+        # of waiting on the remaining pending sessions.
+        datagen = FakeSessionGenerator(num_sessions=3)
+        stage = TraceSessionReplayLoadStage(concurrent_sessions=0, session_rate=0.001, timeout=0.3)
+        load_generator = _make_load_generator(datagen, [stage])
+        load_generator.session_metrics_collector = self.collector
+
+        await self._run(load_generator, stage)
+
+        self.assertEqual(datagen.activated, ["s0"], "rate limit must gate later dispatches")
+        self.assertEqual(self.collector.record_metric.call_count, 1)
+        info = load_generator.stage_runtime_info[0]
+        self.assertEqual(info.status.name, "FAILED")
+        self.assertEqual(info.rate, 0.001)
+        self.assertEqual(info.timeout, 0.3)
+
+    async def test_dispatch_stamps_events_and_remaps_affinity(self) -> None:
+        datagen = FakeSessionGenerator(num_sessions=1, events_per_session=4, preferred_worker_ids=[0, 1, 2, -1])
+        stage = TraceSessionReplayLoadStage(concurrent_sessions=0)
+        load_generator = _make_load_generator(datagen, [stage], num_workers=3)
+        load_generator.session_metrics_collector = self.collector
+        request_queue = MagicMock(spec=RequestQueue)
+
+        await self._run(load_generator, stage, stage_id=9, request_queue=request_queue)
+
+        channels = [call.args[1] for call in request_queue.put.call_args_list]
+        self.assertEqual(channels, [0, 1, 2, -1], "preferred workers wrap modulo num_workers; unaffined stay broadcast")
+        for event in datagen.events["s0"]:
+            self.assertEqual(event.session_id, "s0")
+            self.assertEqual(event.stage_id, 9)
+        request_queue.drain.assert_called_once()
+        request_queue.join.assert_called_once()
+
+    async def test_unbuildable_session_counts_complete_but_goes_unreported(self) -> None:
+        # Pins the documented behavior: a session whose graph cannot be built
+        # is counted complete (so the stage can finish) but produces no
+        # session lifecycle metric and dispatches no events.
+        datagen = FakeSessionGenerator(num_sessions=2, unbuildable_indices=[0])
+        stage = TraceSessionReplayLoadStage(concurrent_sessions=0)
+        load_generator = _make_load_generator(datagen, [stage])
+        load_generator.session_metrics_collector = self.collector
+        request_queue = MagicMock(spec=RequestQueue)
+
+        await self._run(load_generator, stage, request_queue=request_queue)
+
+        self.assertEqual(datagen.activated, ["s1"], "unbuildable session is never activated")
+        self.assertEqual(len(request_queue.put.call_args_list), datagen.events_per_session)
+        self.assertEqual(self.collector.record_metric.call_count, 1)
+        self.assertEqual(self.collector.record_metric.call_args.args[0]["session_id"], "s1")
+        self.assertEqual(load_generator.stage_runtime_info[0].status.name, "COMPLETED")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/test_run_stage_dispatch.py
+++ b/tests/required/loadgen/test_run_stage_dispatch.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for run_stage's dispatch semantics: how many requests are enqueued,
+onto which worker channel, and how the stage exits on worker death."""
+
+import multiprocessing as mp
+import unittest
+from typing import Any, List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from inference_perf.config import LoadConfig, LoadType, StandardLoadStage
+from inference_perf.datagen import DataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator, RequestQueueData
+from inference_perf.utils.request_queue import RequestQueue
+
+
+def _make_load_generator(num_workers: int = 4) -> LoadGenerator:
+    datagen = MagicMock(spec=DataGenerator)
+    datagen.trace = None
+    load_config = LoadConfig(
+        type=LoadType.CONSTANT,
+        num_workers=num_workers,
+        worker_max_concurrency=10,
+        stages=[StandardLoadStage(rate=1, duration=1)],
+        base_seed=42,
+    )
+    with patch("inference_perf.loadgen.load_generator.get_circuit_breaker"):
+        return LoadGenerator(datagen, load_config)
+
+
+def _mock_requests(preferred_worker_ids: List[int]) -> Any:
+    return iter([MagicMock(preferred_worker_id=worker_id) for worker_id in preferred_worker_ids])
+
+
+class TestRunStageDispatch(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.load_generator = _make_load_generator()
+        self.request_queue = MagicMock(spec=RequestQueue)
+        self.finished_counter = mp.Value("i", 0)
+        self.active_counter = mp.Value("i", 0)
+        self.request_phase = MagicMock()
+        self.cancel_signal = MagicMock()
+
+    def _put_calls(self) -> List[Tuple[RequestQueueData, int]]:
+        return [(call.args[0], call.args[1]) for call in self.request_queue.put.call_args_list]
+
+    async def _run_stage(
+        self,
+        num_requests: int,
+        stage_id: int = 0,
+        rate: float = 1,
+        duration: int = 1,
+        concurrency_level: Optional[int] = None,
+    ) -> None:
+        """Run one stage, completing the wait loop by advancing the counter."""
+
+        async def finish_all(*_args: Any, **_kwargs: Any) -> None:
+            self.finished_counter.value = num_requests
+
+        with patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = finish_all
+            await self.load_generator.run_stage(
+                stage_id=stage_id,
+                rate=rate,
+                duration=duration,
+                request_queue=self.request_queue,
+                active_requests_counter=self.active_counter,
+                finished_requests_counter=self.finished_counter,
+                request_phase=self.request_phase,
+                cancel_signal=self.cancel_signal,
+                concurrency_level=concurrency_level,
+            )
+
+    async def test_enqueues_rate_times_duration_requests_with_increasing_times(self) -> None:
+        self.load_generator.datagen.get_data.return_value = _mock_requests([-1] * 10)  # type: ignore[attr-defined]
+        await self._run_stage(num_requests=10, stage_id=5, rate=5, duration=2)
+
+        puts = self._put_calls()
+        self.assertEqual(len(puts), 10)
+        for item, channel in puts:
+            self.assertEqual(item.stage_id, 5)
+            self.assertEqual(channel, -1, "unaffined requests keep the broadcast channel id")
+        times = [item.request_time for item, _ in puts]
+        self.assertTrue(
+            all(b > a for a, b in zip(times, times[1:], strict=False)), "dispatch times must be strictly increasing"
+        )
+        self.assertEqual(self.load_generator.stage_runtime_info[5].status.name, "COMPLETED")
+
+    async def test_affinity_remaps_preferred_worker_onto_num_workers(self) -> None:
+        self.load_generator.datagen.get_data.return_value = _mock_requests([0, 1, 2, 3, 4, 5])  # type: ignore[attr-defined]
+        await self._run_stage(num_requests=6, rate=6, duration=1)
+
+        channels = [channel for _, channel in self._put_calls()]
+        self.assertEqual(channels, [0, 1, 2, 3, 0, 1], "preferred_worker_id must wrap modulo num_workers")
+
+    async def test_affinity_remaps_onto_active_workers_under_concurrency_level(self) -> None:
+        # concurrency_level=2 leaves only 2 workers with permits, so affinity
+        # must wrap onto the active workers, not all workers.
+        self.load_generator.datagen.get_data.return_value = _mock_requests([0, 1, 2, 3, 4, 5])  # type: ignore[attr-defined]
+        await self._run_stage(num_requests=6, rate=6, duration=1, concurrency_level=2)
+
+        channels = [channel for _, channel in self._put_calls()]
+        self.assertEqual(channels, [0, 1, 0, 1, 0, 1], "affinity must wrap modulo min(num_workers, concurrency_level)")
+
+    async def test_trace_bound_request_count_overrides_rate(self) -> None:
+        self.load_generator.datagen.trace = MagicMock()  # type: ignore[attr-defined]
+        self.load_generator.datagen.get_request_count.return_value = 3  # type: ignore[attr-defined]
+        self.load_generator.datagen.get_data.return_value = _mock_requests([-1] * 3)  # type: ignore[attr-defined]
+        await self._run_stage(num_requests=3, rate=100, duration=100)
+
+        self.assertEqual(len(self._put_calls()), 3, "trace-driven stages enqueue the trace's request count")
+
+    async def test_worker_death_fails_stage_and_cleans_up(self) -> None:
+        self.load_generator.datagen.get_data.return_value = _mock_requests([-1] * 5)  # type: ignore[attr-defined]
+        alive_worker = MagicMock()
+        alive_worker.is_alive.return_value = True
+        dead_worker = MagicMock()
+        dead_worker.is_alive.return_value = False
+        self.load_generator.workers = [alive_worker, dead_worker]
+        self.load_generator.num_workers = 2
+
+        with patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock):
+            await self.load_generator.run_stage(
+                stage_id=0,
+                rate=5,
+                duration=1,
+                request_queue=self.request_queue,
+                active_requests_counter=self.active_counter,
+                finished_requests_counter=self.finished_counter,
+                request_phase=self.request_phase,
+                cancel_signal=self.cancel_signal,
+            )
+
+        self.assertEqual(self.load_generator.stage_runtime_info[0].status.name, "FAILED")
+        self.cancel_signal.set.assert_called_once()
+        self.cancel_signal.clear.assert_called_once()
+        self.request_queue.drain.assert_called_once()
+        self.request_phase.clear.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/test_worker_loop.py
+++ b/tests/required/loadgen/test_worker_loop.py
@@ -1,0 +1,283 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""In-process tests for the real Worker.loop dispatch path.
+
+The Worker is constructed directly with multiprocessing primitives and its
+async loop() is awaited on the test's event loop — never .start()ed — so the
+dispatch loop that produces every latency metric runs under coverage and
+plain CI. Stage-boundary signals (request_phase / stage_barrier) are driven
+from a controller thread, mirroring the main process's side of the protocol
+in mp_run.
+"""
+
+import asyncio
+import multiprocessing as mp
+import threading
+import time
+import unittest
+from typing import Any, List, Optional, Tuple, cast
+from unittest.mock import AsyncMock, MagicMock
+
+from inference_perf.apis import CompletionAPIData, InferenceAPIData, LazyLoadInferenceAPIData
+from inference_perf.client.modelserver import ModelServerClient
+from inference_perf.datagen import DataGenerator
+from inference_perf.loadgen.load_generator import RequestQueueData, Worker
+from inference_perf.utils.request_queue import RequestQueue
+
+
+def _make_data() -> CompletionAPIData:
+    # A real, picklable InferenceAPIData: items cross a JoinableQueue feeder thread.
+    return CompletionAPIData(prompt="hello", max_tokens=5)
+
+
+class _ProbeClient:
+    """Client double that records calls and observed in-flight concurrency."""
+
+    def __init__(self, latency: float = 0.0) -> None:
+        self.latency = latency
+        self.active = 0
+        self.max_active = 0
+        self.calls: List[Tuple[InferenceAPIData, int, float, Optional[str]]] = []
+
+    async def process_request(
+        self, data: InferenceAPIData, stage_id: int, scheduled_time: float, lora_adapter: Optional[str] = None
+    ) -> None:
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        self.calls.append((data, stage_id, scheduled_time, lora_adapter))
+        try:
+            if self.latency:
+                await asyncio.sleep(self.latency)
+        finally:
+            self.active -= 1
+
+
+class TestWorkerLoop(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.request_queue: RequestQueue[RequestQueueData] = RequestQueue(1)
+        self.channel = self.request_queue.get_channel(0)
+        self.stop_signal = mp.Event()
+        self.cancel_signal = mp.Event()
+        self.request_phase = mp.Event()
+        self.finished_counter = mp.Value("i", 0)
+        self.active_counter = mp.Value("i", 0)
+        self.datagen = MagicMock(spec=DataGenerator)
+        self.barrier = mp.Barrier(2)
+        self.controller: Optional[threading.Thread] = None
+
+    def tearDown(self) -> None:
+        if self.controller is not None:
+            self.controller.join(timeout=15)
+
+    def _make_worker(
+        self,
+        client: Any,
+        max_concurrency: int = 4,
+        shared_max_concurrency: Optional[Any] = None,
+    ) -> Worker:
+        return Worker(
+            0,
+            cast(ModelServerClient, client),
+            self.channel,
+            self.datagen,
+            max_concurrency,
+            self.stop_signal,
+            self.cancel_signal,
+            self.request_phase,
+            self.finished_counter,
+            self.active_counter,
+            shared_max_concurrency,
+            base_seed=42,
+            stage_barrier=self.barrier,
+        )
+
+    def _put(self, n: int, stage_id: int = 3, lora_adapter: Optional[str] = None) -> None:
+        for _ in range(n):
+            self.request_queue.put(RequestQueueData(stage_id, _make_data(), 0.0, lora_adapter), 0)
+
+    async def _wait_until(self, predicate: Any, timeout: float = 10.0) -> None:
+        deadline = time.perf_counter() + timeout
+        while time.perf_counter() < deadline:
+            if predicate():
+                return
+            await asyncio.sleep(0.01)
+        self.fail("condition not met within timeout")
+
+    def _end_stage_and_stop(self) -> None:
+        """Drive the main-process side of the stage-end protocol from a thread.
+
+        Mirrors mp_run: clear request_phase to end the stage, pair the
+        worker's stage_barrier arrival, and only after the barrier trips
+        re-set request_phase (with stop_signal already set) so the worker's
+        final wait() releases. The barrier pairing is what makes re-setting
+        the phase race-free: without it the worker can miss the cleared
+        phase entirely and spin in the dispatch loop forever.
+        """
+
+        def _run() -> None:
+            try:
+                self.stop_signal.set()
+                self.request_phase.clear()
+                self.barrier.wait(timeout=10)
+            finally:
+                # Always release the worker from request_phase.wait(), even if
+                # the barrier timed out — the test then fails on assertions
+                # instead of hanging.
+                self.request_phase.set()
+
+        self.controller = threading.Thread(target=_run, daemon=True)
+        self.controller.start()
+
+    async def test_processes_requests_and_updates_counters(self) -> None:
+        client = _ProbeClient()
+        worker = self._make_worker(client)
+        self.request_phase.set()
+        self._put(3, stage_id=7, lora_adapter="adapter-a")
+
+        task = asyncio.get_event_loop().create_task(worker.loop())
+        await self._wait_until(lambda: self.finished_counter.value == 3)
+        self._end_stage_and_stop()
+        await asyncio.wait_for(task, timeout=15)
+
+        self.assertEqual(len(client.calls), 3)
+        for data, stage_id, scheduled_time, lora_adapter in client.calls:
+            self.assertIsInstance(data, CompletionAPIData)
+            self.assertEqual(stage_id, 7)
+            self.assertEqual(scheduled_time, 0.0)
+            self.assertEqual(lora_adapter, "adapter-a")
+        self.assertEqual(self.finished_counter.value, 3)
+        self.assertEqual(self.active_counter.value, 0)
+
+    async def test_lazy_load_failure_is_counted_and_loop_continues(self) -> None:
+        # self.datagen is not a LazyLoadDataMixin, so a lazy item fails to
+        # materialize; the worker must count it finished, ack the queue item,
+        # and keep serving later requests.
+        client = _ProbeClient()
+        worker = self._make_worker(client)
+        self.request_phase.set()
+        self.request_queue.put(RequestQueueData(0, LazyLoadInferenceAPIData(data_index=0), 0.0, None), 0)
+        self._put(1)
+
+        task = asyncio.get_event_loop().create_task(worker.loop())
+        await self._wait_until(lambda: self.finished_counter.value == 2)
+        self._end_stage_and_stop()
+        await asyncio.wait_for(task, timeout=15)
+
+        self.assertEqual(len(client.calls), 1, "only the materializable request reaches the client")
+        self.assertEqual(self.finished_counter.value, 2, "the failed request still counts as finished")
+        self.assertEqual(self.active_counter.value, 0)
+
+    async def test_semaphore_bounds_in_flight_concurrency(self) -> None:
+        client = _ProbeClient(latency=0.05)
+        worker = self._make_worker(client, max_concurrency=2)
+        self.request_phase.set()
+        self._put(6)
+
+        task = asyncio.get_event_loop().create_task(worker.loop())
+        await self._wait_until(lambda: self.finished_counter.value == 6)
+        self._end_stage_and_stop()
+        await asyncio.wait_for(task, timeout=15)
+
+        self.assertEqual(len(client.calls), 6)
+        self.assertLessEqual(client.max_active, 2)
+
+    async def test_cancel_signal_cancels_in_flight_requests(self) -> None:
+        client = _ProbeClient(latency=30.0)
+        worker = self._make_worker(client)
+        self.request_phase.set()
+        self._put(2)
+
+        task = asyncio.get_event_loop().create_task(worker.loop())
+        await self._wait_until(lambda: self.active_counter.value == 2)
+
+        # Mirror run_stage's cancellation protocol: set cancel_signal, wait for
+        # workers to unwind their in-flight tasks, clear cancel_signal, and
+        # only then end the stage.
+        self.cancel_signal.set()
+        await self._wait_until(lambda: self.active_counter.value == 0 and self.finished_counter.value == 2)
+        self.cancel_signal.clear()
+        self._end_stage_and_stop()
+        await asyncio.wait_for(task, timeout=15)
+
+        self.assertEqual(self.active_counter.value, 0, "cancelled requests are no longer in flight")
+        self.assertEqual(self.finished_counter.value, 2, "cancelled requests still count as finished")
+
+    async def test_zero_shared_concurrency_skips_until_raised(self) -> None:
+        # CONCURRENT load type: shared value 0 means this worker sits out the
+        # stage; raising it mid-run must resume consumption.
+        shared = mp.Value("i", 0)
+        client = _ProbeClient()
+        worker = self._make_worker(client, max_concurrency=4, shared_max_concurrency=shared)
+        self.request_phase.set()
+        self._put(2)
+
+        task = asyncio.get_event_loop().create_task(worker.loop())
+        await asyncio.sleep(0.3)
+        self.assertEqual(len(client.calls), 0, "worker with 0 concurrency must not consume requests")
+        self.assertEqual(self.finished_counter.value, 0)
+
+        with shared.get_lock():
+            shared.value = 2
+        await self._wait_until(lambda: self.finished_counter.value == 2)
+        self._end_stage_and_stop()
+        await asyncio.wait_for(task, timeout=15)
+        self.assertEqual(len(client.calls), 2)
+
+    async def test_shared_concurrency_update_rebinds_semaphore(self) -> None:
+        # Worker starts with max_concurrency=4 but the shared value says 1:
+        # the loop must drain the old semaphore and enforce the new bound.
+        shared = mp.Value("i", 1)
+        client = _ProbeClient(latency=0.05)
+        worker = self._make_worker(client, max_concurrency=4, shared_max_concurrency=shared)
+        self.request_phase.set()
+        self._put(4)
+
+        task = asyncio.get_event_loop().create_task(worker.loop())
+        await self._wait_until(lambda: self.finished_counter.value == 4)
+        self._end_stage_and_stop()
+        await asyncio.wait_for(task, timeout=15)
+
+        self.assertEqual(len(client.calls), 4)
+        self.assertEqual(client.max_active, 1)
+
+    async def test_stage_barrier_pairing_contract(self) -> None:
+        # The worker arrives at stage_barrier exactly once per stage end, and
+        # proceeds only when the main side pairs the arrival (mp_run's wait()
+        # after each stage). The sweep pre-pass historically violated this
+        # pairing; this locks the seam any stage-driving caller must respect.
+        client = _ProbeClient()
+        worker = self._make_worker(client)
+        self.request_phase.set()
+        self._put(2)
+
+        task = asyncio.get_event_loop().create_task(worker.loop())
+        await self._wait_until(lambda: self.finished_counter.value == 2)
+        self._end_stage_and_stop()
+        await asyncio.wait_for(task, timeout=15)
+
+        self.assertEqual(len(client.calls), 2)
+        self.assertFalse(self.barrier.broken, "worker-side arrival must pair with the main-side wait")
+        self.assertEqual(self.barrier.n_waiting, 0)
+
+    async def test_stop_signal_exits_loop_without_work(self) -> None:
+        client = AsyncMock(spec=ModelServerClient)
+        worker = self._make_worker(client)
+        self.stop_signal.set()
+        self.request_phase.set()
+        await asyncio.wait_for(worker.loop(), timeout=15)
+        client.process_request.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/test_worker_rng.py
+++ b/tests/required/loadgen/test_worker_rng.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ast
-import multiprocessing as mp
-import sys
 import unittest
 from typing import Any
 
@@ -33,14 +31,6 @@ from inference_perf.datagen.synthetic.synthetic_datagen import SyntheticDataGene
 from inference_perf.loadgen.load_generator import LoadGenerator
 from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
-
-# Match the start method used in production (main.py) so the tokenizer and
-# datagen objects are inherited rather than pickled into worker processes.
-if sys.platform == "darwin":
-    try:
-        mp.set_start_method("fork", force=True)
-    except RuntimeError:
-        pass
 
 
 class _DummyHFTokenizer:


### PR DESCRIPTION
Part of #659 (unit tests for the load generator execution core) and the #606 Unit tier.

## What this adds

Five test files, 20 tests, covering the loadgen execution core directly and in-process:

- **`test_worker_loop.py`**: the real `Worker.loop` dispatch path. The Worker is constructed with real multiprocessing primitives and its async loop is awaited on the test's event loop, never `.start()`ed, so the loop that produces every latency metric runs under plain CI and coverage. A controller thread drives the main-process side of the stage-end protocol exactly the way `mp_run` does. Covers request processing and counter accounting, lazy-load failure accounting, the cancellation protocol, semaphore concurrency bounds, CONCURRENT skip/resize semantics, and the stage-barrier pairing contract.
- **`test_run_stage_dispatch.py`**: `run_stage` dispatch semantics. Enqueue counts and payloads, preferred-worker affinity remap modulo active workers (with and without `concurrency_level`), trace-bound request counts, and the dead-worker breakout to FAILED with cleanup.
- **`test_run_session_stage.py`**: session pool management driven by a scripted `SessionGenerator`. Pool refill up to `concurrent_sessions`, the cross-stage session cursor (including clamping and the exhausted-corpus skip), rate limiting under stage timeout, event stamping and affinity remap, and the documented unbuildable-session semantics (counted complete, unreported).
- **`test_load_timer.py`**: the dispatch-schedule contracts (`int(rate * duration)` count, strict monotonicity, exact span) without pinning timer internals.
- **`test_mp_run_stages.py`**: a two-stage `mp_run` with a real worker process under a deadline, locking the invariant that every stage end pairs one main-side `stage_barrier.wait()` with one arrival per worker. A violation deadlocks instead of failing, so the test bounds the run with `asyncio.wait_for`.

## Coverage

`inference_perf/loadgen/load_generator.py`: 38% to 74% (the previously uncovered blocks were exactly `Worker.loop` at 131-265 and `run_session_stage` at 413-734). `inference_perf/loadgen/load_timer.py`: 75% to 93%. Repo total: 72% to 74%.

## Deliberately out of scope: the sweep pre-pass

`preprocess()` (the sweep saturation probe and stage generation, `load_generator.py:852-935`) is the one execution-core surface this PR does not touch, and that is intentional: sweep is slated for replacement, and tests written against the current implementation would pin behavior we intend to change (see also the open deadlock report it is involved in, #608). Its tests should ship with the replacement. The remaining uncovered block in `load_generator.py` is dominated by that range plus `Worker.run`, which only executes inside child processes.

The barrier-pairing test in `test_worker_loop.py` and the multi-stage `mp_run` test are the flip side of that exclusion: they lock the stage-boundary protocol that any stage-driving caller, including a future sweep implementation, must respect. Running a stage outside the `mp_run` stage loop leaves workers waiting on a barrier arrival that never comes, which is consistent with the hang reported in #608.
