### PR TITLE
feat(reportgen): add per-session KV cache hit rate

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -33,3 +33,18 @@ This document outlines the key metrics used for evaluating performance, their de
 | **Throughput / $** | `(output tokens / second) / (accelerator $ / second)` | million output tokens | Calculating the performance to price ratio to get the throughput we are able to achieve for the cost spent
 
 *\*Note: input and output token cost might need to be divided in mixed-batching cases since they are handled together by the server, using some factor like 1:4 for cost to generate input vs output tokens.*
+
+---
+
+## Session-Based KV Cache Hit Rate
+
+| Metric | Formula | Unit | Used For
+| :--- | :--- | :--- | :---
+| **kv_cache_hit_percent** | `100 × (total cached prompt tokens / total prompt tokens)` | percent (0–100) | Token-weighted cache hit rate across all sessions
+| **kv_cache_hit_per_session_percent** | distribution of `100 × (session cached tokens / session prompt tokens)` | percent (0–100) | Per-session cache hit rate distribution (min/mean/max/percentiles)
+
+Both metrics use the server-reported `prompt_tokens` as the denominator and `prompt_tokens_details.cached_tokens` as the numerator. Sessions where the server does not report cache information are excluded (reported as `None`, not 0%).
+
+**Server requirement:** vLLM must be started with `--enable-prompt-tokens-details` for the server to populate `prompt_tokens_details.cached_tokens` in the usage response.
+
+**Note:** vLLM's `cached_tokens` is block-granular — the reported value is quantized by the KV cache block size, so the hit rate may not reflect exact token-level precision.

--- a/docs/otel_trace_replay.md
+++ b/docs/otel_trace_replay.md
@@ -356,6 +356,10 @@ At the end of a run, the CLI also prints these session-level statistics as
 summary tables (Session Summary, Session Duration & Events, Session Token
 Totals) alongside the standard per-stage tables.
 
