### PR TITLE
[PENDING: #694] test: pin reported latency metrics to injected values

### DIFF
--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -266,11 +266,18 @@ async def parse_anthropic_stream_response(
     response: ClientResponse,
 ) -> tuple[str, dict[str, Any], list[float], str, list[str], dict[str, Any] | None]:
     extract_content, build_output_message = _build_anthropic_stream_handlers()
-    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+    parsed = await parse_sse_stream(
         response,
         extract_content=extract_content,
     )
-    return output_text, build_output_message(output_text), chunk_times, raw_content, response_chunks, server_usage
+    return (
+        parsed.output_text,
+        build_output_message(parsed.output_text),
+        parsed.chunk_times,
+        parsed.raw_content,
+        parsed.response_chunks,
+        parsed.server_usage,
+    )
 
 
 class AnthropicMessagesAPIData(InferenceAPIData):

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -36,6 +36,12 @@ class StreamedResponseMetrics(ResponseMetrics):
     response_chunks: List[str] = []
     chunk_times: List[float] = []
     output_token_times: List[float] = []
+    # Reasoning-channel chunks (delta.reasoning_content / delta.reasoning) are
+    # tracked separately from content: they anchor TTFT, since the server
+    # starts generating at the first reasoning token, but stay out of
+    # output-length, TPOT, and ITL, which remain content-based. See #559.
+    reasoning_chunks: List[str] = []
+    reasoning_chunk_times: List[float] = []
 
 
 class InferenceInfo(BaseModel):

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -561,25 +561,36 @@ class ChatCompletionAPIData(InferenceAPIData):
         self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: Optional[str] = None
     ) -> InferenceInfo:
         if config.streaming:
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
+            parsed = await parse_sse_stream(
+                response,
+                extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content"),
+                # Reasoning models stream thinking on a separate delta field
+                # (reasoning_content on vLLM/DeepSeek, reasoning on some
+                # gateways) before any content. Captured apart from content so
+                # TTFT sees it while output_len/TPOT/ITL don't (#559).
+                extract_reasoning=lambda data: (
+                    data.get("choices", [{}])[0].get("delta", {}).get("reasoning_content")
+                    or data.get("choices", [{}])[0].get("delta", {}).get("reasoning")
+                ),
             )
-            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
+            prompt_len = self._resolve_prompt_tokens(parsed.server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
             # with special tokens would add a BOS the server's completion_tokens
             # never contains.
-            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
+            output_len = tokenizer.count_tokens(parsed.output_text, add_special_tokens=False)
             return InferenceInfo(
                 request_metrics=self._build_request_metrics(prompt_len, output_len),
                 response_metrics=StreamedResponseMetrics(
-                    response_chunks=response_chunks,
-                    chunk_times=chunk_times,
+                    response_chunks=parsed.response_chunks,
+                    chunk_times=parsed.chunk_times,
                     output_tokens=output_len,
-                    output_token_times=chunk_times,
-                    server_usage=server_usage,
+                    output_token_times=parsed.chunk_times,
+                    server_usage=parsed.server_usage,
+                    reasoning_chunks=parsed.reasoning_chunks,
+                    reasoning_chunk_times=parsed.reasoning_chunk_times,
                 ),
                 lora_adapter=lora_adapter,
-                extra_info={"raw_response": raw_content},
+                extra_info={"raw_response": parsed.raw_content},
             )
 
         data = await response.json()

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -75,27 +75,25 @@ class CompletionAPIData(InferenceAPIData):
     ) -> InferenceInfo:
         if config.streaming:
             # Use shared streaming parser with completion-specific content extraction
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=lambda data: data.get("choices", [{}])[0].get("text")
-            )
+            parsed = await parse_sse_stream(response, extract_content=lambda data: data.get("choices", [{}])[0].get("text"))
 
-            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
+            prompt_len = self._resolve_prompt_tokens(parsed.server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
             # with special tokens would add a BOS the server's completion_tokens
             # never contains.
-            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
-            self.model_response = output_text
+            output_len = tokenizer.count_tokens(parsed.output_text, add_special_tokens=False)
+            self.model_response = parsed.output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
                 response_metrics=StreamedResponseMetrics(
-                    response_chunks=response_chunks,
-                    chunk_times=chunk_times,
+                    response_chunks=parsed.response_chunks,
+                    chunk_times=parsed.chunk_times,
                     output_tokens=output_len,
-                    output_token_times=chunk_times,
-                    server_usage=server_usage,
+                    output_token_times=parsed.chunk_times,
+                    server_usage=parsed.server_usage,
                 ),
                 lora_adapter=lora_adapter,
-                extra_info={"raw_response": raw_content},
+                extra_info={"raw_response": parsed.raw_content},
             )
         else:
             data = await response.json()

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -21,9 +21,42 @@ LLM APIs, reducing code duplication across different API types.
 
 import json
 import time
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, NamedTuple, Optional
 
 from aiohttp import ClientResponse
+
+
+class ParsedSSEStream(NamedTuple):
+    """Result of ``parse_sse_stream``, split by generation channel.
+
+    Content and reasoning are tracked separately so downstream metrics can
+    anchor TTFT to the first generated token of either channel while keeping
+    output-length, TPOT, and ITL content-based (#559): reasoning is "thinking",
+    not user-facing output, but the server starts generating at the first
+    reasoning token.
+    """
+
+    # Concatenated delta.content text.
+    output_text: str
+    # Timestamps for content-bearing chunks only. Role-only deltas, usage-only
+    # chunks, [DONE] signals, and unparseable messages are excluded so they
+    # don't corrupt downstream TPOT/TTFT/ITL.
+    chunk_times: List[float]
+    # The raw string content of the entire stream.
+    raw_content: str
+    # Raw JSON strings of content-bearing chunks, 1:1 with chunk_times.
+    response_chunks: List[str]
+    # Merged `usage` fields from chunks that carried one (e.g. OpenAI trailing
+    # `{"choices":[],"usage":{...}}` or Anthropic `message.usage` /
+    # `message_delta.usage`). None if the server didn't emit usage.
+    server_usage: Optional[dict[str, Any]]
+    # Concatenated reasoning-channel text, when extract_reasoning is given.
+    reasoning_text: str
+    # Raw JSON strings of reasoning-bearing chunks, 1:1 with
+    # reasoning_chunk_times.
+    reasoning_chunks: List[str]
+    # Timestamps for reasoning-bearing chunks only.
+    reasoning_chunk_times: List[float]
 
 
 class StreamInterruptedError(Exception):
