### PR TITLE
test: assert delivered rate and concurrency match config

### DIFF
--- a/e2e/tests/test_load_shape_accuracy_sim.py
+++ b/e2e/tests/test_load_shape_accuracy_sim.py
@@ -1,0 +1,354 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sim-backed load-shape accuracy e2e (#633).
+
+Everything else in the e2e tier checks what inference-perf *reports* about
+the responses it got. This checks the stimulus: that the load actually
+offered matches the load that was configured. For a load generator that is
+the more fundamental correctness claim, and `docs/loadgen.md` makes it
+explicitly ("workers are dynamically allocated to achieve the exact
+concurrency specified") without anything verifying it.
+
+What is faked and what is the oracle
+------------------------------------
+Faked: the server. `llm-d-inference-sim` stands in for vLLM, with pinned
+latencies so request duration is known and the run is short.
+
+Oracle: the configured load, which is a known-good input, plus a
+reconstruction of delivered rate and in-flight concurrency computed in
+`utils.load_shape` from the raw per-request `start_time`/`end_time` pairs.
+The reconstruction does not read reportgen's summary numbers, so the
+reported `achieved_rate` can be checked against it rather than merely
+restated.
+
+This stays on the sim deliberately. Against a real vLLM these assertions
+would measure the server's capacity, not the load generator: a slow server
+delays responses, and under a concurrency limit that changes the offered
+load itself.
+
+Scope, versus the neighbouring issues
+-------------------------------------
+Dispatch scheduling arithmetic (what times the timers emit, how a
+concurrency level is split across workers) is unit-level and belongs to
+#659. What only a real process with real sockets can show is whether the
+generator keeps up with its own schedule and holds its semaphore under load,
+so that is all this file asserts.
+
+Known limit of the oracle
+-------------------------
+The timestamps come from the client, so this measures the load generator's
+own view of what it offered. That is enough to catch a generator that falls
+behind, a semaphore that admits the wrong number of requests, and a reportgen
+that derives the rate wrongly, but not a bug in the timestamping itself. A
+server that recorded arrivals independently would be strictly stronger and
+this test can be retargeted at one later without changing its assertions.
+"""
+
+import pytest
+
+from utils.accuracy import assert_successful_run
+from utils.benchmark import run_benchmark_minimal
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
+from utils.load_shape import (
+    assert_delivered_concurrency,
+    fraction_at_level,
+    inflight_segments,
+    max_inflight,
+    mean_inflight,
+    observed_send_rate,
+    plateau_window,
+    rate_tolerance,
+)
+from utils.net import get_free_port
+from utils.testdata import extract_tarball
+
+TEST_MODEL_NAME = "google/gemma-3-270m"
+TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+
+# Rate stage: 600 requests is the smallest count at which a Poisson stage can
+# be held to a tolerance worth gating on (see rate_tolerance), and 40 qps is
+# already exercised by the existing sim suite (test_llm_d_inference_sim runs
+# 100 qps), so the client is not the bottleneck.
+RATE = 40
+DURATION = 15
+EXPECTED_RATE_REQUESTS = RATE * DURATION
+
+# Concurrency stages: pinned sim latencies put each request at roughly
+# 150ms + 15 * 15ms = 375ms, so 12 rounds of requests is about 4.5s of load.
+SIM_TTFT_MS = 150
+SIM_ITL_MS = 15
+OUTPUT_TOKENS = 16
+ROUNDS = 12
+
+
+def _sim_args(*extra: str) -> list[str]:
+    return [
+        # Default max-num-seqs is 5. Server-side queueing does not change what
+        # the client offers, but it does stretch request duration and with it
+        # the length of the run, so keep every request scheduled immediately.
+        *("--max-num-seqs", "64"),
+        *extra,
+    ]
+
+
+def _server_block(sim: LLMDInferenceSimRunner, model_name: str) -> dict:
+    return {
+        "type": "vllm",
+        "model_name": model_name,
+        "base_url": f"http://{sim.host}:{sim.port}",
+        "ignore_eos": True,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+@pytest.mark.parametrize("arrival", ["constant", "poisson"])
+async def test_achieved_rate_matches_configured_rate(arrival: str):
+    """A fixed-rate stage must deliver the rate it was configured with.
+
+    Two separate claims, deliberately not collapsed into one:
+
+    1. reportgen's `achieved_rate` is the count over the span of send times,
+       recomputed here from the raw per-request timestamps. Checking the
+       reported value against the independent recomputation is what makes
+       this more than a restatement of the tool's own summary.
+    2. that rate matches the configured `rate` within a tolerance derived
+       from the arrival process (see `rate_tolerance`), not from a number
+       chosen after watching a run.
+    """
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+
+    async with LLMDInferenceSimRunner(model_name, *_sim_args(), port=get_free_port()) as sim:
+        result = await run_benchmark_minimal(
+            {
+                "data": {"type": "mock"},
+                "load": {
+                    "type": arrival,
+                    "stages": [{"rate": RATE, "duration": DURATION}],
+                    "num_workers": 2,
+                },
+                "api": {"type": "completion", "streaming": True},
+                "server": _server_block(sim, model_name),
+                "tokenizer": {"pretrained_model_name_or_path": str(model_path)},
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                        "per_stage": True,
+                        "per_request": True,
+                    },
+                },
+            },
+            timeout_sec=180,
+        )
+
+    entries = assert_successful_run(result, EXPECTED_RATE_REQUESTS)
+
+    stage = result.reports["stage_0_lifecycle_metrics.json"]["load_summary"]
+    assert stage["count"] == EXPECTED_RATE_REQUESTS
+    assert stage["requested_rate"] == RATE, f"stage echoed requested_rate {stage['requested_rate']}, configured {RATE}"
+
+    # (1) reportgen's derivation, against the same quantity recomputed from
+    # the raw per-request send times. Exact: it is the same arithmetic on the
+    # same data, so any drift here is a reportgen bug, not timing noise.
+    send_duration, recomputed_rate = observed_send_rate(entries)
+    assert stage["send_duration"] == pytest.approx(send_duration, rel=1e-9), (
+        f"reported send_duration {stage['send_duration']} != {send_duration} recomputed from per-request starts"
+    )
+    assert stage["achieved_rate"] == pytest.approx(recomputed_rate, rel=1e-9), (
+        f"reported achieved_rate {stage['achieved_rate']} != {recomputed_rate} recomputed from per-request starts"
+    )
+
+    # (2) the load-shape claim itself.
+    tolerance = rate_tolerance(EXPECTED_RATE_REQUESTS, arrival)
+    error = abs(recomputed_rate - RATE) / RATE
+    assert error <= tolerance, (
+        f"{arrival} stage delivered {recomputed_rate:.3f} req/s against a configured {RATE} req/s "
+        f"({error:.1%} off, tolerance {tolerance:.1%} for n={EXPECTED_RATE_REQUESTS})"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+@pytest.mark.parametrize(
+    ("concurrency", "num_workers"),
+    [
+        pytest.param(8, 2, id="c8_w2_divisible"),
+        # concurrency_level % num_workers != 0: workers get 3 and 2. The split
+        # arithmetic is unit-tested, but nothing has checked that the sum of
+        # the split semaphores is what actually goes on the wire.
+        pytest.param(5, 2, id="c5_w2_remainder"),
+    ],
+)
+async def test_delivered_concurrency_matches_configured_level(concurrency: int, num_workers: int):
+    """A fixed-concurrency stage must hold exactly `concurrency_level` in flight.
+
+    Note what the report does and does not give us here. `load_summary`
+    carries a `concurrency` field, but reportgen copies it straight off the
+    stage config, so asserting on it proves only that the value was threaded
+    through. The delivered value has to be reconstructed from the per-request
+    start and end timestamps; that reconstruction is the actual oracle and
+    `assert_delivered_concurrency` carries the reasoning for its window.
+
+    `achieved_rate` is not asserted for this load type: main.py rewrites a
+    concurrent stage to rate=num_requests, duration=1 to enqueue everything at
+    once, so `requested_rate` on a concurrent stage is a dispatch detail and
+    not a load-shape claim.
+    """
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+    num_requests = concurrency * ROUNDS
+
+    async with LLMDInferenceSimRunner(
+        model_name,
+        *_sim_args(
+            *("--time-to-first-token", str(SIM_TTFT_MS)),
+            *("--inter-token-latency", str(SIM_ITL_MS)),
+            # Deterministic sleeps: request duration must not jitter, or the
+            # length of the plateau moves with it.
+            *("--time-to-first-token-std-dev", "0"),
+            *("--inter-token-latency-std-dev", "0"),
+            *("--seed", "42"),
+        ),
+        port=get_free_port(),
+    ) as sim:
+        result = await run_benchmark_minimal(
+            {
+                "data": {
+                    "type": "synthetic",
+                    "input_distribution": {"type": "fixed", "min": 32, "max": 32, "mean": 32},
+                    "output_distribution": {
+                        "type": "fixed",
+                        "min": OUTPUT_TOKENS,
+                        "max": OUTPUT_TOKENS,
+                        "mean": OUTPUT_TOKENS,
+                    },
+                },
+                "load": {
+                    "type": "concurrent",
+                    "stages": [{"num_requests": num_requests, "concurrency_level": concurrency}],
+                    "num_workers": num_workers,
+                },
+                "api": {"type": "completion", "streaming": True},
+                "server": _server_block(sim, model_name),
+                "tokenizer": {"pretrained_model_name_or_path": str(model_path)},
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                        "per_stage": True,
+                        "per_request": True,
+                    },
+                },
+            },
+            timeout_sec=180,
+        )
+
+    entries = assert_successful_run(result, num_requests)
+
+    # Wiring check only, called out as such: this field is an echo of config.
+    stage = result.reports["stage_0_lifecycle_metrics.json"]["load_summary"]
+    assert stage["concurrency"] == concurrency, f"stage echoed concurrency {stage['concurrency']}, configured {concurrency}"
+
+    # The load-shape claim: what was actually in flight.
+    assert_delivered_concurrency(entries, concurrency)
+
+
+# --- Helper self-tests: prove the assertions can actually fail. -------------
+# Same guard as the golden accuracy suite: a load-shape assertion that cannot
+# go red is worse than no assertion, because it reads as coverage. These run
+# without the sim, so the reasoning stays checked even where the binary is
+# absent.
+
+
+def _closed_loop_entries(delivered: int, rounds: int, duration: float = 1.0) -> list[dict]:
+    """A perfect closed loop holding `delivered` requests in flight.
+
+    `delivered` slots run back to back for `rounds` rounds, every request
+    taking exactly `duration`, so in-flight is `delivered` throughout.
+    """
+    return [{"start_time": r * duration, "end_time": (r + 1) * duration} for r in range(rounds) for _ in range(delivered)]
+
+
+def test_rate_tolerance_is_a_function_of_n_and_arrival():
+    # Poisson tightens as 1/sqrt(n), constant as 1/n, so at equal n the
+    # Poisson budget is the looser of the two.
+    assert rate_tolerance(2_500, "poisson") == pytest.approx(0.08)  # 4/sqrt(n), above the floor
+    assert rate_tolerance(2_500, "constant") == pytest.approx(0.05)  # 12/n is below the floor here
+    assert rate_tolerance(2_500, "poisson") > rate_tolerance(2_500, "constant")
+    assert rate_tolerance(10_000, "poisson") < rate_tolerance(2_500, "poisson")
+    # The floor is a floor for both: no request count buys a tolerance under 5%.
+    assert rate_tolerance(10_000, "poisson") == pytest.approx(0.05)
+    with pytest.raises(ValueError, match="unknown arrival process"):
+        rate_tolerance(100, "lognormal")
+    with pytest.raises(ValueError, match="meaningless"):
+        rate_tolerance(1, "constant")
+
+
+def test_observed_send_rate_matches_reportgen_arithmetic():
+    entries = [{"start_time": t, "end_time": t + 0.5} for t in [0.0, 1.0, 2.0, 3.0]]
+    send_duration, rate = observed_send_rate(entries)
+    assert send_duration == pytest.approx(3.0)
+    # 4 requests spanning 3s: this is count/span, the same edge effect
+    # reportgen has, which is exactly why rate_tolerance accounts for it.
+    assert rate == pytest.approx(4.0 / 3.0)
+
+
+def test_inflight_reconstruction_counts_overlap():
+    segments = inflight_segments(
+        [
+            {"start_time": 0.0, "end_time": 3.0},
+            {"start_time": 1.0, "end_time": 2.0},
+        ]
+    )
+    assert segments == [(0.0, 1.0, 1), (1.0, 2.0, 2), (2.0, 3.0, 1)]
+    assert max_inflight(segments) == 2
+    assert mean_inflight(segments, (0.0, 3.0)) == pytest.approx(4.0 / 3.0)
+    assert fraction_at_level(segments, (0.0, 3.0), 2) == pytest.approx(1.0 / 3.0)
+
+
+def test_inflight_reconstruction_does_not_double_count_a_handoff():
+    # One request ending exactly as its replacement starts is one slot, not
+    # two: ties resolve ends before starts.
+    segments = inflight_segments(
+        [
+            {"start_time": 0.0, "end_time": 1.0},
+            {"start_time": 1.0, "end_time": 2.0},
+        ]
+    )
+    assert max_inflight(segments) == 1
+
+
+def test_plateau_window_excludes_ramp_up_and_drain():
+    entries = _closed_loop_entries(delivered=4, rounds=5)
+    # Fourth earliest start is still 0.0 (the pipeline fills instantly here),
+    # and the window closes at the last start, before the drain.
+    assert plateau_window(entries, 4) == (0.0, 4.0)
+    with pytest.raises(ValueError, match="need at least"):
+        plateau_window(_closed_loop_entries(delivered=4, rounds=1), 4)
+
+
+def test_delivered_concurrency_accepts_a_faithful_closed_loop():
+    assert_delivered_concurrency(_closed_loop_entries(delivered=8, rounds=6), 8)
+
+
+def test_delivered_concurrency_rejects_under_delivery():
+    # The #633 failure mode: a distribution bug throttles the run to
+    # concurrency_level - 1 and every existing e2e assertion still passes.
+    with pytest.raises(AssertionError, match="averaged"):
+        assert_delivered_concurrency(_closed_loop_entries(delivered=7, rounds=6), 8)
+
+
+def test_delivered_concurrency_rejects_over_delivery():
+    with pytest.raises(AssertionError, match="peaked at"):
+        assert_delivered_concurrency(_closed_loop_entries(delivered=9, rounds=6), 8)

--- a/e2e/utils/load_shape.py
+++ b/e2e/utils/load_shape.py
@@ -1,0 +1,206 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared load-shape assertions: was the configured load actually offered (#633).
+
+The golden accuracy helpers in ``utils.accuracy`` check the measurement side
+(what the tool reports about each response). These check the stimulus side:
+the request rate and the in-flight concurrency the load generator actually
+delivered.
+
+Everything here works off the raw ``start_time`` / ``end_time`` pairs in
+``per_request_lifecycle_metrics.json``, deliberately not off the numbers
+``summarize_requests`` prints, so the reconstruction is independent of
+reportgen and can be used to check reportgen's own derivation.
+
+Honest limits of this oracle, stated once so callers do not overclaim:
+
+- The timestamps are recorded by the client around its own send and receive,
+  so this is the load generator's view of what it offered. It catches a
+  generator that fails to keep up with its own schedule, a semaphore that
+  admits too few or too many requests, and a reportgen that derives the rate
+  wrongly. It cannot catch a bug in the timestamping itself.
+- A server that recorded arrivals independently would be a strictly stronger
+  oracle for the same claim. See the Status note on the PR for #633.
+"""
+
+import math
+from typing import Any, Dict, List, Sequence, Tuple
+
+# Piecewise-constant in-flight count: (segment start, segment end, in-flight).
+Segment = Tuple[float, float, int]
+
+
+def rate_tolerance(n: int, arrival: str) -> float:
+    """Relative tolerance on achieved_rate for a stage of ``n`` requests.
+
+    Sized from the arrival process rather than picked to make a run pass.
+
+    ``constant``: ``ConstantLoadTimer`` draws n exponential gaps and rescales
+    them so they sum to exactly ``duration``, so the schedule carries no
+    cumulative drift. The only stochastic term left in reportgen's
+    ``send_duration = max(start) - min(start)`` is the first gap, which n
+    points do not span (n points bound n-1 gaps). That gap is Exp(1/rate), so
+    the relative error is Exp(1)/n and P(error > k/n) = e^-k. k = 12 puts the
+    statistical false-failure rate near 1e-5.
+
+    ``poisson``: ``PoissonLoadTimer`` draws a Poisson(rate) count per second,
+    so the wall-clock time to emit n requests is a renewal time with standard
+    deviation sqrt(n)/rate against a mean of n/rate. The coefficient of
+    variation of the achieved rate is therefore 1/sqrt(n), and 4 sigma is
+    4/sqrt(n): tighten it by raising n, never by shrinking the multiplier.
+
+    Both are floored at 5% so ordinary scheduler and socket jitter on a busy
+    shared runner cannot fail the gate. At the request counts used by the e2e
+    tier the floor binds only for ``constant``.
+    """
+    if n < 2:
+        raise ValueError(f"a rate tolerance is meaningless for n={n} requests")
+    floor = 0.05
+    if arrival == "poisson":
+        return max(floor, 4.0 / math.sqrt(n))
+    if arrival == "constant":
+        return max(floor, 12.0 / n)
+    raise ValueError(f"unknown arrival process: {arrival!r}")
+
+
+def observed_send_rate(entries: Sequence[Dict[str, Any]]) -> Tuple[float, float]:
+    """Recompute (send_duration, achieved_rate) from raw per-request starts.
+
+    Mirrors ``summarize_requests`` exactly (count over the span of send
+    times), so the result can be diffed against the reported value to check
+    reportgen rather than to restate it.
+    """
+    starts = sorted(float(e["start_time"]) for e in entries)
+    if len(starts) < 2:
+        raise ValueError("need at least two requests to observe a send rate")
+    send_duration = starts[-1] - starts[0]
+    if send_duration <= 0:
+        raise ValueError("all requests share one send timestamp; no rate to observe")
+    return send_duration, len(starts) / send_duration
+
+
+def inflight_segments(entries: Sequence[Dict[str, Any]]) -> List[Segment]:
+    """Reconstruct the in-flight request count over time as a step function.
+
+    A sweep line over request starts and ends. Ends are applied before starts
+    at an identical timestamp, so a tie never credits an extra concurrent
+    slot: the reconstruction under-reports rather than over-reports.
+    """
+    events: List[Tuple[float, int]] = []
+    for entry in entries:
+        start = float(entry["start_time"])
+        end = float(entry["end_time"])
+        if end < start:
+            raise ValueError(f"request ends before it starts: {start} -> {end}")
+        events.append((start, 1))
+        events.append((end, -1))
+    events.sort(key=lambda ev: (ev[0], ev[1]))
+
+    segments: List[Segment] = []
+    inflight = 0
+    prev_t = events[0][0]
+    for t, delta in events:
+        if t > prev_t:
+            segments.append((prev_t, t, inflight))
+            prev_t = t
+        inflight += delta
+    return segments
+
+
+def max_inflight(segments: Sequence[Segment]) -> int:
+    return max((n for _, _, n in segments), default=0)
+
+
+def plateau_window(entries: Sequence[Dict[str, Any]], concurrency: int) -> Tuple[float, float]:
+    """Steady-state window of a closed-loop stage, derived not guessed.
+
+    Under a concurrency limit of C, request k cannot start until request k-C
+    has finished, so the pipeline is full from the C-th earliest start and
+    stays full until the last start, after which only the drain remains.
+    ``[C-th earliest start, latest start]`` therefore excludes ramp-up and
+    drain by construction, with no hand-tuned margin to tune away a failure.
+    """
+    if concurrency < 1:
+        raise ValueError(f"concurrency must be positive, got {concurrency}")
+    starts = sorted(float(e["start_time"]) for e in entries)
+    if len(starts) < 2 * concurrency:
+        raise ValueError(f"need at least 2*concurrency={2 * concurrency} requests for a plateau, got {len(starts)}")
+    return starts[concurrency - 1], starts[-1]
+
+
+def mean_inflight(segments: Sequence[Segment], window: Tuple[float, float]) -> float:
+    """Time-weighted mean in-flight count over ``window``.
+
+    Time weighted, not sample weighted: a run that sits at C for seconds and
+    dips to C-1 for microseconds between requests must not read as C-0.5.
+    """
+    lo, hi = window
+    if hi <= lo:
+        raise ValueError(f"empty window {window}")
+    weighted = 0.0
+    covered = 0.0
+    for seg_lo, seg_hi, n in segments:
+        a, b = max(seg_lo, lo), min(seg_hi, hi)
+        if b > a:
+            weighted += n * (b - a)
+            covered += b - a
+    if covered <= 0:
+        raise ValueError(f"no in-flight segments overlap window {window}")
+    return weighted / covered
+
+
+def fraction_at_level(segments: Sequence[Segment], window: Tuple[float, float], level: int) -> float:
+    """Fraction of ``window`` spent at exactly ``level`` in-flight requests."""
+    lo, hi = window
+    if hi <= lo:
+        raise ValueError(f"empty window {window}")
+    at_level = 0.0
+    covered = 0.0
+    for seg_lo, seg_hi, n in segments:
+        a, b = max(seg_lo, lo), min(seg_hi, hi)
+        if b > a:
+            covered += b - a
+            if n == level:
+                at_level += b - a
+    if covered <= 0:
+        raise ValueError(f"no in-flight segments overlap window {window}")
+    return at_level / covered
+
+
+def assert_delivered_concurrency(entries: Sequence[Dict[str, Any]], concurrency: int, *, slack: float = 0.5) -> None:
+    """Delivered in-flight concurrency must match the configured level.
+
+    Two claims, both against the configured level as the known-good value:
+
+    - never above it: the semaphore is an upper bound, so this is exact.
+    - within ``slack`` of it on time-weighted average across the plateau. The
+      default half-slot budget fails an off-by-one distribution bug (C-1 in
+      flight) for any C, while absorbing the sub-millisecond gap between one
+      request completing and its replacement being dispatched. Measured
+      against the sim at C=5 and C=8, that handoff costs about 0.04 of a slot
+      (roughly 96% of plateau time sits at exactly C), so the default leaves
+      an order of magnitude of headroom over real behaviour and still fails a
+      deficit of a whole slot.
+    """
+    segments = inflight_segments(entries)
+    window = plateau_window(entries, concurrency)
+    peak = max_inflight(segments)
+    assert peak <= concurrency, f"delivered concurrency peaked at {peak}, above the configured limit of {concurrency}"
+
+    mean = mean_inflight(segments, window)
+    held = fraction_at_level(segments, window, concurrency)
+    assert mean >= concurrency - slack, (
+        f"delivered concurrency averaged {mean:.3f} over the plateau, below the configured {concurrency} "
+        f"by more than {slack} (only {held:.1%} of plateau time was spent at exactly {concurrency})"
+    )


### PR DESCRIPTION
Part of #633. Asserts for the first time that the load inference-perf actually offered matches the load it was configured with: achieved request rate against configured rate, and delivered in-flight concurrency against `concurrency_level`.

Row in #606: "Load-shape accuracy (#633)", sim tier.

## Why this is needed

Every other e2e test checks the measurement side; nothing checks the stimulus side, which sweep silently depends on. `docs/loadgen.md` promises "the exact concurrency specified"; unit tests cover only the split arithmetic of `_set_worker_concurrency`, not whether workers honour it over real sockets. A semaphore bug throttling to `concurrency_level - 1` passes everything today.

## What the test does

- **Faked:** the server. `llm-d-inference-sim` with pinned per-request latencies. Deliberately `sim`: against real vLLM these assertions would measure the server's capacity, not the load generator.
- **Oracle:** the configured load, plus delivered rate and in-flight concurrency reconstructed in the new `e2e/utils/load_shape.py` from raw per-request `start_time`/`end_time` pairs, never from reportgen's summary numbers.
- **Rate (constant and poisson, 600 requests at 40 qps):** `count` and `requested_rate` exact; reported `send_duration` and `achieved_rate` must equal the recomputation (rel 1e-9, so any drift is a reportgen bug); delivered rate within a tolerance derived from the arrival process.
- **Tolerance as a function of n, not a magic number.** `constant`: gaps are rescaled to sum to exactly `duration`, so the only stochastic term is the first gap, `Exp(1)/n` relative, `k = 12` for ~1e-5 false failure. `poisson`: renewal time, CoV `1/sqrt(n)`, 4 sigma. Both floored at 5% for jitter. At n=600: 5% and 16.3%; tightens by raising n, never by shrinking the multiplier.
- **Concurrency (`concurrency_level` 8 and 5, 2 workers each, so one split leaves a remainder):** in-flight is a sweep line over starts and ends, ties resolved ends-before-starts. The plateau window `[C-th earliest start, latest start]` excludes ramp-up and drain by construction (request k cannot start until k-C finished). Delivered concurrency must never exceed C (exact) and must be within half a slot of C time-weighted (measured handoff deficit on the sim is about 0.04 slot, so 10x headroom while still failing a whole-slot deficit).
- **`load_summary["concurrency"]` is asserted only as a wiring check**, labelled as one (reportgen copies it off the stage config). `achieved_rate` is not asserted on concurrent stages, which main.py rewrites to `rate=num_requests, duration=1`.
- **Eight helper self-tests run without the sim** and prove the assertions go red: `C-1` and `C+1` both raise, the tolerance function is checked at known values, the sweep line against hand-computed segments.

Per the row's lane note, dispatch scheduling arithmetic stays unit level in #659; only what needs real processes and sockets is asserted here.

## Status

Stands alone on `main` (`7bfbaed`).

Verified locally with `llm-d-inference-sim` v0.6.1: **12 passed** for the new module (4 sim-backed, 8 self-tests), 109s serial, 64s at `-n 4`. `pdm run validate` clean; unit suite unaffected (889 passed, 15 skipped). Kill-mutant: dropping the concurrency slack to 0.001 fails both cases.

Not yet verified: the CI runner. Tolerances have roughly 10x headroom over what was observed (constant 0.5% off a 5% budget, poisson 1.5% off 16.3%), but a merge-gating timing assertion earns its flake budget over repeated runs.

Limit of the oracle (in the module docstring): the timestamps are the client's own, so this catches a generator falling behind schedule, a semaphore admitting the wrong count, and a wrong reportgen rate, but not a timestamping bug. The #481 absorber records offered load server-side; once it lands this test can be retargeted at it without changing assertions.

Helpers live in `e2e/utils/load_shape.py`, as #633 asks, so the #632 worker matrix can reuse them.