+The session summary also includes KV cache hit rate metrics (`kv_cache_hit_percent`, `kv_cache_hit_per_session_percent`) when the server reports cached token counts. See [Metrics Definition](metrics.md#kv-cache-hit-rate) for details.
+
+> **Note:** vLLM requires `--enable-prompt-tokens-details` to populate cache token counts in the usage response. Without this flag, cache metrics will be `None`.
+
 These complement the standard per-request metrics, giving you both micro (individual LLM calls) and macro (complete workflows) views of performance.
 
 ## OpenTelemetry Background

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -97,6 +97,20 @@ class SessionLifecycleMetric(BaseModel):
     error: Optional[ErrorResponseInfo] = None
     total_input_tokens: Optional[int] = None
     total_output_tokens: Optional[int] = None
+    # Per-session sum of prompt tokens served from the server-side KV/prefix
+    # cache (usage.prompt_tokens_details.cached_tokens). None when no request in
+    # the session reported server usage (non-streaming, or a vLLM build that
+    # omits or nulls prompt_tokens_details) — distinct from 0, which means the
+    # field was present but no tokens were cached.
+    total_cached_tokens: Optional[int] = None
+    # Denominator for the per-session cache hit rate: sum of the server-reported
+    # usage.prompt_tokens over exactly the requests that contributed to
+    # total_cached_tokens. This is deliberately NOT total_input_tokens, which is
+    # the client-side re-tokenized count — mixing a server numerator with a
+    # client denominator skews the ratio by the tokenizer's disagreement with the
+    # server (chat template and tool-schema overhead the client does not model)
+    # and can push it above 1.0. None whenever total_cached_tokens is None.
+    total_cacheable_input_tokens: Optional[int] = None
 
 
 class InferenceAPIData(BaseModel):

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -179,6 +179,63 @@ def summarize(items: List[float], percentiles: List[float]) -> Optional[dict[str
     return result
 
 
+def extract_cached_prompt_tokens(server_usage: Optional[dict[str, Any]]) -> Optional[tuple[int, int]]:
+    """Cached and total prompt tokens from a server ``usage`` dict.
+
+    Returns ``(cached_tokens, prompt_tokens)`` taken from the *same* source so a
+    hit rate built from them never mixes a server numerator with a client-side
+    denominator. Returns ``None`` — not ``(0, 0)`` — when the response carries no
+    cache information at all, so "the server never told us" stays distinguishable
+    from a genuine 0% hit rate.
+
+    Two usage *layouts* reach this function, differing in whether the reported
+    input count already includes the cached tokens. The branch below keys on
+    field shape, not on provider identity — a gateway or proxy that re-emits
+    either layout is handled the same as the API it came from.
+
+    - **Nested** (OpenAI, vLLM): ``prompt_tokens`` is the whole prompt and
+      ``prompt_tokens_details.cached_tokens`` is a subset of it, so the
+      denominator is read directly.
+    - **Sibling** (Anthropic Messages): the cached prefix is reported *beside*
+      the input count rather than within it, so the whole prompt has to be
+      reconstructed by summing them.
+
+    Returns ``None`` when the dict carries no cache field in either layout, so
+    "the server never reported" stays distinguishable from a genuine 0% rate.
+
+    Cached tokens are clamped to ``[0, prompt_tokens]``: a hit rate above 1.0 is
+    never a real measurement, and reporting one would be worse than clamping.
+
+    NOTE: the sibling branch assumes ``input_tokens`` *excludes* the cache-read
+    prefix, and ignores ``cache_creation_input_tokens`` (a cache write is a miss,
+    so it belongs in neither the numerator nor — if it is already inside
+    ``input_tokens`` — added again to the denominator). Both points are
+    unverified against the live API; only the nested layout is covered by a
+    real-run golden shape.
+    """
+    if not server_usage:
+        return None
+
+    # Nested layout first: when a normalizing proxy emits both, `prompt_tokens`
+    # is the authoritative whole-prompt total and needs no reconstruction.
+    prompt_tokens_details = server_usage.get("prompt_tokens_details")
+    if prompt_tokens_details and "cached_tokens" in prompt_tokens_details:
+        cached = int(safe_float(prompt_tokens_details.get("cached_tokens")))
+        prompt = int(safe_float(server_usage.get("prompt_tokens")))
+    elif "cache_read_input_tokens" in server_usage:
+        # Sibling layout: `input_tokens` is only the uncached remainder, so the
+        # comparable whole-prompt total is uncached + cache-read.
+        cached = int(safe_float(server_usage.get("cache_read_input_tokens")))
+        uncached = int(safe_float(server_usage.get("input_tokens")))
+        prompt = uncached + max(cached, 0)
+    else:
+        # No cache field in either layout — `prompt_tokens_details` absent, or
+        # present-but-null on some vLLM builds (see #664).
+        return None
+
+    return min(max(cached, 0), max(prompt, 0)), max(prompt, 0)
+
+
 def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric], percentiles: List[float]) -> dict[str, float]:
     """Input tokens already resolved at request time (request_metrics.text.input_tokens).
 
@@ -912,6 +969,26 @@ class ReportGenerator:
             if total_span > 0:
                 sessions_per_second = num_sessions / total_span
 
+        # Per-session KV/prefix cache hit rate = cached / total server-reported
+        # prompt tokens. Both sides come from the same server usage dicts (see
+        # extract_cached_prompt_tokens) rather than pairing the server numerator
+        # with the client-side total_input_tokens. Only sessions that reported
+        # cache info with a positive prompt-token count contribute; the rest are
+        # skipped so a missing/None field never becomes a misleading 0.0.
+        kv_cache_hit_rate = [
+            m.total_cached_tokens / m.total_cacheable_input_tokens
+            for m in metrics
+            if m.total_cached_tokens is not None and m.total_cacheable_input_tokens
+        ]
+        # Aggregate (token-weighted) hit rate over all reporting sessions. The
+        # percentile summary above is a mean *of ratios*, which weights a
+        # 10-token session the same as a 100k-token one; this is the figure that
+        # answers "what fraction of this run's prompt tokens were cached" and is
+        # the one comparable to the stage-level prompt_token_usage split.
+        cached_total = sum(m.total_cached_tokens for m in metrics if m.total_cached_tokens is not None)
+        prompt_total = sum(m.total_cacheable_input_tokens for m in metrics if m.total_cacheable_input_tokens is not None)
+        kv_cache_hit_rate_aggregate = (cached_total / prompt_total) if prompt_total else None
+
         return {
             "num_sessions": num_sessions,
             "num_sessions_succeeded": num_succeeded,
@@ -933,6 +1010,16 @@ class ReportGenerator:
             "total_output_tokens": summarize(
                 [float(m.total_output_tokens) for m in metrics if m.total_output_tokens is not None], percentiles
             ),
+            "total_cached_tokens": summarize(
+                [float(m.total_cached_tokens) for m in metrics if m.total_cached_tokens is not None], percentiles
+            ),
+            "total_cacheable_input_tokens": summarize(
+                [float(m.total_cacheable_input_tokens) for m in metrics if m.total_cacheable_input_tokens is not None],
+                percentiles,
+            ),
+            "sessions_with_cache_info": sum(1 for m in metrics if m.total_cached_tokens is not None),
+            "kv_cache_hit_rate": summarize(kv_cache_hit_rate, percentiles),
+            "kv_cache_hit_rate_aggregate": kv_cache_hit_rate_aggregate,
         }
 
     def _enrich_sessions(
@@ -944,11 +1031,19 @@ class ReportGenerator:
         """Aggregate per-request token totals and error status onto each session.
 
         Mutates each ``SessionLifecycleMetric`` in ``session_metrics`` in place,
-        setting ``total_input_tokens``, ``total_output_tokens``, ``error``, and
-        ``success`` from the matching request-level metrics.
+        setting ``total_input_tokens``, ``total_output_tokens``,
+        ``total_cached_tokens``, ``error``, and ``success`` from the matching
+        request-level metrics.
         """
         token_by_session: dict[str, tuple[int, int]] = defaultdict(lambda: (0, 0))
         error_by_session: dict[str, Any] = {}
+        # session_id -> (summed cached prompt tokens, summed server prompt tokens),
+        # or absent when no request in the session reported cache info. Absence is
+        # preserved as None on the session (not coerced to 0) so a session with no
+        # cache info is distinguishable from one that had usage but zero cached
+        # tokens. Numerator and denominator accumulate over exactly the same
+        # requests so the ratio never mixes sources.
+        cache_by_session: dict[str, tuple[int, int]] = {}
 
         for m in request_metrics:
             if m.session_id:
@@ -960,10 +1055,21 @@ class ReportGenerator:
                 if m.session_id not in error_by_session and m.error is not None:
                     error_by_session[m.session_id] = m.error
 
+                response_metrics = m.info.response_metrics
+                server_usage = response_metrics.server_usage if response_metrics else None
+                cache_usage = extract_cached_prompt_tokens(server_usage)
+                if cache_usage is not None:
+                    cached, prompt = cache_usage
+                    prev_cached, prev_prompt = cache_by_session.get(m.session_id, (0, 0))
+                    cache_by_session[m.session_id] = (prev_cached + cached, prev_prompt + prompt)
+
         for sm in session_metrics:
             inp, out = token_by_session.get(sm.session_id, (0, 0))
             sm.total_input_tokens = inp
             sm.total_output_tokens = out
+            cache_usage = cache_by_session.get(sm.session_id)
+            sm.total_cached_tokens = cache_usage[0] if cache_usage else None
+            sm.total_cacheable_input_tokens = cache_usage[1] if cache_usage else None
             request_error = error_by_session.get(sm.session_id)
             if request_error is not None:
                 sm.error = request_error

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -188,52 +188,29 @@ def extract_cached_prompt_tokens(server_usage: Optional[dict[str, Any]]) -> Opti
     cache information at all, so "the server never told us" stays distinguishable
     from a genuine 0% hit rate.
 
-    Two usage *layouts* reach this function, differing in whether the reported
-    input count already includes the cached tokens. The branch below keys on
-    field shape, not on provider identity — a gateway or proxy that re-emits
-    either layout is handled the same as the API it came from.
+    Supports the **nested** layout (OpenAI, vLLM) where ``prompt_tokens`` is the
+    whole prompt and ``prompt_tokens_details.cached_tokens`` is a subset of it.
 
-    - **Nested** (OpenAI, vLLM): ``prompt_tokens`` is the whole prompt and
-      ``prompt_tokens_details.cached_tokens`` is a subset of it, so the
-      denominator is read directly.
-    - **Sibling** (Anthropic Messages): the cached prefix is reported *beside*
-      the input count rather than within it, so the whole prompt has to be
-      reconstructed by summing them.
-
-    Returns ``None`` when the dict carries no cache field in either layout, so
-    "the server never reported" stays distinguishable from a genuine 0% rate.
+    Returns ``None`` when the dict carries no cache field, so "the server never
+    reported" stays distinguishable from a genuine 0% rate.
 
     Cached tokens are clamped to ``[0, prompt_tokens]``: a hit rate above 1.0 is
     never a real measurement, and reporting one would be worse than clamping.
-
-    NOTE: the sibling branch assumes ``input_tokens`` *excludes* the cache-read
-    prefix, and ignores ``cache_creation_input_tokens`` (a cache write is a miss,
-    so it belongs in neither the numerator nor — if it is already inside
-    ``input_tokens`` — added again to the denominator). Both points are
-    unverified against the live API; only the nested layout is covered by a
-    real-run golden shape.
     """
     if not server_usage:
         return None
 
-    # Nested layout first: when a normalizing proxy emits both, `prompt_tokens`
-    # is the authoritative whole-prompt total and needs no reconstruction.
     prompt_tokens_details = server_usage.get("prompt_tokens_details")
-    if prompt_tokens_details and "cached_tokens" in prompt_tokens_details:
+    if prompt_tokens_details and prompt_tokens_details.get("cached_tokens") is not None:
         cached = int(safe_float(prompt_tokens_details.get("cached_tokens")))
         prompt = int(safe_float(server_usage.get("prompt_tokens")))
-    elif "cache_read_input_tokens" in server_usage:
-        # Sibling layout: `input_tokens` is only the uncached remainder, so the
-        # comparable whole-prompt total is uncached + cache-read.
-        cached = int(safe_float(server_usage.get("cache_read_input_tokens")))
-        uncached = int(safe_float(server_usage.get("input_tokens")))
-        prompt = uncached + max(cached, 0)
     else:
-        # No cache field in either layout — `prompt_tokens_details` absent, or
-        # present-but-null on some vLLM builds (see #664).
         return None
 
-    return min(max(cached, 0), max(prompt, 0)), max(prompt, 0)
+    if prompt <= 0:
+        return None
+
+    return min(max(cached, 0), prompt), prompt
 
 
 def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric], percentiles: List[float]) -> dict[str, float]:
@@ -975,19 +952,14 @@ class ReportGenerator:
         # with the client-side total_input_tokens. Only sessions that reported
         # cache info with a positive prompt-token count contribute; the rest are
         # skipped so a missing/None field never becomes a misleading 0.0.
-        kv_cache_hit_rate = [
-            m.total_cached_tokens / m.total_cacheable_input_tokens
+        kv_cache_hit_per_session_percent = [
+            100.0 * m.total_cached_tokens / m.total_cacheable_input_tokens
             for m in metrics
             if m.total_cached_tokens is not None and m.total_cacheable_input_tokens
         ]
-        # Aggregate (token-weighted) hit rate over all reporting sessions. The
-        # percentile summary above is a mean *of ratios*, which weights a
-        # 10-token session the same as a 100k-token one; this is the figure that
-        # answers "what fraction of this run's prompt tokens were cached" and is
-        # the one comparable to the stage-level prompt_token_usage split.
         cached_total = sum(m.total_cached_tokens for m in metrics if m.total_cached_tokens is not None)
         prompt_total = sum(m.total_cacheable_input_tokens for m in metrics if m.total_cacheable_input_tokens is not None)
-        kv_cache_hit_rate_aggregate = (cached_total / prompt_total) if prompt_total else None
+        kv_cache_hit_percent = (100.0 * cached_total / prompt_total) if prompt_total else None
 
         return {
             "num_sessions": num_sessions,
@@ -1017,9 +989,11 @@ class ReportGenerator:
                 [float(m.total_cacheable_input_tokens) for m in metrics if m.total_cacheable_input_tokens is not None],
                 percentiles,
             ),
-            "sessions_with_cache_info": sum(1 for m in metrics if m.total_cached_tokens is not None),
-            "kv_cache_hit_rate": summarize(kv_cache_hit_rate, percentiles),
-            "kv_cache_hit_rate_aggregate": kv_cache_hit_rate_aggregate,
+            "sessions_with_cache_info": sum(
+                1 for m in metrics if m.total_cached_tokens is not None and m.total_cacheable_input_tokens
+            ),
+            "kv_cache_hit_percent": kv_cache_hit_percent,
+            "kv_cache_hit_per_session_percent": summarize(kv_cache_hit_per_session_percent, percentiles),
         }
 
     def _enrich_sessions(
@@ -1055,13 +1029,14 @@ class ReportGenerator:
                 if m.session_id not in error_by_session and m.error is not None:
                     error_by_session[m.session_id] = m.error
 
-                response_metrics = m.info.response_metrics
-                server_usage = response_metrics.server_usage if response_metrics else None
-                cache_usage = extract_cached_prompt_tokens(server_usage)
-                if cache_usage is not None:
-                    cached, prompt = cache_usage
-                    prev_cached, prev_prompt = cache_by_session.get(m.session_id, (0, 0))
-                    cache_by_session[m.session_id] = (prev_cached + cached, prev_prompt + prompt)
+                if m.error is None:
+                    response_metrics = m.info.response_metrics
+                    server_usage = response_metrics.server_usage if response_metrics else None
+                    cache_usage = extract_cached_prompt_tokens(server_usage)
+                    if cache_usage is not None:
+                        cached, prompt = cache_usage
+                        prev_cached, prev_prompt = cache_by_session.get(m.session_id, (0, 0))
+                        cache_by_session[m.session_id] = (prev_cached + cached, prev_prompt + prompt)
 
         for sm in session_metrics:
             inp, out = token_by_session.get(sm.session_id, (0, 0))

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -439,10 +439,41 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
             f"{output_p90:.1f}",
         )
 
