### PR TITLE
ci: cache the Nix store and pdm venvs across CI workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,6 +38,7 @@ jobs:
           fi
       - name: Set up Python
         if: steps.changes.outputs.code == 'true'
+        id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -46,6 +47,17 @@ jobs:
         uses: pdm-project/setup-pdm@c6081998a653693a457d93c70b8007d979bc6741 # v4
         with:
           python-version: ${{ matrix.python-version }}
+      # Same key as Unit Tests (same install set), so the two workflows share
+      # one cache. Keyed on the exact interpreter version because the venv
+      # symlinks into the runner's hostedtoolcache.
+      - name: Restore pdm venv
+        if: steps.changes.outputs.code == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-dev-analysis-otel-${{ hashFiles('pdm.lock') }}
+      # Kept on cache hits: pdm sync verifies the restored venv against
+      # pdm.lock in seconds and repairs a partial restore.
       - name: Install dependencies
         if: steps.changes.outputs.code == 'true'
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,5 @@
+# The workflow name is load-bearing: merge_gate.yml keys on it, in both its
+# workflow_run trigger and its REQUIRED_WORKFLOWS list. Rename in lockstep.
 name: Code Coverage
 
 on:
@@ -10,7 +12,7 @@ on:
   pull_request:
 
 jobs:
-  format-check:
+  coverage:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -62,6 +64,6 @@ jobs:
         if: steps.changes.outputs.code == 'true'
         run: |
           pdm sync -d -G analysis -G otel
-      - name: Run Validation
+      - name: Run coverage regression check
         if: steps.changes.outputs.code == 'true'
         run: pdm run check:cov

