### PR TITLE
feat: make predecessor wait timeout configurable, 0 means indefinite

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -134,7 +134,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--data.otel_trace_replay.inject_random_session_id` | boolean | Inject random string into unique segments to invalidate KV-cache between sessions |
 | `--data.otel_trace_replay.duplicate_sessions_target` | int | Target number of sessions to reach by duplicating existing sessions. If None, no duplication occurs. |
 | `--data.otel_trace_replay.max_wait_ms` | int | Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace. |
-| `--data.otel_trace_replay.predecessor_wait_timeout_sec` | float | Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely. |
+| `--data.otel_trace_replay.predecessor_wait_timeout_sec` | float | Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely; use with care because a genuinely stuck predecessor will then never time out and successors will wait forever. |
 | `--data.otel_trace_replay.include_errors` | boolean | Include spans with error status |
 | `--data.otel_trace_replay.skip_invalid_files` | boolean | Skip invalid trace files instead of failing |
 | `--data.otel_trace_replay.trace_directory` | str | Directory containing OTel JSON trace files |
@@ -158,7 +158,7 @@ Security: Filter expressions use eval() and should only contain trusted input. |
 | `--data.weka_trace_replay.inject_random_session_id` | boolean | Inject random string into unique segments to invalidate KV-cache between sessions |
 | `--data.weka_trace_replay.duplicate_sessions_target` | int | Target number of sessions to reach by duplicating existing sessions. If None, no duplication occurs. |
 | `--data.weka_trace_replay.max_wait_ms` | int | Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace. |
-| `--data.weka_trace_replay.predecessor_wait_timeout_sec` | float | Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely. |
+| `--data.weka_trace_replay.predecessor_wait_timeout_sec` | float | Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely; use with care because a genuinely stuck predecessor will then never time out and successors will wait forever. |
 | `--data.weka_trace_replay.include_errors` | boolean | Include spans with error status |
 | `--data.weka_trace_replay.skip_invalid_files` | boolean | Skip invalid trace files instead of failing |
 | `--data.weka_trace_replay.trace_directory` | str | Directory containing Weka JSON trace files |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -134,6 +134,7 @@ These command line flags are automatically generated from the CLI parser. The gl
 | `--data.otel_trace_replay.inject_random_session_id` | boolean | Inject random string into unique segments to invalidate KV-cache between sessions |
 | `--data.otel_trace_replay.duplicate_sessions_target` | int | Target number of sessions to reach by duplicating existing sessions. If None, no duplication occurs. |
 | `--data.otel_trace_replay.max_wait_ms` | int | Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace. |
+| `--data.otel_trace_replay.predecessor_wait_timeout_sec` | float | Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely. |
 | `--data.otel_trace_replay.include_errors` | boolean | Include spans with error status |
 | `--data.otel_trace_replay.skip_invalid_files` | boolean | Skip invalid trace files instead of failing |
 | `--data.otel_trace_replay.trace_directory` | str | Directory containing OTel JSON trace files |
@@ -157,6 +158,7 @@ Security: Filter expressions use eval() and should only contain trusted input. |
 | `--data.weka_trace_replay.inject_random_session_id` | boolean | Inject random string into unique segments to invalidate KV-cache between sessions |
 | `--data.weka_trace_replay.duplicate_sessions_target` | int | Target number of sessions to reach by duplicating existing sessions. If None, no duplication occurs. |
 | `--data.weka_trace_replay.max_wait_ms` | int | Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace. |
+| `--data.weka_trace_replay.predecessor_wait_timeout_sec` | float | Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely. |
 | `--data.weka_trace_replay.include_errors` | boolean | Include spans with error status |
 | `--data.weka_trace_replay.skip_invalid_files` | boolean | Skip invalid trace files instead of failing |
 | `--data.weka_trace_replay.trace_directory` | str | Directory containing Weka JSON trace files |

--- a/examples/otel/configs/simple/two-sessions-sequential.yml
+++ b/examples/otel/configs/simple/two-sessions-sequential.yml
@@ -20,6 +20,10 @@ data:
     # Request settings
     default_max_tokens: 100000
 
+    # Wait indefinitely for predecessor events instead of failing deep chains
+    # whose cumulative ancestor latency exceeds a fixed timeout.
+    predecessor_wait_timeout_sec: 0
+
     # Error handling
     include_errors: true
     skip_invalid_files: true

--- a/examples/otel/configs/simple/two-sessions-sequential.yml
+++ b/examples/otel/configs/simple/two-sessions-sequential.yml
@@ -20,9 +20,10 @@ data:
     # Request settings
     default_max_tokens: 100000
 
-    # Wait indefinitely for predecessor events instead of failing deep chains
-    # whose cumulative ancestor latency exceeds a fixed timeout.
-    predecessor_wait_timeout_sec: 0
+    # predecessor_wait_timeout_sec (default: 3600). Increase it to make the sessions wait longer.
+    # Set to 0 to wait indefinitely for predecessor events instead of failing deep chains whose cumulative ancestor
+    # latency exceeds a fixed timeout. Use with care: a genuinely stuck predecessor
+    # will then never time out, and successors will wait forever.
 
     # Error handling
     include_errors: true

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -134,7 +134,11 @@ class SessionReplayConfig(StrictBaseModel):
     predecessor_wait_timeout_sec: float = Field(
         3600.0,
         ge=0,
-        description="Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely.",
+        description=(
+            "Seconds to wait for predecessor events to complete before failing. "
+            "0 waits indefinitely; use with care because a genuinely stuck predecessor "
+            "will then never time out and successors will wait forever."
+        ),
     )
 
     # Error handling

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -131,6 +131,11 @@ class SessionReplayConfig(StrictBaseModel):
         ge=0,
         description="Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace.",
     )
+    predecessor_wait_timeout_sec: float = Field(
+        3600.0,
+        ge=0,
+        description="Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely.",
+    )
 
     # Error handling
     include_errors: bool = Field(True, description="Include spans with error status")

--- a/inference_perf/datagen/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay_graph_session_datagen.py
@@ -275,6 +275,7 @@ class EventOutputRegistry:
         return event_id in self._failed_event_ids
 
     async def require_async(self, event_id: str, timeout_sec: float = 3600.0) -> str:
+        # timeout_sec=0 waits indefinitely (see the asyncio.wait_for call below).
         if event_id in self._failed_event_ids:
             raise EventFailedError(event_id)
 
@@ -295,7 +296,7 @@ class EventOutputRegistry:
         logger.debug(f"Event {event_id} waiting on asyncio signal (zero threads)")
 
         try:
-            await asyncio.wait_for(signal.wait(), timeout=timeout_sec)
+            await asyncio.wait_for(signal.wait(), timeout=timeout_sec if timeout_sec > 0 else None)
         except asyncio.TimeoutError as e:
             raise TimeoutError(
                 f"EventOutputRegistry: output for '{event_id}' not available after "
@@ -339,6 +340,9 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
     inject_random_session_id: bool = False
     session_random_string: Optional[str] = None
     override_tool_call_max_tokens: bool = False
+    # Seconds to wait for predecessors before failing this event. 0 waits indefinitely;
+    # see SessionReplayConfig.predecessor_wait_timeout_sec.
+    predecessor_wait_timeout_sec: float = 3600.0
     # Mitigation for tool-call responses with malformed JSON in `arguments`.
     # `none` (default) is byte-identical to upstream main; `use_recorded`
     # substitutes the recorded assistant message at the affected slot.
@@ -468,7 +472,10 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
             logger.debug(f"Event {self.event_id} waiting for {len(self.predecessor_event_ids)} predecessor(s)")
             try:
                 await asyncio.gather(
-                    *[self.registry.require_async(event_id, timeout_sec=3600.0) for event_id in self.predecessor_event_ids]
+                    *[
+                        self.registry.require_async(event_id, timeout_sec=self.predecessor_wait_timeout_sec)
+                        for event_id in self.predecessor_event_ids
+                    ]
                 )
             except EventFailedError:
                 self._fail_and_notify(session_id, "predecessor failed")
@@ -1743,6 +1750,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             inject_random_session_id=self.replay_config.inject_random_session_id if self.replay_config else False,
             session_random_string=state.random_string if state else None,
             override_tool_call_max_tokens=self.replay_config.override_tool_call_max_tokens if self.replay_config else False,
+            predecessor_wait_timeout_sec=self.replay_config.predecessor_wait_timeout_sec if self.replay_config else 3600.0,
             # Mitigation knob: read once per event from replay_config. Default
             # NONE keeps the wire format byte-identical to upstream main.
             bad_tool_call_handling=getattr(self.replay_config, "bad_tool_call_handling", BadToolCallHandling.NONE)

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -101,6 +101,30 @@ def make_mock_api_config_streaming(streaming: bool = False) -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
+# SessionReplayConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionReplayConfigPredecessorWaitTimeout:
+    """Test the predecessor_wait_timeout_sec config field."""
+
+    def test_default_is_3600(self) -> None:
+        """Default preserves the previous hardcoded 3600s behavior."""
+        config = SessionReplayConfig()
+        assert config.predecessor_wait_timeout_sec == 3600.0
+
+    def test_accepts_zero(self) -> None:
+        """0 is a valid value, meaning 'wait indefinitely'."""
+        config = SessionReplayConfig(predecessor_wait_timeout_sec=0)
+        assert config.predecessor_wait_timeout_sec == 0
+
+    def test_rejects_negative(self) -> None:
+        """Negative timeouts are rejected."""
+        with pytest.raises(ValidationError):
+            SessionReplayConfig(predecessor_wait_timeout_sec=-1)
+
+
+# ---------------------------------------------------------------------------
 # EventOutputRegistry tests
 # ---------------------------------------------------------------------------
 
@@ -146,6 +170,37 @@ class TestEventOutputRegistry:
         reg = EventOutputRegistry()
         with pytest.raises(TimeoutError):
             asyncio.run(reg.require_async("event_001", timeout_sec=0.1))
+
+    def test_require_async_zero_timeout_waits_indefinitely(self) -> None:
+        """timeout_sec=0 waits indefinitely instead of timing out immediately."""
+        reg = EventOutputRegistry()
+
+        async def _run() -> str:
+            async def producer() -> None:
+                # Longer than any timeout that would previously have fired.
+                await asyncio.sleep(0.2)
+                reg.record("event_001", "delayed output", [])
+
+            asyncio.create_task(producer())
+            return str(await reg.require_async("event_001", timeout_sec=0))
+
+        result = asyncio.run(_run())
+        assert result == "delayed output"
+
+    def test_require_async_zero_timeout_still_propagates_failure(self) -> None:
+        """timeout_sec=0 (indefinite) still raises promptly on predecessor failure."""
+        reg = EventOutputRegistry()
+
+        async def _run() -> None:
+            async def fail_producer() -> None:
+                await asyncio.sleep(0.05)
+                reg.record_failure("event_001")
+
+            asyncio.create_task(fail_producer())
+            await reg.require_async("event_001", timeout_sec=0)
+
+        with pytest.raises(EventFailedError):
+            asyncio.run(_run())
 
     def test_double_record_raises_error(self) -> None:
         """Recording the same event twice should raise ValueError."""
@@ -420,6 +475,66 @@ class TestSessionChatCompletionAPIData:
         # Messages should be substituted
         assert len(api_data.messages) == 2
         assert api_data.messages[1].content == "Predecessor output"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_predecessors_uses_configured_timeout(self) -> None:
+        """wait_for_predecessors_and_substitute forwards predecessor_wait_timeout_sec to require_async."""
+        registry = EventOutputRegistry()
+        tracker = WorkerSessionTracker()
+        registry.record("session_1:event_0", "Predecessor output", [])
+
+        api_data = SessionChatCompletionAPIData(
+            messages=[ChatMessage(role="user", content="Question")],
+            max_tokens=50,
+            event_id="session_1:event_1",
+            registry=registry,
+            worker_tracker=tracker,
+            completion_queue=None,
+            total_events_in_session=2,
+            predecessor_event_ids=["session_1:event_0"],
+            predecessor_wait_timeout_sec=0,
+        )
+
+        seen_timeouts = []
+        original_require_async = registry.require_async
+
+        async def spy_require_async(event_id: str, timeout_sec: float = 3600.0) -> str:
+            seen_timeouts.append(timeout_sec)
+            return await original_require_async(event_id, timeout_sec=timeout_sec)
+
+        registry.require_async = spy_require_async  # type: ignore[method-assign]
+
+        await api_data.wait_for_predecessors_and_substitute()
+
+        assert seen_timeouts == [0]
+
+    @pytest.mark.asyncio
+    async def test_wait_for_predecessors_zero_timeout_does_not_time_out(self) -> None:
+        """predecessor_wait_timeout_sec=0 waits indefinitely rather than failing immediately."""
+        registry = EventOutputRegistry()
+        tracker = WorkerSessionTracker()
+
+        api_data = SessionChatCompletionAPIData(
+            messages=[ChatMessage(role="user", content="Question")],
+            max_tokens=50,
+            event_id="session_1:event_1",
+            registry=registry,
+            worker_tracker=tracker,
+            completion_queue=None,
+            total_events_in_session=2,
+            predecessor_event_ids=["session_1:event_0"],
+            predecessor_wait_timeout_sec=0,
+        )
+
+        async def producer() -> None:
+            await asyncio.sleep(0.1)
+            registry.record("session_1:event_0", "Predecessor output", [])
+
+        asyncio.create_task(producer())
+        await api_data.wait_for_predecessors_and_substitute()
+
+        assert api_data.skip_request is False
+        assert not registry.is_event_failed("session_1:event_1")
 
     @pytest.mark.asyncio
     async def test_disable_output_substitution_keeps_recorded(self) -> None:


### PR DESCRIPTION
This is a short-term fix, a configurable timeout, as discussed in #552.

## Changes
- Add `predecessor_wait_timeout_sec` to `SessionReplayConfig`, default `3600.0` (unchanged behavior)
- `0` waits indefinitely instead of failing deep chains on cumulative ancestor latency
- Predecessor failure still fails the successor immediately regardless of this setting
- Tests for the indefinite-wait path, failure propagation, and config validation
- `docs/cli_flags.md` regenerated

closes #552 