+    # Table 4: KV Cache Hit Rate (only when at least one stage reports it)
+    has_cache_info = any(session_reports[stage_id].get("kv_cache_hit_percent") is not None for stage_id in sorted_stages)
+    cache_table: Optional[Table] = None
+    if has_cache_info:
+        cache_table = Table(
+            title="[bold magenta]Session KV Cache Hit Rate[/bold magenta]", show_header=True, header_style="bold cyan"
+        )
+        cache_table.add_column("Stage", justify="right")
+        cache_table.add_column("Hit % (pooled)", justify="right")
+        cache_table.add_column("Hit %/Sess Mean", justify="right")
+        cache_table.add_column("Hit %/Sess Med", justify="right")
+        cache_table.add_column("Hit %/Sess P90", justify="right")
+        cache_table.add_column("Sessions w/ Info", justify="right")
+
+        for stage_id in sorted_stages:
+            contents = session_reports[stage_id]
+            pooled = contents.get("kv_cache_hit_percent")
+            per_session = contents.get("kv_cache_hit_per_session_percent") or {}
+            sessions_info = contents.get("sessions_with_cache_info", 0)
+
+            cache_table.add_row(
+                str(stage_id),
+                f"{pooled:.1f}" if pooled is not None else "N/A",
+                f"{per_session.get('mean', 0.0):.1f}" if per_session else "N/A",
+                f"{per_session.get('median', 0.0):.1f}" if per_session else "N/A",
+                f"{per_session.get('p90', 0.0):.1f}" if per_session else "N/A",
+                str(sessions_info),
+            )
+
     # Print all session tables
     console.print(session_summary_table)
     console.print(session_duration_table)
     console.print(session_tokens_table)