--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -60,6 +60,25 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Cache the Nix store (dev shell closure, including the sim built from
+      # source) keyed on the flake files. On a key miss the nearest older
+      # cache is restored and Nix fetches only the delta.
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+
+      # Cache the pdm venv. Keyed on the flake files too because the venv's
+      # interpreter is the store path of the dev shell's Python.
+      - name: Restore pdm venv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: venv-nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock', 'pdm.lock') }}
+
+      # Kept on cache hits: pdm sync verifies the restored venv against
+      # pdm.lock in seconds and repairs a partial restore.
       - name: Install dependencies
         run: |
           nix develop -c pdm sync -d

--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -1,3 +1,5 @@
+# The workflow name is load-bearing: merge_gate.yml keys on it, in both its
+# workflow_run trigger and its REQUIRED_WORKFLOWS list. Rename in lockstep.
 name: E2E Test on change
 
 on:

--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -218,8 +218,8 @@ jobs:
       # download inside the job, which the green run measured at 14s for the
       # VLM and 29s for the speech model, 43s of a 25 minute job. Caching it
       # would put a ~6GB entry into a 10GB repo-wide budget and evict the nix
-      # and venv caches (#670, #720) that stand to save the 4m36s of `pdm
-      # sync` below, which is the part of this job actually worth caching.
+      # and venv caches below, which save most of the 4m36s of `pdm sync`
+      # that is the part of this job actually worth caching.
       - name: Prefetch vLLM images
         run: |
           for v in $VLLM_VERSIONS; do
@@ -231,6 +231,22 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # The same two caches as the job above, under the same keys: this job
+      # runs on the same runner image with the same flake and pdm.lock, so
+      # it restores whatever that job or an earlier run saved.
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+
+      - name: Restore pdm venv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: venv-nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock', 'pdm.lock') }}
+
+      # Kept on cache hits for the reason the job above gives.
       - name: Install dependencies
         run: |
           nix develop -c pdm sync -d

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -27,6 +28,15 @@ jobs:
         uses: pdm-project/setup-pdm@c6081998a653693a457d93c70b8007d979bc6741 # v4
         with:
           python-version: ${{ matrix.python-version }}
+      # Keyed on the exact interpreter version because the venv symlinks into
+      # the runner's hostedtoolcache; a patch bump invalidates the venv.
+      - name: Restore pdm venv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-dev-${{ hashFiles('pdm.lock') }}
+      # Kept on cache hits: pdm sync verifies the restored venv against
+      # pdm.lock in seconds and repairs a partial restore.
       - name: Install dependencies
         run: |
           pdm sync -d

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,3 +1,5 @@
+# The workflow name is load-bearing: merge_gate.yml keys on it, in both its
+# workflow_run trigger and its REQUIRED_WORKFLOWS list. Rename in lockstep.
 name: Python Linting and Type Checks
 
 on:
@@ -11,7 +13,7 @@ on:
       - 'feature/**'
 
 jobs:
-  format-check:
+  validate:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,6 +42,6 @@ jobs:
       - name: Install dependencies
         run: |
           pdm sync -d
-      - name: Do Linting and Type Checks
+      - name: Run validate (format, lint, mypy, CLI flag docs)
         run: |
           pdm run validate

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -24,6 +25,16 @@ jobs:
         uses: pdm-project/setup-pdm@c6081998a653693a457d93c70b8007d979bc6741 # v4
         with:
           python-version: ${{ matrix.python-version }}
+      # Same key as Code Coverage (same install set), so the two workflows
+      # share one cache. Keyed on the exact interpreter version because the
+      # venv symlinks into the runner's hostedtoolcache.
+      - name: Restore pdm venv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-dev-analysis-otel-${{ hashFiles('pdm.lock') }}
+      # Kept on cache hits: pdm sync verifies the restored venv against
+      # pdm.lock in seconds and repairs a partial restore.
       - name: Install dependencies
         run: |
           pdm sync -d -G analysis -G otel

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,3 +1,5 @@
+# The workflow name is load-bearing: merge_gate.yml keys on it, in both its
+# workflow_run trigger and its REQUIRED_WORKFLOWS list. Rename in lockstep.
 name: Unit Tests
 
 on:
@@ -8,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  format-check:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Fixes #670

Every CI job reinstalls its dependencies from scratch. On the most recent runs the e2e job spent 375s in `nix develop -c pdm sync -d` before running a single test, which is over the entire 5-minute per-change budget from #606 on its own. This PR implements items 1 and 2 of #670; item 3 (caching the baseline coverage report by `main` SHA) is left as a follow-up, as the issue suggests.

**E2E Test on change**
- Caches the Nix store with [`nix-community/cache-nix-action`](https://github.com/nix-community/cache-nix-action) (pinned to v7.0.2), keyed on `flake.nix` + `flake.lock`. On a key miss it restores the nearest older cache first, so a flake bump only fetches the delta. The existing `cachix/install-nix-action` step is unchanged; it is on the action's compatible-installers list.
- Caches the pdm venv keyed on the flake files plus `pdm.lock`, since the venv's interpreter is a store path of the dev shell's Python.

**Lint, unit, coverage**
- Caches `.venv` keyed on the exact interpreter version (`setup-python`'s resolved output, so a hostedtoolcache patch bump invalidates cleanly), the install group set, and `pdm.lock`. Unit Tests and Code Coverage install identical sets and share one cache; linting installs a smaller set and gets its own key. #670 floated sharing one venv across all four workflows, but that would mean changing install sets, so this keeps them as they are.

**Failure mode is the status quo.** Install steps still run `pdm sync` on cache hits: it verifies the restored venv against `pdm.lock` in seconds and repairs partial restores. A cache miss behaves exactly as CI does today. No install set changes, no test changes.

**Also in this PR:** the Unit Tests and Code Coverage jobs were both named `format-check` (copy-pasted from the lint workflow), and Code Coverage's `check:cov` step was labeled "Run Validation". Jobs and steps are now named after what they run, and each gated workflow's `name:` carries a note that the Merge Gate keys on it. Workflow-level names are unchanged: renaming one here would strand this PR's own `do-not-merge` label, since the gate runs the default branch's copy.

**Verification, from this PR's own runs (cold = cache miss = today's CI; hit = second run on the same lock):** dependency install lint 58s -> 8s, unit 71s -> 10s, coverage 50s -> 9s, e2e `nix develop -c pdm sync -d` 5m52s -> 51s (32s of that is the Nix store restore). Job wall time: lint 2m07s -> 1m05s, unit 2m21s -> 1m22s, coverage 3m46s -> 3m41s, e2e 15m24s -> 9m56s. Test steps unchanged within noise. Cold: runs 31748594690 / 31748594628 / 31748594677 / 31748594723; hit: 32069142393 / 32069142470 / 32069142294 / 32069141927. Caches are PR-scoped until the push run on `main` seeds them after merge.

