### PR TITLE
docs: make pdm run --list the dev-command reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,12 @@ To contribute to this project, please adhere to the following procedure:
 - **Create an issue** detailing the proposed changes. Upon confirmation of assignment, you may proceed to submit a Pull Request.
 - **Initial Setup**: Run `pdm run setup` to install dependencies and set up pre-commit hooks.
 - Implement the required code modifications and perform **manual verification** by executing a benchmark run.
-- **Include comprehensive unit tests** to validate the changes. You can use `pdm test:picked` to run tests only on modified files.
+- **Include comprehensive unit tests** to validate the changes. You can use `pdm run test:picked` to run tests only on modified files.
 - Execute **validation** before pushing:
-  - `pdm check`: Fast check (formatting and linting).
-  - `pdm run validate`: Full check (formatting, linting, and strict type checking).
-- Conduct **full test execution and code coverage analysis** using `pdm test` and `pdm check:cov`.
+  - `pdm run check`: Fast check (formatting and linting).
+  - `pdm run validate`: Full check (formatting, linting, strict type checking, and CLI-flags doc sync).
+- Conduct **full test execution and code coverage analysis** using `pdm run test` and `pdm run check:cov`.
+- All development commands are defined as pdm scripts; run `pdm run --list` to see the full list with descriptions.
 - **Branch Up-to-Date Requirement**: Your branch must be based on the latest `origin/main` before you can push. A pre-push hook enforces this by running `git fetch origin main` automatically. If it fails, you will need to rebase or merge `origin/main`.
 - **Submit the Pull Request** utilizing the provided template.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,29 +81,33 @@ build-backend = "setuptools.build_meta"
 distribution = true
 
 [tool.pdm.scripts]
-format = "ruff format"
-lint = "ruff check"
-type-check = "mypy --strict ./inference_perf ./tests"
-"check:cli-flags" = "python scripts/sync_cli_flags_doc.py --check"
-"update:cli-flags" = "python scripts/sync_cli_flags_doc.py"
-check = {composite = ["format", "lint"]}
-validate = {composite = ["format", "lint", "type-check", "check:cli-flags"]}
-setup = {shell = "pdm install && pre-commit install --config .pre-push-config.yaml && pre-commit install --config .pre-push-config.yaml --hook-type pre-push"}
+# Every script must set `help` so `pdm run --list` doubles as the dev-command
+# reference; tests/test_pdm_scripts.py enforces this.
+format = {cmd = "ruff format", help = "Format code with ruff"}
+lint = {cmd = "ruff check", help = "Lint code with ruff"}
+type-check = {cmd = "mypy --strict ./inference_perf ./tests", help = "Strict mypy over inference_perf and tests"}
+"check:cli-flags" = {cmd = "python scripts/sync_cli_flags_doc.py --check", help = "Verify docs/cli_flags.md is in sync with the CLI"}
+"update:cli-flags" = {cmd = "python scripts/sync_cli_flags_doc.py", help = "Regenerate docs/cli_flags.md from the CLI"}
+check = {composite = ["format", "lint"], help = "Fast check: format + lint"}
+validate = {composite = ["format", "lint", "type-check", "check:cli-flags"], help = "Full check: format, lint, type-check, cli-flags doc sync"}
+setup = {shell = "pdm install && pre-commit install --config .pre-push-config.yaml && pre-commit install --config .pre-push-config.yaml --hook-type pre-push", help = "Install dependencies and git hooks"}
 
-"test" = "pytest tests"
-"test:picked" = "pytest --picked"
-"test:e2e" = "pytest e2e tests/optional -n auto --dist loadgroup {args}"
+"test" = {cmd = "pytest tests", help = "Run unit tests"}
+"test:picked" = {cmd = "pytest --picked", help = "Run tests in files changed since the last commit"}
+"test:e2e" = {cmd = "pytest e2e tests/optional -n auto --dist loadgroup {args}", help = "Run e2e and optional tests"}
 # The live-oracle slice: every e2e test that needs a real vLLM server
 # (start one with e2e/vllm_cpu_server.sh). Selection is by naming
 # convention, so a new e2e/tests/test_vllm_*.py joins the slice with no
 # edits here or in CI. Serial on purpose: the modules share one server.
-"test:e2e:live" = {shell = "pytest e2e/tests/test_vllm_*.py {args}"}
-"test:e2e:docker" = "pdm run docker:e2e-test:run"
+"test:e2e:live" = {shell = "pytest e2e/tests/test_vllm_*.py {args}", help = "Run the e2e live-oracle slice against a running vLLM server"}
+"test:e2e:docker" = {cmd = "pdm run docker:e2e-test:run", help = "Run e2e tests inside Docker"}
 
-"check:cov" = "python scripts/check_coverage_regression.py"
+"check:cov" = {cmd = "python scripts/check_coverage_regression.py", help = "Check unit-test coverage for regressions"}
 
 "docker:e2e-test:build".cmd = "docker buildx b -f Dockerfile.e2e-test {args:-t inference-perf-e2e-test} ."
+"docker:e2e-test:build".help = "Build the e2e-test Docker image"
 "docker:e2e-test:run".shell = "rm result && pdm run docker:e2e-test:build --iidfile result && docker run --rm -it $(< result)"
+"docker:e2e-test:run".help = "Build and run the e2e-test Docker image"
 
 [tool.ruff]
 # The GitHub editor is 127 chars wide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,34 +81,38 @@ build-backend = "setuptools.build_meta"
 distribution = true
 
 [tool.pdm.scripts]
