### PR TITLE
Add kaushikmitr to inference-perf-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,6 +16,7 @@ aliases:
   inference-perf-reviewers:
   - Bslabe123
   - alonh
+  - kaushikmitr
 
   wg-serving-leads:
   - ArangoGutierrez


### PR DESCRIPTION
This adds @kaushikmitr to the `inference-perf-reviewers` alias.

Descoped: @yangligt2 is adding himself in #725, so this PR now covers kaushikmitr only.

@kaushikmitr please confirm here that you're up for this.

/cc @achandrasekar @jjk-g @lenadankin @SachinVarghese
