### PR TITLE
Add loadgen/probe: closed-loop capacity probe core for sweep autoselection

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -233,6 +233,13 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--load.sweep.num_stages` | int | Number of load stages to generate. |
 | `--load.sweep.stage_duration` | int | Duration of each generated stage in seconds. |
 | `--load.sweep.saturation_percentile` | float | Percentile of observed request rates taken as the saturation point. |
+| `--load.sweep.probe.rung_duration` | float | Measurement window per concurrency rung in seconds. |
+| `--load.sweep.probe.settle_duration` | float | Seconds each rung runs before its measurement window opens. |
+| `--load.sweep.probe.start_concurrency` | int | Concurrency of the first rung, also the unloaded baseline. |
+| `--load.sweep.probe.growth_factor` | float | Multiplier applied to concurrency between rungs. |
+| `--load.sweep.probe.max_concurrency` | int | Concurrency ceiling for the ladder. |
+| `--load.sweep.probe.gain_threshold` | float | Stop when the relative throughput gain between the top two rungs is confidently below this fraction. |
+| `--load.sweep.probe.knee_fraction` | float | Fraction of the saturation rate that defines the knee concurrency. |
 | `--load.num_workers` | int | Number of worker processes sending requests. Defaults to the CPU count. |
 | `--load.worker_max_concurrency` | int | Maximum concurrent in-flight requests per worker. |
 | `--load.worker_max_tcp_connections` | int | Maximum TCP connections per worker. |

--- a/inference_perf/config/__init__.py
+++ b/inference_perf/config/__init__.py
@@ -68,6 +68,7 @@ from inference_perf.config.loadgen import (
     MultiLoRAConfig,
     StageGenType,
     StandardLoadStage,
+    ProbeConfig,
     SweepConfig,
     TraceSessionReplayLoadStage,
 )
@@ -128,6 +129,7 @@ __all__ = [
     "StandardLoadStage",
     "StorageConfig",
     "StorageConfigBase",
+    "ProbeConfig",
     "SweepConfig",
     "SyntheticMultimodalDatagenConfig",
     "TraceConfig",

--- a/inference_perf/config/loadgen/__init__.py
+++ b/inference_perf/config/loadgen/__init__.py
@@ -19,6 +19,7 @@ from inference_perf.config.loadgen.config import (
     MultiLoRAConfig,
     StageGenType,
     StandardLoadStage,
+    ProbeConfig,
     SweepConfig,
     TraceSessionReplayLoadStage,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "MultiLoRAConfig",
     "StageGenType",
     "StandardLoadStage",
+    "ProbeConfig",
     "SweepConfig",
     "TraceSessionReplayLoadStage",
 ]

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -141,6 +141,39 @@ class StageGenType(Enum):
     LINEAR = "linear"
 
 
+class ProbeConfig(StrictBaseModel):
+    """Closed-loop concurrency probe used to find the saturation rate.
+
+    The probe holds in-flight concurrency fixed per rung, grows it geometrically
+    until throughput gains flatten, and estimates the saturation rate from the
+    rung curve. See inference_perf/loadgen/probe/ for the estimation details.
+    """
+
+    rung_duration: float = Field(default=30.0, gt=0, description="Measurement window per concurrency rung in seconds.")
+    settle_duration: float = Field(
+        default=5.0, ge=0, description="Seconds each rung runs before its measurement window opens."
+    )
+    start_concurrency: int = Field(default=1, ge=1, description="Concurrency of the first rung, also the unloaded baseline.")
+    growth_factor: float = Field(default=2.0, gt=1.0, description="Multiplier applied to concurrency between rungs.")
+    max_concurrency: int = Field(default=1024, ge=1, description="Concurrency ceiling for the ladder.")
+    gain_threshold: float = Field(
+        default=0.05,
+        gt=0,
+        description="Stop when the relative throughput gain between the top two rungs is confidently below this fraction.",
+    )
+    knee_fraction: float = Field(
+        default=0.9, gt=0, lt=1, description="Fraction of the saturation rate that defines the knee concurrency."
+    )
+
+    @model_validator(mode="after")
+    def validate_probe_config(self) -> "ProbeConfig":
+        if self.max_concurrency < self.start_concurrency:
+            raise ValueError(
+                f"max_concurrency ({self.max_concurrency}) must be >= start_concurrency ({self.start_concurrency})"
+            )
+        return self
+
+
 class SweepConfig(StrictBaseModel):
     type: StageGenType = Field(description="How stage rates are spaced up to the saturation rate: 'geometric' or 'linear'.")
     num_requests: int = Field(
@@ -151,6 +184,11 @@ class SweepConfig(StrictBaseModel):
     stage_duration: int = Field(default=180, description="Duration of each generated stage in seconds.")
     saturation_percentile: float = Field(
         default=95, description="Percentile of observed request rates taken as the saturation point."
+    )
+    probe: Optional[ProbeConfig] = Field(
+        default=None,
+        description="Find the saturation rate with a closed-loop concurrency probe instead of the burst estimator."
+        " Requires num_workers > 0.",
     )
 
 
@@ -194,6 +232,10 @@ class LoadConfig(StrictBaseModel):
         # Validate that sweep is not used with concurrent or trace session replay load types
         if self.type in (LoadType.CONCURRENT, LoadType.TRACE_SESSION_REPLAY) and self.sweep is not None:
             raise ValueError(f"Cannot have sweep config with {self.type.value.upper()} load type")
+
+        # The closed-loop probe drives worker concurrency, which only exists in the multiprocess path
+        if self.sweep is not None and self.sweep.probe is not None and self.num_workers < 1:
+            raise ValueError("sweep.probe requires num_workers > 0")
 
         # Validate stage types match load type
         if self.type == LoadType.CONCURRENT:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -17,16 +17,28 @@ from inference_perf.datagen.base import BaseGenerator
 from inference_perf.utils.trace_reader import AzurePublicDatasetReader
 from inference_perf.utils.request_queue import RequestQueue
 from .load_timer import LoadTimer, ConstantLoadTimer, PoissonLoadTimer, TraceReplayLoadTimer
+from .probe import (
+    ConcurrencyLadder,
+    LadderConfig,
+    LatencyProfile,
+    ProbeResult,
+    RungResult,
+    estimate_constants,
+    latency_profile,
+    rung_from_metrics,
+)
 from inference_perf.datagen import DataGenerator, SessionGenerator, LazyLoadDataMixin
-from inference_perf.apis import InferenceAPIData
+from inference_perf.apis import InferenceAPIData, RequestLifecycleMetric
 from inference_perf.apis.user_session import LocalUserSession
 from inference_perf.client.modelserver import ModelServerClient
 from inference_perf.client.modelserver.otel_instrumentation import get_otel_instrumentation
 from inference_perf.circuit_breaker import get_circuit_breaker
 from inference_perf.metrics import SessionMetricsCollector
+from inference_perf.metrics.request_collector import RequestMetricCollector
 from inference_perf.config import (
     LoadConfig,
     LoadType,
+    ProbeConfig,
     StageGenType,
     TraceFormat,
     ConcurrentLoadStage,
@@ -86,6 +98,14 @@ class RequestQueueData(NamedTuple):
     request_data: InferenceAPIData
     request_time: float
     lora_adapter: Optional[str]
+
+
+def generate_stage_rates(target_request_rate: float, size: int, gen_type: StageGenType) -> List[float]:
+    """Space `size` stage rates from 1 up to the target rate, geometrically or linearly."""
+    if gen_type == StageGenType.GEOM:
+        return [float(round(1 + target_request_rate - rr, 2)) for rr in np.geomspace(target_request_rate, 1, num=size)]
+    elif gen_type == StageGenType.LINEAR:
+        return [float(round(r, 2)) for r in np.linspace(1, target_request_rate, size)]
 
 
 class Worker(mp.Process):
@@ -296,6 +316,7 @@ class LoadGenerator:
         datagen: BaseGenerator,
         load_config: LoadConfig,
         session_metrics_collector: Optional[SessionMetricsCollector] = None,
+        request_metric_collector: Optional[RequestMetricCollector] = None,
     ) -> None:
         self.datagen = datagen
         self.stageInterval = load_config.interval
@@ -307,6 +328,8 @@ class LoadGenerator:
         self.workers: List[Worker] = []
         self.circuit_breakers = [get_circuit_breaker(breaker_name) for breaker_name in load_config.circuit_breakers]
         self.sweep_config = load_config.sweep
+        self.request_metric_collector = request_metric_collector
+        self.probe_result: Optional[ProbeResult] = None
         self.interrupt_sig = False
         self.session_metrics_collector = session_metrics_collector
         signal.signal(signal.SIGINT, self._sigint_handler)
@@ -360,6 +383,13 @@ class LoadGenerator:
             if worker.shared_max_concurrency:
                 with worker.shared_max_concurrency.get_lock():
                     worker.shared_max_concurrency.value = worker_concurrency
+
+    def _restore_worker_concurrency(self) -> None:
+        """Reset every worker to the configured per-worker concurrency ceiling."""
+        for worker in self.workers:
+            if worker.shared_max_concurrency:
+                with worker.shared_max_concurrency.get_lock():
+                    worker.shared_max_concurrency.value = self.worker_max_concurrency
 
     def _get_lora_adapter(self) -> Optional[str]:
         """Returns a randomly selected LoRA adapter based on configured probability weights, or None if not configured."""
@@ -858,21 +888,33 @@ class LoadGenerator:
         finished_requests_counter: "Synchronized[int]",
         request_phase: SyncEvent,
         cancel_signal: SyncEvent,
-        stage_barrier: Optional[SyncBarrier] = None,
+        stage_barrier: SyncBarrier,
     ) -> None:
         """
         Runs a preliminary load test to automatically determine the server's saturation point
         and generate a suitable series of load stages for the main benchmark.
 
-        An aggregator task samples the active requests and then the burn down rate is
-        calculated from the samples. Saturation is derived from a percentile of the
-        sampled burn down rates.
+        With `sweep.probe` configured, saturation is measured by the closed-loop
+        concurrency probe. Otherwise an aggregator task samples the active
+        requests during a single burst and saturation is derived from a
+        percentile of the sampled burn down rates.
         """
         logger.info("Running preprocessing stage")
         results: List[Tuple[float, int]] = []
 
         if self.sweep_config is None:
             raise Exception("sweep_config cannot be none")
+
+        if self.sweep_config.probe is not None:
+            await self._probe_preprocess(
+                request_queue,
+                active_requests_counter,
+                finished_requests_counter,
+                request_phase,
+                cancel_signal,
+                stage_barrier,
+            )
+            return
 
         # Aggregator collects timestamped value of active_requests throughout the preprocessing
         async def aggregator() -> None:
@@ -927,14 +969,214 @@ class LoadGenerator:
         saturation_point = float(np.percentile(rates, self.sweep_config.saturation_percentile))
         logger.info(f"Saturation point estimated at {saturation_point:0.2f} concurrent requests.")
 
-        def generateRates(target_request_rate: float, size: int, gen_type: StageGenType) -> List[float]:
-            if gen_type == StageGenType.GEOM:
-                return [float(round(1 + target_request_rate - rr, 2)) for rr in np.geomspace(target_request_rate, 1, num=size)]
-            elif gen_type == StageGenType.LINEAR:
-                return [float(round(r, 2)) for r in np.linspace(1, target_request_rate, size)]
-
-        rates = generateRates(saturation_point, self.sweep_config.num_stages, self.sweep_config.type)
+        rates = generate_stage_rates(saturation_point, self.sweep_config.num_stages, self.sweep_config.type)
         self.stages = [StandardLoadStage(rate=r, duration=self.sweep_config.stage_duration) for r in rates]
+        logger.info(f"Generated load stages: {[s.rate for s in self.stages]}")
+
+    async def _run_probe_rung(
+        self,
+        stage_id: int,
+        concurrency: int,
+        probe_config: ProbeConfig,
+        request_queue: RequestQueue[RequestQueueData],
+        active_requests_counter: "Synchronized[int]",
+        finished_requests_counter: "Synchronized[int]",
+        request_phase: SyncEvent,
+        cancel_signal: SyncEvent,
+        stage_barrier: SyncBarrier,
+    ) -> Tuple[float, float, int]:
+        """Dispatch one closed-loop rung and return (window_start, window_end, enqueued).
+
+        Holds worker concurrency at `concurrency` while keeping the request
+        queue topped up through the settle and measurement windows, then stops
+        feeding and lets the tail drain naturally so no request is cancelled
+        mid-measurement. Window bounds are in the perf_counter clock that
+        lifecycle metrics use.
+        """
+        # Workers only re-read the shared concurrency between request phases,
+        # so it must be set before the phase flag goes up.
+        self._set_worker_concurrency(concurrency)
+        with finished_requests_counter.get_lock():
+            finished_requests_counter.value = 0
+        request_phase.set()
+
+        if not isinstance(self.datagen, DataGenerator):
+            raise TypeError("the sweep probe requires DataGenerator")
+        data_generator = self.datagen.get_data()
+        active_workers = min(self.num_workers, concurrency)
+        # Enough backlog that workers never starve between top-ups.
+        high_watermark = max(4 * concurrency, 32)
+        enqueued = 0
+
+        start = time.perf_counter()
+        window_start = start + probe_config.settle_duration
+        window_end = window_start + probe_config.rung_duration
+
+        while time.perf_counter() < window_end and not self.interrupt_sig:
+            backlog = enqueued - finished_requests_counter.value
+            for _ in range(max(0, high_watermark - backlog)):
+                request_data = next(data_generator)
+                request_data.stage_id = stage_id
+                lora_adapter = self._get_lora_adapter()
+                worker_id = request_data.preferred_worker_id
+                if worker_id >= 0:
+                    worker_id = worker_id % active_workers
+                request_queue.put(
+                    RequestQueueData(stage_id, request_data, time.perf_counter(), lora_adapter),
+                    worker_id,
+                )
+                enqueued += 1
+            await sleep(0.1)
+
+        # Let the backlog drain; cancel only on interrupt or if the server
+        # stops making progress.
+        drain_deadline = time.perf_counter() + max(60.0, probe_config.rung_duration)
+        while finished_requests_counter.value < enqueued:
+            if self.interrupt_sig or time.perf_counter() > drain_deadline:
+                logger.warning(
+                    "Probe rung %d: cancelling %d unfinished requests",
+                    stage_id,
+                    enqueued - finished_requests_counter.value,
+                )
+                # Cancel signal must be set before request_phase
+                cancel_signal.set()
+                await sleep(1)
+                while active_requests_counter.value > 0:
+                    await sleep(1)
+                request_queue.drain()
+                cancel_signal.clear()
+                break
+            await sleep(0.2)
+
+        # Same order run_stage uses: stop workers consuming, rendezvous so every
+        # worker has run task_done() on what it pulled, only then join. Joining
+        # first can hang on items a worker pulled but has not yet marked done.
+        # Pairing here also makes the next rung's concurrency land before its
+        # phase flag goes up. Run in the executor so the metrics collector keeps
+        # draining while main waits.
+        request_phase.clear()
+        await get_event_loop().run_in_executor(None, stage_barrier.wait)
+        request_queue.join()
+        return window_start, window_end, enqueued
+
+    async def _collect_rung_metrics(self, stage_id: int, expected: int) -> List[RequestLifecycleMetric]:
+        """Wait for a probe rung's lifecycle metrics to arrive from the workers.
+
+        Metrics travel through the collector's queue asynchronously, so arrival
+        lags the stage barrier. Waits until `expected` metrics for this stage
+        land, or until their count stops growing (cancelled requests never
+        record one).
+        """
+        if self.request_metric_collector is None:
+            raise Exception("the sweep probe requires a request metric collector")
+        last_count = -1
+        last_change = time.perf_counter()
+        while True:
+            metrics = [m for m in self.request_metric_collector.snapshot() if m.stage_id == stage_id]
+            if len(metrics) >= expected:
+                return metrics
+            now = time.perf_counter()
+            if len(metrics) != last_count:
+                last_count = len(metrics)
+                last_change = now
+            elif now - last_change > 5.0:
+                logger.warning("Probe rung %d: expected %d metrics, proceeding with %d", stage_id, expected, len(metrics))
+                return metrics
+            await sleep(0.1)
+
+    async def _probe_preprocess(
+        self,
+        request_queue: RequestQueue[RequestQueueData],
+        active_requests_counter: "Synchronized[int]",
+        finished_requests_counter: "Synchronized[int]",
+        request_phase: SyncEvent,
+        cancel_signal: SyncEvent,
+        stage_barrier: SyncBarrier,
+    ) -> None:
+        """Find the saturation rate with the closed-loop concurrency probe and generate stages.
+
+        Runs the ladder rung by rung with negative stage ids (the report only
+        keeps stage ids >= 0, so probe traffic never pollutes results),
+        estimates {r_sat, n_knee} with confidence intervals, and spaces the
+        generated stages up to r_sat.
+        """
+        if self.sweep_config is None or self.sweep_config.probe is None:
+            raise Exception("probe preprocessing requires sweep.probe config")
+        if self.request_metric_collector is None:
+            raise Exception("the sweep probe requires a request metric collector")
+        probe_config = self.sweep_config.probe
+
+        max_concurrency = min(probe_config.max_concurrency, self.num_workers * self.worker_max_concurrency)
+        if max_concurrency < probe_config.max_concurrency:
+            logger.info("Probe concurrency capped at %d by num_workers * worker_max_concurrency", max_concurrency)
+        ladder = ConcurrencyLadder(
+            config=LadderConfig(
+                start_concurrency=probe_config.start_concurrency,
+                growth_factor=probe_config.growth_factor,
+                max_concurrency=max_concurrency,
+                gain_threshold=probe_config.gain_threshold,
+            )
+        )
+
+        # Park every worker at a phase boundary before the first rung: workers
+        # only read the shared concurrency between phases, and at startup the
+        # phase flag is already up.
+        request_phase.clear()
+        await get_event_loop().run_in_executor(None, stage_barrier.wait)
+
+        history: List[RungResult] = []
+        baseline: Optional[LatencyProfile] = None
+        while (concurrency := ladder.next_concurrency(history)) is not None:
+            if self.interrupt_sig:
+                raise Exception("sweep probe interrupted")
+            stage_id = -1 - len(history)
+            window_start, window_end, enqueued = await self._run_probe_rung(
+                stage_id,
+                concurrency,
+                probe_config,
+                request_queue,
+                active_requests_counter,
+                finished_requests_counter,
+                request_phase,
+                cancel_signal,
+                stage_barrier,
+            )
+            metrics = await self._collect_rung_metrics(stage_id, enqueued)
+            try:
+                rung = rung_from_metrics(concurrency, metrics, window_start, window_end, baseline=baseline)
+            except ValueError as e:
+                raise Exception(f"Probe rung at concurrency {concurrency} failed to measure: {e}") from e
+            if baseline is None:
+                in_window = [m for m in metrics if m.error is None and window_start <= m.end_time < window_end]
+                baseline = latency_profile(in_window)
+            history.append(rung)
+            logger.info(
+                "Probe rung N=%d: X=%.2f req/s (se %.2f), R=%.3fs, residual %.2f, stationary=%s, signal=%s",
+                rung.concurrency,
+                rung.throughput,
+                rung.throughput_se,
+                rung.latency,
+                rung.littles_law_residual,
+                rung.stationary,
+                rung.signal.value,
+            )
+
+        logger.info("Probe ladder stopped: %s", ladder.stop_reason)
+        constants = estimate_constants(history, knee_fraction=probe_config.knee_fraction)
+        self.probe_result = ProbeResult(rungs=tuple(history), constants=constants)
+        r_sat = constants["r_sat"]
+        n_knee = constants["n_knee"]
+        logger.info(
+            "Saturation rate estimated at %.2f req/s (95%% CI [%.2f, %.2f]), knee at N=%d",
+            r_sat.value,
+            r_sat.ci.low,
+            r_sat.ci.high,
+            int(n_knee.value),
+        )
+
+        rates = generate_stage_rates(r_sat.value, self.sweep_config.num_stages, self.sweep_config.type)
+        self.stages = [StandardLoadStage(rate=r, duration=self.sweep_config.stage_duration) for r in rates]
+        self._restore_worker_concurrency()
         logger.info(f"Generated load stages: {[s.rate for s in self.stages]}")
 
     async def mp_run(self, client: ModelServerClient) -> None:
@@ -954,11 +1196,10 @@ class LoadGenerator:
 
         # Create list of workers to process requests
         for id in range(self.num_workers):
-            # Create shared value for each worker's max concurrency if concurrent load type
-            if self.load_type == LoadType.CONCURRENT:
-                shared_max_concurrency = mp.Value("i", self.worker_max_concurrency)
-            else:
-                shared_max_concurrency = None
+            # Shared so concurrent stages and the sweep probe can retune worker
+            # concurrency at phase boundaries; starts at the configured ceiling,
+            # which leaves non-concurrent stages unaffected.
+            shared_max_concurrency = mp.Value("i", self.worker_max_concurrency)
 
             self.workers.append(
                 Worker(

--- a/inference_perf/loadgen/probe/README.md
+++ b/inference_perf/loadgen/probe/README.md
@@ -1,0 +1,150 @@
+# Capacity Probe
+
+**Sweep rate selection is a measurement problem, and this package treats it
+as one.** Instead of guessing a max rate from a transient burst, the probe
+holds concurrency fixed, climbs a geometric ladder, and reports capacity
+constants with confidence intervals. Everything in this directory is pure
+measurement and estimation logic: no dispatch, no config, no expression
+grammar. The single inward-facing dependency is `metrics.py`, which adapts
+`RequestLifecycleMetric` records into rung measurements. All wiring into the
+sweep lives in `load_generator.py` (`_probe_preprocess` and
+`_run_probe_rung`).
+
+## File map
+
+| File | Contents |
+| --- | --- |
+| `result.py` | `RungResult`, `ProbeResult`, `BoundConstant`, `ConfidenceInterval`, `SaturationSignal`, `RESERVED_SYMBOLS` |
+| `estimator.py` | Batch-means throughput, isotonic regression (PAVA), saturating-curve fit, `estimate_constants` (bootstrap CIs) |
+| `ladder.py` | `LadderConfig`, `ConcurrencyLadder` (rung schedule and stop policy) |
+| `stationarity.py` | CUSUM drift check over the measurement window |
+| `metrics.py` | Adapter from request lifecycle metrics to `RungResult`, TTFT/ITL phase classification |
+
+## Why closed loop
+
+A closed loop keeps exactly N requests in flight: each completion admits the
+next request, so the offered load adapts to whatever the server can serve.
+Little's law (N = X * R) then holds for any arrival process and any backend
+topology, which makes every rung self-checking: we measure throughput X and
+latency R independently and report the relative residual of N = X * R
+(`littles_law_residual`). A large residual means the measurement itself is
+broken (clock skew, dispatch starvation, window misalignment), not that the
+server is slow. Rungs also carry a CUSUM stationarity verdict, batch-means
+standard errors for throughput, and an optional saturation signal
+(`PREFILL_BOUND` / `DECODE_BOUND`) from TTFT/ITL inflation against the
+first rung's unloaded baseline.
+
+## How the ladder stops
+
+Concurrency grows geometrically (`growth_factor`, default 2.0) from
+`start_concurrency` until one of three sticky stop reasons:
+
+- **plateau**: the relative throughput gain between the top two rungs is
+  confidently below `gain_threshold`, using a one-sided upper confidence
+  bound on the gain built from the batch-means standard errors. The SE
+  awareness matters: a noisy rung must not fake a plateau.
+- **client_bound**: the rung reports the load generator, not the server, as
+  the bottleneck (signal plumbing exists; no source sets it yet, see limits).
+- **max_concurrency**: the configured or worker-capacity ceiling.
+
+After a plateau, one geometric-midpoint rung is optionally measured
+(`refine`) to sharpen the knee estimate. A non-stationary rung is re-measured
+once (`max_retries`) before being used as-is.
+
+## How constants are estimated
+
+`estimate_constants` produces the reserved symbols `r_sat` (saturation
+throughput) and `n_knee` (concurrency where isotonic throughput first
+reaches `knee_fraction` of `r_sat`). The estimator is deliberately
+two-layered:
+
+1. Isotonic regression (pool-adjacent-violators) over the rungs gives a
+   nonparametric, monotone throughput curve whose top value is the
+   empirical plateau.
+2. A saturating fit X(N) = mu * N / (K + N) supplies the asymptote, but is
+   **accepted only when it lands within `fit_acceptance_ratio` (1.3x) of the
+   empirical plateau**. If the ladder never got near saturation the fit
+   extrapolates wildly, so the estimator falls back to the plateau, which is
+   an honest lower bound.
+
+Confidence intervals come from a parametric bootstrap that resamples each
+rung's throughput from its batch-means standard error and re-runs the whole
+estimate. The output is a dict of `BoundConstant`s: the measure-then-bind
+contract under which a later phase may bind these symbols into sweep stage
+rate expressions (#449, #563) without this package ever depending on the
+expression grammar.
+
+## Dispatch protocol (wiring, lives in load_generator.py)
+
+The probe runs during sweep preprocessing, before stage generation:
+
+- **Rungs use negative stage ids** (-1, -2, ...), which the report generator
+  already filters out, so probe traffic never pollutes reports.
+- **Concurrency is retuned through the workers' shared per-worker value.**
+  Workers only read it between phases, and at process start the phase flag is
+  already up, so the probe first parks all workers at a phase boundary
+  (phase clear + barrier) before rung 1.
+- **Every phase clear pairs a main-side `stage_barrier.wait()`** with one
+  arrival per worker. This pairing is a hard protocol: a worker that
+  observes the flag down proceeds to the barrier and, without a main-side
+  wait, parks forever. The legacy burst path historically had no pairing and
+  survived only because workers poll the flag on a ~0.5 s cadence and
+  usually miss the microseconds-long window in which it is down; that race
+  is now closed with an explicit pairing there too.
+- **Rungs enqueue via chunked top-up** (high watermark `max(4N, 32)`) and
+  end with a natural tail drain rather than `run_stage`'s enqueue-everything
+  plus timeout-cancel, so no cancellations land inside a measurement window.
+- The measurement window opens `settle_duration` after the rung starts and
+  lasts `rung_duration`; metrics are collected mid-run through the request
+  collector's `snapshot()` API.
+
+## Forgone approaches, and why
+
+- **Open-loop rate ramp** (step the request rate up until latency degrades).
+  Above capacity an open-loop queue grows without bound, so every
+  measurement taken there depends on how long you waited, and
+  arrival-process variance confounds the capacity estimate. The closed loop
+  self-regulates and measures a stable operating point per rung.
+- **Burst drain-rate estimation** (the legacy sweep estimator this
+  supersedes). A one-shot burst measures a transient: the drain-rate
+  percentile mixes queue drain with steady-state capacity and carries no
+  error bar. It remains the default; the probe is opt-in via `sweep.probe`.
+- **Binary search on request rate against an SLO oracle.** Needs an SLO to
+  define pass/fail, and sweep autoselection must work without one. It also
+  yields a single point; the ladder yields the whole X(N) curve, from which
+  an SLO-conditioned rate (`r_slo`) can later be derived.
+- **Latency inflation as the stop rule.** TTFT/ITL inflation thresholds are
+  model and hardware dependent, so inflation is demoted to a per-rung
+  classification signal. The stop rule is throughput-gain based, which is
+  scale free.
+- **Parametric fit as the sole estimator.** Real serving stacks do not owe
+  us a Monod-shaped curve (batching regimes, KV-cache pressure, and
+  scheduler phase changes bend it). Hence the isotonic guardrail and the
+  1.3x acceptance gate.
+- **Reusing `run_stage` for rung dispatch.** Its enqueue-all plus
+  timeout-cancel shape cancels stragglers, and cancellations inside the
+  window would bias the rung. Hence the dedicated top-up loop.
+- **A dedicated probe worker pool.** Rejected so the probe exercises exactly
+  the dispatch path the real stages use, and to avoid new process machinery;
+  retuning the existing workers' shared concurrency at phase boundaries is
+  sufficient.
+- **Report-schema integration of rung data.** Deferred: negative stage ids
+  keep the report generator untouched. `ProbeResult` lives on the
+  `LoadGenerator` for now.
+- **Binding constants into expressions in this change.** Deferred by design
+  (measure-then-bind): this package emits `BoundConstant`s and reserves the
+  symbol names; the grammar dependency stays out.
+
+## Known limits
+
+- The probe consumes items from the data generator, shared with the burst
+  estimator: finite corpora (`total_count`) must be large enough to cover
+  probe traffic or generation raises past the end.
+- Closed-loop R(N) is a measurement device. It is not open-loop request
+  latency and is never reported as such.
+- `CLIENT_BOUND` has a ladder stop reason but no instrumentation source yet;
+  until one exists, a client-bottlenecked probe reads as a plateau.
+- Phase classification requires streaming token timestamps; non-streaming
+  runs degrade to `NONE` rather than guessing.
+- `settle_duration` is a heuristic warm-in, not a detected steady-state
+  onset; the CUSUM check catches drift that survives it, but only flags it.

--- a/inference_perf/loadgen/probe/__init__.py
+++ b/inference_perf/loadgen/probe/__init__.py
@@ -1,0 +1,73 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Closed-loop capacity probe for sweep request-rate autoselection.
+
+This package is the computational core of a saturation probe that replaces
+transient-based capacity estimation (burst drain-rate percentiles, stepped
+open-loop ramps) with a closed-loop concurrency ladder:
+
+1. Hold the number of in-flight requests fixed at N (semaphore dispatch) and
+   measure throughput X(N) and mean latency R(N) over a stationary window.
+   Little's law (N = X * R) holds for any arrival process and any backend
+   topology, so each rung is a self-checking measurement.
+2. Grow N geometrically until throughput gains flatten (`ConcurrencyLadder`).
+3. Estimate the capacity asymptote and knee from the rung curve
+   (`estimate_constants`), preferring a saturating-curve fit when the plateau
+   was actually approached and falling back to the empirical plateau when not.
+
+The probe's outputs are named constants with confidence intervals
+(`BoundConstant`). The names (`RESERVED_SYMBOLS`) form an internal-only
+symbol namespace: sweep stage definitions may reference them, users may never
+set them, and the harness binds their values after the probe runs. This
+module deliberately has no dependency on the expression grammar or on any
+dispatch/wiring code; it is pure measurement and estimation logic.
+"""
+
+from .estimator import (
+    batch_means_throughput,
+    estimate_constants,
+    fit_saturating_curve,
+    isotonic_regression,
+    make_rung,
+)
+from .ladder import ConcurrencyLadder, LadderConfig
+from .result import (
+    RESERVED_SYMBOLS,
+    BoundConstant,
+    ConfidenceInterval,
+    ProbeResult,
+    RungResult,
+    SaturationSignal,
+    classify_saturation,
+)
+from .stationarity import cusum_drift_index, is_stationary
+
+__all__ = [
+    "RESERVED_SYMBOLS",
+    "BoundConstant",
+    "ConcurrencyLadder",
+    "ConfidenceInterval",
+    "LadderConfig",
+    "ProbeResult",
+    "RungResult",
+    "SaturationSignal",
+    "batch_means_throughput",
+    "classify_saturation",
+    "cusum_drift_index",
+    "estimate_constants",
+    "fit_saturating_curve",
+    "is_stationary",
+    "isotonic_regression",
+    "make_rung",
+]

--- a/inference_perf/loadgen/probe/__init__.py
+++ b/inference_perf/loadgen/probe/__init__.py
@@ -31,7 +31,8 @@ The probe's outputs are named constants with confidence intervals
 symbol namespace: sweep stage definitions may reference them, users may never
 set them, and the harness binds their values after the probe runs. This
 module deliberately has no dependency on the expression grammar or on any
-dispatch/wiring code; it is pure measurement and estimation logic.
+dispatch code; it is measurement and estimation logic, plus one adapter
+(`metrics`) from request lifecycle metrics to rung measurements.
 """
 
 from .estimator import (
@@ -42,6 +43,7 @@ from .estimator import (
     make_rung,
 )
 from .ladder import ConcurrencyLadder, LadderConfig
+from .metrics import LatencyProfile, latency_profile, rung_from_metrics
 from .result import (
     RESERVED_SYMBOLS,
     BoundConstant,
@@ -59,6 +61,7 @@ __all__ = [
     "ConcurrencyLadder",
     "ConfidenceInterval",
     "LadderConfig",
+    "LatencyProfile",
     "ProbeResult",
     "RungResult",
     "SaturationSignal",
@@ -69,5 +72,7 @@ __all__ = [
     "fit_saturating_curve",
     "is_stationary",
     "isotonic_regression",
+    "latency_profile",
     "make_rung",
+    "rung_from_metrics",
 ]

--- a/inference_perf/loadgen/probe/estimator.py
+++ b/inference_perf/loadgen/probe/estimator.py
@@ -1,0 +1,242 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rung measurement and capacity estimation.
+
+Throughput per rung is measured with batch means: the analysis window is split
+into equal sub-windows and the completion rate of each becomes one sample, so
+the standard error is estimated without assuming independence of individual
+completions. The capacity estimate reads the rung curve X(N) two ways:
+
+- Empirical plateau: isotonic regression (X(N) must be non-decreasing) and
+  take the top level. Never extrapolates; valid on any backend topology.
+- Saturating-curve fit: X(N) = mu * N / (K + N) via the Hanes linearization
+  (N / X regressed on N). Extrapolates to the asymptote, but the form is a
+  fitting device, not physics; multi-replica and scheduler-capped backends
+  can violate it.
+
+`estimate_constants` prefers the fit only when its asymptote is close to the
+measured plateau (i.e. the ladder actually approached saturation) and falls
+back to the empirical plateau otherwise. Uncertainty comes from a parametric
+bootstrap over the per-rung standard errors.
+"""
+
+from typing import Dict, Optional, Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+from .result import BoundConstant, ConfidenceInterval, RungResult, SaturationSignal
+from .stationarity import is_stationary
+
+_FloatArray = npt.NDArray[np.float64]
+
+
+def batch_means_throughput(
+    completion_times: npt.ArrayLike,
+    window_start: float,
+    window_end: float,
+    num_batches: int = 8,
+) -> Tuple[float, float, _FloatArray]:
+    """Measure throughput over [window_start, window_end) with a batch-means standard error.
+
+    Returns (throughput, standard_error, per_batch_rates). Completion times
+    outside the window are ignored; an empty window raises ValueError because
+    a rung with zero completions is a measurement failure, not a zero rate.
+    """
+    if num_batches < 2:
+        raise ValueError(f"num_batches must be >= 2, got {num_batches}")
+    duration = window_end - window_start
+    if duration <= 0:
+        raise ValueError(f"window must have positive duration, got {duration}")
+
+    times = np.asarray(completion_times, dtype=np.float64)
+    times = times[(times >= window_start) & (times < window_end)]
+    if times.size == 0:
+        raise ValueError("no completions inside the analysis window")
+
+    throughput = times.size / duration
+    edges = np.linspace(window_start, window_end, num_batches + 1)
+    counts, _ = np.histogram(times, bins=edges)
+    batch_rates = counts.astype(np.float64) / (duration / num_batches)
+    standard_error = float(np.std(batch_rates, ddof=1) / np.sqrt(num_batches))
+    return float(throughput), standard_error, batch_rates
+
+
+def make_rung(
+    concurrency: int,
+    completion_times: npt.ArrayLike,
+    latencies: npt.ArrayLike,
+    window_start: float,
+    window_end: float,
+    num_batches: int = 8,
+    signal: SaturationSignal = SaturationSignal.NONE,
+) -> RungResult:
+    """Build a `RungResult` from raw per-request completion times and latencies.
+
+    `latencies[i]` must correspond to `completion_times[i]`. Stationarity is
+    judged on the per-batch completion rates, and the Little's law residual
+    |N - X * R| / N is computed as the rung's self-consistency check.
+    """
+    times = np.asarray(completion_times, dtype=np.float64)
+    lats = np.asarray(latencies, dtype=np.float64)
+    if times.shape != lats.shape:
+        raise ValueError(f"completion_times and latencies must align, got {times.shape} vs {lats.shape}")
+
+    throughput, standard_error, batch_rates = batch_means_throughput(times, window_start, window_end, num_batches)
+    in_window = (times >= window_start) & (times < window_end)
+    latency = float(np.mean(lats[in_window]))
+    residual = abs(concurrency - throughput * latency) / concurrency
+    return RungResult(
+        concurrency=concurrency,
+        throughput=throughput,
+        throughput_se=standard_error,
+        latency=latency,
+        littles_law_residual=residual,
+        stationary=is_stationary(batch_rates),
+        signal=signal,
+    )
+
+
+def isotonic_regression(values: npt.ArrayLike, weights: Optional[npt.ArrayLike] = None) -> _FloatArray:
+    """Weighted least-squares fit of a non-decreasing sequence (pool adjacent violators)."""
+    y = np.asarray(values, dtype=np.float64)
+    if y.ndim != 1:
+        raise ValueError(f"values must be one-dimensional, got shape {y.shape}")
+    w = np.ones_like(y) if weights is None else np.asarray(weights, dtype=np.float64)
+    if w.shape != y.shape or np.any(w <= 0):
+        raise ValueError("weights must be positive and align with values")
+
+    level_means: list[float] = []
+    level_weights: list[float] = []
+    level_sizes: list[int] = []
+    for yi, wi in zip(y, w, strict=True):
+        level_means.append(float(yi))
+        level_weights.append(float(wi))
+        level_sizes.append(1)
+        while len(level_means) > 1 and level_means[-2] > level_means[-1]:
+            merged_weight = level_weights[-2] + level_weights[-1]
+            merged_mean = (level_means[-2] * level_weights[-2] + level_means[-1] * level_weights[-1]) / merged_weight
+            merged_size = level_sizes[-2] + level_sizes[-1]
+            for level in (level_means, level_weights, level_sizes):
+                level.pop()
+            level_means[-1] = merged_mean
+            level_weights[-1] = merged_weight
+            level_sizes[-1] = merged_size
+    return np.concatenate([np.full(size, mean) for mean, size in zip(level_means, level_sizes, strict=True)])
+
+
+def fit_saturating_curve(
+    concurrencies: npt.ArrayLike,
+    throughputs: npt.ArrayLike,
+) -> Optional[Tuple[float, float]]:
+    """Fit X(N) = mu * N / (K + N) and return (mu, K), or None if degenerate.
+
+    Uses the Hanes linearization: N / X = N / mu + K / mu is linear in N, so a
+    least-squares line gives mu from the slope and K from the intercept. A
+    non-positive slope or negative intercept means the data carry no evidence
+    of saturation in this functional form.
+    """
+    n = np.asarray(concurrencies, dtype=np.float64)
+    x = np.asarray(throughputs, dtype=np.float64)
+    if n.shape != x.shape or n.ndim != 1:
+        raise ValueError("concurrencies and throughputs must be aligned one-dimensional arrays")
+    if np.unique(n).size < 3:
+        return None
+    if np.any(n <= 0) or np.any(x <= 0):
+        raise ValueError("concurrencies and throughputs must be positive")
+
+    slope, intercept = np.polyfit(n, n / x, 1)
+    if slope <= 0 or intercept < 0:
+        return None
+    mu = 1.0 / float(slope)
+    knee_constant = float(intercept) * mu
+    return mu, knee_constant
+
+
+def _point_estimate(
+    concurrencies: _FloatArray,
+    throughputs: _FloatArray,
+    knee_fraction: float,
+    fit_acceptance_ratio: float,
+) -> Tuple[float, float]:
+    """Estimate (r_sat, n_knee) from one realization of the rung curve."""
+    isotonic = isotonic_regression(throughputs)
+    plateau = float(isotonic[-1])
+    fit = fit_saturating_curve(concurrencies, throughputs)
+    r_sat = plateau
+    if fit is not None and fit[0] <= fit_acceptance_ratio * plateau:
+        r_sat = fit[0]
+    # Relative tolerance so a rung sitting exactly at the knee fraction is not
+    # excluded by floating-point error in the fitted asymptote.
+    at_knee = concurrencies[isotonic >= knee_fraction * r_sat * (1.0 - 1e-9)]
+    n_knee = float(at_knee[0]) if at_knee.size > 0 else float(concurrencies[-1])
+    return r_sat, n_knee
+
+
+def estimate_constants(
+    rungs: Sequence[RungResult],
+    rng: Optional[np.random.Generator] = None,
+    knee_fraction: float = 0.9,
+    fit_acceptance_ratio: float = 1.3,
+    num_bootstrap: int = 500,
+    confidence: float = 0.95,
+) -> Dict[str, BoundConstant]:
+    """Estimate the internal symbols {r_sat, n_knee} from a measured ladder.
+
+    Only stationary, non-client-bound rungs participate; retried concurrencies
+    keep their latest measurement. The saturating-curve asymptote is used for
+    r_sat only when it lies within `fit_acceptance_ratio` of the empirical
+    plateau, meaning the ladder actually got close to saturation; otherwise
+    the plateau itself is reported, which is an honest lower bound.
+    Confidence intervals come from a parametric bootstrap resampling each
+    rung's throughput from its batch-means standard error.
+    """
+    if not 0 < knee_fraction < 1:
+        raise ValueError(f"knee_fraction must be in (0, 1), got {knee_fraction}")
+    if not 0 < confidence < 1:
+        raise ValueError(f"confidence must be in (0, 1), got {confidence}")
+
+    usable = [r for r in rungs if r.stationary and r.signal is not SaturationSignal.CLIENT_BOUND]
+    latest_by_concurrency = {r.concurrency: r for r in usable}
+    if len(latest_by_concurrency) < 2:
+        raise ValueError(f"need at least 2 usable rungs at distinct concurrencies, got {len(latest_by_concurrency)}")
+    ordered = [latest_by_concurrency[c] for c in sorted(latest_by_concurrency)]
+
+    concurrencies = np.asarray([r.concurrency for r in ordered], dtype=np.float64)
+    throughputs = np.asarray([r.throughput for r in ordered], dtype=np.float64)
+    standard_errors = np.asarray([r.throughput_se for r in ordered], dtype=np.float64)
+
+    r_sat_hat, n_knee_hat = _point_estimate(concurrencies, throughputs, knee_fraction, fit_acceptance_ratio)
+
+    generator = rng if rng is not None else np.random.default_rng()
+    tiny = np.finfo(np.float64).tiny
+    r_sat_draws = np.empty(num_bootstrap, dtype=np.float64)
+    n_knee_draws = np.empty(num_bootstrap, dtype=np.float64)
+    for i in range(num_bootstrap):
+        resampled = np.maximum(throughputs + generator.normal(0.0, 1.0, throughputs.size) * standard_errors, tiny)
+        r_sat_draws[i], n_knee_draws[i] = _point_estimate(concurrencies, resampled, knee_fraction, fit_acceptance_ratio)
+
+    alpha = (1.0 - confidence) / 2.0
+    r_sat_ci = ConfidenceInterval(
+        low=float(np.quantile(r_sat_draws, alpha)),
+        high=float(np.quantile(r_sat_draws, 1.0 - alpha)),
+    )
+    n_knee_ci = ConfidenceInterval(
+        low=float(np.quantile(n_knee_draws, alpha)),
+        high=float(np.quantile(n_knee_draws, 1.0 - alpha)),
+    )
+    return {
+        "r_sat": BoundConstant(name="r_sat", value=r_sat_hat, ci=r_sat_ci),
+        "n_knee": BoundConstant(name="n_knee", value=n_knee_hat, ci=n_knee_ci),
+    }

--- a/inference_perf/loadgen/probe/ladder.py
+++ b/inference_perf/loadgen/probe/ladder.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Concurrency ladder policy: which N to measure next, and when to stop.
+
+The ladder grows concurrency geometrically and stops when the marginal
+throughput gain between the top two rungs is confidently below a threshold.
+The confidence direction is deliberate: probing continues until the upper
+confidence bound of the gain is small, so noise extends the ladder (bounded
+by `max_concurrency`) rather than truncating it into an underestimate of
+capacity. A client-bound rung stops the ladder immediately because every
+larger rung would measure the client, not the server.
+
+This is pure decision logic: it consumes `RungResult`s and returns the next
+concurrency to measure (or None to stop). Dispatch is the caller's job.
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Sequence
+
+from .result import RungResult, SaturationSignal
+
+
+@dataclass(frozen=True)
+class LadderConfig:
+    start_concurrency: int = 1
+    growth_factor: float = 2.0
+    max_concurrency: int = 1024
+    # Plateau: stop when the relative gain between the top two rungs is
+    # confidently below this fraction.
+    gain_threshold: float = 0.05
+    # One-sided z-score for the gain's upper confidence bound (1.64 ~ 95%).
+    z_score: float = 1.64
+    # Re-measurements allowed for a non-stationary rung before using it as-is.
+    max_retries: int = 1
+    # After the plateau is found, measure one geometric-midpoint rung to
+    # sharpen the knee estimate.
+    refine: bool = True
+
+    def __post_init__(self) -> None:
+        if self.start_concurrency < 1:
+            raise ValueError(f"start_concurrency must be >= 1, got {self.start_concurrency}")
+        if self.growth_factor <= 1.0:
+            raise ValueError(f"growth_factor must be > 1, got {self.growth_factor}")
+        if self.max_concurrency < self.start_concurrency:
+            raise ValueError(f"max_concurrency must be >= start_concurrency, got {self.max_concurrency}")
+        if self.gain_threshold <= 0:
+            raise ValueError(f"gain_threshold must be positive, got {self.gain_threshold}")
+        if self.max_retries < 0:
+            raise ValueError(f"max_retries must be non-negative, got {self.max_retries}")
+
+
+@dataclass
+class ConcurrencyLadder:
+    """Stateful next-rung policy. Feed it the full measurement history each call."""
+
+    config: LadderConfig = field(default_factory=LadderConfig)
+    stop_reason: Optional[str] = None
+    _retries: Dict[int, int] = field(default_factory=dict)
+    _refined: bool = False
+
+    def next_concurrency(self, history: Sequence[RungResult]) -> Optional[int]:
+        """Return the next concurrency to measure, or None when the ladder is done.
+
+        Once None is returned the decision is sticky; `stop_reason` records why
+        ("client_bound", "plateau", or "max_concurrency").
+        """
+        if self.stop_reason is not None:
+            return None
+        if not history:
+            return self.config.start_concurrency
+
+        last = history[-1]
+        if last.signal is SaturationSignal.CLIENT_BOUND:
+            self.stop_reason = "client_bound"
+            return None
+        if not last.stationary:
+            attempts = self._retries.get(last.concurrency, 0)
+            if attempts < self.config.max_retries:
+                self._retries[last.concurrency] = attempts + 1
+                return last.concurrency
+
+        # Latest measurement wins for retried concurrencies.
+        latest = {r.concurrency: r for r in history}
+        ordered = sorted(latest)
+
+        if len(ordered) >= 2 and self._plateau_reached(latest[ordered[-2]], latest[ordered[-1]]):
+            if self.config.refine and not self._refined:
+                self._refined = True
+                midpoint = round(math.sqrt(ordered[-2] * ordered[-1]))
+                if midpoint not in latest and midpoint >= 1:
+                    return midpoint
+            self.stop_reason = "plateau"
+            return None
+
+        proposed = max(last.concurrency + 1, math.ceil(last.concurrency * self.config.growth_factor))
+        if proposed > self.config.max_concurrency:
+            self.stop_reason = "max_concurrency"
+            return None
+        return proposed
+
+    def _plateau_reached(self, lower: RungResult, upper: RungResult) -> bool:
+        gain = upper.throughput - lower.throughput
+        gain_upper_bound = gain + self.config.z_score * math.hypot(lower.throughput_se, upper.throughput_se)
+        return gain_upper_bound < self.config.gain_threshold * lower.throughput

--- a/inference_perf/loadgen/probe/metrics.py
+++ b/inference_perf/loadgen/probe/metrics.py
@@ -1,0 +1,114 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Adapter from request lifecycle metrics to probe rung measurements.
+
+This is the probe package's single inward-facing module: it consumes
+`RequestLifecycleMetric` records produced by the model server clients and
+turns them into `RungResult`s for the estimator. Timestamps on lifecycle
+metrics come from `time.perf_counter()`, so window bounds passed here must
+be captured with the same clock.
+
+Phase classification compares a rung's median TTFT and inter-token latency
+against the unloaded baseline rung. It needs token-level timestamps, which
+only streaming APIs record; without them rungs keep `SaturationSignal.NONE`
+and the ladder still works on throughput alone.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+from inference_perf.apis import RequestLifecycleMetric, StreamedResponseMetrics
+
+from .estimator import make_rung
+from .result import RungResult, SaturationSignal, classify_saturation
+
+
+@dataclass(frozen=True)
+class LatencyProfile:
+    """Median per-request TTFT and inter-token latency over one measurement window."""
+
+    ttft: float
+    itl: float
+
+
+def latency_profile(metrics: Sequence[RequestLifecycleMetric]) -> Optional[LatencyProfile]:
+    """Median TTFT and inter-token latency of the streamed requests in `metrics`.
+
+    Returns None when no request carries at least two token-level timestamps
+    (non-streaming APIs, or single-token responses), in which case phase
+    classification is unavailable.
+    """
+    ttfts: List[float] = []
+    itls: List[float] = []
+    for metric in metrics:
+        response_metrics = metric.info.response_metrics
+        if not isinstance(response_metrics, StreamedResponseMetrics) or len(response_metrics.output_token_times) < 2:
+            continue
+        token_times = np.asarray(response_metrics.output_token_times, dtype=np.float64)
+        ttfts.append(float(token_times[0] - metric.start_time))
+        itls.append(float(np.mean(np.diff(token_times))))
+    if not ttfts:
+        return None
+    ttft = float(np.median(np.asarray(ttfts)))
+    itl = float(np.median(np.asarray(itls)))
+    if ttft <= 0 or itl <= 0:
+        return None
+    return LatencyProfile(ttft=ttft, itl=itl)
+
+
+def rung_from_metrics(
+    concurrency: int,
+    metrics: Sequence[RequestLifecycleMetric],
+    window_start: float,
+    window_end: float,
+    baseline: Optional[LatencyProfile] = None,
+    inflation_threshold: float = 2.0,
+    num_batches: int = 8,
+) -> RungResult:
+    """Build a `RungResult` for one closed-loop rung from its lifecycle metrics.
+
+    Only successful requests count toward throughput: a saturated backend that
+    fails fast must not read as a fast backend. When `baseline` (the unloaded
+    rung's latency profile) and streamed timestamps are both available, the
+    rung is classified prefill- or decode-bound from TTFT and inter-token
+    inflation; otherwise the signal stays NONE.
+
+    Raises ValueError when no successful request completed inside the window,
+    which is a measurement failure, not a zero rate.
+    """
+    successes = [metric for metric in metrics if metric.error is None]
+    completion_times = [metric.end_time for metric in successes]
+    latencies = [metric.end_time - metric.start_time for metric in successes]
+
+    signal = SaturationSignal.NONE
+    if baseline is not None:
+        in_window = [metric for metric in successes if window_start <= metric.end_time < window_end]
+        profile = latency_profile(in_window)
+        if profile is not None:
+            signal = classify_saturation(
+                ttft_inflation=profile.ttft / baseline.ttft,
+                itl_inflation=profile.itl / baseline.itl,
+                threshold=inflation_threshold,
+            )
+    return make_rung(
+        concurrency,
+        completion_times,
+        latencies,
+        window_start,
+        window_end,
+        num_batches=num_batches,
+        signal=signal,
+    )

--- a/inference_perf/loadgen/probe/result.py
+++ b/inference_perf/loadgen/probe/result.py
@@ -1,0 +1,140 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Result types for the capacity probe.
+
+The probe communicates with the rest of the harness exclusively through these
+types: per-rung measurements (`RungResult`) and named constants with
+confidence intervals (`BoundConstant`). Constant names are drawn from a
+reserved, internal-only symbol namespace so that sweep stage definitions can
+reference them while user config can never define them.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping, Tuple
+
+# Internal-only symbol names the probe may bind. Config validation must reject
+# any user-supplied definition of these names; stage expressions may reference
+# them and the harness binds their values after the probe runs.
+#
+#   r_sat  - capacity asymptote, requests/sec
+#   n_knee - concurrency at which throughput reaches the knee fraction of r_sat
+#   r_slo  - highest request rate meeting latency SLOs (reserved; not yet
+#            produced by `estimate_constants`, which needs open-loop refinement)
+RESERVED_SYMBOLS = frozenset({"r_sat", "n_knee", "r_slo"})
+
+
+class SaturationSignal(str, Enum):
+    """Client-side classification of what bound a rung, if anything.
+
+    On disaggregated or routed backends the bottleneck identity matters as
+    much as the knee location: first-token delays indicate queue/prefill/router
+    saturation while inter-token stalls indicate decode saturation. A client
+    that cannot keep up invalidates the rung entirely.
+    """
+
+    NONE = "none"
+    PREFILL_BOUND = "prefill_bound"
+    DECODE_BOUND = "decode_bound"
+    CLIENT_BOUND = "client_bound"
+
+
+def classify_saturation(
+    ttft_inflation: float,
+    itl_inflation: float,
+    client_lag_inflation: float = 1.0,
+    threshold: float = 2.0,
+) -> SaturationSignal:
+    """Classify a rung's bottleneck from degradation ratios versus an unloaded baseline.
+
+    Each inflation argument is the rung's observed value divided by its
+    baseline value (time to first token, inter-token latency, and client
+    event-loop lag respectively), so 1.0 means "unchanged". Client saturation
+    is checked first because it invalidates the other two signals.
+    """
+    if ttft_inflation <= 0 or itl_inflation <= 0 or client_lag_inflation <= 0:
+        raise ValueError("inflation ratios must be positive")
+    if client_lag_inflation >= threshold:
+        return SaturationSignal.CLIENT_BOUND
+    if ttft_inflation >= threshold and ttft_inflation >= itl_inflation:
+        return SaturationSignal.PREFILL_BOUND
+    if itl_inflation >= threshold:
+        return SaturationSignal.DECODE_BOUND
+    return SaturationSignal.NONE
+
+
+@dataclass(frozen=True)
+class ConfidenceInterval:
+    low: float
+    high: float
+
+    def __post_init__(self) -> None:
+        if self.low > self.high:
+            raise ValueError(f"invalid confidence interval: low={self.low} > high={self.high}")
+
+    @property
+    def width(self) -> float:
+        return self.high - self.low
+
+
+@dataclass(frozen=True)
+class BoundConstant:
+    """A probe-estimated constant destined for the internal symbol namespace."""
+
+    name: str
+    value: float
+    ci: ConfidenceInterval
+
+    def __post_init__(self) -> None:
+        if self.name not in RESERVED_SYMBOLS:
+            raise ValueError(f"'{self.name}' is not a reserved probe symbol; allowed: {sorted(RESERVED_SYMBOLS)}")
+
+
+@dataclass(frozen=True)
+class RungResult:
+    """One measured rung of the concurrency ladder.
+
+    `littles_law_residual` is |N - X * R| / N over the analysis window; a large
+    value means the window was not stationary or the concurrency was not
+    actually held at N, and the rung should not be trusted.
+    """
+
+    concurrency: int
+    throughput: float
+    throughput_se: float = 0.0
+    latency: float = 0.0
+    littles_law_residual: float = 0.0
+    stationary: bool = True
+    signal: SaturationSignal = SaturationSignal.NONE
+
+    def __post_init__(self) -> None:
+        if self.concurrency < 1:
+            raise ValueError(f"concurrency must be >= 1, got {self.concurrency}")
+        if self.throughput <= 0:
+            raise ValueError(f"throughput must be positive, got {self.throughput}")
+        if self.throughput_se < 0:
+            raise ValueError(f"throughput_se must be non-negative, got {self.throughput_se}")
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Everything a probe run produced: the rung curve and the bound constants."""
+
+    rungs: Tuple[RungResult, ...]
+    constants: Mapping[str, BoundConstant]
+
+    def constant(self, name: str) -> BoundConstant:
+        if name not in self.constants:
+            raise KeyError(f"probe did not bind '{name}'; bound symbols: {sorted(self.constants)}")
+        return self.constants[name]

--- a/inference_perf/loadgen/probe/stationarity.py
+++ b/inference_perf/loadgen/probe/stationarity.py
@@ -1,0 +1,86 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CUSUM drift detection for probe measurement windows.
+
+A rung measurement is only meaningful if the window it averages over was
+stationary: no warmup ramp, no cache-fill transient, no capacity drift. CUSUM
+(cumulative sum of standardized deviations from the window median) is the
+classic sequential test for a sustained mean shift; it accumulates evidence
+in both directions and flags the first point where either side exceeds a
+threshold. Slack `k` and threshold `h` are in units of the series' robust
+standard deviation (MAD-based, falling back to the sample standard deviation
+for degenerate series).
+"""
+
+from typing import Optional
+
+import numpy as np
+import numpy.typing as npt
+
+# Minimum points for the test to have any power; shorter series fail closed
+# (treated as non-stationary) so callers re-measure rather than silently trust.
+MIN_SERIES_LENGTH = 4
+
+# 1 / Phi^{-1}(0.75): scales the median absolute deviation to estimate the
+# standard deviation consistently under normality.
+_MAD_TO_SIGMA = 1.4826
+
+
+def cusum_drift_index(
+    series: npt.ArrayLike,
+    k: float = 0.5,
+    h: float = 5.0,
+) -> Optional[int]:
+    """Return the index where a sustained mean shift is first detected, or None.
+
+    A perfectly constant series is stationary by definition. Series shorter
+    than `MIN_SERIES_LENGTH` raise ValueError; use `is_stationary` for the
+    fail-closed boolean form.
+    """
+    values = np.asarray(series, dtype=np.float64)
+    if values.ndim != 1:
+        raise ValueError(f"series must be one-dimensional, got shape {values.shape}")
+    if values.size < MIN_SERIES_LENGTH:
+        raise ValueError(f"series must have at least {MIN_SERIES_LENGTH} points, got {values.size}")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("series contains non-finite values")
+
+    center = float(np.median(values))
+    scale = float(np.median(np.abs(values - center))) * _MAD_TO_SIGMA
+    if scale == 0.0:
+        scale = float(np.std(values))
+    if scale == 0.0:
+        return None
+
+    standardized = (values - center) / scale
+    upper = 0.0
+    lower = 0.0
+    for i, z in enumerate(standardized):
+        upper = max(0.0, upper + z - k)
+        lower = max(0.0, lower - z - k)
+        if upper > h or lower > h:
+            return i
+    return None
+
+
+def is_stationary(series: npt.ArrayLike, k: float = 0.5, h: float = 5.0) -> bool:
+    """True if no sustained mean shift is detected.
+
+    Fails closed: series too short to test are reported as non-stationary so
+    the ladder re-measures instead of trusting an unverifiable window.
+    """
+    values = np.asarray(series, dtype=np.float64)
+    if values.ndim != 1 or values.size < MIN_SERIES_LENGTH:
+        return False
+    return cusum_drift_index(values, k=k, h=h) is None

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -376,7 +376,7 @@ def main_cli() -> None:
     # Define LoadGenerator with session metrics collector
     if isinstance(metrics_client, PrometheusMetricsClient) and config.report.prometheus and config.report.prometheus.per_stage:
         config.load.interval = max(config.load.interval, metrics_client.scrape_interval)
-    loadgen = LoadGenerator(datagen, config.load, session_metrics_collector)
+    loadgen = LoadGenerator(datagen, config.load, session_metrics_collector, request_metric_collector=collector)
 
     # Wire session metrics collector into reportgen if it exists
     if session_metrics_collector:

--- a/inference_perf/metrics/request_collector/base.py
+++ b/inference_perf/metrics/request_collector/base.py
@@ -31,6 +31,15 @@ class RequestMetricCollector(ABC):
     def get_metrics(self) -> List[RequestLifecycleMetric]:
         raise NotImplementedError
 
+    @abstractmethod
+    def snapshot(self) -> List[RequestLifecycleMetric]:
+        """Copy of the metrics collected so far, safe to read mid-run.
+
+        Unlike `get_metrics`, this must not require the collector to be
+        stopped first; the sweep capacity probe reads it between rungs.
+        """
+        raise NotImplementedError
+
     @asynccontextmanager
     async def start(self) -> AsyncIterator[None]:
         yield

--- a/inference_perf/metrics/request_collector/local.py
+++ b/inference_perf/metrics/request_collector/local.py
@@ -30,3 +30,6 @@ class LocalRequestMetricCollector(RequestMetricCollector):
 
     def get_metrics(self) -> List[RequestLifecycleMetric]:
         return self.metrics
+
+    def snapshot(self) -> List[RequestLifecycleMetric]:
+        return list(self.metrics)

--- a/inference_perf/metrics/request_collector/multiprocess.py
+++ b/inference_perf/metrics/request_collector/multiprocess.py
@@ -32,12 +32,15 @@ class MultiprocessRequestMetricCollector(RequestMetricCollector):
 
     def __init__(self) -> None:
         self.queue: "mp.JoinableQueue[Optional[RequestLifecycleMetric]]" = mp.JoinableQueue()
+        self.metrics: list[RequestLifecycleMetric] = []
 
     def record_metric(self, metric: RequestLifecycleMetric) -> None:
         self.queue.put(metric)
 
     async def collect_metrics(self) -> list[RequestLifecycleMetric]:
-        metrics: list[RequestLifecycleMetric] = []
+        # Accumulate onto self.metrics (not a local) so snapshot() can serve
+        # partial results to mid-run readers like the sweep capacity probe.
+        metrics = self.metrics
         event_loop = get_event_loop()
         # prevent get from blocking the executor for too long:
         get_queue = partial(self.queue.get, timeout=0.5)
@@ -70,3 +73,6 @@ class MultiprocessRequestMetricCollector(RequestMetricCollector):
 
     def get_metrics(self) -> list[RequestLifecycleMetric]:
         return self.metrics
+
+    def snapshot(self) -> list[RequestLifecycleMetric]:
+        return list(self.metrics)

--- a/tests/required/config/loadgen/test_load_config.py
+++ b/tests/required/config/loadgen/test_load_config.py
@@ -26,6 +26,7 @@ from inference_perf.config import (
     LoadConfig,
     LoadType,
     MultiLoRAConfig,
+    ProbeConfig,
     StandardLoadStage,
     StageGenType,
     SweepConfig,
@@ -171,3 +172,22 @@ def test_multilora_traffic_split_summing_to_one_is_ok() -> None:
     )
     assert cfg.lora_traffic_split is not None
     assert len(cfg.lora_traffic_split) == 2
+
+
+# --- ProbeConfig ---------------------------------------------------------
+
+
+def test_probe_config_defaults_valid() -> None:
+    cfg = LoadConfig(sweep=SweepConfig(type=StageGenType.GEOM, probe=ProbeConfig()))
+    assert cfg.sweep is not None and cfg.sweep.probe is not None
+    assert cfg.sweep.probe.start_concurrency == 1
+
+
+def test_probe_config_cap_below_start_is_error() -> None:
+    with pytest.raises(ValidationError, match="max_concurrency"):
+        ProbeConfig(start_concurrency=8, max_concurrency=4)
+
+
+def test_probe_requires_workers() -> None:
+    with pytest.raises(ValidationError, match="sweep.probe requires num_workers > 0"):
+        LoadConfig(num_workers=0, sweep=SweepConfig(type=StageGenType.GEOM, probe=ProbeConfig()))

--- a/tests/required/loadgen/probe/test_estimator.py
+++ b/tests/required/loadgen/probe/test_estimator.py
@@ -1,0 +1,200 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+
+from inference_perf.loadgen.probe import (
+    RungResult,
+    SaturationSignal,
+    batch_means_throughput,
+    estimate_constants,
+    fit_saturating_curve,
+    isotonic_regression,
+    make_rung,
+)
+
+
+def saturating_throughput(concurrency: float, mu: float = 20.0, knee_constant: float = 8.0) -> float:
+    """Closed-loop throughput of an idealized backend: X(N) = mu * N / (K + N)."""
+    return mu * concurrency / (knee_constant + concurrency)
+
+
+def ideal_rungs(concurrencies: list[int], mu: float = 20.0, knee_constant: float = 8.0) -> list[RungResult]:
+    return [
+        RungResult(concurrency=n, throughput=saturating_throughput(n, mu, knee_constant), throughput_se=0.0)
+        for n in concurrencies
+    ]
+
+
+class TestBatchMeansThroughput(unittest.TestCase):
+    def test_uniform_completions(self) -> None:
+        times = np.arange(0.0, 10.0, 0.1)
+        throughput, standard_error, batch_rates = batch_means_throughput(times, 0.0, 10.0, num_batches=8)
+        self.assertAlmostEqual(throughput, 10.0)
+        self.assertLess(standard_error, 0.5)
+        self.assertEqual(batch_rates.size, 8)
+
+    def test_window_filtering(self) -> None:
+        times = np.arange(0.0, 20.0, 0.1)
+        throughput, _, _ = batch_means_throughput(times, 5.0, 15.0)
+        self.assertAlmostEqual(throughput, 10.0)
+
+    def test_empty_window_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            batch_means_throughput([100.0], 0.0, 10.0)
+
+    def test_invalid_window_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            batch_means_throughput([1.0], 10.0, 10.0)
+
+    def test_too_few_batches_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            batch_means_throughput([1.0], 0.0, 10.0, num_batches=1)
+
+
+class TestMakeRung(unittest.TestCase):
+    def test_littles_law_consistency(self) -> None:
+        # Closed loop at N=5 with R=0.5s implies X=10/s; the residual must vanish.
+        times = np.arange(0.0, 10.0, 0.1)
+        latencies = np.full_like(times, 0.5)
+        rung = make_rung(5, times, latencies, 0.0, 10.0)
+        self.assertAlmostEqual(rung.throughput, 10.0)
+        self.assertAlmostEqual(rung.latency, 0.5)
+        self.assertAlmostEqual(rung.littles_law_residual, 0.0)
+        self.assertTrue(rung.stationary)
+        self.assertIs(rung.signal, SaturationSignal.NONE)
+
+    def test_inconsistent_window_has_large_residual(self) -> None:
+        # Claiming N=50 while X*R=5 leaves a residual of 0.9.
+        times = np.arange(0.0, 10.0, 0.1)
+        latencies = np.full_like(times, 0.5)
+        rung = make_rung(50, times, latencies, 0.0, 10.0)
+        self.assertGreater(rung.littles_law_residual, 0.85)
+
+    def test_misaligned_inputs_raise(self) -> None:
+        with self.assertRaises(ValueError):
+            make_rung(1, [1.0, 2.0], [0.5], 0.0, 10.0)
+
+
+class TestIsotonicRegression(unittest.TestCase):
+    def test_pools_violators(self) -> None:
+        fitted = isotonic_regression([1.0, 3.0, 2.0])
+        self.assertTrue(np.allclose(fitted, [1.0, 2.5, 2.5]))
+
+    def test_decreasing_pools_to_mean(self) -> None:
+        fitted = isotonic_regression([3.0, 2.0, 1.0])
+        self.assertTrue(np.allclose(fitted, [2.0, 2.0, 2.0]))
+
+    def test_monotone_input_unchanged(self) -> None:
+        values = [1.0, 2.0, 4.0, 8.0]
+        self.assertTrue(np.allclose(isotonic_regression(values), values))
+
+    def test_weights_shift_pooled_mean(self) -> None:
+        fitted = isotonic_regression([3.0, 1.0], weights=[3.0, 1.0])
+        self.assertTrue(np.allclose(fitted, [2.5, 2.5]))
+
+    def test_invalid_weights_raise(self) -> None:
+        with self.assertRaises(ValueError):
+            isotonic_regression([1.0, 2.0], weights=[1.0, 0.0])
+
+
+class TestFitSaturatingCurve(unittest.TestCase):
+    def test_recovers_noiseless_parameters(self) -> None:
+        concurrencies = [1, 2, 4, 8, 16, 32, 64]
+        throughputs = [saturating_throughput(n) for n in concurrencies]
+        fit = fit_saturating_curve(concurrencies, throughputs)
+        self.assertIsNotNone(fit)
+        assert fit is not None
+        mu, knee_constant = fit
+        self.assertAlmostEqual(mu, 20.0, places=6)
+        self.assertAlmostEqual(knee_constant, 8.0, places=6)
+
+    def test_superlinear_data_rejected(self) -> None:
+        concurrencies = [1.0, 2.0, 4.0, 8.0]
+        throughputs = [n * n for n in concurrencies]
+        self.assertIsNone(fit_saturating_curve(concurrencies, throughputs))
+
+    def test_too_few_points_rejected(self) -> None:
+        self.assertIsNone(fit_saturating_curve([1.0, 2.0], [1.0, 2.0]))
+
+    def test_non_positive_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            fit_saturating_curve([1.0, 2.0, 3.0], [1.0, -2.0, 3.0])
+
+
+class TestEstimateConstants(unittest.TestCase):
+    def test_noiseless_ladder_recovers_asymptote(self) -> None:
+        rungs = ideal_rungs([1, 2, 4, 8, 16, 32, 64])
+        constants = estimate_constants(rungs, rng=np.random.default_rng(0), num_bootstrap=50)
+        self.assertAlmostEqual(constants["r_sat"].value, 20.0, places=5)
+        self.assertAlmostEqual(constants["r_sat"].ci.width, 0.0, places=5)
+
+    def test_knee_fraction_controls_knee(self) -> None:
+        # X(32) = 16 = 0.8 * mu exactly, so the 0.8-knee sits at N=32.
+        rungs = ideal_rungs([1, 2, 4, 8, 16, 32, 64])
+        constants = estimate_constants(rungs, rng=np.random.default_rng(0), num_bootstrap=50, knee_fraction=0.8)
+        self.assertAlmostEqual(constants["n_knee"].value, 32.0, places=5)
+
+    def test_censored_knee_falls_back_to_largest_rung(self) -> None:
+        # No measured rung reaches 0.9 * mu, so n_knee is censored at N=64.
+        rungs = ideal_rungs([1, 2, 4, 8, 16, 32, 64])
+        constants = estimate_constants(rungs, rng=np.random.default_rng(0), num_bootstrap=50, knee_fraction=0.9)
+        self.assertAlmostEqual(constants["n_knee"].value, 64.0, places=5)
+
+    def test_noisy_ladder_recovers_asymptote_within_ci(self) -> None:
+        rng = np.random.default_rng(7)
+        concurrencies = [1, 2, 4, 8, 16, 32, 64]
+        rungs = [
+            RungResult(
+                concurrency=n,
+                throughput=float(saturating_throughput(n) + rng.normal(0.0, 0.2)),
+                throughput_se=0.2,
+            )
+            for n in concurrencies
+        ]
+        constants = estimate_constants(rungs, rng=np.random.default_rng(0))
+        r_sat = constants["r_sat"]
+        self.assertAlmostEqual(r_sat.value, 20.0, delta=2.0)
+        self.assertLessEqual(r_sat.ci.low, 20.0)
+        self.assertGreaterEqual(r_sat.ci.high, 19.0)
+
+    def test_unsaturated_ladder_falls_back_to_plateau(self) -> None:
+        # Linear X(N) = 2N carries no evidence of an asymptote; report the
+        # measured plateau instead of a wild extrapolation.
+        rungs = [RungResult(concurrency=n, throughput=2.0 * n, throughput_se=0.0) for n in [1, 2, 4, 8, 16, 32]]
+        constants = estimate_constants(rungs, rng=np.random.default_rng(0), num_bootstrap=50)
+        self.assertAlmostEqual(constants["r_sat"].value, 64.0, places=5)
+
+    def test_unusable_rungs_excluded(self) -> None:
+        rungs = ideal_rungs([1, 2, 4, 8, 16, 32, 64])
+        rungs.append(RungResult(concurrency=128, throughput=100.0, throughput_se=0.0, stationary=False))
+        rungs.append(RungResult(concurrency=256, throughput=1.0, throughput_se=0.0, signal=SaturationSignal.CLIENT_BOUND))
+        constants = estimate_constants(rungs, rng=np.random.default_rng(0), num_bootstrap=50)
+        self.assertAlmostEqual(constants["r_sat"].value, 20.0, places=5)
+
+    def test_retried_rung_uses_latest_measurement(self) -> None:
+        rungs = ideal_rungs([1, 2, 4, 8, 16, 32])
+        stale = RungResult(concurrency=64, throughput=5.0, throughput_se=0.0)
+        fresh = RungResult(concurrency=64, throughput=saturating_throughput(64), throughput_se=0.0)
+        constants = estimate_constants([stale, *rungs, fresh], rng=np.random.default_rng(0), num_bootstrap=50)
+        self.assertAlmostEqual(constants["r_sat"].value, 20.0, places=5)
+
+    def test_too_few_rungs_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            estimate_constants(ideal_rungs([1]), rng=np.random.default_rng(0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/probe/test_ladder.py
+++ b/tests/required/loadgen/probe/test_ladder.py
@@ -1,0 +1,119 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from inference_perf.loadgen.probe import ConcurrencyLadder, LadderConfig, RungResult, SaturationSignal
+
+
+def saturating_rung(
+    concurrency: int,
+    mu: float = 20.0,
+    knee_constant: float = 2.0,
+    stationary: bool = True,
+    signal: SaturationSignal = SaturationSignal.NONE,
+) -> RungResult:
+    throughput = mu * concurrency / (knee_constant + concurrency)
+    return RungResult(concurrency=concurrency, throughput=throughput, throughput_se=0.0, stationary=stationary, signal=signal)
+
+
+class TestLadderConfig(unittest.TestCase):
+    def test_validation(self) -> None:
+        with self.assertRaises(ValueError):
+            LadderConfig(start_concurrency=0)
+        with self.assertRaises(ValueError):
+            LadderConfig(growth_factor=1.0)
+        with self.assertRaises(ValueError):
+            LadderConfig(max_concurrency=2, start_concurrency=4)
+        with self.assertRaises(ValueError):
+            LadderConfig(gain_threshold=0.0)
+
+
+class TestConcurrencyLadder(unittest.TestCase):
+    def test_starts_at_configured_concurrency(self) -> None:
+        ladder = ConcurrencyLadder(config=LadderConfig(start_concurrency=2))
+        self.assertEqual(ladder.next_concurrency([]), 2)
+
+    def test_grows_geometrically_until_cap(self) -> None:
+        # Linear throughput never plateaus, so the ladder doubles to the cap.
+        ladder = ConcurrencyLadder(config=LadderConfig(max_concurrency=16, refine=False))
+        history: list[RungResult] = []
+        visited: list[int] = []
+        concurrency = ladder.next_concurrency(history)
+        while concurrency is not None:
+            visited.append(concurrency)
+            history.append(RungResult(concurrency=concurrency, throughput=2.0 * concurrency, throughput_se=0.0))
+            concurrency = ladder.next_concurrency(history)
+        self.assertEqual(visited, [1, 2, 4, 8, 16])
+        self.assertEqual(ladder.stop_reason, "max_concurrency")
+
+    def test_plateau_stops_with_refinement_midpoint(self) -> None:
+        ladder = ConcurrencyLadder()
+        history: list[RungResult] = []
+        visited: list[int] = []
+        concurrency = ladder.next_concurrency(history)
+        while concurrency is not None:
+            visited.append(concurrency)
+            history.append(saturating_rung(concurrency))
+            concurrency = ladder.next_concurrency(history)
+        self.assertEqual(ladder.stop_reason, "plateau")
+        # Geometric ascent, then exactly one non-doubling refinement rung
+        # between the top two ladder steps.
+        self.assertEqual(visited[:-1], [2**i for i in range(len(visited) - 1)])
+        top, second = visited[-2], visited[-3]
+        self.assertGreater(visited[-1], second)
+        self.assertLess(visited[-1], top)
+
+    def test_plateau_without_refinement(self) -> None:
+        ladder = ConcurrencyLadder(config=LadderConfig(refine=False))
+        history: list[RungResult] = []
+        concurrency = ladder.next_concurrency(history)
+        while concurrency is not None:
+            history.append(saturating_rung(concurrency))
+            concurrency = ladder.next_concurrency(history)
+        self.assertEqual(ladder.stop_reason, "plateau")
+        self.assertEqual([r.concurrency for r in history], [2**i for i in range(len(history))])
+
+    def test_noise_defers_plateau(self) -> None:
+        # A gain of 0.4 on 18.0 is within the 5% threshold, but wide standard
+        # errors make it unconfident, so the ladder keeps climbing.
+        ladder = ConcurrencyLadder()
+        history = [
+            RungResult(concurrency=8, throughput=18.0, throughput_se=1.0),
+            RungResult(concurrency=16, throughput=18.4, throughput_se=1.0),
+        ]
+        self.assertEqual(ladder.next_concurrency(history), 32)
+
+    def test_non_stationary_rung_retried_once(self) -> None:
+        ladder = ConcurrencyLadder()
+        history = [saturating_rung(1), saturating_rung(2), saturating_rung(4, stationary=False)]
+        self.assertEqual(ladder.next_concurrency(history), 4)
+        history.append(saturating_rung(4, stationary=False))
+        self.assertEqual(ladder.next_concurrency(history), 8)
+
+    def test_client_bound_stops_immediately(self) -> None:
+        ladder = ConcurrencyLadder()
+        history = [saturating_rung(1), saturating_rung(2, signal=SaturationSignal.CLIENT_BOUND)]
+        self.assertIsNone(ladder.next_concurrency(history))
+        self.assertEqual(ladder.stop_reason, "client_bound")
+
+    def test_stop_is_sticky(self) -> None:
+        ladder = ConcurrencyLadder()
+        history = [saturating_rung(1, signal=SaturationSignal.CLIENT_BOUND)]
+        self.assertIsNone(ladder.next_concurrency(history))
+        self.assertIsNone(ladder.next_concurrency([saturating_rung(1)]))
+        self.assertEqual(ladder.stop_reason, "client_bound")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/probe/test_metrics.py
+++ b/tests/required/loadgen/probe/test_metrics.py
@@ -1,0 +1,124 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from typing import List, Optional
+
+import numpy as np
+
+from inference_perf.apis import (
+    ErrorResponseInfo,
+    InferenceInfo,
+    RequestLifecycleMetric,
+    StreamedResponseMetrics,
+)
+from inference_perf.loadgen.probe import LatencyProfile, SaturationSignal, latency_profile, rung_from_metrics
+from inference_perf.payloads import RequestMetrics, Text
+
+
+def make_metric(
+    start_time: float,
+    end_time: float,
+    token_times: Optional[List[float]] = None,
+    error: Optional[ErrorResponseInfo] = None,
+    stage_id: int = -1,
+) -> RequestLifecycleMetric:
+    info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=10)))
+    if token_times is not None:
+        info.response_metrics = StreamedResponseMetrics(output_token_times=token_times)
+    return RequestLifecycleMetric(
+        stage_id=stage_id,
+        scheduled_time=start_time,
+        start_time=start_time,
+        end_time=end_time,
+        request_data="{}",
+        info=info,
+        error=error,
+    )
+
+
+def streamed_metric(start_time: float, ttft: float, itl: float, num_tokens: int = 3) -> RequestLifecycleMetric:
+    token_times = [start_time + ttft + i * itl for i in range(num_tokens)]
+    return make_metric(start_time, token_times[-1], token_times=token_times)
+
+
+class TestLatencyProfile(unittest.TestCase):
+    def test_medians_of_streamed_requests(self) -> None:
+        metrics = [
+            streamed_metric(0.0, ttft=0.1, itl=0.01),
+            streamed_metric(1.0, ttft=0.2, itl=0.02),
+            streamed_metric(2.0, ttft=0.3, itl=0.03),
+        ]
+        profile = latency_profile(metrics)
+        self.assertIsNotNone(profile)
+        assert profile is not None
+        self.assertAlmostEqual(profile.ttft, 0.2)
+        self.assertAlmostEqual(profile.itl, 0.02)
+
+    def test_no_streamed_requests_is_none(self) -> None:
+        self.assertIsNone(latency_profile([make_metric(0.0, 0.5)]))
+
+    def test_single_token_time_is_ignored(self) -> None:
+        self.assertIsNone(latency_profile([make_metric(0.0, 0.5, token_times=[0.4])]))
+
+
+class TestRungFromMetrics(unittest.TestCase):
+    def test_littles_law_consistency(self) -> None:
+        # Closed loop at N=5 with R=0.5s implies X=10/s; the residual must vanish.
+        metrics = [make_metric(end - 0.5, float(end)) for end in np.arange(0.0, 10.0, 0.1)]
+        rung = rung_from_metrics(5, metrics, 0.0, 10.0)
+        self.assertAlmostEqual(rung.throughput, 10.0)
+        self.assertAlmostEqual(rung.latency, 0.5)
+        self.assertAlmostEqual(rung.littles_law_residual, 0.0)
+        self.assertIs(rung.signal, SaturationSignal.NONE)
+
+    def test_errors_do_not_count_toward_throughput(self) -> None:
+        error = ErrorResponseInfo(error_type="server", error_msg="boom")
+        metrics = [make_metric(end - 0.5, float(end)) for end in np.arange(0.0, 10.0, 0.1)]
+        metrics += [make_metric(end - 0.01, float(end), error=error) for end in np.arange(0.05, 10.0, 0.1)]
+        rung = rung_from_metrics(5, metrics, 0.0, 10.0)
+        self.assertAlmostEqual(rung.throughput, 10.0)
+
+    def test_empty_window_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            rung_from_metrics(1, [make_metric(99.0, 100.0)], 0.0, 10.0)
+
+    def test_prefill_inflation_classified(self) -> None:
+        baseline = LatencyProfile(ttft=0.1, itl=0.01)
+        metrics = [streamed_metric(float(start), ttft=0.5, itl=0.011) for start in np.arange(0.0, 10.0, 0.1)]
+        rung = rung_from_metrics(4, metrics, 0.0, 11.0, baseline=baseline)
+        self.assertIs(rung.signal, SaturationSignal.PREFILL_BOUND)
+
+    def test_decode_inflation_classified(self) -> None:
+        baseline = LatencyProfile(ttft=0.1, itl=0.01)
+        metrics = [streamed_metric(float(start), ttft=0.11, itl=0.05) for start in np.arange(0.0, 10.0, 0.1)]
+        rung = rung_from_metrics(4, metrics, 0.0, 11.0, baseline=baseline)
+        self.assertIs(rung.signal, SaturationSignal.DECODE_BOUND)
+
+    def test_uninflated_rung_stays_none(self) -> None:
+        baseline = LatencyProfile(ttft=0.1, itl=0.01)
+        metrics = [streamed_metric(float(start), ttft=0.1, itl=0.01) for start in np.arange(0.0, 10.0, 0.1)]
+        rung = rung_from_metrics(4, metrics, 0.0, 11.0, baseline=baseline)
+        self.assertIs(rung.signal, SaturationSignal.NONE)
+
+    def test_non_streaming_with_baseline_stays_none(self) -> None:
+        # Without token timestamps the inflation ratios are unavailable, so
+        # classification degrades to NONE rather than guessing.
+        baseline = LatencyProfile(ttft=0.1, itl=0.01)
+        metrics = [make_metric(end - 2.0, float(end)) for end in np.arange(0.0, 10.0, 0.1)]
+        rung = rung_from_metrics(4, metrics, 0.0, 10.0, baseline=baseline)
+        self.assertIs(rung.signal, SaturationSignal.NONE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/probe/test_probe_preprocess.py
+++ b/tests/required/loadgen/probe/test_probe_preprocess.py
@@ -1,0 +1,159 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end probe preprocessing test with real worker processes.
+
+Runs the closed-loop capacity probe against the mock client (fixed 50ms
+latency, so closed-loop throughput is ideally X(N) = 20N and never
+saturates) and then the generated stages, locking three invariants:
+
+- Every probe rung's phase boundary pairs a main-side stage_barrier.wait()
+  with one arrival per worker, so the run completes instead of deadlocking
+  (asyncio.wait_for turns a pairing bug into a test failure).
+- Rung measurements obey Little's law against the known mock latency.
+- Probe traffic stays on negative stage ids, which the report generator
+  drops, and the generated stages run to completion afterwards.
+"""
+
+import asyncio
+import multiprocessing as mp
+import sys
+import unittest
+from typing import Any
+
+from inference_perf.client.modelserver.mock_client import MockModelServerClient
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    DataConfig,
+    DataGenType,
+    Distribution,
+    LoadConfig,
+    LoadType,
+    ProbeConfig,
+    StageGenType,
+    StandardLoadStage,
+    SweepConfig,
+)
+from inference_perf.datagen.synthetic.random_datagen import RandomDataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+# Match the start method used in production (main.py) so the tokenizer and
+# datagen objects are inherited rather than pickled into worker processes.
+if sys.platform == "darwin":
+    try:
+        mp.set_start_method("fork", force=True)
+    except RuntimeError:
+        pass
+
+MOCK_LATENCY = 0.05
+
+
+class _DummyHFTokenizer:
+    """Minimal HuggingFace-shaped tokenizer backed by space-delimited integers."""
+
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def decode(self, tokens: list[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+    def encode(self, text: str) -> list[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return list(range(10, 10010))
+
+
+class _DummyCustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return _DummyHFTokenizer()
+
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
+        # Each space-separated integer is one token.
+        return len(text.split()) if text else 0
+
+
+class TestProbePreprocess(unittest.IsolatedAsyncioTestCase):
+    async def test_probe_measures_generates_and_runs_stages(self) -> None:
+        num_stages = 2
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        data_config = DataConfig(
+            type=DataGenType.Random,
+            input_distribution=Distribution(min=10, max=10, mean=10.0, std_dev=0.0, total_count=2000),
+            output_distribution=Distribution(min=5, max=5, mean=5.0, std_dev=0.0, total_count=2000),
+        )
+        datagen = RandomDataGenerator(api_config, data_config, _DummyCustomTokenizer())
+
+        collector = MultiprocessRequestMetricCollector()
+        client = MockModelServerClient(collector, api_config, mock_latency=MOCK_LATENCY)
+
+        load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            num_workers=1,
+            worker_max_concurrency=16,
+            interval=0,
+            stages=[],
+            sweep=SweepConfig(
+                type=StageGenType.LINEAR,
+                num_stages=num_stages,
+                stage_duration=1,
+                probe=ProbeConfig(rung_duration=1.0, settle_duration=0.25, start_concurrency=1, max_concurrency=4),
+            ),
+            base_seed=42,
+        )
+        load_gen = LoadGenerator(datagen, load_config, request_metric_collector=collector)
+
+        async with collector.start():
+            # A broken barrier pairing deadlocks instead of failing, so bound
+            # the whole run.
+            await asyncio.wait_for(load_gen.mp_run(client), timeout=120)
+        await load_gen.stop()
+
+        # The ladder never saturates against a fixed-latency backend, so it
+        # climbs to the cap: rungs at N = 1, 2, 4.
+        probe_result = load_gen.probe_result
+        assert probe_result is not None
+        self.assertEqual([r.concurrency for r in probe_result.rungs], [1, 2, 4])
+        for rung in probe_result.rungs:
+            ideal = rung.concurrency / MOCK_LATENCY
+            self.assertGreater(rung.throughput, 0.5 * ideal)
+            self.assertLessEqual(rung.throughput, 1.5 * ideal)
+            self.assertLess(rung.littles_law_residual, 0.5)
+
+        r_sat = probe_result.constant("r_sat")
+        self.assertGreaterEqual(r_sat.ci.low, probe_result.rungs[0].throughput)
+
+        # Generated stages are spaced up to r_sat and actually ran.
+        stage_rates = [s.rate for s in load_gen.stages if isinstance(s, StandardLoadStage)]
+        self.assertEqual(len(stage_rates), num_stages)
+        self.assertAlmostEqual(max(stage_rates), round(r_sat.value, 2), places=2)
+        for stage_id in range(num_stages):
+            self.assertEqual(load_gen.stage_runtime_info[stage_id].status.name, "COMPLETED")
+
+        # Probe traffic is confined to negative stage ids (dropped from
+        # reports) and no probe rung leaks into stage_runtime_info.
+        metrics = collector.get_metrics()
+        probe_metrics = [m for m in metrics if m.stage_id is not None and m.stage_id < 0]
+        self.assertGreater(len(probe_metrics), 0)
+        self.assertEqual({m.stage_id for m in probe_metrics}, {-1, -2, -3})
+        self.assertTrue(all(stage_id >= 0 for stage_id in load_gen.stage_runtime_info))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/probe/test_result.py
+++ b/tests/required/loadgen/probe/test_result.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from inference_perf.loadgen.probe import (
+    RESERVED_SYMBOLS,
+    BoundConstant,
+    ConfidenceInterval,
+    ProbeResult,
+    RungResult,
+    SaturationSignal,
+    classify_saturation,
+)
+
+
+class TestConfidenceInterval(unittest.TestCase):
+    def test_valid_interval(self) -> None:
+        ci = ConfidenceInterval(low=1.0, high=3.0)
+        self.assertEqual(ci.width, 2.0)
+
+    def test_inverted_interval_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ConfidenceInterval(low=3.0, high=1.0)
+
+
+class TestBoundConstant(unittest.TestCase):
+    def test_reserved_names_accepted(self) -> None:
+        for name in RESERVED_SYMBOLS:
+            constant = BoundConstant(name=name, value=1.0, ci=ConfidenceInterval(0.5, 1.5))
+            self.assertEqual(constant.name, name)
+
+    def test_unreserved_name_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            BoundConstant(name="rate", value=1.0, ci=ConfidenceInterval(0.5, 1.5))
+
+
+class TestRungResult(unittest.TestCase):
+    def test_validation(self) -> None:
+        with self.assertRaises(ValueError):
+            RungResult(concurrency=0, throughput=1.0)
+        with self.assertRaises(ValueError):
+            RungResult(concurrency=1, throughput=0.0)
+        with self.assertRaises(ValueError):
+            RungResult(concurrency=1, throughput=1.0, throughput_se=-0.1)
+
+
+class TestProbeResult(unittest.TestCase):
+    def test_constant_lookup(self) -> None:
+        r_sat = BoundConstant(name="r_sat", value=20.0, ci=ConfidenceInterval(19.0, 21.0))
+        result = ProbeResult(rungs=(RungResult(concurrency=1, throughput=5.0),), constants={"r_sat": r_sat})
+        self.assertIs(result.constant("r_sat"), r_sat)
+        with self.assertRaises(KeyError):
+            result.constant("n_knee")
+
+
+class TestClassifySaturation(unittest.TestCase):
+    def test_client_bound_wins(self) -> None:
+        signal = classify_saturation(ttft_inflation=5.0, itl_inflation=5.0, client_lag_inflation=3.0)
+        self.assertIs(signal, SaturationSignal.CLIENT_BOUND)
+
+    def test_prefill_bound(self) -> None:
+        signal = classify_saturation(ttft_inflation=4.0, itl_inflation=1.1)
+        self.assertIs(signal, SaturationSignal.PREFILL_BOUND)
+
+    def test_decode_bound(self) -> None:
+        signal = classify_saturation(ttft_inflation=1.1, itl_inflation=4.0)
+        self.assertIs(signal, SaturationSignal.DECODE_BOUND)
+
+    def test_prefill_wins_ties(self) -> None:
+        signal = classify_saturation(ttft_inflation=4.0, itl_inflation=4.0)
+        self.assertIs(signal, SaturationSignal.PREFILL_BOUND)
+
+    def test_unloaded_is_none(self) -> None:
+        signal = classify_saturation(ttft_inflation=1.0, itl_inflation=1.0)
+        self.assertIs(signal, SaturationSignal.NONE)
+
+    def test_non_positive_ratio_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            classify_saturation(ttft_inflation=0.0, itl_inflation=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/probe/test_stationarity.py
+++ b/tests/required/loadgen/probe/test_stationarity.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import numpy as np
+
+from inference_perf.loadgen.probe import cusum_drift_index, is_stationary
+
+
+class TestCusumDriftIndex(unittest.TestCase):
+    def test_constant_series_is_stationary(self) -> None:
+        self.assertIsNone(cusum_drift_index([5.0] * 16))
+        self.assertTrue(is_stationary([5.0] * 16))
+
+    def test_stationary_noise_is_stationary(self) -> None:
+        rng = np.random.default_rng(42)
+        series = rng.normal(10.0, 1.0, 64)
+        self.assertTrue(is_stationary(series))
+
+    def test_warmup_transient_detected_early(self) -> None:
+        series = [0.0] * 5 + [10.0] * 27
+        index = cusum_drift_index(series)
+        self.assertIsNotNone(index)
+        assert index is not None
+        self.assertLess(index, 8)
+        self.assertFalse(is_stationary(series))
+
+    def test_ramp_detected(self) -> None:
+        series = np.linspace(0.0, 20.0, 64)
+        self.assertIsNotNone(cusum_drift_index(series))
+        self.assertFalse(is_stationary(series))
+
+    def test_short_series_raises_and_fails_closed(self) -> None:
+        with self.assertRaises(ValueError):
+            cusum_drift_index([1.0, 2.0, 3.0])
+        self.assertFalse(is_stationary([1.0, 2.0, 3.0]))
+
+    def test_non_finite_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            cusum_drift_index([1.0, float("nan"), 1.0, 1.0])
+
+    def test_two_dimensional_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            cusum_drift_index(np.ones((4, 4)))
+        self.assertFalse(is_stationary(np.ones((4, 4))))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/metrics/test_request_collector_snapshot.py
+++ b/tests/required/metrics/test_request_collector_snapshot.py
@@ -1,0 +1,66 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import unittest
+
+from inference_perf.apis import InferenceInfo, RequestLifecycleMetric
+from inference_perf.metrics.request_collector import (
+    LocalRequestMetricCollector,
+    MultiprocessRequestMetricCollector,
+)
+from inference_perf.payloads import RequestMetrics, Text
+
+
+def make_metric(stage_id: int) -> RequestLifecycleMetric:
+    return RequestLifecycleMetric(
+        stage_id=stage_id,
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="{}",
+        info=InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=10))),
+        error=None,
+    )
+
+
+class TestLocalCollectorSnapshot(unittest.TestCase):
+    def test_snapshot_is_a_copy(self) -> None:
+        collector = LocalRequestMetricCollector()
+        collector.record_metric(make_metric(0))
+        snapshot = collector.snapshot()
+        self.assertEqual(len(snapshot), 1)
+        snapshot.clear()
+        self.assertEqual(len(collector.get_metrics()), 1)
+
+
+class TestMultiprocessCollectorSnapshot(unittest.IsolatedAsyncioTestCase):
+    async def test_snapshot_serves_partial_results_mid_run(self) -> None:
+        collector = MultiprocessRequestMetricCollector()
+        self.assertEqual(collector.snapshot(), [])
+
+        async with collector.start():
+            collector.record_metric(make_metric(-1))
+            collector.record_metric(make_metric(-1))
+            # The collector task drains the queue asynchronously; wait for it
+            # the same way the sweep probe does between rungs.
+            async with asyncio.timeout(10):
+                while len(collector.snapshot()) < 2:
+                    await asyncio.sleep(0.05)
+            self.assertEqual({m.stage_id for m in collector.snapshot()}, {-1})
+
+        self.assertEqual(len(collector.get_metrics()), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of the fix for #300. Supersedes #360.

Reworks sweep request-rate autoselection: a standalone
`inference_perf/loadgen/probe/` package with the measurement and
estimation core, replacing transient-based capacity estimation with a
closed-loop concurrency ladder, plus (second commit) wiring into sweep
preprocessing behind an opt-in `sweep.probe` config.

## Why the current estimator fails

`preprocess` sends a burst and takes the 95th percentile of 0.5s finite
differences of the in-flight counter while it drains: an extreme order
statistic of a noisy derivative measured during a transient, biased
upward, high variance, and not converging with more data. The
stepped-ramp alternative in #360 estimates from the unstable side of the
boundary, where detection time diverges as offered rate approaches
capacity, which is why tolerance and window tuning never made it reliable.

## Approach

1. Hold in-flight concurrency fixed at N and measure throughput X(N) and
   mean latency R(N) over a stationary window. Little's law (N = X * R)
   holds for any arrival process and topology, so every rung is
   self-checking (`make_rung`, batch-means standard errors).
2. Grow N geometrically until the marginal gain is confidently below
   threshold (`ConcurrencyLadder`); noise extends the ladder rather than
   truncating it into an underestimate.
3. Estimate capacity two ways (`estimate_constants`): empirical plateau via
   isotonic regression (never extrapolates) and a saturating-curve fit
   X(N) = mu*N/(K+N), accepted only when its asymptote is within 1.3x of
   the measured plateau. CIs via parametric bootstrap.
4. CUSUM stationarity detection per window rejects warmup and cache-fill
   transients; non-stationary rungs are re-measured.
5. Bottleneck classification from client-observable signals (TTFT inflation
   vs inter-token inflation vs client event-loop lag): prefill-, decode-,
   or client-bound. A client-bound rung stops the ladder, since larger
   rungs would measure the client, not the server.

Outputs are named constants with confidence intervals (`r_sat`, `n_knee`;
`r_slo` reserved) in an internal-only symbol namespace: sweep stage
definitions will reference them, users never set them, and the harness
binds values after the probe runs.

## Wiring

`sweep.probe` in the load config selects the closed-loop probe over the
burst estimator (omitted = burst path, unchanged). The probe runs during
preprocessing on negative stage ids, which the report generator already
drops, so probe traffic never pollutes results. Concurrency is driven
through the workers' shared per-worker concurrency value, now created for
every load type instead of only CONCURRENT (initialized to the configured
ceiling, so non-probe runs are unchanged). Rungs are measured from
request lifecycle metrics via a new collector `snapshot()` API serving
partial results mid-run. Afterwards stages are spaced up to the estimated
saturation rate and worker concurrency restored.

Every probe phase boundary pairs a main-side `stage_barrier.wait()` with
one arrival per worker. The same pairing is added after the legacy burst
stage, which previously had none and only avoided deadlock because workers
usually miss the microseconds-long window in which the phase flag is down;
a worker that catches it parks at the barrier forever. The new mp
integration test bounds the run with `asyncio.wait_for` so a pairing
regression fails rather than hangs.

## Scope and caveats

Probe core (measurement, estimation, ladder policy) plus sweep wiring.
69 unit tests, including an end-to-end mp run against the mock client
that checks measured rungs against Little's law. Follow-ups: `r_slo`
(needs SLO config plus an open-loop refinement), binding the
constants into stage rate expressions (#449, #563), and a client-side
lag signal to activate the client-bound ladder stop.

Known limits, shared with the burst estimator unless noted: the probe
consumes data generator items, so finite corpora must cover probe
traffic; phase classification needs streaming token timestamps and
degrades to unclassified without them; closed-loop per-rung latency is a
measurement device and is not reported as open-loop latency.