+    if cache_table is not None:
+        console.print(cache_table)
 
 
 def _collect_error_labels(failures_by_stage: Dict[int, Dict[str, Any]]) -> list[str]:

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -550,8 +550,8 @@ def test_enrich_sessions_cache_denominator_uses_server_prompt_tokens() -> None:
     assert session.total_cacheable_input_tokens == 120  # server count drives the ratio
 
     summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
-    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(110 / 120)
-    assert summary["kv_cache_hit_rate"]["max"] <= 1.0
+    assert summary["kv_cache_hit_per_session_percent"]["mean"] == pytest.approx(100.0 * 110 / 120)
+    assert summary["kv_cache_hit_per_session_percent"]["max"] <= 100.0
 
 
 def test_enrich_sessions_cache_matches_stage_level_prompt_token_usage() -> None:
@@ -573,25 +573,7 @@ def test_enrich_sessions_cache_matches_stage_level_prompt_token_usage() -> None:
     stage = summarize_prompt_token_usage(requests, DEFAULT_PERCENTILES)
     summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
 
-    assert summary["kv_cache_hit_rate_aggregate"] == pytest.approx(stage["cached"] / stage["total"])
-
-
-def test_enrich_sessions_cache_reads_anthropic_usage_shape() -> None:
-    """Anthropic's cache_read_input_tokens counts, and its input_tokens excludes it.
-
-    Regression: only the OpenAI/vLLM shape was read, so an Anthropic run reported
-    total_cached_tokens=0 -- indistinguishable from a genuine 0% hit rate.
-    """
-    requests = [_cached_request("s1", 100, {"input_tokens": 20, "output_tokens": 5, "cache_read_input_tokens": 80})]
-    session = _cache_session("s1")
-    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
-
-    assert session.total_cached_tokens == 80
-    # Anthropic's input_tokens is the uncached remainder, so the prompt total is 20 + 80.
-    assert session.total_cacheable_input_tokens == 100
-
-    summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
-    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(0.8)
+    assert summary["kv_cache_hit_percent"] == pytest.approx(100.0 * stage["cached"] / stage["total"])
 
 
 def test_enrich_sessions_cache_clamps_cached_above_prompt_tokens() -> None:
@@ -603,7 +585,7 @@ def test_enrich_sessions_cache_clamps_cached_above_prompt_tokens() -> None:
     assert session.total_cached_tokens == 100
 
     summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
-    assert summary["kv_cache_hit_rate"]["max"] == pytest.approx(1.0)
+    assert summary["kv_cache_hit_per_session_percent"]["max"] == pytest.approx(100.0)
 
 
 def test_summarize_sessions_reports_kv_cache_hit_rate() -> None:
@@ -623,7 +605,7 @@ def test_summarize_sessions_reports_kv_cache_hit_rate() -> None:
 
     assert summary["total_cached_tokens"]["mean"] == pytest.approx(32.0)
     # Only s1 contributes: 32/99. s2 (None) is skipped, not treated as 0.
-    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(32.0 / 99.0)
+    assert summary["kv_cache_hit_per_session_percent"]["mean"] == pytest.approx(100.0 * 32.0 / 99.0)
     assert summary["sessions_with_cache_info"] == 1
 
 
@@ -635,8 +617,8 @@ def test_summarize_sessions_kv_cache_hit_rate_none_when_no_cache_info() -> None:
 
     summary = ReportGenerator.summarize_sessions(None, [s], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
 
-    assert summary["kv_cache_hit_rate"] is None
-    assert summary["kv_cache_hit_rate_aggregate"] is None
+    assert summary["kv_cache_hit_percent"] is None
+    assert summary["kv_cache_hit_per_session_percent"] is None
     assert summary["total_cached_tokens"] is None
     assert summary["sessions_with_cache_info"] == 0
 
@@ -655,8 +637,8 @@ def test_summarize_sessions_kv_cache_aggregate_is_token_weighted() -> None:
 
     summary = ReportGenerator.summarize_sessions(None, [small, large], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
 
-    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(0.5)  # mean of ratios
-    assert summary["kv_cache_hit_rate_aggregate"] == pytest.approx(10 / 10010)  # token-weighted
+    assert summary["kv_cache_hit_per_session_percent"]["mean"] == pytest.approx(50.0)  # mean of ratios
+    assert summary["kv_cache_hit_percent"] == pytest.approx(100.0 * 10 / 10010)  # token-weighted
 
 
 def test_use_server_output_tokens_falls_back_without_usage() -> None:

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -1,7 +1,8 @@
+from typing import Any
 from typing import cast
 
 import pytest
-from inference_perf.reportgen.base import summarize_requests, ReportGenerator
+from inference_perf.reportgen.base import summarize_requests, summarize_prompt_token_usage, ReportGenerator
 from inference_perf.apis.base import (
     RequestLifecycleMetric,
     InferenceInfo,
@@ -460,6 +461,202 @@ def test_enrich_sessions_honors_use_server_output_tokens() -> None:
     server_session = make_session()
     ReportGenerator._enrich_sessions(None, [server_session], [request_metric], use_server_output_tokens=True)  # type: ignore[arg-type]
     assert server_session.total_output_tokens == 5
+
+
+def _cached_request(session_id: str, input_tokens: int, server_usage: dict[str, Any] | None) -> RequestLifecycleMetric:
+    """A session request whose response optionally carries a server usage dict."""
+    return RequestLifecycleMetric(
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="r",
+        info=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=input_tokens)),
+            response_metrics=StreamedResponseMetrics(output_tokens=1, server_usage=server_usage),
+        ),
+        error=None,
+        session_id=session_id,
+    )
+
+
+def _cache_session(session_id: str = "s1") -> SessionLifecycleMetric:
+    return SessionLifecycleMetric(
+        session_id=session_id,
+        stage_id=0,
+        file_path=f"{session_id}.json",
+        start_time=0.0,
+        end_time=1.0,
+        duration_sec=1.0,
+        num_events=1,
+        num_events_completed=1,
+    )
+
+
+def test_enrich_sessions_sums_cached_tokens_across_requests() -> None:
+    """total_cached_tokens sums prompt_tokens_details.cached_tokens over a session's requests."""
+    requests = [
+        _cached_request("s1", 20, {"prompt_tokens": 20, "prompt_tokens_details": {"cached_tokens": 0}}),
+        _cached_request("s1", 40, {"prompt_tokens": 40, "prompt_tokens_details": {"cached_tokens": 20}}),
+        _cached_request("s1", 39, {"prompt_tokens": 39, "prompt_tokens_details": {"cached_tokens": 12}}),
+    ]
+    session = _cache_session("s1")
+    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
+
+    assert session.total_input_tokens == 99
+    assert session.total_cached_tokens == 32  # 0 + 20 + 12
+    assert session.total_cacheable_input_tokens == 99  # server prompt_tokens: 20 + 40 + 39
+
+
+def test_enrich_sessions_cached_none_without_server_usage() -> None:
+    """No request reporting server usage leaves total_cached_tokens as None (not 0)."""
+    requests = [_cached_request("s1", 10, None), _cached_request("s1", 10, None)]
+    session = _cache_session("s1")
+    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
+
+    assert session.total_cached_tokens is None
+    assert session.total_cacheable_input_tokens is None
+    assert session.total_input_tokens == 20
+
+
+def test_enrich_sessions_cached_handles_null_prompt_tokens_details() -> None:
+    """server_usage present with prompt_tokens_details: null contributes nothing (see #664)."""
+    requests = [
+        _cached_request("s1", 10, {"prompt_tokens": 10, "prompt_tokens_details": None}),
+        _cached_request("s1", 10, {"prompt_tokens": 10, "prompt_tokens_details": {"cached_tokens": 4}}),
+    ]
+    session = _cache_session("s1")
+    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
+
+    # The null-details request reported no cache info at all, so it contributes to
+    # neither side of the ratio — only the request that did report is counted.
+    assert session.total_cached_tokens == 4
+    assert session.total_cacheable_input_tokens == 10
+
+
+def test_enrich_sessions_cache_denominator_uses_server_prompt_tokens() -> None:
+    """The hit-rate denominator is the server's prompt_tokens, not the client-side count.
+
+    Regression: the denominator was total_input_tokens (a client-side
+    re-tokenization). The client undercounts what the server actually prompts on
+    -- chat template and tool-schema overhead it does not model -- so pairing it
+    with the server-reported cached_tokens inflated the rate, here past 1.0.
+    """
+    # Client re-tokenizes 100 tokens; the server prompted on 120 and cached 110.
+    requests = [_cached_request("s1", 100, {"prompt_tokens": 120, "prompt_tokens_details": {"cached_tokens": 110}})]
+    session = _cache_session("s1")
+    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
+
+    assert session.total_input_tokens == 100  # client count, unchanged
+    assert session.total_cacheable_input_tokens == 120  # server count drives the ratio
+
+    summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(110 / 120)
+    assert summary["kv_cache_hit_rate"]["max"] <= 1.0
+
+
+def test_enrich_sessions_cache_matches_stage_level_prompt_token_usage() -> None:
+    """Per-session hit rate agrees with the stage-level prompt_token_usage split.
+
+    Regression: the two lived in one report and disagreed (0.6621 vs 0.64 on this
+    data) because only one of them used the server-side denominator.
+    """
+    client = [900, 1900, 2900, 3900, 4900]  # client under-counts each turn
+    server = [1000, 2000, 3000, 4000, 5000]
+    cached = [0, 900, 1900, 2900, 3900]
+    requests = [
+        _cached_request("s1", c, {"prompt_tokens": s, "prompt_tokens_details": {"cached_tokens": k}})
+        for c, s, k in zip(client, server, cached, strict=True)
+    ]
+    session = _cache_session("s1")
+    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
+
+    stage = summarize_prompt_token_usage(requests, DEFAULT_PERCENTILES)
+    summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+
+    assert summary["kv_cache_hit_rate_aggregate"] == pytest.approx(stage["cached"] / stage["total"])
+
+
+def test_enrich_sessions_cache_reads_anthropic_usage_shape() -> None:
+    """Anthropic's cache_read_input_tokens counts, and its input_tokens excludes it.
+
+    Regression: only the OpenAI/vLLM shape was read, so an Anthropic run reported
+    total_cached_tokens=0 -- indistinguishable from a genuine 0% hit rate.
+    """
+    requests = [_cached_request("s1", 100, {"input_tokens": 20, "output_tokens": 5, "cache_read_input_tokens": 80})]
+    session = _cache_session("s1")
+    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
+
+    assert session.total_cached_tokens == 80
+    # Anthropic's input_tokens is the uncached remainder, so the prompt total is 20 + 80.
+    assert session.total_cacheable_input_tokens == 100
+
+    summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(0.8)
+
+
+def test_enrich_sessions_cache_clamps_cached_above_prompt_tokens() -> None:
+    """A cached count exceeding prompt_tokens is clamped instead of yielding a rate > 1."""
+    requests = [_cached_request("s1", 100, {"prompt_tokens": 100, "prompt_tokens_details": {"cached_tokens": 150}})]
+    session = _cache_session("s1")
+    ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]
+
+    assert session.total_cached_tokens == 100
+
+    summary = ReportGenerator.summarize_sessions(None, [session], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+    assert summary["kv_cache_hit_rate"]["max"] == pytest.approx(1.0)
+
+
+def test_summarize_sessions_reports_kv_cache_hit_rate() -> None:
+    """summarize_sessions emits per-session cached totals and the cached/prompt ratio."""
+    with_cache = _cache_session("s1")
+    with_cache.total_input_tokens = 99
+    with_cache.total_cached_tokens = 32  # golden shape from a real qwen32 run
+    with_cache.total_cacheable_input_tokens = 99
+
+    no_cache = _cache_session("s2")
+    no_cache.total_input_tokens = 50
+    no_cache.total_cached_tokens = None  # no server usage — excluded from the ratio
+    no_cache.total_cacheable_input_tokens = None
+
+    # summarize_sessions doesn't use `self`, so call it unbound with a dummy self.
+    summary = ReportGenerator.summarize_sessions(None, [with_cache, no_cache], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+
+    assert summary["total_cached_tokens"]["mean"] == pytest.approx(32.0)
+    # Only s1 contributes: 32/99. s2 (None) is skipped, not treated as 0.
+    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(32.0 / 99.0)
+    assert summary["sessions_with_cache_info"] == 1
+
+
+def test_summarize_sessions_kv_cache_hit_rate_none_when_no_cache_info() -> None:
+    """With no session reporting cache info, the ratio summary is None, not a crash."""
+    s = _cache_session("s1")
+    s.total_input_tokens = 30
+    s.total_cached_tokens = None
+
+    summary = ReportGenerator.summarize_sessions(None, [s], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+
+    assert summary["kv_cache_hit_rate"] is None
+    assert summary["kv_cache_hit_rate_aggregate"] is None
+    assert summary["total_cached_tokens"] is None
+    assert summary["sessions_with_cache_info"] == 0
+
+
+def test_summarize_sessions_kv_cache_aggregate_is_token_weighted() -> None:
+    """The aggregate rate weights sessions by tokens; the percentile mean does not.
+
+    A tiny fully-cached session and a huge uncached one average to 50% as a
+    mean-of-ratios, which misreads a run that cached ~0.1% of its tokens.
+    """
+    small = _cache_session("small")
+    small.total_cached_tokens, small.total_cacheable_input_tokens = 10, 10
+
+    large = _cache_session("large")
+    large.total_cached_tokens, large.total_cacheable_input_tokens = 0, 10000
+
+    summary = ReportGenerator.summarize_sessions(None, [small, large], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+
+    assert summary["kv_cache_hit_rate"]["mean"] == pytest.approx(0.5)  # mean of ratios
+    assert summary["kv_cache_hit_rate_aggregate"] == pytest.approx(10 / 10010)  # token-weighted
 
 
 def test_use_server_output_tokens_falls_back_without_usage() -> None:

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -557,15 +557,14 @@ def test_enrich_sessions_cache_denominator_uses_server_prompt_tokens() -> None:
 def test_enrich_sessions_cache_matches_stage_level_prompt_token_usage() -> None:
     """Per-session hit rate agrees with the stage-level prompt_token_usage split.
 
-    Regression: the two lived in one report and disagreed (0.6621 vs 0.64 on this
-    data) because only one of them used the server-side denominator.
+    Post-#678, input_tokens is resolved to the server value at construction time,
+    so the fixture passes the server count as input_tokens (the single source of truth).
     """
-    client = [900, 1900, 2900, 3900, 4900]  # client under-counts each turn
     server = [1000, 2000, 3000, 4000, 5000]
     cached = [0, 900, 1900, 2900, 3900]
     requests = [
-        _cached_request("s1", c, {"prompt_tokens": s, "prompt_tokens_details": {"cached_tokens": k}})
-        for c, s, k in zip(client, server, cached, strict=True)
+        _cached_request("s1", s, {"prompt_tokens": s, "prompt_tokens_details": {"cached_tokens": k}})
+        for s, k in zip(server, cached, strict=True)
     ]
     session = _cache_session("s1")
     ReportGenerator._enrich_sessions(None, [session], requests)  # type: ignore[arg-type]


### PR DESCRIPTION
Sum server-reported cached prompt tokens per session; report per-session and token-weighted aggregate hit rates. Denominator is the server's prompt_tokens, not the client-side count. Sessions with no cache info stay None, not 0.
Requires the flag `--enable-prompt-tokens-details ` on the server side.