@@ -43,8 +76,10 @@ class StreamInterruptedError(Exception):
 
 
 async def parse_sse_stream(
-    response: ClientResponse, extract_content: Callable[[dict[str, Any]], Optional[str]]
-) -> Tuple[str, List[float], str, List[str], Optional[dict[str, Any]]]:
+    response: ClientResponse,
+    extract_content: Callable[[dict[str, Any]], Optional[str]],
+    extract_reasoning: Optional[Callable[[dict[str, Any]], Optional[str]]] = None,
+) -> ParsedSSEStream:
     """
     Parse Server-Sent Events (SSE) stream and extract content.
 
@@ -58,20 +93,15 @@ async def parse_sse_stream(
         extract_content: Function to extract text content from parsed JSON data.
                         Should return the text content or None if not found.
                         Example: lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
+        extract_reasoning: Optional function to extract reasoning-channel text
+                        (e.g. delta.reasoning_content) from parsed JSON data.
+                        Chunks bearing reasoning but no content are recorded in
+                        the reasoning_* fields of the result, not in
+                        chunk_times/response_chunks, so content-based metrics
+                        are unaffected.
 
     Returns:
-        Tuple of (output_text, chunk_times, raw_content, response_chunks, server_usage):
-        - output_text: The concatenated text content from all chunks
-        - chunk_times: Timestamps for content-bearing chunks only. Role-only
-          deltas, usage-only chunks, [DONE] signals, and unparseable messages
-          are excluded so they don't corrupt downstream TPOT/TTFT/ITL.
-        - raw_content: The raw string content of the stream
-        - response_chunks: Raw JSON strings of content-bearing chunks, 1:1 with
-          chunk_times.
-        - server_usage: Merged `usage` fields from chunks that carried one
-          (e.g. OpenAI trailing `{"choices":[],"usage":{...}}` or Anthropic
-          `message.usage`/`message_delta.usage`). None if the server didn't
-          emit usage.
+        A ParsedSSEStream; see its field comments.
     """
     output_text = ""
     chunk_times: List[float] = []