-format = "ruff format"
-lint = "ruff check"
-type-check = "mypy --strict ./inference_perf ./tests"
-"check:cli-flags" = "python scripts/sync_cli_flags_doc.py --check"
-"update:cli-flags" = "python scripts/sync_cli_flags_doc.py"
-check = {composite = ["format", "lint"]}
-validate = {composite = ["format", "lint", "type-check", "check:cli-flags"]}
-setup = {shell = "pdm install && pre-commit install --config .pre-push-config.yaml && pre-commit install --config .pre-push-config.yaml --hook-type pre-push"}
+# Every script must set `help` so `pdm run --list` doubles as the dev-command
+# reference; tests/test_pdm_scripts.py enforces this.
+format = {cmd = "ruff format", help = "Format code with ruff"}
+lint = {cmd = "ruff check", help = "Lint code with ruff"}
+type-check = {cmd = "mypy --strict ./inference_perf ./tests", help = "Strict mypy over inference_perf and tests"}
+"check:cli-flags" = {cmd = "python scripts/sync_cli_flags_doc.py --check", help = "Verify docs/cli_flags.md is in sync with the CLI"}
+"update:cli-flags" = {cmd = "python scripts/sync_cli_flags_doc.py", help = "Regenerate docs/cli_flags.md from the CLI"}
+check = {composite = ["format", "lint"], help = "Fast check: format + lint"}
+validate = {composite = ["format", "lint", "type-check", "check:cli-flags"], help = "Full check: format, lint, type-check, cli-flags doc sync"}
+setup = {shell = "pdm install && pre-commit install --config .pre-push-config.yaml && pre-commit install --config .pre-push-config.yaml --hook-type pre-push", help = "Install dependencies and git hooks"}
 
-"test" = "pytest tests"
-"test:picked" = "pytest --picked"
-"test:e2e" = "pytest e2e tests/optional -n auto --dist loadgroup {args}"
+"test" = {cmd = "pytest tests", help = "Run unit tests"}
+"test:picked" = {cmd = "pytest --picked", help = "Run tests in files changed since the last commit"}
+"test:e2e" = {cmd = "pytest e2e tests/optional -n auto --dist loadgroup {args}", help = "Run e2e and optional tests"}
 # The live-oracle slice: every e2e test that needs a real vLLM server
 # (start one with e2e/vllm_cpu_server.sh). Selection is by naming
 # convention, so a new e2e/tests/test_vllm_*.py joins the slice with no
 # edits here or in CI. Serial on purpose: the modules share one server.
-"test:e2e:live" = {shell = "pytest e2e/tests/test_vllm_*.py {args}"}
+"test:e2e:live" = {shell = "pytest e2e/tests/test_vllm_*.py {args}", help = "Run the e2e live-oracle slice against a running vLLM server"}
 # The multimodal acceptance slice: real vLLM CPU servers with a
 # vision-language and a speech model (see e2e/vllm_multimodal_releases.txt
 # and the module docstring for how to start them). Also part of the live
 # slice above, where it runs the text-only case and skips the rest.
-"test:e2e:multimodal" = {shell = "pytest e2e/tests/test_vllm_cpu_multimodal.py {args}"}
-"test:e2e:docker" = "pdm run docker:e2e-test:run"
+"test:e2e:multimodal" = {shell = "pytest e2e/tests/test_vllm_cpu_multimodal.py {args}", help = "Run the e2e multimodal slice against running vLLM CPU servers"}
+"test:e2e:docker" = {cmd = "pdm run docker:e2e-test:run", help = "Run e2e tests inside Docker"}
 
-"check:cov" = "python scripts/check_coverage_regression.py"
+"check:cov" = {cmd = "python scripts/check_coverage_regression.py", help = "Check unit-test coverage for regressions"}
 
 "docker:e2e-test:build".cmd = "docker buildx b -f Dockerfile.e2e-test {args:-t inference-perf-e2e-test} ."
+"docker:e2e-test:build".help = "Build the e2e-test Docker image"
 "docker:e2e-test:run".shell = "rm result && pdm run docker:e2e-test:build --iidfile result && docker run --rm -it $(< result)"
+"docker:e2e-test:run".help = "Build and run the e2e-test Docker image"
 
 [tool.ruff]
 # The GitHub editor is 127 chars wide

--- a/tests/test_pdm_scripts.py
+++ b/tests/test_pdm_scripts.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+def load_pdm_scripts() -> dict[str, Any]:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    scripts: dict[str, Any] = data["tool"]["pdm"]["scripts"]
+    return scripts
+
+
+def test_every_pdm_script_has_help() -> None:
+    """`pdm run --list` is the reference for dev commands, so every script must
+    carry a `help` text. Scripts prefixed with `_` are hidden from the listing
+    and exempt."""
+    scripts = load_pdm_scripts()
+    missing = [
+        name
+        for name, spec in scripts.items()
+        if not name.startswith("_") and not (isinstance(spec, dict) and spec.get("help"))
+    ]
+    assert not missing, f"pdm scripts missing a `help` text (shown by `pdm run --list`): {missing}"


### PR DESCRIPTION
Every `[tool.pdm.scripts]` entry now carries a `help` text, so `pdm run --list` renders a table of all dev commands with descriptions. The commands themselves are unchanged.

To keep the listing complete, `tests/test_pdm_scripts.py` asserts that every script defines `help` (scripts prefixed with `_` are exempt because pdm hides them from the listing). Because `help` only exists in the table form, the test also keeps new scripts out of the bare-string form. It runs with the normal unit-test suite, so no CI changes are needed.

CONTRIBUTING.md updates:
- Normalized the mixed `pdm <script>` / `pdm run <script>` invocations to `pdm run <script>`.
- The `pdm run validate` description now includes the `check:cli-flags` step it already runs.
- Added a pointer to `pdm run --list` as the full command reference.
