### PR TITLE
test: integration coverage for partial response body on a broken SSE stream

### DIFF
--- a/tests/required/integration/fake_truncating_server.py
+++ b/tests/required/integration/fake_truncating_server.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A fake model server that 200s and then breaks the stream, for the
+integration tier.
+
+The sim cannot fail on cue, so the truncated-stream condition has to be
+induced. This speaks raw HTTP/1.1 rather than going through an server
+framework because the failure being reproduced *is* a protocol-level lie: the
+response declares a ``Content-Length`` larger than the body it actually sends
+and then half-closes. aiohttp raises a real ``ClientPayloadError`` when the
+connection ends early, so tests exercise the client's genuine exception path
+instead of a patched-in exception (the #606 Integration tier's "fake the
+conditions, never the oracle" principle).
+"""
+
+import asyncio
+from types import TracebackType
+from typing import List, Optional, Type
+
+
+class TruncatingSSEServer:
+    """Serves a 200 SSE response that stops short of its declared length.
+
+    ``events`` are the JSON payloads to emit as ``data:`` frames before the
+    break; pass an empty list to break before any body byte is sent.
+    ``sent_body`` records exactly what went out on the wire so a test can
+    assert the client preserved that text and not an approximation of it.
+    """
+
+    def __init__(self, events: List[str], missing_bytes: int = 64) -> None:
+        self.events = events
+        # How far the declared Content-Length overshoots what we actually
+        # write. Any positive value triggers the client-side error.
+        self.missing_bytes = missing_bytes
+        self.sent_body = ""
+        self._server: Optional[asyncio.AbstractServer] = None
+        self.port = 0
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def __aenter__(self) -> "TruncatingSSEServer":
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+        return self
+
+    async def __aexit__(
+        self, exc_type: Optional[Type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
+    ) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    @staticmethod
+    async def _drain_request(reader: asyncio.StreamReader) -> None:
+        """Read the full request so the client's own write completes cleanly and
+        the only failure under test is the response-side truncation."""
+        header = await reader.readuntil(b"\r\n\r\n")
+        content_length = 0
+        for line in header.split(b"\r\n"):
+            if line.lower().startswith(b"content-length:"):
+                content_length = int(line.split(b":", 1)[1])
+        if content_length:
+            await reader.readexactly(content_length)
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await self._drain_request(reader)
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+            writer.close()
+            return
+
+        body = "".join(f"data: {event}\n\n" for event in self.events)
+        encoded = body.encode()
+        headers = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/event-stream\r\n"
+            # The lie: promise more than we are going to send.
+            f"Content-Length: {len(encoded) + self.missing_bytes}\r\n"
+            "\r\n"
+        )
+        writer.write(headers.encode() + encoded)
+        await writer.drain()
+        self.sent_body = body
+        # Half-close so the partial body is delivered and *then* the stream
+        # ends early. An abrupt reset here would surface as a connection error
+        # rather than the incomplete-payload case #531 describes.
+        if writer.can_write_eof():
+            writer.write_eof()
+        writer.close()

--- a/tests/required/integration/test_streaming_failure_body.py
+++ b/tests/required/integration/test_streaming_failure_body.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration test for issue #531 (#606 Integration tier, per-change lane).
+
+#530 fixed the bug: ``parse_sse_stream`` now wraps a mid-stream failure in
+``StreamInterruptedError`` carrying the bytes read so far, and
+``process_request`` recovers them into ``response_data`` so the per-request
+report still shows what the server sent. Nothing gates that recovery, and an
+ungated fix is how #410 reached the #564 postmortem.
+
+These tests drive the real client against a fake that returns 200, writes
+valid SSE frames, then ends the connection short of its declared
+``Content-Length``. That is the reproduction described in #531, and it raises a
+genuine ``aiohttp.ClientPayloadError`` inside the client, so the recovery
+branch is exercised through the real exception path rather than a patched-in
+one.
+"""
+
+import time
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fake_truncating_server import TruncatingSSEServer
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
+from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
+from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+from inference_perf.reportgen.base import ReportGenerator
+
+# Two well-formed frames, so a break after them leaves a body that is both
+# non-empty and recognizably SSE.
+EVENTS = [
+    '{"choices":[{"text":"Hello "}]}',
+    '{"choices":[{"text":"world "}]}',
+]
+
+
+class _ConcreteOpenAIClient(openAIModelServerClient):
+    """openAIModelServerClient is abstract only in the two methods below, and
+    neither participates in the streaming path under test."""
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion]
+
+    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
+        raise NotImplementedError("no server metrics are scraped in the integration tier")
+
+
+def make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+async def run_request_against(server: TruncatingSSEServer) -> RequestLifecycleMetric:
+    """One streaming completion through the real client, returning the metric
+    the client recorded for it."""
+    collector = LocalRequestMetricCollector()
+    # The client builds a CustomTokenizer, which would otherwise fetch from the
+    # Hub; token counts are irrelevant to this test, only the response body is.
+    with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
+        client = _ConcreteOpenAIClient(
+            metrics_collector=collector,
+            api_config=APIConfig(type=APIType.Completion, streaming=True),
+            uri=server.base_url,
+            model_name="fake-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+
+    session = client.new_session()
+    try:
+        await session.process_request(
+            CompletionAPIData(prompt="the quick brown fox", max_tokens=16),
+            stage_id=0,
+            scheduled_time=time.perf_counter(),
+        )
+    finally:
+        await session.close()
+
+    metrics = collector.get_metrics()
+    assert len(metrics) == 1, "the client must record exactly one metric for one request"
+    return metrics[0]
+
+
+@pytest.mark.asyncio
+async def test_partial_body_is_preserved_when_the_stream_breaks() -> None:
+    """The #531 regression: bytes received before the break must reach
+    response_data, byte for byte."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+
+    assert metric.response_data == server.sent_body, "the partial body must be preserved exactly as sent"
+    # Guards against a future "fix" that stores the parsed text instead: the
+    # value has to be the raw wire bytes, framing included, or it is useless
+    # for diagnosing a malformed stream.
+    assert "data: " in (metric.response_data or ""), "response_data must hold raw SSE framing, not reassembled output"
+    assert "Hello " in (metric.response_data or "")
+
+
+@pytest.mark.asyncio
+async def test_underlying_exception_is_reported_not_the_wrapper() -> None:
+    """StreamInterruptedError is plumbing. The report must name the error the
+    client actually hit, or the bucket in build_error_counts is useless."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+
+    assert metric.error is not None, "a broken stream must be recorded as a failure"
+    assert metric.error.error_type == "ClientPayloadError"
+    assert metric.error.error_type != "StreamInterruptedError"
+
+
+@pytest.mark.asyncio
+async def test_break_before_any_body_byte_leaves_the_response_empty() -> None:
+    """The empty-raw_content branch: with nothing received there is nothing to
+    preserve, and the 200 path must not fall through to the placeholder text
+    the non-200 path writes."""
+    async with TruncatingSSEServer([]) as server:
+        metric = await run_request_against(server)
+
+    assert metric.response_data == ""
+    assert metric.error is not None
+    assert metric.error.error_type == "ClientPayloadError"
+    assert "Failed to read response text" not in (metric.response_data or "")
+
+
+@pytest.mark.asyncio
+async def test_per_request_report_carries_the_partial_body() -> None:
+    """End of the chain: the preserved bytes have to survive into
+    per_request_lifecycle_metrics, which is the escape hatch #531 is about."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+        sent_body = server.sent_body
+
+    config = MagicMock()
+    config.tokenizer = None
+    config.model_dump = MagicMock(return_value={})
+    generator = ReportGenerator(
+        metrics_client=None,
+        metrics_collector=MagicMock(get_metrics=MagicMock(return_value=[metric])),
+        config=config,
+    )
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=0.0,
+        duration=1.0,
+        model_server_metrics=BaseMetrics(),
+        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
+    )
+    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(per_request=True))
+
+    reports = await generator.generate_reports(report_config, runtime_parameters)
+
+    per_request = [report for report in reports if report.name == "per_request_lifecycle_metrics"]
+    assert len(per_request) == 1, "per_request: true must emit the per-request report"
+    entries: List[Dict[str, Any]] = per_request[0].contents
+    assert len(entries) == 1
+    assert entries[0]["response"] == sent_body, "the per-request entry must carry the partial body, not an empty string"
+    assert entries[0]["error"]["error_type"] == "ClientPayloadError"


### PR DESCRIPTION
Closes #531.

## What

Adds the Integration-tier test for #531 from the v0.7.0 testing plan (#606, per-change lane, no model server).

#530 already fixed the bug: `parse_sse_stream` wraps a mid-stream failure in `StreamInterruptedError` carrying the bytes read so far, and `process_request` recovers them into `response_data`. Nothing held that recovery in place, which is the shape #410 shipped in the #564 lineage: a correct fix in the tree with no test gating it.

Filing this as `Closes` per @achandrasekar's request on the issue to close it once the merged fix is verified. The two follow-ups #531 lists as out of scope will be filed separately.

## How

`TruncatingSSEServer` speaks raw HTTP/1.1 and does exactly what #531 describes: returns 200, writes valid SSE frames, declares a `Content-Length` larger than the body it actually sends, then half-closes. aiohttp raises a real `ClientPayloadError`, so the recovery branch runs through the genuine exception path rather than a patched-in exception. Per the tier's "fake the conditions, never the oracle" rule, the induced condition is faked and the assertion is against the bytes the fake recorded sending.

Four tests:

| Test | Pins |
|---|---|
| `test_partial_body_is_preserved_when_the_stream_breaks` | `response_data` equals the sent bytes, raw SSE framing included |
| `test_underlying_exception_is_reported_not_the_wrapper` | `error_type` is `ClientPayloadError`, not the `StreamInterruptedError` wrapper |
| `test_break_before_any_body_byte_leaves_the_response_empty` | the empty-`raw_content` branch does not fall through to the non-200 placeholder text |
| `test_per_request_report_carries_the_partial_body` | the bytes survive into `per_request_lifecycle_metrics`, the surface #531 is actually about |

## Verification

Mutation-tested rather than just observed green. Each mutation reverts one piece of the #530 fix:

| Mutation | Tests that fail |
|---|---|
| drop `response_content = read_error.raw_content` | 1, 4 |
| drop `original_error = read_error.original` | 2, 3, 4 |
| `parse_sse_stream` raises with empty `raw_content` | 1, 4 |

Every test is killed by at least one mutation.

Suite: 861 passed, 15 skipped. `ruff format`, `ruff check`, `mypy --strict`, and the CLI-flags check are clean. The four tests run in 0.9s, which keeps them inside the per-change budget.

## Notes

- Test-only. No production code changes.
- `tests/required/integration/` is new here. #694 adds its own `fake_openai_server.py` to the same directory for the #559 test; the two fakes are separate files and do not conflict. Once both land, consolidating them behind one helper module is a reasonable follow-up.
- The two follow-ups #531 lists as out of scope (a 200 whose SSE body is an in-band error payload being marked success, and per-request entries omitting `stage_id`/latency) are untouched here.