@@ -79,6 +109,9 @@ async def parse_sse_stream(
     raw_content = b""
     response_chunks: List[str] = []
     server_usage: Optional[dict[str, Any]] = None
+    reasoning_text = ""
+    reasoning_chunks: List[str] = []
+    reasoning_chunk_times: List[float] = []
 
     try:
         async for chunk in response.content.iter_any():
@@ -107,6 +140,10 @@ async def parse_sse_stream(
                                 output_text += content
                                 chunk_times.append(message_time)
                                 response_chunks.append(data_str.decode("utf-8", errors="ignore"))
+                            elif extract_reasoning is not None and (reasoning := extract_reasoning(data)):
+                                reasoning_text += reasoning
+                                reasoning_chunk_times.append(message_time)
+                                reasoning_chunks.append(data_str.decode("utf-8", errors="ignore"))
                         except (json.JSONDecodeError, IndexError):
                             continue
                 if done:
@@ -118,4 +155,13 @@ async def parse_sse_stream(
         # what the server actually sent instead of an empty response body.
         raise StreamInterruptedError(e, raw_content.decode("utf-8", errors="ignore")) from e
 
-    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage
+    return ParsedSSEStream(
+        output_text=output_text,
+        chunk_times=chunk_times,
+        raw_content=raw_content.decode("utf-8", errors="ignore"),
+        response_chunks=response_chunks,
+        server_usage=server_usage,
+        reasoning_text=reasoning_text,
+        reasoning_chunks=reasoning_chunks,
+        reasoning_chunk_times=reasoning_chunk_times,
+    )

--- a/inference_perf/datagen/replay/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay/replay_graph_session_datagen.py
@@ -890,9 +890,24 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 content = delta.get("content")
                 return str(content) if content is not None else None
 
-            text_content, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=_extract_streaming_content
+            parsed = await parse_sse_stream(
+                response,
+                extract_content=_extract_streaming_content,
+                # Reasoning text itself is accumulated above (which also covers
+                # chunks carrying both channels); this extractor is what gets
+                # reasoning-only chunks timestamped so TTFT can see them (#559).
+                extract_reasoning=lambda data: (
+                    data.get("choices", [{}])[0].get("delta", {}).get("reasoning_content")
+                    or data.get("choices", [{}])[0].get("delta", {}).get("reasoning")
+                ),
             )
+            text_content, chunk_times, response_chunks, server_usage = (
+                parsed.output_text,
+                parsed.chunk_times,
+                parsed.response_chunks,
+                parsed.server_usage,
+            )
+            raw_content = parsed.raw_content
 
             # Combine reasoning_content with text_content in output_text (used for token count)
             reasoning_text = "".join(reasoning_content_chunks) if reasoning_content_chunks else ""
@@ -930,6 +945,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     output_tokens=output_len,
                     output_token_times=chunk_times,
                     server_usage=server_usage,
+                    reasoning_chunks=parsed.reasoning_chunks,
+                    reasoning_chunk_times=parsed.reasoning_chunk_times,
                 ),
                 lora_adapter=lora_adapter,
                 output_text=output_text or None,

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -554,6 +554,21 @@ def summarize_requests(
             # Do not overwrite output_tokens with the per-chunk sum. Keep the API layer's whole-message
             # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
 
+            # The server's completion_tokens counts reasoning tokens too, so the
+            # client-side accounting must include them or every reasoning-model
+            # request would flag as mismatched. They stay out of
+            # output_token_times: reasoning anchors TTFT only (#559).
+            for chunk_str in m.info.response_metrics.reasoning_chunks:
+                try:
+                    data = json.loads(chunk_str)
+                    if choices := data.get("choices"):
+                        delta = choices[0].get("delta", {})
+                        reasoning = delta.get("reasoning_content") or delta.get("reasoning")
+                        if reasoning:
+                            accumulated_tokens += tokenizer.count_tokens(reasoning, add_special_tokens=False)
+                except json.JSONDecodeError:
+                    continue
+
             if expected_output_tokens is not None and accumulated_tokens != expected_output_tokens:
                 mismatched_requests += 1
 
@@ -564,13 +579,33 @@ def summarize_requests(
         else:
             ntpot_values.append(0.0)
 
-        # Check if streamable: Must have more than 1 output token timestamp
+        # Check if streamable: must have more than 1 timestamped generation
+        # event across both channels.
         response_metrics = m.info.response_metrics
-        if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
-            # TTFT: First Token Time - Start Time
-            ttft = response_metrics.output_token_times[0] - m.start_time
-            ttft_values.append(ttft)
+        if isinstance(response_metrics, StreamedResponseMetrics):
+            first_token_candidates = [
+                times[0] for times in (response_metrics.output_token_times, response_metrics.reasoning_chunk_times) if times
+            ]
+            ttft_streamable = len(response_metrics.output_token_times) + len(response_metrics.reasoning_chunk_times) > 1
+        else:
+            first_token_candidates = []
+            ttft_streamable = False
 
+        if ttft_streamable and first_token_candidates:
+            # TTFT: First Token Time - Start Time, where the first token is the
+            # first generated token of ANY channel (#559): reasoning models
+            # stream reasoning deltas before (and, when the output budget is
+            # exhausted, instead of) content, and the server generates from the
+            # first reasoning token (vllm:time_to_first_token counts it).
+            # Anchoring to content would inflate TTFT by the whole
+            # reasoning-decode phase, or yield null when no content ever
+            # arrives. TPOT and ITL stay content-based below: reasoning is
+            # "thinking", not user-facing output.
+            ttft_values.append(min(first_token_candidates) - m.start_time)
+        else:
+            ttft_values.append(None)
+
+        if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
             # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
             duration = response_metrics.output_token_times[-1] - response_metrics.output_token_times[0]
             tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
@@ -591,8 +626,7 @@ def summarize_requests(
             else:
                 itl_values.append(None)
         else:
-            # Not streamable, so TTFT and TPOT are undefined
-            ttft_values.append(None)
+            # No streamed content, so TPOT and ITL are undefined
             tpot_values.append(None)
             itl_values.append(None)
 

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -39,21 +39,19 @@ async def test_parse_sse_stream() -> None:
     def extract_content(data: dict[str, Any]) -> Optional[str]:
         return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
 
-    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-        mock_response, extract_content
-    )
+    parsed = await parse_sse_stream(mock_response, extract_content)
 
-    assert output_text == "Hello world"
-    assert len(chunk_times) == 2
-    assert "Hello" in raw_content
-    assert "world" in raw_content
-    assert "[DONE]" in raw_content
-    assert len(response_chunks) == 2
-    assert "Hello" in response_chunks[0]
-    assert "world" in response_chunks[1]
+    assert parsed.output_text == "Hello world"
+    assert len(parsed.chunk_times) == 2
+    assert "Hello" in parsed.raw_content
+    assert "world" in parsed.raw_content
+    assert "[DONE]" in parsed.raw_content
+    assert len(parsed.response_chunks) == 2
+    assert "Hello" in parsed.response_chunks[0]
+    assert "world" in parsed.response_chunks[1]
     # response_chunks and chunk_times must stay in lockstep — reportgen zips them with strict=True.
-    assert len(chunk_times) == len(response_chunks)
-    assert server_usage is None
+    assert len(parsed.chunk_times) == len(parsed.response_chunks)
+    assert parsed.server_usage is None
 
 
 @pytest.mark.asyncio
@@ -87,15 +85,15 @@ async def test_parse_sse_stream_timestamps_only_content_events() -> None:
     def extract_content(data: dict[str, Any]) -> Optional[str]:
         return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
 
-    output_text, chunk_times, _, response_chunks, server_usage = await parse_sse_stream(mock_response, extract_content)
+    parsed = await parse_sse_stream(mock_response, extract_content)
 
-    assert output_text == "Hello world"
-    assert len(chunk_times) == 2, (
-        f"expected 2 timestamps for content-bearing chunks, got {len(chunk_times)} "
+    assert parsed.output_text == "Hello world"
+    assert len(parsed.chunk_times) == 2, (
+        f"expected 2 timestamps for content-bearing chunks, got {len(parsed.chunk_times)} "
         "(role-only, usage, or [DONE] events leaking into chunk_times)"
     )
-    assert len(response_chunks) == len(chunk_times), "response_chunks must stay 1:1 aligned with chunk_times"
-    assert server_usage == {"prompt_tokens": 5, "completion_tokens": 2}, (
+    assert len(parsed.response_chunks) == len(parsed.chunk_times), "response_chunks must stay 1:1 aligned with chunk_times"
+    assert parsed.server_usage == {"prompt_tokens": 5, "completion_tokens": 2}, (
         "usage info from a content-less chunk should still be surfaced separately"
     )
 
@@ -136,3 +134,108 @@ async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
     # The bytes received before the break are retained, not discarded.
     assert "Hello" in err.raw_content
     assert "world" in err.raw_content
+
+
+def extract_delta_content(data: dict[str, Any]) -> Optional[str]:
+    return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
+
+
+def extract_delta_reasoning(data: dict[str, Any]) -> Optional[str]:
+    delta = data.get("choices", [{}])[0].get("delta", {})
+    return delta.get("reasoning_content") or delta.get("reasoning")  # type: ignore[no-any-return]
+
+
+def make_response(chunks: list[bytes]) -> Mock:
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+
+    mock_content.iter_any = mock_iter_any
+    return mock_response
+
+
+REASONING_THEN_CONTENT_CHUNKS = [
+    b'data: {"choices": [{"delta": {"role": "assistant"}}]}\n\n',
+    b'data: {"choices": [{"delta": {"reasoning_content": "Let me"}}]}\n\n',
+    b'data: {"choices": [{"delta": {"reasoning_content": " think."}}]}\n\n',
+    b'data: {"choices": [{"delta": {"content": "The answer"}}]}\n\n',
+    b'data: {"choices": [{"delta": {"content": " is 4."}}]}\n\n',
+    b"data: [DONE]\n\n",
+]
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_tracked_separately_from_content() -> None:
+    """Reasoning models (gpt-oss, DeepSeek-R1, QwQ) stream delta.reasoning_content
+    before delta.content. The channels must stay separate (#559): reasoning
+    timestamps anchor TTFT, while output_text (the basis for output_len) and
+    chunk_times (the basis for TPOT/ITL) must remain content-only so reasoning
+    doesn't count as user-facing output."""
+    parsed = await parse_sse_stream(
+        make_response(REASONING_THEN_CONTENT_CHUNKS), extract_delta_content, extract_delta_reasoning
+    )
+
+    assert parsed.output_text == "The answer is 4."
+    assert parsed.reasoning_text == "Let me think."
+    assert len(parsed.chunk_times) == 2
+    assert len(parsed.response_chunks) == 2
+    assert len(parsed.reasoning_chunk_times) == 2
+    # reasoning_chunks and reasoning_chunk_times stay 1:1, mirroring the content lists.
+    assert len(parsed.reasoning_chunks) == len(parsed.reasoning_chunk_times)
+    assert all("reasoning_content" in chunk for chunk in parsed.reasoning_chunks)
+    # Reasoning arrived before content, so its timestamps must precede content's:
+    # this ordering is what lets reportgen anchor TTFT to the reasoning channel.
+    assert parsed.reasoning_chunk_times[0] <= parsed.chunk_times[0]
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_field_variant() -> None:
+    """Some OpenAI-compatible servers name the channel delta.reasoning rather
+    than delta.reasoning_content; both must be recognized."""
+    chunks = [
+        b'data: {"choices": [{"delta": {"reasoning": "Step 1."}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": "Result."}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    parsed = await parse_sse_stream(make_response(chunks), extract_delta_content, extract_delta_reasoning)
+
+    assert parsed.output_text == "Result."
+    assert parsed.reasoning_text == "Step 1."
+    assert len(parsed.reasoning_chunk_times) == 1
+    assert len(parsed.chunk_times) == 1
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_only_stream() -> None:
+    """When the output budget is exhausted mid-reasoning (max_tokens below the
+    reasoning length), the stream ends with no content chunk at all. The
+    reasoning channel must still be captured: it is the only TTFT anchor such
+    a request has (#559's null-TTFT case)."""
+    chunks = [
+        b'data: {"choices": [{"delta": {"reasoning_content": "Thinking"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"reasoning_content": " hard"}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    parsed = await parse_sse_stream(make_response(chunks), extract_delta_content, extract_delta_reasoning)
+
+    assert parsed.output_text == ""
+    assert parsed.reasoning_text == "Thinking hard"
+    assert len(parsed.chunk_times) == 0
+    assert len(parsed.reasoning_chunk_times) == 2
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_ignored_without_extractor() -> None:
+    """Callers that pass no extract_reasoning (e.g. the completions API) must
+    see exactly the pre-#559 behavior: reasoning chunks contribute nothing."""
+    parsed = await parse_sse_stream(make_response(REASONING_THEN_CONTENT_CHUNKS), extract_delta_content)
+
+    assert parsed.output_text == "The answer is 4."
+    assert parsed.reasoning_text == ""
+    assert len(parsed.chunk_times) == 2
+    assert parsed.reasoning_chunks == []
+    assert parsed.reasoning_chunk_times == []

--- a/tests/required/integration/fake_openai_server.py
+++ b/tests/required/integration/fake_openai_server.py
@@ -1,0 +1,113 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""In-process OpenAI-compatible streaming fake for the integration tier.
+
+The sim-backed e2e tier (llm-d-inference-sim) exercises realistic server
+behavior, but the sim cannot emit reasoning-channel deltas or pace chunks on
+cue. This fake serves a scripted SSE event sequence over real HTTP with
+controlled per-event delays, and records a timestamp for every chunk it
+actually sent, so tests can assert client-side metrics against the server's
+own timeline rather than against configured intent (the #606 Integration
+tier's "fake the conditions, never the oracle" principle).
+"""
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import List, Optional, Type
+
+from aiohttp import web
+
+
+@dataclass(frozen=True)
+class StreamEvent:
+    """One scripted SSE delta: which channel carries the text and how long the
+    server waits before sending it."""
+
+    channel: str  # "reasoning" | "content"
+    text: str
+    delay_before: float = 0.0
+
+
+@dataclass
+class ServedStream:
+    """What the fake actually did for one request.
+
+    Timestamps are ``perf_counter()`` stamped immediately after each event was
+    written and drained. The client can only observe a chunk at or after its
+    send stamp (same clock, same process), so these bound TTFT assertions
+    tightly without trusting ``asyncio.sleep`` accuracy.
+    """
+
+    reasoning_send_times: List[float] = field(default_factory=list)
+    content_send_times: List[float] = field(default_factory=list)
+
+
+class FakeOpenAIServer:
+    """Serves /v1/chat/completions, streaming the configured script for every
+    request. Use as an async context manager; ``url`` is the endpoint."""
+
+    def __init__(self, script: List[StreamEvent], completion_tokens: Optional[int] = None) -> None:
+        self.script = script
+        # Emitted as a trailing usage chunk (stream_options.include_usage
+        # style) when set.
+        self.completion_tokens = completion_tokens
+        self.served: List[ServedStream] = []
+        self._runner: Optional[web.AppRunner] = None
+        self.port = 0
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1/chat/completions"
+
+    async def __aenter__(self) -> "FakeOpenAIServer":
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", self._handle)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        self.port = self._runner.addresses[0][1]
+        return self
+
+    async def __aexit__(
+        self, exc_type: Optional[Type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
+    ) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    async def _handle(self, request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+        await response.prepare(request)
+        record = ServedStream()
+        self.served.append(record)
+        for event in self.script:
+            if event.delay_before > 0:
+                await asyncio.sleep(event.delay_before)
+            key = "reasoning_content" if event.channel == "reasoning" else "content"
+            payload = {"choices": [{"delta": {key: event.text}}]}
+            await response.write(f"data: {json.dumps(payload)}\n\n".encode())
+            stamp = time.perf_counter()
+            if event.channel == "reasoning":
+                record.reasoning_send_times.append(stamp)
+            else:
+                record.content_send_times.append(stamp)
+        if self.completion_tokens is not None:
+            usage = {"choices": [], "usage": {"completion_tokens": self.completion_tokens}}
+            await response.write(f"data: {json.dumps(usage)}\n\n".encode())
+        await response.write(b"data: [DONE]\n\n")
+        await response.write_eof()
+        return response

--- a/tests/required/integration/test_latency_metric_accuracy.py
+++ b/tests/required/integration/test_latency_metric_accuracy.py
@@ -1,0 +1,397 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration test for issue #726 (#606 Integration tier, per-change lane).
+
+This release has token-count oracles (#631, #627, #580) and unit coverage of the latency
+arithmetic (`tests/required/reportgen/test_summarize_requests.py`), but nothing that
+injects a known latency profile and asserts the numbers that come back out equal it.
+#564 was exactly that gap: a latency metric silently wrong for roughly two months.
+
+These tests script a stream with a known first-token delay and known per-chunk gaps,
+serve it over real HTTP, and drive the real path end to end: the real
+`openAIModelServerClient` session, the real aiohttp streaming parser, the real
+`LocalRequestMetricCollector`, and `ReportGenerator.generate_reports`. The reported
+TTFT, ITL, TPOT and request latency are then checked against the injected profile.
+
+What is faked and what is the oracle:
+
+* Faked: the model server. `FakeOpenAIServer` (added by #694) serves a scripted SSE
+  sequence with controlled pauses.
+* Oracle: the server's own `perf_counter` send stamps. They are taken in the same
+  process on the same clock as the client's receive stamps, so they bound the reported
+  values directly and do not inherit `asyncio.sleep` imprecision. The configured script
+  is the second, looser oracle: it says the pauses under test were really injected.
+
+Deliberately out of scope: coordinated-omission semantics, that is, whether reported
+latency should be corrected by `schedule_delay` under offered load. That is a
+metric-definition decision, it is tracked on #726, and it does not gate v0.7.0.
+"""
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fake_openai_server import FakeOpenAIServer, ServedStream, StreamEvent
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    Config,
+    CustomTokenizerConfig,
+    ReportConfig,
+    RequestLifecycleMetricsReportConfig,
+)
+from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+from inference_perf.reportgen.base import ReportGenerator
+
+# --- Tolerances -------------------------------------------------------------------
+#
+# The fake server and the client run in one process on one `perf_counter` clock, so the
+# client cannot observe a chunk before the server's send stamp for it. CLOCK_EPS absorbs
+# float comparison noise on that lower bound and nothing else.
+CLOCK_EPS = 1e-6
+
+# How much later than a send stamp the client may observe the chunk: one loopback write
+# plus one SSE line parse. That is sub-millisecond when measured locally, so 50 ms is
+# roughly two orders of magnitude of headroom for a contended CI runner. Every gap these
+# tests distinguish is separated by at least 300 ms, so the bound stays far from the
+# values it is asserting about.
+DELIVERY_TOLERANCE = 0.05
+
+# `asyncio.sleep` guarantees a lower bound, not a duration, so the server's own send
+# stamps drift later than the configured script. This is the tolerance for the separate,
+# looser check that the injected pauses actually happened.
+SCHEDULING_TOLERANCE = 0.10
+
+# Combined bound for a reported value checked straight against the configured script.
+INJECTION_TOLERANCE = SCHEDULING_TOLERANCE + DELIVERY_TOLERANCE
+
+# --- Injected profile -------------------------------------------------------------
+#
+# One chunk per token: the fake tokenizer counts whitespace-separated words, and every
+# chunk below carries exactly one, so the arithmetic is checkable by hand.
+FIRST_TOKEN_DELAY = 0.25
+# Alternating slow and fast gaps, so ITL min/max/median describe the distribution rather
+# than collapsing onto the mean. An implementation that reported only the average gap
+# would pass on `mean` and fail on `min` and `max`.
+CHUNK_GAPS = [0.40, 0.10, 0.40, 0.10]
+CHUNK_TEXTS = ["alpha", " beta", " gamma", " delta", " epsilon"]
+# "alpha beta gamma delta epsilon" is five whitespace-separated words.
+EXPECTED_OUTPUT_TOKENS = 5
+
+SCRIPT = [
+    StreamEvent("content", text, delay) for text, delay in zip(CHUNK_TEXTS, [FIRST_TOKEN_DELAY] + CHUNK_GAPS, strict=True)
+]
+
+
+class _ConcreteOpenAIClient(openAIModelServerClient):
+    """`openAIModelServerClient` is abstract only in the two methods below, and neither
+    participates in the streaming path under test."""
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion]
+
+    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
+        raise NotImplementedError("no server metrics are scraped in the integration tier")
+
+
+def make_tokenizer() -> MagicMock:
+    """Counts whitespace-separated words. Real enough for chunk accounting, and exact,
+    so no expected value below depends on a model vocabulary."""
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+async def run_scripted_request(
+    script: List[StreamEvent],
+    *,
+    completion_tokens: Optional[int] = None,
+    tokenize_in_reportgen: bool = False,
+) -> Tuple[Dict[str, Any], ServedStream, RequestLifecycleMetric]:
+    """Serve `script` once and return (summary report contents, what the server did, the
+    metric the collector recorded).
+
+    Everything between the socket and the report is the shipped code path: the real
+    client session, the real streaming parser, the real collector, and the real report
+    generator. Only the tokenizer is substituted, and only to keep token counts exact.
+
+    `tokenize_in_reportgen` decides whether `summarize_requests` re-derives
+    `output_token_times` from the raw chunks (the #564 code path) or passes the API
+    layer's per-chunk arrival times straight through.
+    """
+    collector = LocalRequestMetricCollector()
+
+    async with FakeOpenAIServer(script, completion_tokens=completion_tokens) as server:
+        # The client would otherwise build a CustomTokenizer by fetching from the Hub.
+        with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
+            client = _ConcreteOpenAIClient(
+                metrics_collector=collector,
+                api_config=APIConfig(type=APIType.Chat, streaming=True),
+                uri=f"http://127.0.0.1:{server.port}",
+                model_name="fake-model",
+                tokenizer_config=None,
+                max_tcp_connections=1,
+                additional_filters=[],
+            )
+        try:
+            await client.process_request(
+                ChatCompletionAPIData(messages=[ChatMessage(role="user", content="prompt")], max_tokens=64),
+                stage_id=0,
+                scheduled_time=0.0,
+            )
+        finally:
+            await client.close()
+
+    metrics = collector.get_metrics()
+    assert len(metrics) == 1, "one request must produce exactly one collected metric"
+    metric = metrics[0]
+    assert metric.error is None, f"the scripted stream must succeed, got {metric.error}"
+
+    config = Config()
+    if tokenize_in_reportgen:
+        config.tokenizer = CustomTokenizerConfig(pretrained_model_name_or_path="fake-model")
+    generator = ReportGenerator(metrics_client=None, metrics_collector=collector, config=config)
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=0.0,
+        duration=1.0,
+        model_server_metrics=BaseMetrics(),
+        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
+    )
+    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(summary=True))
+
+    with patch("inference_perf.utils.custom_tokenizer.CustomTokenizer", return_value=make_tokenizer()):
+        reports = await generator.generate_reports(report_config, runtime_parameters)
+
+    summaries = [report for report in reports if report.name == "summary_lifecycle_metrics"]
+    assert len(summaries) == 1, "the summary report must be emitted"
+    return summaries[0].contents, server.served[-1], metric
+
+
+def offsets_from(send_times: Sequence[float], start: float) -> List[float]:
+    """Server send stamps expressed against the client's request start, which is the
+    zero point every reported latency is measured from."""
+    return [t - start for t in send_times]
+
+
+def gaps(values: Sequence[float]) -> List[float]:
+    return [b - a for a, b in zip(values, values[1:], strict=False)]
+
+
+def assert_matches_send_stamp(reported: float, expected: float, label: str) -> None:
+    """A value the client derived from chunk arrivals, against the server's send stamp
+    for the same chunk. The client cannot see a chunk early, so this is one-sided."""
+    assert reported >= expected - CLOCK_EPS, f"{label}: {reported} precedes the server's send stamp {expected}"
+    assert reported <= expected + DELIVERY_TOLERANCE, (
+        f"{label}: {reported} exceeds send stamp {expected} by more than delivery"
+    )
+
+
+def assert_matches_injection(reported: float, configured: float, label: str) -> None:
+    """A reported value straight against the configured script. Looser, because
+    `asyncio.sleep` only promises to sleep at least as long as asked."""
+    assert reported >= configured - DELIVERY_TOLERANCE, f"{label}: {reported} is below the injected {configured}"
+    assert reported <= configured + INJECTION_TOLERANCE, f"{label}: {reported} is above the injected {configured}"
+
+
+@pytest.mark.asyncio
+async def test_injected_pauses_actually_happen_on_the_wire() -> None:
+    """Guards the oracle before anything is asserted against it.
+
+    If the fake did not really pause, every accuracy assertion below would still pass
+    while measuring nothing. This checks the server's own send stamps against the
+    configured script: each gap must be at least what was asked for, and not wildly
+    more.
+    """
+    _, served, metric = await run_scripted_request(SCRIPT, completion_tokens=EXPECTED_OUTPUT_TOKENS)
+
+    sent = offsets_from(served.content_send_times, metric.start_time)
+    assert len(sent) == len(CHUNK_TEXTS)
+    assert sent[0] >= FIRST_TOKEN_DELAY - CLOCK_EPS
+    assert sent[0] <= FIRST_TOKEN_DELAY + SCHEDULING_TOLERANCE
+
+    for observed, configured in zip(gaps(sent), CHUNK_GAPS, strict=True):
+        assert observed >= configured - CLOCK_EPS, f"gap {observed} is shorter than the injected {configured}"
+        assert observed <= configured + SCHEDULING_TOLERANCE, f"gap {observed} overshot the injected {configured}"
+
+
+@pytest.mark.asyncio
+async def test_reported_ttft_matches_the_injected_first_token_delay() -> None:
+    """TTFT must equal the time the first content chunk was put on the wire.
+
+    Checked twice: against the server's send stamp for that chunk (tight) and against
+    the 0.25s the script asked for (loose). A TTFT anchored to the wrong event, for
+    instance to response headers or to stream completion, fails both.
+    """
+    summary, served, metric = await run_scripted_request(SCRIPT, completion_tokens=EXPECTED_OUTPUT_TOKENS)
+
+    ttft = summary["successes"]["latency"]["time_to_first_token"]
+    assert ttft is not None, "a streaming response must report a TTFT"
+    # One request, so mean, min, median and max are all the same single observation.
+    for key in ("mean", "min", "median", "max"):
+        assert ttft[key] == pytest.approx(ttft["mean"]), key
+
+    first_chunk_offset = offsets_from(served.content_send_times, metric.start_time)[0]
+    assert_matches_send_stamp(ttft["mean"], first_chunk_offset, "ttft")
+    assert_matches_injection(ttft["mean"], FIRST_TOKEN_DELAY, "ttft")
+
+
+@pytest.mark.asyncio
+async def test_reported_ttft_tracks_a_change_in_the_injected_delay() -> None:
+    """Two runs differing only in the first-token pause must differ by that pause.
+
+    A single-script test can pass on a TTFT that happens to be near-constant, for
+    instance one measured from the wrong anchor on a short stream. Changing only the
+    injected delay isolates it: 0.55s more waiting must show up as 0.55s more TTFT.
+    """
+    fast_delay, slow_delay = 0.05, 0.60
+    tail = [StreamEvent("content", " beta", 0.05)]
+
+    fast_summary, _, _ = await run_scripted_request([StreamEvent("content", "alpha", fast_delay)] + tail)
+    slow_summary, _, _ = await run_scripted_request([StreamEvent("content", "alpha", slow_delay)] + tail)
+
+    fast_ttft = fast_summary["successes"]["latency"]["time_to_first_token"]["mean"]
+    slow_ttft = slow_summary["successes"]["latency"]["time_to_first_token"]["mean"]
+
+    assert_matches_injection(fast_ttft, fast_delay, "fast ttft")
+    assert_matches_injection(slow_ttft, slow_delay, "slow ttft")
+    # The difference cancels the fixed connect and parse overhead common to both runs,
+    # so it is bounded by scheduling jitter alone.
+    assert slow_ttft - fast_ttft == pytest.approx(slow_delay - fast_delay, abs=INJECTION_TOLERANCE)
+
+
+@pytest.mark.asyncio
+async def test_reported_itl_matches_the_injected_per_chunk_gaps() -> None:
+    """ITL must reproduce the gap distribution, not just its average.
+
+    The script alternates 0.40s and 0.10s pauses, so the reported summary has to show
+    min near 0.10, max near 0.40 and mean near 0.25. #564 is the reason this asserts the
+    distribution: that bug halved ITL by inventing extra tokens at already-recorded
+    timestamps, which moves the mean while leaving the metric present and plausible.
+    """
+    summary, served, metric = await run_scripted_request(SCRIPT, completion_tokens=EXPECTED_OUTPUT_TOKENS)
+
+    itl = summary["successes"]["latency"]["inter_token_latency"]
+    assert itl is not None
+
+    observed_gaps = gaps(offsets_from(served.content_send_times, metric.start_time))
+    assert len(observed_gaps) == len(CHUNK_GAPS)
+
+    # Tight: against what the server actually did.
+    assert itl["min"] == pytest.approx(min(observed_gaps), abs=DELIVERY_TOLERANCE)
+    assert itl["max"] == pytest.approx(max(observed_gaps), abs=DELIVERY_TOLERANCE)
+    assert itl["mean"] == pytest.approx(sum(observed_gaps) / len(observed_gaps), abs=DELIVERY_TOLERANCE)
+
+    # Loose: against the script, which is what a reader of the report cares about.
+    assert_matches_injection(itl["min"], min(CHUNK_GAPS), "itl min")
+    assert_matches_injection(itl["max"], max(CHUNK_GAPS), "itl max")
+    assert_matches_injection(itl["mean"], sum(CHUNK_GAPS) / len(CHUNK_GAPS), "itl mean")
+    # Two slow and two fast gaps put the median midway between them: (0.10 + 0.40) / 2.
+    assert_matches_injection(itl["median"], 0.25, "itl median")
+
+
+@pytest.mark.asyncio
+async def test_reported_tpot_matches_the_injected_decode_span() -> None:
+    """TPOT is the decode span divided by output tokens minus one, and must exclude the
+    prefill wait.
+
+    Injected: 5 tokens, first at 0.25s, last at 1.25s, so the span is 1.00s over 4
+    intervals and TPOT is 0.25s. Note it is not `request_latency / tokens`: that is
+    `normalized_time_per_output_token`, which the same report emits separately and which
+    is checked below to be strictly larger because it does include the 0.25s prefill.
+    """
+    summary, served, metric = await run_scripted_request(SCRIPT, completion_tokens=EXPECTED_OUTPUT_TOKENS)
+
+    assert summary["successes"]["output_len"]["mean"] == EXPECTED_OUTPUT_TOKENS
+
+    tpot = summary["successes"]["latency"]["time_per_output_token"]
+    assert tpot is not None
+
+    sent = offsets_from(served.content_send_times, metric.start_time)
+    expected_tpot = (sent[-1] - sent[0]) / (EXPECTED_OUTPUT_TOKENS - 1)
+    assert tpot["mean"] == pytest.approx(expected_tpot, abs=DELIVERY_TOLERANCE)
+    assert_matches_injection(tpot["mean"], sum(CHUNK_GAPS) / (EXPECTED_OUTPUT_TOKENS - 1), "tpot")
+
+    ntpot = summary["successes"]["latency"]["normalized_time_per_output_token"]
+    assert ntpot is not None
+    assert ntpot["mean"] > tpot["mean"], "NTPOT must include the prefill wait that TPOT excludes"
+
+
+@pytest.mark.asyncio
+async def test_reported_request_latency_matches_the_injected_total() -> None:
+    """Request latency must cover the whole injected profile and nothing beyond it.
+
+    The script spends 0.25s before the first token and 1.00s streaming the rest, so the
+    injected total is 1.25s. The reported value has to be at least that, at least as
+    large as the last send stamp, and within one delivery window of it: anything much
+    larger means the client is charging the request for teardown it did not spend.
+    """
+    summary, served, metric = await run_scripted_request(SCRIPT, completion_tokens=EXPECTED_OUTPUT_TOKENS)
+
+    latency = summary["successes"]["latency"]["request_latency"]
+    assert latency is not None
+
+    injected_total = FIRST_TOKEN_DELAY + sum(CHUNK_GAPS)
+    assert_matches_injection(latency["mean"], injected_total, "request_latency")
+
+    last_send_offset = offsets_from(served.content_send_times, metric.start_time)[-1]
+    assert latency["mean"] >= last_send_offset - CLOCK_EPS, "latency cannot end before the last chunk was sent"
+    assert latency["mean"] <= last_send_offset + DELIVERY_TOLERANCE
+
+    # The report's own consistency: the request cannot finish before its first token.
+    ttft = summary["successes"]["latency"]["time_to_first_token"]
+    assert ttft is not None
+    assert latency["mean"] > ttft["mean"]
+
+
+@pytest.mark.asyncio
+async def test_itl_is_not_deflated_when_reportgen_retokenizes_chunks() -> None:
+    """The #564 shape, through the path that produced it.
+
+    With a tokenizer configured, `summarize_requests` rebuilds `output_token_times` from
+    the raw chunks rather than using the API layer's arrival times. #564 was a
+    per-chunk BOS in that rebuild: every one-token chunk counted as two, which duplicated
+    each timestamp, inserted a zero-length interval between the copies, and roughly
+    halved reported ITL while leaving the metric present and plausible.
+
+    Three chunks of one word each, 0.35s apart, must therefore report ITL near 0.35s.
+    Under the #564 behavior the same stream reports near 0.175s.
+    """
+    gap = 0.35
+    script = [
+        StreamEvent("content", "alpha", 0.10),
+        StreamEvent("content", " beta", gap),
+        StreamEvent("content", " gamma", gap),
+    ]
+
+    summary, served, metric = await run_scripted_request(script, completion_tokens=3, tokenize_in_reportgen=True)
+
+    itl = summary["successes"]["latency"]["inter_token_latency"]
+    assert itl is not None
+    observed_gaps = gaps(offsets_from(served.content_send_times, metric.start_time))
+    assert itl["mean"] == pytest.approx(sum(observed_gaps) / len(observed_gaps), abs=DELIVERY_TOLERANCE)
+    assert_matches_injection(itl["mean"], gap, "itl mean via reportgen tokenizer")
+    # No zero-length interval, which is the fingerprint of a duplicated timestamp.
+    assert itl["min"] > 0.0, "a zero ITL sample means two tokens were recorded at one arrival time"
+
+    # The client's own accounting agrees with the server's completion_tokens, so the
+    # mismatch detector added for #564 stays quiet on a correct stream.
+    assert summary["successes"]["token_count_mismatches"] == 0

--- a/tests/required/integration/test_reasoning_ttft_integration.py
+++ b/tests/required/integration/test_reasoning_ttft_integration.py
@@ -1,0 +1,117 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration test for issue #559 (#606 Integration tier, per-change lane).
+
+Drives the full client pipeline (real HTTP request, real SSE wire bytes,
+real timing) against an in-process fake reasoning model and asserts that
+reported TTFT anchors to the first reasoning token, using the server's own
+send timestamps as the oracle. The unit tests in tests/test_reasoning_ttft.py
+pin the arithmetic with synthetic timestamps; this test pins the wiring: that
+a reasoning delta on the wire actually reaches the TTFT calculation.
+"""
+
+import time
+from typing import Tuple
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+
+from fake_openai_server import FakeOpenAIServer, ServedStream, StreamEvent
+
+from inference_perf.apis.base import RequestLifecycleMetric, StreamedResponseMetrics
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.config import APIConfig, APIType
+from inference_perf.reportgen.base import ResponsesSummary, summarize_requests
+
+
+def make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+async def run_request(server: FakeOpenAIServer) -> Tuple[ResponsesSummary, RequestLifecycleMetric, ServedStream, float]:
+    """One benchmark request against the fake, through the real parse and
+    summarize path. Returns (summary, metric, what the server did, start)."""
+    tokenizer = make_tokenizer()
+    config = APIConfig(type=APIType.Chat, streaming=True)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="prompt")], max_tokens=100)
+
+    async with aiohttp.ClientSession() as session:
+        start = time.perf_counter()
+        async with session.post(server.url, json={}) as response:
+            info = await data.process_response(response, config, tokenizer)
+        end = time.perf_counter()
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=start, start_time=start, end_time=end, request_data="prompt", info=info, error=None
+    )
+    return summarize_requests([metric], [50], tokenizer=tokenizer), metric, server.served[-1], start
+
+
+@pytest.mark.asyncio
+async def test_ttft_anchors_to_first_reasoning_token_on_the_wire() -> None:
+    """The inflated-TTFT case: reasoning streams promptly, content only after a
+    long reasoning phase. TTFT must land at the first reasoning chunk, not be
+    inflated by the reasoning-decode phase to the first content chunk."""
+    reasoning_phase = [StreamEvent("reasoning", "Let me", 0.02), StreamEvent("reasoning", " think.", 0.02)]
+    # The pause before content is the reasoning-decode phase TTFT must NOT
+    # include. Large relative to loopback parse latency so the bound is robust.
+    content_phase = [StreamEvent("content", "The answer", 0.35), StreamEvent("content", " is 4.", 0.02)]
+
+    async with FakeOpenAIServer(reasoning_phase + content_phase, completion_tokens=7) as server:
+        result, metric, served, start = await run_request(server)
+
+    ttft_summary = result.successes["latency"]["time_to_first_token"]
+    assert ttft_summary is not None
+    ttft = ttft_summary["mean"]
+    # The client cannot observe a chunk before the server sent it (same
+    # perf_counter clock, same process), so TTFT is at least the first
+    # reasoning send offset...
+    assert ttft >= served.reasoning_send_times[0] - start - 1e-6
+    # ...and anchoring to reasoning means it must come in strictly before the
+    # first content chunk was even sent. Pre-#559 this read ~0.4s, not ~0.02s.
+    assert ttft < served.content_send_times[0] - start
+
+    # Output length stays content-based: reasoning is thinking, not output.
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    assert metric.info.response_metrics.output_tokens == 4  # "The answer is 4."
+    # Client accounting (content + reasoning) matches the server's
+    # completion_tokens, so the mismatch detector stays quiet.
+    assert result.successes["token_count_mismatches"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ttft_reported_when_output_budget_exhausted_mid_reasoning() -> None:
+    """The null-TTFT case: max_tokens below the reasoning length means the
+    stream ends while still in the reasoning channel, so no content token ever
+    arrives. TTFT must still be reported; TPOT and ITL stay undefined."""
+    script = [
+        StreamEvent("reasoning", "Thinking", 0.02),
+        StreamEvent("reasoning", " quite", 0.02),
+        StreamEvent("reasoning", " hard", 0.02),
+    ]
+
+    async with FakeOpenAIServer(script, completion_tokens=3) as server:
+        result, metric, served, start = await run_request(server)
+
+    ttft_summary = result.successes["latency"]["time_to_first_token"]
+    assert ttft_summary is not None, "reasoning-only stream must yield a TTFT, not null"
+    assert ttft_summary["mean"] >= served.reasoning_send_times[0] - start - 1e-6
+
+    assert result.successes["latency"]["time_per_output_token"] is None
+    assert result.successes["latency"]["inter_token_latency"] is None
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    assert metric.info.response_metrics.output_tokens == 0

--- a/tests/test_reasoning_ttft.py
+++ b/tests/test_reasoning_ttft.py
@@ -1,0 +1,202 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for issue #559.
+
+Reasoning models emit reasoning-channel tokens before (and, when the output
+budget is exhausted, instead of) any content token. Pre-#559 only
+delta.content chunks were timestamped, so time_to_first_token was inflated to
+time-to-first-CONTENT (prefill plus the entire reasoning-decode phase), and
+null when the stream ended while still in the reasoning channel.
+
+TTFT must anchor to the first generated token of ANY channel, matching
+server-side metrics (vllm:time_to_first_token). TPOT, ITL, and output-length
+stay content-based: reasoning is "thinking", not user-facing output.
+"""
+
+from typing import AsyncGenerator, List, Optional, cast
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import ClientResponse
+
+from inference_perf.apis.base import InferenceInfo, RequestLifecycleMetric, StreamedResponseMetrics
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.config import APIConfig, APIType
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.reportgen.base import summarize_requests
+
+
+def make_streamed_metric(
+    start_time: float,
+    end_time: float,
+    output_token_times: List[float],
+    reasoning_chunk_times: Optional[List[float]] = None,
+    output_tokens: int = 0,
+) -> RequestLifecycleMetric:
+    """A successful streamed request with synthetic timestamps, bypassing the
+    chunk re-parse (no tokenizer is passed to summarize_requests) so the TTFT
+    arithmetic is tested against exact, controlled inputs."""
+    return RequestLifecycleMetric(
+        scheduled_time=start_time,
+        start_time=start_time,
+        end_time=end_time,
+        request_data="prompt",
+        info=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=1)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=output_tokens,
+                output_token_times=output_token_times,
+                reasoning_chunk_times=reasoning_chunk_times or [],
+            ),
+        ),
+        error=None,
+    )
+
+
+def test_ttft_anchors_to_reasoning_not_first_content() -> None:
+    """The inflated case: reasoning starts at t=2.0 but content only at t=5.0.
+    Pre-#559 TTFT reported 4.0s (time-to-first-content, i.e. prefill + the
+    whole reasoning-decode phase); it must report 1.0s, the first generated
+    token. ITL and TPOT keep ignoring the reasoning channel."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=6.0,
+        output_token_times=[5.0, 5.1, 5.2],
+        reasoning_chunk_times=[2.0, 2.5],
+        output_tokens=3,
+    )
+    result = summarize_requests([metric], [50])
+
+    ttft = result.successes["latency"]["time_to_first_token"]
+    assert ttft is not None
+    assert ttft["mean"] == pytest.approx(1.0)
+    # ITL only spans content gaps (5.0->5.1->5.2); the 2.5s reasoning->content
+    # gap must not appear in it.
+    itl = result.successes["latency"]["inter_token_latency"]
+    assert itl is not None
+    assert itl["max"] == pytest.approx(0.1)
+
+
+def test_ttft_defined_for_reasoning_only_stream() -> None:
+    """The null case: the output budget is exhausted mid-reasoning so no
+    content token ever arrives. Pre-#559 TTFT was null; it must report the
+    first reasoning token, while TPOT and ITL stay undefined (no content)."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=4.0,
+        output_token_times=[],
+        reasoning_chunk_times=[2.0, 2.5, 3.0],
+    )
+    result = summarize_requests([metric], [50])
+
+    ttft = result.successes["latency"]["time_to_first_token"]
+    assert ttft is not None, "reasoning-only stream must still yield a TTFT"
+    assert ttft["mean"] == pytest.approx(1.0)
+    assert result.successes["latency"]["time_per_output_token"] is None
+    assert result.successes["latency"]["inter_token_latency"] is None
+
+
+def test_ttft_unchanged_for_content_only_stream() -> None:
+    """Non-reasoning responses must keep the exact pre-#559 semantics."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=6.0,
+        output_token_times=[3.0, 3.2, 3.4],
+        output_tokens=3,
+    )
+    result = summarize_requests([metric], [50])
+
+    ttft = result.successes["latency"]["time_to_first_token"]
+    assert ttft is not None
+    assert ttft["mean"] == pytest.approx(2.0)
+
+
+def test_ttft_undefined_below_two_generation_events() -> None:
+    """A single timestamped event across both channels is indistinguishable
+    from a unary response, so TTFT stays undefined, matching the pre-#559
+    guard against single-event streams."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=4.0,
+        output_token_times=[],
+        reasoning_chunk_times=[2.0],
+    )
+    result = summarize_requests([metric], [50])
+
+    assert result.successes["latency"]["time_to_first_token"] is None
+
+
+def _build_reasoning_sse(reasoning_texts: List[str], content_texts: List[str], completion_tokens: int) -> bytes:
+    parts = [f'data: {{"choices":[{{"delta":{{"reasoning_content":"{t}"}}}}]}}\n\n'.encode() for t in reasoning_texts]
+    parts += [f'data: {{"choices":[{{"delta":{{"content":"{t}"}}}}]}}\n\n'.encode() for t in content_texts]
+    parts.append(f'data: {{"choices":[],"usage":{{"completion_tokens":{completion_tokens}}}}}\n\n'.encode())
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+class FakeStreamingResponse:
+    """Minimal aiohttp ClientResponse stand-in that yields preset SSE bytes."""
+
+    def __init__(self, body: bytes) -> None:
+        self.status = 200
+        self.content = MagicMock()
+
+        async def iter_any() -> AsyncGenerator[bytes, None]:
+            yield body
+
+        self.content.iter_any = iter_any
+
+
+@pytest.mark.asyncio
+async def test_pipeline_output_len_content_only_and_accounting_includes_reasoning() -> None:
+    """Full pipeline (SSE bytes -> process_response -> summarize_requests):
+    client output_len must count content tokens only, while the token-count
+    mismatch check must include reasoning tokens, since the server's
+    completion_tokens counts them. With a tokenizer matching the server the
+    request must therefore NOT flag as mismatched."""
+    reasoning_texts = ["think one two", " three four"]  # 5 tokens
+    content_texts = ["answer is", " four ok"]  # 4 tokens
+    sse = _build_reasoning_sse(reasoning_texts, content_texts, completion_tokens=9)
+
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+
+    config = APIConfig(type=APIType.Chat, streaming=True)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="prompt")], max_tokens=100)
+    info = await data.process_response(cast(ClientResponse, FakeStreamingResponse(sse)), config, tokenizer)
+
+    assert isinstance(info.response_metrics, StreamedResponseMetrics)
+    # output_tokens (client) is content-only: reasoning is not user-facing output.
+    assert info.response_metrics.output_tokens == 4
+    assert len(info.response_metrics.reasoning_chunks) == 2
+    assert len(info.response_metrics.chunk_times) == 2
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="prompt", info=info, error=None
+    )
+    result = summarize_requests([metric], [50], tokenizer=tokenizer)
+    assert result.successes["token_count_mismatches"] == 0
+
+    # The capped variant: no content at all, TTFT still defined end-to-end.
+    capped_sse = _build_reasoning_sse(["think one two", "three four"], [], completion_tokens=5)
+    capped_info = await data.process_response(cast(ClientResponse, FakeStreamingResponse(capped_sse)), config, tokenizer)
+    assert isinstance(capped_info.response_metrics, StreamedResponseMetrics)
+    assert capped_info.response_metrics.output_tokens == 0
+
+    capped_metric = RequestLifecycleMetric(
+        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="prompt", info=capped_info, error=None
+    )
+    capped_result = summarize_requests([capped_metric], [50], tokenizer=tokenizer)
+    assert capped_result.successes["latency"]["time_to_first_token"] is not None
+    assert capped_result.successes["token_count_mismatches"] == 0


### PR DESCRIPTION
Part of #726. Row in #606: Integration / "Metric accuracy gate, latency (#726)".

## The gap

inference-perf reports four latency metrics per request: time to first token (TTFT), inter-token latency (ITL, the gap between streamed chunks), time per output token (TPOT) and request latency. The only test that checks these numbers against a known input is `e2e/tests/test_metrics_fidelity.py` (#614), which runs in the e2e tier against `llm-d-inference-sim` with fixed TTFT and inter-token latency, so it needs the sim binary and is not in the per-PR unit suite. Everything in `tests/required` either hands the latency math pre-made timestamps or only checks that a metric is present and plausible.

That is how #564 happened: #410 changed how streamed chunks were tokenized, ITL was under-reported, and nothing caught it for about two months.

## What this adds

One new file, `tests/required/integration/test_latency_metric_accuracy.py`, 7 tests. Each:

1. Starts a fake OpenAI-compatible server (`FakeOpenAIServer` from #694) that streams five word-chunks over real HTTP with scripted pauses: 250 ms to first token, then gaps of 400, 100, 400, 100 ms.
2. Runs a normal inference-perf request against it through the real client, streaming parser, metric collector and report generator. Only the model server is fake.
3. Reads TTFT, ITL, TPOT and request latency from the generated report and checks each against the injected pauses.

The reference values are the fake server's own per-chunk send timestamps. Server and client share one process and clock, so each reported number is compared to when the bytes actually left, not to how long `asyncio.sleep` was asked for. Tolerances (50 ms delivery, 100 ms scheduling) are documented in the file; 100 vs 400 ms gaps stay separable.

The seven checks:

- the fake server really pauses (so nothing below passes by accident)
- TTFT matches the 250 ms first-token delay
- changing the first-token delay moves reported TTFT by the same amount
- ITL min, max, mean and median match the 400/100 ms gaps
- TPOT excludes the first-token wait and is below normalized TPOT
- request latency is bounded both ways by the injected total
- the re-tokenization branch where #564 lived does not halve ITL or emit zero-length intervals

Compared with #614: runs in `tests/required` on every PR with no external binary; the reference is the send timestamp, not the configured sleep, so each value is bounded on both sides; the gaps are uneven (400/100 ms) so ITL min, max, mean and median are each checked, where #614 uses a constant gap and asserts only the median; and the report-time re-tokenization branch is exercised directly rather than sidestepped with `use_server_output_tokens`. The tokenizer here maps one word to one token, so the multi-token-per-chunk case #614 notes (zero-length gaps dragging the ITL mean down) is covered by neither test.

Breaking `summarize_requests` locally four ways (the #564 re-tokenization, TTFT anchored to end of stream, first-token wait folded into TPOT, flat average as ITL) fails the matching test each time. Product code is unchanged.

## Status

Stacked on #694 (base `3b17a21`), which supplies `fake_openai_server.py`. Once #694 merges the diff shrinks to this file and the `[PENDING]` prefix comes off.

Verified locally on #694: 7 new tests pass, `pdm run validate` clean, unit suite 892 passed / 15 skipped. About 10 seconds, almost all injected sleep.

Notes: the #606 row says this "requires giving `MockModelServerClient` a controllable response profile"; that mock is unary-only with no chunk timeline and would bypass the HTTP client and parser, so the row should read "uses the `FakeOpenAIServer` fake from #694". Coordinated-omission correction (adjusting latency by `schedule_delay`) is out of scope: a metric-definition question, open on #726 after v0.7.0.
