### PR TITLE
[PENDING: #735] test: side-by-side offered-load parity against vllm bench

### DIFF
--- a/e2e/tests/parity/README.md
+++ b/e2e/tests/parity/README.md
@@ -24,9 +24,9 @@ Words used below:
 
 Both tools are pointed at the **absorber** (`e2e/utils/absorber.py`). It does
 not run a model. It answers on the usual OpenAI-style URLs, writes down every
-request it receives (when it arrived, how many others were in progress, the
-full request body), and replies with filler text streamed at a fixed pace so
-the tools behave as they would against a real server.
+request it receives (when it arrived, when its reply finished, the full
+request body), and replies with filler text streamed at a fixed pace so the
+tools behave as they would against a real server.
 
 After each tool runs, the absorber's list of recorded requests is the truth
 about what that tool sent. The test checks that list against the numbers in
@@ -34,6 +34,15 @@ about what that tool sent. The test checks that list against the numbers in
 failure names the setting that leaked: request count, prompt lengths,
 `max_tokens`, the `stream` or `ignore_eos` flags, arrival rate, or
 concurrency.
+
+Rate and concurrency are not computed here. The arrival/finish times go
+through `e2e/utils/load_shape.py`, the same helpers the load-shape accuracy
+test (`e2e/tests/test_load_shape_accuracy_sim.py`, #633) uses to check
+inference-perf against its own config: the same sweep line for "how many were
+in flight", and the same `rate_tolerance(n, arrival)` for "how far off the
+configured rate is still fine". One definition of each, shared. The only
+difference is where the timestamps come from: that test reads the client's
+own, this one reads the absorber's.
 
 Only the *sent* traffic is compared. The latency and throughput numbers each
 tool prints are never looked at here. Those are the tools' output; this test
@@ -73,7 +82,7 @@ absorber:                 # how fast the absorber replies
   ttft_ms: 40             # wait before the first chunk
   itl_ms: 5               # wait between later chunks
 workload:
-  num_requests: 40        # exact, per tool, after dropping declared warmup requests
+  num_requests: 600       # exact, per tool, after dropping declared warmup requests
   prompt_tokens: 128      # per request, measured by re-tokenizing the prompt text
   prompt_tokens_rel_tol: 0.15
   max_tokens: 64          # exact, every request
@@ -81,11 +90,14 @@ workload:
   ignore_eos: true        # exact
 load:
   mode: rate              # "rate" (open loop) or "concurrency" (closed loop)
-  rate: 8.0               # rate mode: average requests per second actually sent
-  rate_rel_tol: 0.25
-  # concurrency: 8        # concurrency mode: exact peak number in flight at once
+  rate: 40.0              # rate mode: average requests per second actually sent
+  # concurrency: 8        # concurrency mode: never above 8 in flight, and on
+                          # average within half a slot of 8 in steady state
 tools:
+  inference-perf:
+    arrival: constant     # rate mode: how this tool spaces requests (sets its tolerance)
   vllm-bench:
+    arrival: poisson
     leading_extra_requests: 1   # vllm bench sends one warmup request first
 ```
 
@@ -94,12 +106,22 @@ warmup traffic to ignore before checking anything. If a tool needs a nonzero
 value here, that is itself a difference between the tools, and it stays
 written down in the case file on purpose.
 
+`arrival` is required in rate mode and is either `constant` (evenly spaced)
+or `poisson` (random gaps). There is no rate tolerance number in the file:
+the allowed wobble is `rate_tolerance(num_requests, arrival)` from
+`load_shape.py`, which at 600 requests is 5% for `constant` and about 16% for
+`poisson` (four standard deviations of the random spacing). The way to
+tighten a case is to raise `num_requests`, never to edit a number.
+
 ## Differences that are expected and allowed for
 
 - **Spacing between requests.** At the same rate, `vllm bench serve` picks
   random gaps between requests (Poisson) while inference-perf's `constant`
   load spaces them evenly. Cases check the average rate only, never the
-  spacing pattern.
+  spacing pattern, and each tool gets the tolerance its own spacing earns
+  (`tools.<tool>.arrival`). When the two tools are compared directly, the
+  looser of the two tolerances applies, since the evenly spaced tool adds
+  almost no wobble of its own.
 - **Prompt length is approximate.** Both tools aim for `prompt_tokens` under
   the same tokenizer, but text built from random token ids does not always
   tokenize back to the same count. Hence `prompt_tokens_rel_tol` instead of an

--- a/e2e/tests/parity/README.md
+++ b/e2e/tests/parity/README.md
@@ -1,112 +1,136 @@
 # Tool-parity cases
 
-Each subdirectory of `cases/` is one parity case: a workload described twice,
-once per tool, plus the invariants both descriptions must satisfy. The test
-(`test_offered_load_parity.py`) discovers every case directory automatically,
-so adding a case means adding files, not editing Python.
+## The problem this solves
 
-A case that holds proves the two configs describe the same workload. A case
-that fails names the knob that leaked: request count, prompt lengths,
-`max_tokens`, sampling flags, arrival rate, or concurrency.
+inference-perf and `vllm bench serve` do the same job: send a stream of
+requests at an LLM server and time the answers. When the two print different
+numbers for "the same" benchmark, the first question is whether they were
+actually asked to send the same traffic. In the past the answer has often been
+no. One tool's `range_ratio: 0` meant "random lengths" while the other's meant
+"fixed". One tool sends a warmup request the other does not. One spaces
+requests evenly, the other spaces them randomly. Each of those took days to
+find because nothing checked it. This directory is that check.
+
+Words used below:
+
+- **workload** or **offered load**: the traffic a tool sends. How many
+  requests, how long each prompt is, how many output tokens it asks for, how
+  fast it sends them, and how many it keeps in flight at once.
+- **case**: one workload written down twice, once per tool, plus the numbers
+  both versions must produce.
+- **absorber**: the fake server both tools are pointed at (next section).
 
 ## How it works
 
-Both tools are pointed at an **absorber** (`e2e/utils/absorber.py`): an
-OpenAI-compatible server whose only job is to record every request it
-receives, while streaming realistically paced responses so closed-loop tools
-behave as they would against a real server. The recorded requests are the
-oracle. Nothing is asserted about either tool's *reported metrics* here; what
-is compared is the load each tool actually *offered*. Historically that is
-where the discrepancies live (range-ratio semantics, warmup requests, arrival
-process, worker caps), not in the runners.
+Both tools are pointed at the **absorber** (`e2e/utils/absorber.py`). It does
+not run a model. It answers on the usual OpenAI-style URLs, writes down every
+request it receives (when it arrived, how many others were in progress, the
+full request body), and replies with filler text streamed at a fixed pace so
+the tools behave as they would against a real server.
 
-## Case layout
+After each tool runs, the absorber's list of recorded requests is the truth
+about what that tool sent. The test checks that list against the numbers in
+`expected.yaml`, then checks the two tools' lists against each other. A
+failure names the setting that leaked: request count, prompt lengths,
+`max_tokens`, the `stream` or `ignore_eos` flags, arrival rate, or
+concurrency.
+
+Only the *sent* traffic is compared. The latency and throughput numbers each
+tool prints are never looked at here. Those are the tools' output; this test
+is about their input.
+
+## What a case looks like
+
+Every subdirectory of `cases/` is one case. The test finds them by listing the
+directory, so adding a case means adding three files and no Python:
 
 ```
 cases/<name>/
-  inference-perf.yaml   # complete inference-perf config for the workload
-  vllm-bench.args       # `vllm bench serve` args, one per line, # comments ok
-  expected.yaml         # the invariants + absorber pacing + tolerances
+  inference-perf.yaml   # a normal inference-perf config for the workload
+  vllm-bench.args       # `vllm bench serve` flags, one per line, # comments ok
+  expected.yaml         # the numbers both tools must hit, plus tolerances
 ```
 
-The harness owns endpoint wiring and overwrites/appends it:
+The test fills in the parts that depend on where the absorber happens to be
+running; everything else in the two files is used exactly as written:
 
 - `inference-perf.yaml`: `server.base_url` and
-  `tokenizer.pretrained_model_name_or_path` are replaced (the bundled
-  gemma-3-270m tokenizer is used, so cases run offline).
-- `vllm-bench.args`: `--base-url`, `--model`, `--tokenizer`, `--save-result`,
-  `--result-filename` are appended. Everything workload-shaped stays in the
-  file, verbatim.
+  `tokenizer.pretrained_model_name_or_path` are replaced. The bundled
+  gemma-3-270m tokenizer is used, so cases run without network access.
+- `vllm-bench.args`: `--base-url`, `--model`, `--tokenizer`, `--save-result`
+  and `--result-filename` are added to the end.
 
-Adding a case needs no Python edit anywhere. The one non-obvious coupling is
-that `tests/required/config/test_yaml_configs.py` schema-validates every YAML
-under `e2e/`: `inference-perf.yaml` is validated there (which is what keeps
-these cases from rotting as the config schema moves), and
-`cases/*/expected.yaml` is excluded by a glob in that file's
-`NON_CONFIG_GLOBS`, so new case directories are covered without touching it.
+One thing to know: `tests/required/config/test_yaml_configs.py` schema-checks
+every YAML file under `e2e/`. That is good for `inference-perf.yaml` (a case
+breaks loudly if the config format changes) and wrong for `expected.yaml`
+(it is not an inference-perf config). `expected.yaml` files under `cases/` are
+skipped there by a wildcard, so new cases still need no Python edit.
 
 ## expected.yaml
 
 ```yaml
-absorber:                 # response pacing the absorber applies
-  ttft_ms: 40
-  itl_ms: 5
+absorber:                 # how fast the absorber replies
+  ttft_ms: 40             # wait before the first chunk
+  itl_ms: 5               # wait between later chunks
 workload:
-  num_requests: 40        # exact, per tool, after trimming leading extras
-  prompt_tokens: 128      # per request, re-encoded with the shared tokenizer
+  num_requests: 40        # exact, per tool, after dropping declared warmup requests
+  prompt_tokens: 128      # per request, measured by re-tokenizing the prompt text
   prompt_tokens_rel_tol: 0.15
   max_tokens: 64          # exact, every request
   stream: true            # exact
   ignore_eos: true        # exact
 load:
-  mode: rate              # "rate" | "concurrency"
-  rate: 8.0               # rate mode: realized mean arrival rate
+  mode: rate              # "rate" (open loop) or "concurrency" (closed loop)
+  rate: 8.0               # rate mode: average requests per second actually sent
   rate_rel_tol: 0.25
-  # concurrency: 8        # concurrency mode: exact max in-flight
+  # concurrency: 8        # concurrency mode: exact peak number in flight at once
 tools:
   vllm-bench:
-    leading_extra_requests: 1   # vllm bench sends one initial test request
+    leading_extra_requests: 1   # vllm bench sends one warmup request first
 ```
 
-`leading_extra_requests` documents per-tool warmup traffic: that many
-earliest-arriving requests are excluded before asserting. That a tool needs a
-nonzero value here is itself a parity finding worth keeping visible.
+`leading_extra_requests` says how many of a tool's earliest requests are
+warmup traffic to ignore before checking anything. If a tool needs a nonzero
+value here, that is itself a difference between the tools, and it stays
+written down in the case file on purpose.
 
-## Known, deliberate asymmetries
+## Differences that are expected and allowed for
 
-- **Arrival process**: at the same request rate, `vllm bench serve` draws
-  Poisson inter-arrivals while inference-perf's `constant` load is evenly
-  spaced. Cases assert the realized *mean* rate, never the shape.
-- **Prompt length recovery**: both tools target `prompt_tokens` under the same
-  tokenizer, but text generated from sampled token ids does not always
-  re-encode to the same count, hence `prompt_tokens_rel_tol` instead of
-  exactness.
-- **vllm flag semantics are version-dependent.** The args files target the
-  vllm pinned in `e2e/utils/vllm_bench.py` (`VLLM_PINNED_REF`), and every flag
-  in them was read off that tag's `vllm/benchmarks/serve.py` and
-  `vllm/benchmarks/datasets.py`. Notably `--random-range-ratio` changed meaning
-  across vllm versions: under the pinned CLI the sampled range is
-  `[len*(1-r), len*(1+r)]` with an inclusive upper bound, so `0` means fixed
-  lengths. This is the exact footgun that motivated #481. Re-read both files
-  when bumping the pin.
-- **Not everything is expressible on both sides.** The pinned vllm hardcodes
+- **Spacing between requests.** At the same rate, `vllm bench serve` picks
+  random gaps between requests (Poisson) while inference-perf's `constant`
+  load spaces them evenly. Cases check the average rate only, never the
+  spacing pattern.
+- **Prompt length is approximate.** Both tools aim for `prompt_tokens` under
+  the same tokenizer, but text built from random token ids does not always
+  tokenize back to the same count. Hence `prompt_tokens_rel_tol` instead of an
+  exact match.
+- **vllm flags change meaning between versions.** The args files are written
+  for the vllm version pinned in `e2e/utils/vllm_bench.py` (`VLLM_PINNED_REF`),
+  and every flag was checked against that version's
+  `vllm/benchmarks/serve.py` and `vllm/benchmarks/datasets.py`. In particular
+  `--random-range-ratio 0` means "fixed lengths" at this pin, but it has meant
+  "anywhere from 0 to the full length" in other versions. That mix-up is what
+  motivated #481. Re-check both files when bumping the pin.
+- **Some things cannot be said on both sides.** The pinned vllm always sends
   `stream: true` on the completions endpoint, so a `stream: false` case cannot
-  be written for the vllm leg today. `--random-input-len` is also reduced by
-  the tokenizer's special-token count before sampling, so a BOS-prepending
-  tokenizer offers `len-1` prompt tokens, which is one of the reasons
-  `prompt_tokens_rel_tol` exists.
+  be written for the vllm leg today. vllm also subtracts the tokenizer's
+  special-token count from `--random-input-len` before sampling, so a tokenizer
+  that adds a BOS token ends up sending `len-1` prompt tokens. That is another
+  reason `prompt_tokens_rel_tol` exists.
 
 ## Running
-
-The vllm leg needs a runnable vllm: set `$VLLM_BENCH_BIN`, or opt into a heavy
-one-time provision with `$VLLM_BENCH_PROVISION=1` (see `e2e/utils/vllm_bench.py`).
-Without one, vllm-side tests skip and the inference-perf side still asserts
-against `expected.yaml`. The absorber itself needs no external binary.
-
-The vllm leg has never been executed: the args and `leading_extra_requests`
-were derived by reading the pinned source, not by running it. Treat a first
-vllm run as the thing that validates this file, not as a regression check.
 
 ```
 pdm run pytest e2e/tests/parity
 ```
+
+The inference-perf side always runs; the absorber needs nothing installed. The
+vllm side needs a runnable vllm: either set `$VLLM_BENCH_BIN` to one you
+already have, or set `$VLLM_BENCH_PROVISION=1` to let the test clone and
+install the pinned version once (large download, see
+`e2e/utils/vllm_bench.py`). Without either, the vllm-side tests skip.
+
+The vllm side has not been run yet. The args files and
+`leading_extra_requests` were worked out by reading the pinned vllm source, not
+by running it. Treat the first real vllm run as the thing that checks this
+directory, not as a regression check.

--- a/e2e/tests/parity/README.md
+++ b/e2e/tests/parity/README.md
@@ -1,0 +1,112 @@
+# Tool-parity cases
+
+Each subdirectory of `cases/` is one parity case: a workload described twice,
+once per tool, plus the invariants both descriptions must satisfy. The test
+(`test_offered_load_parity.py`) discovers every case directory automatically,
+so adding a case means adding files, not editing Python.
+
+A case that holds proves the two configs describe the same workload. A case
+that fails names the knob that leaked: request count, prompt lengths,
+`max_tokens`, sampling flags, arrival rate, or concurrency.
+
+## How it works
+
+Both tools are pointed at an **absorber** (`e2e/utils/absorber.py`): an
+OpenAI-compatible server whose only job is to record every request it
+receives, while streaming realistically paced responses so closed-loop tools
+behave as they would against a real server. The recorded requests are the
+oracle. Nothing is asserted about either tool's *reported metrics* here; what
+is compared is the load each tool actually *offered*. Historically that is
+where the discrepancies live (range-ratio semantics, warmup requests, arrival
+process, worker caps), not in the runners.
+
+## Case layout
+
+```
+cases/<name>/
+  inference-perf.yaml   # complete inference-perf config for the workload
+  vllm-bench.args       # `vllm bench serve` args, one per line, # comments ok
+  expected.yaml         # the invariants + absorber pacing + tolerances
+```
+
+The harness owns endpoint wiring and overwrites/appends it:
+
+- `inference-perf.yaml`: `server.base_url` and
+  `tokenizer.pretrained_model_name_or_path` are replaced (the bundled
+  gemma-3-270m tokenizer is used, so cases run offline).
+- `vllm-bench.args`: `--base-url`, `--model`, `--tokenizer`, `--save-result`,
+  `--result-filename` are appended. Everything workload-shaped stays in the
+  file, verbatim.
+
+Adding a case needs no Python edit anywhere. The one non-obvious coupling is
+that `tests/required/config/test_yaml_configs.py` schema-validates every YAML
+under `e2e/`: `inference-perf.yaml` is validated there (which is what keeps
+these cases from rotting as the config schema moves), and
+`cases/*/expected.yaml` is excluded by a glob in that file's
+`NON_CONFIG_GLOBS`, so new case directories are covered without touching it.
+
+## expected.yaml
+
+```yaml
+absorber:                 # response pacing the absorber applies
+  ttft_ms: 40
+  itl_ms: 5
+workload:
+  num_requests: 40        # exact, per tool, after trimming leading extras
+  prompt_tokens: 128      # per request, re-encoded with the shared tokenizer
+  prompt_tokens_rel_tol: 0.15
+  max_tokens: 64          # exact, every request
+  stream: true            # exact
+  ignore_eos: true        # exact
+load:
+  mode: rate              # "rate" | "concurrency"
+  rate: 8.0               # rate mode: realized mean arrival rate
+  rate_rel_tol: 0.25
+  # concurrency: 8        # concurrency mode: exact max in-flight
+tools:
+  vllm-bench:
+    leading_extra_requests: 1   # vllm bench sends one initial test request
+```
+
+`leading_extra_requests` documents per-tool warmup traffic: that many
+earliest-arriving requests are excluded before asserting. That a tool needs a
+nonzero value here is itself a parity finding worth keeping visible.
+
+## Known, deliberate asymmetries
+
+- **Arrival process**: at the same request rate, `vllm bench serve` draws
+  Poisson inter-arrivals while inference-perf's `constant` load is evenly
+  spaced. Cases assert the realized *mean* rate, never the shape.
+- **Prompt length recovery**: both tools target `prompt_tokens` under the same
+  tokenizer, but text generated from sampled token ids does not always
+  re-encode to the same count, hence `prompt_tokens_rel_tol` instead of
+  exactness.
+- **vllm flag semantics are version-dependent.** The args files target the
+  vllm pinned in `e2e/utils/vllm_bench.py` (`VLLM_PINNED_REF`), and every flag
+  in them was read off that tag's `vllm/benchmarks/serve.py` and
+  `vllm/benchmarks/datasets.py`. Notably `--random-range-ratio` changed meaning
+  across vllm versions: under the pinned CLI the sampled range is
+  `[len*(1-r), len*(1+r)]` with an inclusive upper bound, so `0` means fixed
+  lengths. This is the exact footgun that motivated #481. Re-read both files
+  when bumping the pin.
+- **Not everything is expressible on both sides.** The pinned vllm hardcodes
+  `stream: true` on the completions endpoint, so a `stream: false` case cannot
+  be written for the vllm leg today. `--random-input-len` is also reduced by
+  the tokenizer's special-token count before sampling, so a BOS-prepending
+  tokenizer offers `len-1` prompt tokens, which is one of the reasons
+  `prompt_tokens_rel_tol` exists.
+
+## Running
+
+The vllm leg needs a runnable vllm: set `$VLLM_BENCH_BIN`, or opt into a heavy
+one-time provision with `$VLLM_BENCH_PROVISION=1` (see `e2e/utils/vllm_bench.py`).
+Without one, vllm-side tests skip and the inference-perf side still asserts
+against `expected.yaml`. The absorber itself needs no external binary.
+
+The vllm leg has never been executed: the args and `leading_extra_requests`
+were derived by reading the pinned source, not by running it. Treat a first
+vllm run as the thing that validates this file, not as a regression check.
+
+```
+pdm run pytest e2e/tests/parity
+```

--- a/e2e/tests/parity/cases/a_fixed_rate/expected.yaml
+++ b/e2e/tests/parity/cases/a_fixed_rate/expected.yaml
@@ -2,7 +2,7 @@ absorber:
   ttft_ms: 40
   itl_ms: 3
 workload:
-  num_requests: 40
+  num_requests: 600
   prompt_tokens: 128
   prompt_tokens_rel_tol: 0.15
   max_tokens: 64
@@ -10,20 +10,23 @@ workload:
   ignore_eos: true
 load:
   mode: rate
-  rate: 8.0
-  # Why so loose: vllm spaces its requests randomly (Poisson), so the average
-  # rate measured over only 40 requests wobbles by about 16% (one standard
-  # deviation) from run to run, and averages slightly high (about 8.2/s, not
-  # 8.0). 0.35 accepts 5.2 to 10.8 requests/s, which is roughly two standard
-  # deviations, so about 1 vllm run in 25 will still fail by bad luck. To make
-  # this tighter, raise num_requests rather than lowering the number: the
-  # wobble shrinks with the square root of the request count. inference-perf
-  # spaces requests evenly and lands well inside either way.
-  # (Derivation: realized_rate = (n-1)/span; span of 39 exponential gaps is
-  # Gamma(39, 1/8); the estimator is inverse-gamma with CV 1/sqrt(37).)
-  rate_rel_tol: 0.35
+  rate: 40.0
+  # There is no rate tolerance number here on purpose. How far each tool's
+  # measured rate may sit from 40/s comes from rate_tolerance(num_requests,
+  # arrival) in e2e/utils/load_shape.py, using the spacing pattern each tool
+  # declares under tools.<tool>.arrival below. At 600 requests that is 5% for
+  # even spacing (38.0 to 42.0/s) and about 16% for random spacing (33.5 to
+  # 46.5/s, four standard deviations, so a correct tool fails by bad luck less
+  # than once in 10,000 runs). To tighten it, raise num_requests: the random
+  # spacing's wobble shrinks with the square root of the request count. There
+  # is no number to loosen.
 tools:
+  inference-perf:
+    # inference-perf's `constant` load spaces requests evenly.
+    arrival: constant
   vllm-bench:
+    # vllm bench spaces requests randomly (Poisson) at any --request-rate.
+    arrival: poisson
     # vllm bench always sends one test request before the real run (there is
     # no flag to turn it off at the pinned version; see benchmark() in its
     # vllm/benchmarks/serve.py), then sends all --num-prompts requests. So the

--- a/e2e/tests/parity/cases/a_fixed_rate/expected.yaml
+++ b/e2e/tests/parity/cases/a_fixed_rate/expected.yaml
@@ -11,21 +11,21 @@ workload:
 load:
   mode: rate
   rate: 8.0
-  # Sized for the Poisson arrival variance of the vllm leg. realized_rate is
-  # (n-1)/span over n=40 arrivals, and the span of 39 exponential gaps is
-  # Gamma(39, 1/8), so the estimator is inverse-gamma with CV 1/sqrt(37) =
-  # 16.4% and a mean of 8.21/s, about 2.6% above the configured 8/s.
-  # 0.35 therefore admits [5.2, 10.8], which is 2.2 sigma below the mean but
-  # only 1.9 sigma above it: roughly a 4% chance of a spurious failure per
-  # vllm run, not the ~3% a symmetric 2.2 sigma would give. The inference-perf
-  # leg is evenly spaced and lands well inside this either way. Tightening
-  # this means raising num_requests, since the CV falls as 1/sqrt(n-3).
+  # Why so loose: vllm spaces its requests randomly (Poisson), so the average
+  # rate measured over only 40 requests wobbles by about 16% (one standard
+  # deviation) from run to run, and averages slightly high (about 8.2/s, not
+  # 8.0). 0.35 accepts 5.2 to 10.8 requests/s, which is roughly two standard
+  # deviations, so about 1 vllm run in 25 will still fail by bad luck. To make
+  # this tighter, raise num_requests rather than lowering the number: the
+  # wobble shrinks with the square root of the request count. inference-perf
+  # spaces requests evenly and lands well inside either way.
+  # (Derivation: realized_rate = (n-1)/span; span of 39 exponential gaps is
+  # Gamma(39, 1/8); the estimator is inverse-gamma with CV 1/sqrt(37).)
   rate_rel_tol: 0.35
 tools:
   vllm-bench:
-    # Confirmed against the pinned vllm's vllm/benchmarks/serve.py: benchmark()
-    # awaits one "initial single prompt test run" against the same api_url
-    # before the measured run, unconditionally (no flag disables it at this
-    # pin), and then sends all --num-prompts requests including that same
-    # prompt again. So the absorber sees num_requests + 1.
+    # vllm bench always sends one test request before the real run (there is
+    # no flag to turn it off at the pinned version; see benchmark() in its
+    # vllm/benchmarks/serve.py), then sends all --num-prompts requests. So the
+    # absorber records num_requests + 1, and the first one is ignored.
     leading_extra_requests: 1

--- a/e2e/tests/parity/cases/a_fixed_rate/expected.yaml
+++ b/e2e/tests/parity/cases/a_fixed_rate/expected.yaml
@@ -1,0 +1,31 @@
+absorber:
+  ttft_ms: 40
+  itl_ms: 3
+workload:
+  num_requests: 40
+  prompt_tokens: 128
+  prompt_tokens_rel_tol: 0.15
+  max_tokens: 64
+  stream: true
+  ignore_eos: true
+load:
+  mode: rate
+  rate: 8.0
+  # Sized for the Poisson arrival variance of the vllm leg. realized_rate is
+  # (n-1)/span over n=40 arrivals, and the span of 39 exponential gaps is
+  # Gamma(39, 1/8), so the estimator is inverse-gamma with CV 1/sqrt(37) =
+  # 16.4% and a mean of 8.21/s, about 2.6% above the configured 8/s.
+  # 0.35 therefore admits [5.2, 10.8], which is 2.2 sigma below the mean but
+  # only 1.9 sigma above it: roughly a 4% chance of a spurious failure per
+  # vllm run, not the ~3% a symmetric 2.2 sigma would give. The inference-perf
+  # leg is evenly spaced and lands well inside this either way. Tightening
+  # this means raising num_requests, since the CV falls as 1/sqrt(n-3).
+  rate_rel_tol: 0.35
+tools:
+  vllm-bench:
+    # Confirmed against the pinned vllm's vllm/benchmarks/serve.py: benchmark()
+    # awaits one "initial single prompt test run" against the same api_url
+    # before the measured run, unconditionally (no flag disables it at this
+    # pin), and then sends all --num-prompts requests including that same
+    # prompt again. So the absorber sees num_requests + 1.
+    leading_extra_requests: 1

--- a/e2e/tests/parity/cases/a_fixed_rate/inference-perf.yaml
+++ b/e2e/tests/parity/cases/a_fixed_rate/inference-perf.yaml
@@ -1,6 +1,9 @@
-# Case a: send 8 requests per second, evenly spaced, for 5 seconds = 40
+# Case a: send 40 requests per second, evenly spaced, for 15 seconds = 600
 # requests. Every prompt is 128 tokens and every request asks for 64 output
 # tokens. The parity test replaces server.base_url and the tokenizer path.
+# 600 is the smallest count at which the randomly spaced vllm side can be held
+# to a useful rate tolerance (see expected.yaml), same as the load-shape
+# accuracy test in e2e/tests/test_load_shape_accuracy_sim.py.
 api:
   type: completion
   streaming: true
@@ -21,8 +24,8 @@ data:
 load:
   type: constant
   stages:
-    - rate: 8
-      duration: 5
+    - rate: 40
+      duration: 15
   num_workers: 8
 server:
   type: vllm

--- a/e2e/tests/parity/cases/a_fixed_rate/inference-perf.yaml
+++ b/e2e/tests/parity/cases/a_fixed_rate/inference-perf.yaml
@@ -1,0 +1,37 @@
+# Open loop: constant 8 QPS for 5s = 40 requests, fixed 128-in / 64-out.
+# server.base_url and tokenizer path are overwritten by the parity harness.
+api:
+  type: completion
+  streaming: true
+data:
+  type: random
+  input_distribution:
+    type: fixed
+    min: 128
+    max: 128
+    mean: 128
+    total_count: 64
+  output_distribution:
+    type: fixed
+    min: 64
+    max: 64
+    mean: 64
+    total_count: 64
+load:
+  type: constant
+  stages:
+    - rate: 8
+      duration: 5
+  num_workers: 8
+server:
+  type: vllm
+  model_name: google/gemma-3-270m
+  base_url: http://127.0.0.1:8000
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: google/gemma-3-270m
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: false
+    per_request: false

--- a/e2e/tests/parity/cases/a_fixed_rate/inference-perf.yaml
+++ b/e2e/tests/parity/cases/a_fixed_rate/inference-perf.yaml
@@ -1,5 +1,6 @@
-# Open loop: constant 8 QPS for 5s = 40 requests, fixed 128-in / 64-out.
-# server.base_url and tokenizer path are overwritten by the parity harness.
+# Case a: send 8 requests per second, evenly spaced, for 5 seconds = 40
+# requests. Every prompt is 128 tokens and every request asks for 64 output
+# tokens. The parity test replaces server.base_url and the tokenizer path.
 api:
   type: completion
   streaming: true

--- a/e2e/tests/parity/cases/a_fixed_rate/vllm-bench.args
+++ b/e2e/tests/parity/cases/a_fixed_rate/vllm-bench.args
@@ -1,0 +1,37 @@
+# Open loop: Poisson arrivals at 8 QPS, 40 prompts, fixed 128-in / 64-out.
+# Targets the vllm pinned in e2e/utils/vllm_bench.py (VLLM_PINNED_REF).
+# Every flag below was read off that tag's vllm/benchmarks/serve.py and
+# vllm/benchmarks/datasets.py, which is where the version-dependent semantics
+# live:
+#   --endpoint-type is what selects the request function. --backend also
+#     exists at this pin but is vestigial: it is read only to reject sampling
+#     params on non-OpenAI backends, and this case sets none.
+#   --random-range-ratio 0 means fixed lengths. The sampled range is
+#     [len*(1-r), len*(1+r)] with an inclusive upper bound, so r=0 collapses
+#     both ends onto len. This is the range_ratio footgun that motivated #481,
+#     and it flipped meaning across vllm versions: re-read it on every bump.
+#   --random-input-len is reduced by the tokenizer's special-token count
+#     before sampling, so a BOS-prepending tokenizer offers len-1 prompt
+#     tokens. That is why expected.yaml carries prompt_tokens_rel_tol.
+#   --request-rate draws Poisson inter-arrivals at the default --burstiness 1.0.
+#   --ignore-eos is the only way to get ignore_eos into the payload; stream is
+#     hardcoded true on this endpoint and is not configurable from the CLI.
+# --base-url/--model/--tokenizer/--save-result/--result-filename are appended
+# by the harness.
+--endpoint-type
+openai
+--endpoint
+/v1/completions
+--dataset-name
+random
+--num-prompts
+40
+--random-input-len
+128
+--random-output-len
+64
+--random-range-ratio
+0
+--request-rate
+8
+--ignore-eos

--- a/e2e/tests/parity/cases/a_fixed_rate/vllm-bench.args
+++ b/e2e/tests/parity/cases/a_fixed_rate/vllm-bench.args
@@ -1,23 +1,26 @@
-# Open loop: Poisson arrivals at 8 QPS, 40 prompts, fixed 128-in / 64-out.
-# Targets the vllm pinned in e2e/utils/vllm_bench.py (VLLM_PINNED_REF).
-# Every flag below was read off that tag's vllm/benchmarks/serve.py and
-# vllm/benchmarks/datasets.py, which is where the version-dependent semantics
-# live:
-#   --endpoint-type is what selects the request function. --backend also
-#     exists at this pin but is vestigial: it is read only to reject sampling
-#     params on non-OpenAI backends, and this case sets none.
-#   --random-range-ratio 0 means fixed lengths. The sampled range is
-#     [len*(1-r), len*(1+r)] with an inclusive upper bound, so r=0 collapses
-#     both ends onto len. This is the range_ratio footgun that motivated #481,
-#     and it flipped meaning across vllm versions: re-read it on every bump.
-#   --random-input-len is reduced by the tokenizer's special-token count
-#     before sampling, so a BOS-prepending tokenizer offers len-1 prompt
-#     tokens. That is why expected.yaml carries prompt_tokens_rel_tol.
-#   --request-rate draws Poisson inter-arrivals at the default --burstiness 1.0.
-#   --ignore-eos is the only way to get ignore_eos into the payload; stream is
-#     hardcoded true on this endpoint and is not configurable from the CLI.
-# --base-url/--model/--tokenizer/--save-result/--result-filename are appended
-# by the harness.
+# Case a, vllm side: 40 requests at an average of 8 per second with random
+# (Poisson) spacing, every prompt 128 tokens, every request asking for 64
+# output tokens. Same workload as inference-perf.yaml next to this file.
+#
+# These flags are for the vllm version pinned in e2e/utils/vllm_bench.py
+# (VLLM_PINNED_REF). Each was checked against that version's
+# vllm/benchmarks/serve.py and vllm/benchmarks/datasets.py, because what the
+# flags mean has changed between vllm versions. Notes on the non-obvious ones:
+#   --endpoint-type openai picks the code path that sends requests. (There is
+#     also a --backend flag at this version but it does not affect this case.)
+#   --random-range-ratio 0 means "every prompt exactly the requested length".
+#     At this version the length is drawn from [len*(1-r), len*(1+r)], so r=0
+#     pins both ends to len. Older versions read 0 as "anywhere from 0 to len",
+#     which is the mix-up that motivated #481. Re-check on every pin bump.
+#   --random-input-len 128 does not quite give 128 tokens: vllm first subtracts
+#     the tokenizer's special tokens (1 for a BOS-adding tokenizer), so the
+#     prompt is 127. That is why expected.yaml has prompt_tokens_rel_tol.
+#   --request-rate 8 spaces requests randomly with an average of 8/s (the
+#     default --burstiness 1.0 is what makes it Poisson).
+#   --ignore-eos is the only way to set ignore_eos in the request body. stream
+#     is always true on this endpoint and cannot be changed from the CLI.
+# The parity test adds --base-url/--model/--tokenizer/--save-result/
+# --result-filename at the end.
 --endpoint-type
 openai
 --endpoint

--- a/e2e/tests/parity/cases/a_fixed_rate/vllm-bench.args
+++ b/e2e/tests/parity/cases/a_fixed_rate/vllm-bench.args
@@ -1,4 +1,4 @@
-# Case a, vllm side: 40 requests at an average of 8 per second with random
+# Case a, vllm side: 600 requests at an average of 40 per second with random
 # (Poisson) spacing, every prompt 128 tokens, every request asking for 64
 # output tokens. Same workload as inference-perf.yaml next to this file.
 #
@@ -15,7 +15,7 @@
 #   --random-input-len 128 does not quite give 128 tokens: vllm first subtracts
 #     the tokenizer's special tokens (1 for a BOS-adding tokenizer), so the
 #     prompt is 127. That is why expected.yaml has prompt_tokens_rel_tol.
-#   --request-rate 8 spaces requests randomly with an average of 8/s (the
+#   --request-rate 40 spaces requests randomly with an average of 40/s (the
 #     default --burstiness 1.0 is what makes it Poisson).
 #   --ignore-eos is the only way to set ignore_eos in the request body. stream
 #     is always true on this endpoint and cannot be changed from the CLI.
@@ -28,7 +28,7 @@ openai
 --dataset-name
 random
 --num-prompts
-40
+600
 --random-input-len
 128
 --random-output-len
@@ -36,5 +36,5 @@ random
 --random-range-ratio
 0
 --request-rate
-8
+40
 --ignore-eos

--- a/e2e/tests/parity/cases/b_fixed_concurrency/expected.yaml
+++ b/e2e/tests/parity/cases/b_fixed_concurrency/expected.yaml
@@ -10,6 +10,13 @@ workload:
   ignore_eos: true
 load:
   mode: concurrency
+  # Checked with assert_delivered_concurrency in e2e/utils/load_shape.py: never
+  # more than 8 in flight at the absorber, and on average within half a slot of
+  # 8 over the steady-state window (from the 8th arrival to the last one).
+  # Measured for inference-perf that average is about 7.88: the absorber sees
+  # the gap between one reply finishing and the next request arriving, which
+  # the client's own timestamps do not. Half a slot leaves about 4x headroom
+  # over that and still fails a whole missing slot (7 in flight).
   concurrency: 8
 tools:
   vllm-bench:

--- a/e2e/tests/parity/cases/b_fixed_concurrency/expected.yaml
+++ b/e2e/tests/parity/cases/b_fixed_concurrency/expected.yaml
@@ -1,0 +1,18 @@
+absorber:
+  ttft_ms: 40
+  itl_ms: 3
+workload:
+  num_requests: 48
+  prompt_tokens: 128
+  prompt_tokens_rel_tol: 0.15
+  max_tokens: 64
+  stream: true
+  ignore_eos: true
+load:
+  mode: concurrency
+  concurrency: 8
+tools:
+  vllm-bench:
+    # See a_fixed_rate/expected.yaml: the pinned vllm always issues one initial
+    # single-prompt test request before the measured run.
+    leading_extra_requests: 1

--- a/e2e/tests/parity/cases/b_fixed_concurrency/expected.yaml
+++ b/e2e/tests/parity/cases/b_fixed_concurrency/expected.yaml
@@ -13,6 +13,6 @@ load:
   concurrency: 8
 tools:
   vllm-bench:
-    # See a_fixed_rate/expected.yaml: the pinned vllm always issues one initial
-    # single-prompt test request before the measured run.
+    # vllm bench always sends one test request before the real run; it is
+    # ignored. See a_fixed_rate/expected.yaml.
     leading_extra_requests: 1

--- a/e2e/tests/parity/cases/b_fixed_concurrency/inference-perf.yaml
+++ b/e2e/tests/parity/cases/b_fixed_concurrency/inference-perf.yaml
@@ -1,0 +1,37 @@
+# Closed loop: exactly 8 in flight until 48 requests complete, 128-in / 64-out.
+# server.base_url and tokenizer path are overwritten by the parity harness.
+api:
+  type: completion
+  streaming: true
+data:
+  type: random
+  input_distribution:
+    type: fixed
+    min: 128
+    max: 128
+    mean: 128
+    total_count: 64
+  output_distribution:
+    type: fixed
+    min: 64
+    max: 64
+    mean: 64
+    total_count: 64
+load:
+  type: concurrent
+  stages:
+    - num_requests: 48
+      concurrency_level: 8
+  num_workers: 8
+server:
+  type: vllm
+  model_name: google/gemma-3-270m
+  base_url: http://127.0.0.1:8000
+  ignore_eos: true
+tokenizer:
+  pretrained_model_name_or_path: google/gemma-3-270m
+report:
+  request_lifecycle:
+    summary: true
+    per_stage: false
+    per_request: false

--- a/e2e/tests/parity/cases/b_fixed_concurrency/inference-perf.yaml
+++ b/e2e/tests/parity/cases/b_fixed_concurrency/inference-perf.yaml
@@ -1,5 +1,6 @@
-# Closed loop: exactly 8 in flight until 48 requests complete, 128-in / 64-out.
-# server.base_url and tokenizer path are overwritten by the parity harness.
+# Case b: keep exactly 8 requests in flight at all times until 48 have
+# finished. Every prompt is 128 tokens and every request asks for 64 output
+# tokens. The parity test replaces server.base_url and the tokenizer path.
 api:
   type: completion
   streaming: true

--- a/e2e/tests/parity/cases/b_fixed_concurrency/vllm-bench.args
+++ b/e2e/tests/parity/cases/b_fixed_concurrency/vllm-bench.args
@@ -1,14 +1,15 @@
-# Closed loop: --max-concurrency 8 with unbounded request rate, 48 prompts,
-# fixed 128-in / 64-out. Targets the vllm pinned in e2e/utils/vllm_bench.py
-# (VLLM_PINNED_REF); see a_fixed_rate/vllm-bench.args for the per-flag notes
-# read off that tag's benchmark source. The two flags specific to this case:
-#   --max-concurrency wraps each request in an asyncio.Semaphore, so peak
-#     in-flight is exactly this value once the server is slow enough to hold
-#     that many open (the absorber's pacing guarantees it).
-#   --request-rate is left at its default of inf, which dispatches every
-#     request at t=0 and lets the semaphore alone shape the load.
-# --base-url/--model/--tokenizer/--save-result/--result-filename are appended
-# by the harness.
+# Case b, vllm side: keep exactly 8 requests in flight until 48 have finished,
+# every prompt 128 tokens, every request asking for 64 output tokens. Same
+# workload as inference-perf.yaml next to this file. Flags are for the vllm
+# version pinned in e2e/utils/vllm_bench.py; see a_fixed_rate/vllm-bench.args
+# for notes on the shared flags. The two that are specific to this case:
+#   --max-concurrency 8 caps how many requests can be open at once (an
+#     asyncio.Semaphore). Because the absorber replies slowly enough for 8 to
+#     pile up, the peak in flight is exactly 8.
+#   --request-rate is left at its default (infinite), so vllm tries to send
+#     everything at once and only the cap above shapes the traffic.
+# The parity test adds --base-url/--model/--tokenizer/--save-result/
+# --result-filename at the end.
 --endpoint-type
 openai
 --endpoint

--- a/e2e/tests/parity/cases/b_fixed_concurrency/vllm-bench.args
+++ b/e2e/tests/parity/cases/b_fixed_concurrency/vllm-bench.args
@@ -1,0 +1,28 @@
+# Closed loop: --max-concurrency 8 with unbounded request rate, 48 prompts,
+# fixed 128-in / 64-out. Targets the vllm pinned in e2e/utils/vllm_bench.py
+# (VLLM_PINNED_REF); see a_fixed_rate/vllm-bench.args for the per-flag notes
+# read off that tag's benchmark source. The two flags specific to this case:
+#   --max-concurrency wraps each request in an asyncio.Semaphore, so peak
+#     in-flight is exactly this value once the server is slow enough to hold
+#     that many open (the absorber's pacing guarantees it).
+#   --request-rate is left at its default of inf, which dispatches every
+#     request at t=0 and lets the semaphore alone shape the load.
+# --base-url/--model/--tokenizer/--save-result/--result-filename are appended
+# by the harness.
+--endpoint-type
+openai
+--endpoint
+/v1/completions
+--dataset-name
+random
+--num-prompts
+48
+--random-input-len
+128
+--random-output-len
+64
+--random-range-ratio
+0
+--max-concurrency
+8
+--ignore-eos

--- a/e2e/tests/parity/test_offered_load_parity.py
+++ b/e2e/tests/parity/test_offered_load_parity.py
@@ -1,0 +1,252 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Offered-load parity between inference-perf and `vllm bench serve`.
+
+Every subdirectory of ``cases/`` describes one workload twice (an
+inference-perf config and a vllm bench arg file) plus the invariants both
+must satisfy (``expected.yaml``); see the README next to this file for the
+drop-in contract. Each tool is run against the absorber
+(``e2e/utils/absorber.py``), and the absorber's record of what actually
+arrived is the oracle: request counts, per-request prompt token lengths and
+``max_tokens``, sampling flags, realized arrival rate, and peak concurrency.
+
+Two tests per case: each tool against ``expected.yaml`` (the vllm side skips
+when no vllm is available, see ``e2e/utils/vllm_bench.py``), and the two
+tools against each other. Tool runs are cached per case, so a case costs one
+run per tool regardless of how many tests read it.
+"""
+
+import statistics
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import pytest
+import yaml
+
+from utils.absorber import AbsorbedRequest, AbsorberServer
+from utils.benchmark import run_benchmark_minimal
+from utils.net import get_free_port
+from utils.testdata import extract_tarball
+from utils.vllm_bench import VllmUnavailable, ensure_vllm_bench_bin, run_vllm_bench, warn_if_pin_stale
+
+MODEL_NAME = "google/gemma-3-270m"
+TOKENIZER_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+
+PARITY_DIR = Path(__file__).resolve().parent
+CASE_DIRS = sorted(p for p in (PARITY_DIR / "cases").iterdir() if p.is_dir())
+TOOLS = ("inference-perf", "vllm-bench")
+
+# One xdist worker for the whole module: profiles are cached in-process, and
+# absorber timing assertions should not compete with sibling tests for CPU.
+pytestmark = pytest.mark.xdist_group(name="tool-parity")
+
+
+def test_cases_are_committed() -> None:
+    # An empty cases/ directory would silently deselect every test below, and
+    # a gate that silently skips gates nothing.
+    assert CASE_DIRS, f"no parity cases committed under {PARITY_DIR / 'cases'}"
+
+
+@dataclass(frozen=True)
+class OfferedLoad:
+    """What one tool actually offered the absorber, after trimming declared warmup."""
+
+    n: int
+    prompt_token_lens: List[int]
+    max_tokens: List[Optional[int]]
+    stream_flags: Set[bool]
+    ignore_eos_flags: Set[bool]
+    max_in_flight: int
+    duration_s: float
+
+    @property
+    def realized_rate(self) -> float:
+        if self.n < 2 or self.duration_s <= 0:
+            return 0.0
+        return (self.n - 1) / self.duration_s
+
+
+@lru_cache(maxsize=1)
+def _tokenizer() -> Any:
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(str(extract_tarball(TOKENIZER_TARBALL)))
+
+
+def _prompt_tokens(request: AbsorbedRequest) -> int:
+    ids = request.prompt_token_ids
+    if ids is not None:
+        return len(ids)
+    text = request.prompt_text
+    assert text is not None, f"cannot interpret prompt as text or token ids: {request.body.get('prompt')!r:.100}"
+    return len(_tokenizer().encode(text, add_special_tokens=False))
+
+
+def _expected(case_dir: Path) -> Dict[str, Any]:
+    loaded = yaml.safe_load((case_dir / "expected.yaml").read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _profile(requests: List[AbsorbedRequest], trim: int) -> OfferedLoad:
+    assert len(requests) > trim, f"tool sent {len(requests)} requests, all trimmed as leading extras ({trim})"
+    kept = sorted(requests, key=lambda r: r.arrival_s)[trim:]
+    return OfferedLoad(
+        n=len(kept),
+        prompt_token_lens=[_prompt_tokens(r) for r in kept],
+        max_tokens=[r.max_tokens for r in kept],
+        stream_flags={r.stream for r in kept},
+        ignore_eos_flags={r.ignore_eos for r in kept},
+        max_in_flight=max(r.in_flight_at_arrival for r in kept),
+        duration_s=kept[-1].arrival_s - kept[0].arrival_s,
+    )
+
+
+async def _drive_inference_perf(case_dir: Path, base_url: str) -> None:
+    config = yaml.safe_load((case_dir / "inference-perf.yaml").read_text(encoding="utf-8"))
+    assert isinstance(config, dict)
+    # The harness owns endpoint wiring (see README); everything else is verbatim.
+    config["server"]["base_url"] = base_url
+    config["tokenizer"] = {"pretrained_model_name_or_path": str(extract_tarball(TOKENIZER_TARBALL))}
+    result = await run_benchmark_minimal(config)
+    assert result.success, f"inference-perf run failed (rc={result.return_code}):\n{result.stdout[-4000:]}"
+
+
+async def _drive_vllm_bench(case_dir: Path, base_url: str, vllm_bin: str) -> None:
+    lines = (case_dir / "vllm-bench.args").read_text(encoding="utf-8").splitlines()
+    args = [ln.strip() for ln in lines if ln.strip() and not ln.strip().startswith("#")]
+    args += ["--base-url", base_url, "--model", MODEL_NAME, "--tokenizer", str(extract_tarball(TOKENIZER_TARBALL))]
+    args += ["--save-result", "--result-filename", "vllm_bench_result.json"]
+    warn_if_pin_stale()
+    result = await run_vllm_bench(args, vllm_bin=vllm_bin)
+    assert result.success, f"vllm bench run failed (rc={result.return_code}):\n{result.stdout[-4000:]}"
+
+
+_PROFILES: Dict[Tuple[str, str], OfferedLoad] = {}
+
+
+async def _offered_load(case_dir: Path, tool: str) -> OfferedLoad:
+    key = (case_dir.name, tool)
+    if key in _PROFILES:
+        return _PROFILES[key]
+
+    vllm_bin: Optional[str] = None
+    if tool == "vllm-bench":
+        try:
+            vllm_bin = ensure_vllm_bench_bin()
+        except VllmUnavailable as e:
+            pytest.skip(str(e))
+
+    expected = _expected(case_dir)
+    pacing = expected.get("absorber", {})
+    absorber = AbsorberServer(
+        port=get_free_port(),
+        model=MODEL_NAME,
+        ttft_s=pacing.get("ttft_ms", 40) / 1000.0,
+        itl_s=pacing.get("itl_ms", 5) / 1000.0,
+    )
+    async with absorber:
+        if tool == "inference-perf":
+            await _drive_inference_perf(case_dir, absorber.base_url)
+        else:
+            assert vllm_bin is not None
+            await _drive_vllm_bench(case_dir, absorber.base_url, vllm_bin)
+
+    trim = int(expected.get("tools", {}).get(tool, {}).get("leading_extra_requests", 0))
+    _PROFILES[key] = _profile(absorber.requests, trim)
+    return _PROFILES[key]
+
+
+def _assert_prompt_lens(lens: List[int], target: int, rel_tol: float, who: str) -> None:
+    bound = max(1, int(target * rel_tol))
+    off = [n for n in lens if abs(n - target) > bound]
+    assert not off, (
+        f"{who}: {len(off)}/{len(lens)} prompts outside {target}±{bound} tokens "
+        f"(min={min(lens)}, mean={statistics.mean(lens):.1f}, max={max(lens)}); "
+        f"check the length knobs (input_distribution vs --random-input-len/--random-range-ratio)"
+    )
+
+
+@pytest.mark.parametrize("tool", TOOLS)
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+async def test_offered_load_matches_expected(case_dir: Path, tool: str) -> None:
+    expected = _expected(case_dir)
+    offered = await _offered_load(case_dir, tool)
+    workload, load = expected["workload"], expected["load"]
+
+    assert offered.n == workload["num_requests"], (
+        f"{tool} offered {offered.n} requests, expected {workload['num_requests']} "
+        f"(warmup traffic is declared via tools.{tool}.leading_extra_requests)"
+    )
+    assert set(offered.max_tokens) == {workload["max_tokens"]}, (
+        f"{tool} max_tokens values {sorted(set(offered.max_tokens), key=str)} != {workload['max_tokens']} "
+        f"(check the output-length knobs, and --random-range-ratio semantics for vllm)"
+    )
+    assert offered.stream_flags == {workload["stream"]}, f"{tool} stream flags {offered.stream_flags}"
+    assert offered.ignore_eos_flags == {workload["ignore_eos"]}, f"{tool} ignore_eos flags {offered.ignore_eos_flags}"
+    _assert_prompt_lens(offered.prompt_token_lens, workload["prompt_tokens"], workload["prompt_tokens_rel_tol"], tool)
+
+    if load["mode"] == "rate":
+        rate, tol = float(load["rate"]), float(load["rate_rel_tol"])
+        assert offered.realized_rate == pytest.approx(rate, rel=tol), (
+            f"{tool} realized arrival rate {offered.realized_rate:.2f}/s vs configured {rate}/s "
+            f"(±{tol:.0%}); check rate semantics and worker caps"
+        )
+    elif load["mode"] == "concurrency":
+        level = int(load["concurrency"])
+        assert offered.max_in_flight == level, (
+            f"{tool} peak in-flight {offered.max_in_flight} != configured concurrency {level}; "
+            f"check closed-loop semantics (concurrency_level vs --max-concurrency)"
+        )
+    else:
+        pytest.fail(f"unknown load.mode {load['mode']!r} in {case_dir / 'expected.yaml'}")
+
+
+@pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
+async def test_tools_offer_the_same_workload(case_dir: Path) -> None:
+    expected = _expected(case_dir)
+    ip = await _offered_load(case_dir, "inference-perf")
+    vb = await _offered_load(case_dir, "vllm-bench")
+    workload, load = expected["workload"], expected["load"]
+
+    assert ip.n == vb.n, f"request counts differ: inference-perf {ip.n} vs vllm-bench {vb.n}"
+    assert sorted(ip.max_tokens, key=str) == sorted(vb.max_tokens, key=str), (
+        f"max_tokens multisets differ: inference-perf {sorted(set(ip.max_tokens), key=str)} "
+        f"vs vllm-bench {sorted(set(vb.max_tokens), key=str)}"
+    )
+    assert ip.stream_flags == vb.stream_flags and ip.ignore_eos_flags == vb.ignore_eos_flags, (
+        f"sampling flags differ: stream {ip.stream_flags} vs {vb.stream_flags}, "
+        f"ignore_eos {ip.ignore_eos_flags} vs {vb.ignore_eos_flags}"
+    )
+
+    ip_mean, vb_mean = statistics.mean(ip.prompt_token_lens), statistics.mean(vb.prompt_token_lens)
+    rel_tol = float(workload["prompt_tokens_rel_tol"])
+    assert ip_mean == pytest.approx(vb_mean, rel=rel_tol), (
+        f"mean prompt tokens differ: inference-perf {ip_mean:.1f} vs vllm-bench {vb_mean:.1f} "
+        f"(the two configs describe different workloads; check the length knobs)"
+    )
+
+    if load["mode"] == "rate":
+        tol = float(load["rate_rel_tol"])
+        assert ip.realized_rate == pytest.approx(vb.realized_rate, rel=tol), (
+            f"realized arrival rates differ: inference-perf {ip.realized_rate:.2f}/s "
+            f"vs vllm-bench {vb.realized_rate:.2f}/s (mean rate should agree even though "
+            f"arrival shape legitimately differs: constant vs Poisson)"
+        )
+    elif load["mode"] == "concurrency":
+        assert ip.max_in_flight == vb.max_in_flight, (
+            f"peak in-flight differs: inference-perf {ip.max_in_flight} vs vllm-bench {vb.max_in_flight}"
+        )

--- a/e2e/tests/parity/test_offered_load_parity.py
+++ b/e2e/tests/parity/test_offered_load_parity.py
@@ -11,20 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Offered-load parity between inference-perf and `vllm bench serve`.
+"""Do inference-perf and `vllm bench serve` send the same traffic when configured for the same workload?
 
-Every subdirectory of ``cases/`` describes one workload twice (an
-inference-perf config and a vllm bench arg file) plus the invariants both
-must satisfy (``expected.yaml``); see the README next to this file for the
-drop-in contract. Each tool is run against the absorber
-(``e2e/utils/absorber.py``), and the absorber's record of what actually
-arrived is the oracle: request counts, per-request prompt token lengths and
-``max_tokens``, sampling flags, realized arrival rate, and peak concurrency.
+Each subdirectory of ``cases/`` holds one workload written down twice (an
+inference-perf config and a vllm bench args file) plus ``expected.yaml``, the
+numbers both must hit. See the README next to this file.
 
-Two tests per case: each tool against ``expected.yaml`` (the vllm side skips
-when no vllm is available, see ``e2e/utils/vllm_bench.py``), and the two
-tools against each other. Tool runs are cached per case, so a case costs one
-run per tool regardless of how many tests read it.
+Each tool is pointed at the absorber (``e2e/utils/absorber.py``), a fake server
+that records every request it receives. That recording is what gets checked:
+how many requests arrived, how many prompt tokens and ``max_tokens`` each had,
+the ``stream`` / ``ignore_eos`` flags, how fast they arrived, and how many were
+in flight at once. The numbers the tools themselves print are never read here.
+
+Two kinds of test per case: each tool against ``expected.yaml`` (the vllm side
+skips when no vllm is installed, see ``e2e/utils/vllm_bench.py``), and the two
+tools directly against each other. Each tool is run once per case and the
+result is cached, so the number of tests reading it does not matter.
 """
 
 import statistics
@@ -49,20 +51,25 @@ PARITY_DIR = Path(__file__).resolve().parent
 CASE_DIRS = sorted(p for p in (PARITY_DIR / "cases").iterdir() if p.is_dir())
 TOOLS = ("inference-perf", "vllm-bench")
 
-# One xdist worker for the whole module: profiles are cached in-process, and
-# absorber timing assertions should not compete with sibling tests for CPU.
+# Run this whole file on one pytest-xdist worker. The per-tool results are cached
+# in this process, and the timing checks below should not share a CPU with
+# unrelated tests running at the same time.
 pytestmark = pytest.mark.xdist_group(name="tool-parity")
 
 
+# Guard: at least one case directory exists. If cases/ were empty, every
+# parametrized test below would silently produce zero tests, and this file
+# would pass while checking nothing.
 def test_cases_are_committed() -> None:
-    # An empty cases/ directory would silently deselect every test below, and
-    # a gate that silently skips gates nothing.
     assert CASE_DIRS, f"no parity cases committed under {PARITY_DIR / 'cases'}"
 
 
+# Everything the checks below need to know about one tool's run, computed from
+# the absorber's recording after dropping the tool's declared warmup requests.
+# realized_rate is (n-1)/duration: 40 requests spread over 4.875s = 8.0/s.
 @dataclass(frozen=True)
 class OfferedLoad:
-    """What one tool actually offered the absorber, after trimming declared warmup."""
+    """What one tool actually sent, after dropping declared warmup requests."""
 
     n: int
     prompt_token_lens: List[int]
@@ -79,6 +86,8 @@ class OfferedLoad:
         return (self.n - 1) / self.duration_s
 
 
+# Loads the bundled gemma-3-270m tokenizer once. Used to count prompt tokens
+# the same way for both tools.
 @lru_cache(maxsize=1)
 def _tokenizer() -> Any:
     from transformers import AutoTokenizer
@@ -86,6 +95,9 @@ def _tokenizer() -> Any:
     return AutoTokenizer.from_pretrained(str(extract_tarball(TOKENIZER_TARBALL)))
 
 
+# Prompt length of one recorded request, in tokens. If the tool sent token ids
+# directly, that is just the list length; if it sent text, re-tokenize it
+# (without adding BOS/EOS). Fails if the prompt is neither.
 def _prompt_tokens(request: AbsorbedRequest) -> int:
     ids = request.prompt_token_ids
     if ids is not None:
@@ -95,12 +107,17 @@ def _prompt_tokens(request: AbsorbedRequest) -> int:
     return len(_tokenizer().encode(text, add_special_tokens=False))
 
 
+# Reads cases/<name>/expected.yaml into a dict.
 def _expected(case_dir: Path) -> Dict[str, Any]:
     loaded = yaml.safe_load((case_dir / "expected.yaml").read_text(encoding="utf-8"))
     assert isinstance(loaded, dict)
     return loaded
 
 
+# Turns the absorber's raw recording into an OfferedLoad. Sorts by arrival time,
+# drops the first `trim` requests (declared warmup traffic), then summarizes the
+# rest. 41 recorded requests with trim=1 gives n=40 and a duration measured from
+# the 2nd arrival to the 41st.
 def _profile(requests: List[AbsorbedRequest], trim: int) -> OfferedLoad:
     assert len(requests) > trim, f"tool sent {len(requests)} requests, all trimmed as leading extras ({trim})"
     kept = sorted(requests, key=lambda r: r.arrival_s)[trim:]
@@ -115,16 +132,23 @@ def _profile(requests: List[AbsorbedRequest], trim: int) -> OfferedLoad:
     )
 
 
+# Runs inference-perf with the case's inference-perf.yaml, pointed at the
+# absorber. Only server.base_url and the tokenizer path are replaced (see
+# README); every other setting is used as written. Fails if the run itself
+# fails.
 async def _drive_inference_perf(case_dir: Path, base_url: str) -> None:
     config = yaml.safe_load((case_dir / "inference-perf.yaml").read_text(encoding="utf-8"))
     assert isinstance(config, dict)
-    # The harness owns endpoint wiring (see README); everything else is verbatim.
     config["server"]["base_url"] = base_url
     config["tokenizer"] = {"pretrained_model_name_or_path": str(extract_tarball(TOKENIZER_TARBALL))}
     result = await run_benchmark_minimal(config)
     assert result.success, f"inference-perf run failed (rc={result.return_code}):\n{result.stdout[-4000:]}"
 
 
+# Runs `vllm bench serve` with the case's vllm-bench.args, pointed at the
+# absorber. Blank lines and # comments in the args file are skipped; the
+# harness adds --base-url/--model/--tokenizer/--save-result/--result-filename
+# at the end. Fails if the run itself fails.
 async def _drive_vllm_bench(case_dir: Path, base_url: str, vllm_bin: str) -> None:
     lines = (case_dir / "vllm-bench.args").read_text(encoding="utf-8").splitlines()
     args = [ln.strip() for ln in lines if ln.strip() and not ln.strip().startswith("#")]
@@ -135,9 +159,15 @@ async def _drive_vllm_bench(case_dir: Path, base_url: str, vllm_bin: str) -> Non
     assert result.success, f"vllm bench run failed (rc={result.return_code}):\n{result.stdout[-4000:]}"
 
 
+# Cache of (case name, tool) -> OfferedLoad, so each tool runs once per case.
 _PROFILES: Dict[Tuple[str, str], OfferedLoad] = {}
 
 
+# The one place a tool actually gets run. Starts a fresh absorber on a free port
+# with the pacing from expected.yaml (default 40ms first chunk, 5ms between
+# chunks), runs the tool against it, then summarizes the recording with the
+# tool's leading_extra_requests dropped. Skips (not fails) the vllm side when
+# no vllm is available. Cached, so a second call for the same case+tool is free.
 async def _offered_load(case_dir: Path, tool: str) -> OfferedLoad:
     key = (case_dir.name, tool)
     if key in _PROFILES:
@@ -170,16 +200,25 @@ async def _offered_load(case_dir: Path, tool: str) -> OfferedLoad:
     return _PROFILES[key]
 
 
+# Every prompt length must be within target*rel_tol of target (at least +-1).
+# target=128, rel_tol=0.15 accepts 109..147 tokens. The message lists how many
+# were outside and the min/mean/max, and points at the length settings.
 def _assert_prompt_lens(lens: List[int], target: int, rel_tol: float, who: str) -> None:
     bound = max(1, int(target * rel_tol))
     off = [n for n in lens if abs(n - target) > bound]
     assert not off, (
         f"{who}: {len(off)}/{len(lens)} prompts outside {target}±{bound} tokens "
         f"(min={min(lens)}, mean={statistics.mean(lens):.1f}, max={max(lens)}); "
-        f"check the length knobs (input_distribution vs --random-input-len/--random-range-ratio)"
+        f"check the prompt-length settings (input_distribution vs --random-input-len/--random-range-ratio)"
     )
 
 
+# One tool against expected.yaml. For case a_fixed_rate that means: exactly 40
+# requests (after dropping warmup), every max_tokens == 64, every request has
+# stream=true and ignore_eos=true, every prompt is 128 tokens +-15%, and the
+# average arrival rate is 8/s +-35%. For a concurrency case, the peak number in
+# flight must equal the configured concurrency exactly. Runs once per (case,
+# tool); the vllm side skips when no vllm is installed.
 @pytest.mark.parametrize("tool", TOOLS)
 @pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
 async def test_offered_load_matches_expected(case_dir: Path, tool: str) -> None:
@@ -189,11 +228,11 @@ async def test_offered_load_matches_expected(case_dir: Path, tool: str) -> None:
 
     assert offered.n == workload["num_requests"], (
         f"{tool} offered {offered.n} requests, expected {workload['num_requests']} "
-        f"(warmup traffic is declared via tools.{tool}.leading_extra_requests)"
+        f"(if the extra ones are warmup traffic, declare them in tools.{tool}.leading_extra_requests)"
     )
     assert set(offered.max_tokens) == {workload["max_tokens"]}, (
         f"{tool} max_tokens values {sorted(set(offered.max_tokens), key=str)} != {workload['max_tokens']} "
-        f"(check the output-length knobs, and --random-range-ratio semantics for vllm)"
+        f"(check the output-length settings; for vllm, check what --random-range-ratio means at this pin)"
     )
     assert offered.stream_flags == {workload["stream"]}, f"{tool} stream flags {offered.stream_flags}"
     assert offered.ignore_eos_flags == {workload["ignore_eos"]}, f"{tool} ignore_eos flags {offered.ignore_eos_flags}"
@@ -203,18 +242,23 @@ async def test_offered_load_matches_expected(case_dir: Path, tool: str) -> None:
         rate, tol = float(load["rate"]), float(load["rate_rel_tol"])
         assert offered.realized_rate == pytest.approx(rate, rel=tol), (
             f"{tool} realized arrival rate {offered.realized_rate:.2f}/s vs configured {rate}/s "
-            f"(±{tol:.0%}); check rate semantics and worker caps"
+            f"(±{tol:.0%}); check what the rate setting means for this tool, and whether a worker cap is throttling it"
         )
     elif load["mode"] == "concurrency":
         level = int(load["concurrency"])
         assert offered.max_in_flight == level, (
             f"{tool} peak in-flight {offered.max_in_flight} != configured concurrency {level}; "
-            f"check closed-loop semantics (concurrency_level vs --max-concurrency)"
+            f"check the concurrency settings (concurrency_level vs --max-concurrency)"
         )
     else:
         pytest.fail(f"unknown load.mode {load['mode']!r} in {case_dir / 'expected.yaml'}")
 
 
+# The two tools directly against each other, same quantities as above but with
+# no reference numbers involved: same request count, same multiset of
+# max_tokens, same stream/ignore_eos flags, mean prompt length within
+# prompt_tokens_rel_tol, and (by load mode) average rate within rate_rel_tol or
+# identical peak in-flight. Skips when the vllm side is unavailable.
 @pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
 async def test_tools_offer_the_same_workload(case_dir: Path) -> None:
     expected = _expected(case_dir)
@@ -236,15 +280,15 @@ async def test_tools_offer_the_same_workload(case_dir: Path) -> None:
     rel_tol = float(workload["prompt_tokens_rel_tol"])
     assert ip_mean == pytest.approx(vb_mean, rel=rel_tol), (
         f"mean prompt tokens differ: inference-perf {ip_mean:.1f} vs vllm-bench {vb_mean:.1f} "
-        f"(the two configs describe different workloads; check the length knobs)"
+        f"(the two configs describe different workloads; check the prompt-length settings)"
     )
 
     if load["mode"] == "rate":
         tol = float(load["rate_rel_tol"])
         assert ip.realized_rate == pytest.approx(vb.realized_rate, rel=tol), (
             f"realized arrival rates differ: inference-perf {ip.realized_rate:.2f}/s "
-            f"vs vllm-bench {vb.realized_rate:.2f}/s (mean rate should agree even though "
-            f"arrival shape legitimately differs: constant vs Poisson)"
+            f"vs vllm-bench {vb.realized_rate:.2f}/s (the average should agree even though the "
+            f"spacing between requests differs on purpose: even vs random)"
         )
     elif load["mode"] == "concurrency":
         assert ip.max_in_flight == vb.max_in_flight, (

--- a/e2e/tests/parity/test_offered_load_parity.py
+++ b/e2e/tests/parity/test_offered_load_parity.py
@@ -23,6 +23,14 @@ how many requests arrived, how many prompt tokens and ``max_tokens`` each had,
 the ``stream`` / ``ignore_eos`` flags, how fast they arrived, and how many were
 in flight at once. The numbers the tools themselves print are never read here.
 
+Rate and concurrency are worked out from the absorber's arrival/finish times by
+the same helpers the load-shape accuracy test uses (``e2e/utils/load_shape.py``,
+#633): the same sweep line for "how many in flight", and the same
+``rate_tolerance(n, arrival)`` for "how far off the configured rate is still
+fine". So there is one definition of each in the e2e tier, and the tolerance
+comes from the request count and the tool's spacing pattern, not from a number
+in a case file.
+
 Two kinds of test per case: each tool against ``expected.yaml`` (the vllm side
 skips when no vllm is installed, see ``e2e/utils/vllm_bench.py``), and the two
 tools directly against each other. Each tool is run once per case and the
@@ -40,6 +48,16 @@ import yaml
 
 from utils.absorber import AbsorbedRequest, AbsorberServer
 from utils.benchmark import run_benchmark_minimal
+from utils.load_shape import (
+    Segment,
+    assert_delivered_concurrency,
+    inflight_segments,
+    max_inflight,
+    mean_inflight,
+    observed_send_rate,
+    plateau_window,
+    rate_tolerance,
+)
 from utils.net import get_free_port
 from utils.testdata import extract_tarball
 from utils.vllm_bench import VllmUnavailable, ensure_vllm_bench_bin, run_vllm_bench, warn_if_pin_stale
@@ -66,7 +84,9 @@ def test_cases_are_committed() -> None:
 
 # Everything the checks below need to know about one tool's run, computed from
 # the absorber's recording after dropping the tool's declared warmup requests.
-# realized_rate is (n-1)/duration: 40 requests spread over 4.875s = 8.0/s.
+# `lifecycle` is the list of {start_time, end_time} pairs (arrival at the
+# absorber, reply finished) that e2e/utils/load_shape.py reads; the rate and
+# in-flight numbers below are its functions applied to that list, nothing else.
 @dataclass(frozen=True)
 class OfferedLoad:
     """What one tool actually sent, after dropping declared warmup requests."""
@@ -76,14 +96,30 @@ class OfferedLoad:
     max_tokens: List[Optional[int]]
     stream_flags: Set[bool]
     ignore_eos_flags: Set[bool]
-    max_in_flight: int
-    duration_s: float
+    lifecycle: List[Dict[str, float]]
 
+    # Average arrival rate: request count over the time from first to last
+    # arrival. 600 requests whose first and last arrivals are 15s apart = 40/s.
     @property
     def realized_rate(self) -> float:
-        if self.n < 2 or self.duration_s <= 0:
-            return 0.0
-        return (self.n - 1) / self.duration_s
+        return observed_send_rate(self.lifecycle)[1]
+
+    # In-flight count over time as a step function (load_shape's sweep line).
+    @property
+    def segments(self) -> List[Segment]:
+        return inflight_segments(self.lifecycle)
+
+    # Highest number of requests in flight at any moment.
+    @property
+    def peak_in_flight(self) -> int:
+        return max_inflight(self.segments)
+
+    # Time-weighted average in flight over the steady-state window for a
+    # configured concurrency of `level` (from the level-th arrival to the last
+    # arrival, so ramp-up and drain are excluded). At level=8 with the cap
+    # honoured, this sits just under 8.0.
+    def plateau_mean_in_flight(self, level: int) -> float:
+        return mean_inflight(self.segments, plateau_window(self.lifecycle, level))
 
 
 # Loads the bundled gemma-3-270m tokenizer once. Used to count prompt tokens
@@ -116,8 +152,8 @@ def _expected(case_dir: Path) -> Dict[str, Any]:
 
 # Turns the absorber's raw recording into an OfferedLoad. Sorts by arrival time,
 # drops the first `trim` requests (declared warmup traffic), then summarizes the
-# rest. 41 recorded requests with trim=1 gives n=40 and a duration measured from
-# the 2nd arrival to the 41st.
+# rest. 601 recorded requests with trim=1 gives n=600, with the rate measured
+# from the 2nd arrival to the 601st.
 def _profile(requests: List[AbsorbedRequest], trim: int) -> OfferedLoad:
     assert len(requests) > trim, f"tool sent {len(requests)} requests, all trimmed as leading extras ({trim})"
     kept = sorted(requests, key=lambda r: r.arrival_s)[trim:]
@@ -127,9 +163,29 @@ def _profile(requests: List[AbsorbedRequest], trim: int) -> OfferedLoad:
         max_tokens=[r.max_tokens for r in kept],
         stream_flags={r.stream for r in kept},
         ignore_eos_flags={r.ignore_eos for r in kept},
-        max_in_flight=max(r.in_flight_at_arrival for r in kept),
-        duration_s=kept[-1].arrival_s - kept[0].arrival_s,
+        lifecycle=[r.lifecycle_entry() for r in kept],
     )
+
+
+# The per-tool block of expected.yaml (tools.<tool>), or {} if there is none.
+def _tool_settings(expected: Dict[str, Any], tool: str) -> Dict[str, Any]:
+    settings = expected.get("tools", {}).get(tool, {})
+    assert isinstance(settings, dict)
+    return settings
+
+
+# How far a tool's measured rate may sit from the configured one, from
+# load_shape.rate_tolerance(n, arrival). `arrival` is the tool's spacing pattern
+# declared in expected.yaml under tools.<tool>.arrival ("constant" for evenly
+# spaced, "poisson" for random). At n=600: 5% for constant, about 16% for
+# poisson. Fails with a pointer to the case file if the pattern is missing.
+def _rate_tol(expected: Dict[str, Any], tool: str, n: int, case_dir: Path) -> float:
+    arrival = _tool_settings(expected, tool).get("arrival")
+    assert isinstance(arrival, str), (
+        f"{case_dir / 'expected.yaml'}: load.mode is rate, so tools.{tool}.arrival must say how {tool} "
+        f"spaces its requests (constant or poisson); the tolerance is derived from it"
+    )
+    return rate_tolerance(n, arrival)
 
 
 # Runs inference-perf with the case's inference-perf.yaml, pointed at the
@@ -195,7 +251,7 @@ async def _offered_load(case_dir: Path, tool: str) -> OfferedLoad:
             assert vllm_bin is not None
             await _drive_vllm_bench(case_dir, absorber.base_url, vllm_bin)
 
-    trim = int(expected.get("tools", {}).get(tool, {}).get("leading_extra_requests", 0))
+    trim = int(_tool_settings(expected, tool).get("leading_extra_requests", 0))
     _PROFILES[key] = _profile(absorber.requests, trim)
     return _PROFILES[key]
 
@@ -213,12 +269,15 @@ def _assert_prompt_lens(lens: List[int], target: int, rel_tol: float, who: str) 
     )
 
 
-# One tool against expected.yaml. For case a_fixed_rate that means: exactly 40
+# One tool against expected.yaml. For case a_fixed_rate that means: exactly 600
 # requests (after dropping warmup), every max_tokens == 64, every request has
 # stream=true and ignore_eos=true, every prompt is 128 tokens +-15%, and the
-# average arrival rate is 8/s +-35%. For a concurrency case, the peak number in
-# flight must equal the configured concurrency exactly. Runs once per (case,
-# tool); the vllm side skips when no vllm is installed.
+# average arrival rate is 40/s within rate_tolerance(600, arrival): +-5% for
+# inference-perf (even spacing), +-16% for vllm bench (random spacing). For a
+# concurrency case, load_shape.assert_delivered_concurrency applies: never more
+# than the configured number in flight, and on average within half a slot of it
+# over the steady-state window. Runs once per (case, tool); the vllm side skips
+# when no vllm is installed.
 @pytest.mark.parametrize("tool", TOOLS)
 @pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
 async def test_offered_load_matches_expected(case_dir: Path, tool: str) -> None:
@@ -239,17 +298,18 @@ async def test_offered_load_matches_expected(case_dir: Path, tool: str) -> None:
     _assert_prompt_lens(offered.prompt_token_lens, workload["prompt_tokens"], workload["prompt_tokens_rel_tol"], tool)
 
     if load["mode"] == "rate":
-        rate, tol = float(load["rate"]), float(load["rate_rel_tol"])
+        rate, tol = float(load["rate"]), _rate_tol(expected, tool, offered.n, case_dir)
         assert offered.realized_rate == pytest.approx(rate, rel=tol), (
             f"{tool} realized arrival rate {offered.realized_rate:.2f}/s vs configured {rate}/s "
-            f"(±{tol:.0%}); check what the rate setting means for this tool, and whether a worker cap is throttling it"
+            f"(±{tol:.0%} for {offered.n} requests); check what the rate setting means for this tool, "
+            f"and whether a worker cap is throttling it"
         )
     elif load["mode"] == "concurrency":
         level = int(load["concurrency"])
-        assert offered.max_in_flight == level, (
-            f"{tool} peak in-flight {offered.max_in_flight} != configured concurrency {level}; "
-            f"check the concurrency settings (concurrency_level vs --max-concurrency)"
-        )
+        try:
+            assert_delivered_concurrency(offered.lifecycle, level)
+        except AssertionError as e:
+            pytest.fail(f"{tool}: {e}; check the concurrency settings (concurrency_level vs --max-concurrency)")
     else:
         pytest.fail(f"unknown load.mode {load['mode']!r} in {case_dir / 'expected.yaml'}")
 
@@ -257,8 +317,11 @@ async def test_offered_load_matches_expected(case_dir: Path, tool: str) -> None:
 # The two tools directly against each other, same quantities as above but with
 # no reference numbers involved: same request count, same multiset of
 # max_tokens, same stream/ignore_eos flags, mean prompt length within
-# prompt_tokens_rel_tol, and (by load mode) average rate within rate_rel_tol or
-# identical peak in-flight. Skips when the vllm side is unavailable.
+# prompt_tokens_rel_tol, and by load mode either average rates within the
+# looser of the two tools' rate tolerances (the evenly spaced tool adds almost
+# no wobble of its own, so the randomly spaced tool's tolerance covers the
+# difference), or the same peak in flight and steady-state averages within half
+# a slot of each other. Skips when the vllm side is unavailable.
 @pytest.mark.parametrize("case_dir", CASE_DIRS, ids=lambda p: p.name)
 async def test_tools_offer_the_same_workload(case_dir: Path) -> None:
     expected = _expected(case_dir)
@@ -284,13 +347,19 @@ async def test_tools_offer_the_same_workload(case_dir: Path) -> None:
     )
 
     if load["mode"] == "rate":
-        tol = float(load["rate_rel_tol"])
+        tol = max(_rate_tol(expected, "inference-perf", ip.n, case_dir), _rate_tol(expected, "vllm-bench", vb.n, case_dir))
         assert ip.realized_rate == pytest.approx(vb.realized_rate, rel=tol), (
             f"realized arrival rates differ: inference-perf {ip.realized_rate:.2f}/s "
-            f"vs vllm-bench {vb.realized_rate:.2f}/s (the average should agree even though the "
-            f"spacing between requests differs on purpose: even vs random)"
+            f"vs vllm-bench {vb.realized_rate:.2f}/s (±{tol:.0%}; the average should agree even though "
+            f"the spacing between requests differs on purpose: even vs random)"
         )
     elif load["mode"] == "concurrency":
-        assert ip.max_in_flight == vb.max_in_flight, (
-            f"peak in-flight differs: inference-perf {ip.max_in_flight} vs vllm-bench {vb.max_in_flight}"
+        level = int(load["concurrency"])
+        assert ip.peak_in_flight == vb.peak_in_flight, (
+            f"peak in-flight differs: inference-perf {ip.peak_in_flight} vs vllm-bench {vb.peak_in_flight}"
+        )
+        ip_mean, vb_mean = ip.plateau_mean_in_flight(level), vb.plateau_mean_in_flight(level)
+        assert abs(ip_mean - vb_mean) <= 0.5, (
+            f"steady-state in-flight differs: inference-perf {ip_mean:.3f} vs vllm-bench {vb_mean:.3f} "
+            f"(more than half a slot apart at configured concurrency {level})"
         )

--- a/e2e/tests/test_load_shape_accuracy_sim.py
+++ b/e2e/tests/test_load_shape_accuracy_sim.py
@@ -1,0 +1,354 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sim-backed load-shape accuracy e2e (#633).
+
+Everything else in the e2e tier checks what inference-perf *reports* about
+the responses it got. This checks the stimulus: that the load actually
+offered matches the load that was configured. For a load generator that is
+the more fundamental correctness claim, and `docs/loadgen.md` makes it
+explicitly ("workers are dynamically allocated to achieve the exact
+concurrency specified") without anything verifying it.
+
+What is faked and what is the oracle
+------------------------------------
+Faked: the server. `llm-d-inference-sim` stands in for vLLM, with pinned
+latencies so request duration is known and the run is short.
+
+Oracle: the configured load, which is a known-good input, plus a
+reconstruction of delivered rate and in-flight concurrency computed in
+`utils.load_shape` from the raw per-request `start_time`/`end_time` pairs.
+The reconstruction does not read reportgen's summary numbers, so the
+reported `achieved_rate` can be checked against it rather than merely
+restated.
+
+This stays on the sim deliberately. Against a real vLLM these assertions
+would measure the server's capacity, not the load generator: a slow server
+delays responses, and under a concurrency limit that changes the offered
+load itself.
+
+Scope, versus the neighbouring issues
+-------------------------------------
+Dispatch scheduling arithmetic (what times the timers emit, how a
+concurrency level is split across workers) is unit-level and belongs to
+#659. What only a real process with real sockets can show is whether the
+generator keeps up with its own schedule and holds its semaphore under load,
+so that is all this file asserts.
+
+Known limit of the oracle
+-------------------------
+The timestamps come from the client, so this measures the load generator's
+own view of what it offered. That is enough to catch a generator that falls
+behind, a semaphore that admits the wrong number of requests, and a reportgen
+that derives the rate wrongly, but not a bug in the timestamping itself. A
+server that recorded arrivals independently would be strictly stronger and
+this test can be retargeted at one later without changing its assertions.
+"""
+
+import pytest
+
+from utils.accuracy import assert_successful_run
+from utils.benchmark import run_benchmark_minimal
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
+from utils.load_shape import (
+    assert_delivered_concurrency,
+    fraction_at_level,
+    inflight_segments,
+    max_inflight,
+    mean_inflight,
+    observed_send_rate,
+    plateau_window,
+    rate_tolerance,
+)
+from utils.net import get_free_port
+from utils.testdata import extract_tarball
+
+TEST_MODEL_NAME = "google/gemma-3-270m"
+TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+
+# Rate stage: 600 requests is the smallest count at which a Poisson stage can
+# be held to a tolerance worth gating on (see rate_tolerance), and 40 qps is
+# already exercised by the existing sim suite (test_llm_d_inference_sim runs
+# 100 qps), so the client is not the bottleneck.
+RATE = 40
+DURATION = 15
+EXPECTED_RATE_REQUESTS = RATE * DURATION
+
+# Concurrency stages: pinned sim latencies put each request at roughly
+# 150ms + 15 * 15ms = 375ms, so 12 rounds of requests is about 4.5s of load.
+SIM_TTFT_MS = 150
+SIM_ITL_MS = 15
+OUTPUT_TOKENS = 16
+ROUNDS = 12
+
+
+def _sim_args(*extra: str) -> list[str]:
+    return [
+        # Default max-num-seqs is 5. Server-side queueing does not change what
+        # the client offers, but it does stretch request duration and with it
+        # the length of the run, so keep every request scheduled immediately.
+        *("--max-num-seqs", "64"),
+        *extra,
+    ]
+
+
+def _server_block(sim: LLMDInferenceSimRunner, model_name: str) -> dict:
+    return {
+        "type": "vllm",
+        "model_name": model_name,
+        "base_url": f"http://{sim.host}:{sim.port}",
+        "ignore_eos": True,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+@pytest.mark.parametrize("arrival", ["constant", "poisson"])
+async def test_achieved_rate_matches_configured_rate(arrival: str):
+    """A fixed-rate stage must deliver the rate it was configured with.
+
+    Two separate claims, deliberately not collapsed into one:
+
+    1. reportgen's `achieved_rate` is the count over the span of send times,
+       recomputed here from the raw per-request timestamps. Checking the
+       reported value against the independent recomputation is what makes
+       this more than a restatement of the tool's own summary.
+    2. that rate matches the configured `rate` within a tolerance derived
+       from the arrival process (see `rate_tolerance`), not from a number
+       chosen after watching a run.
+    """
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+
+    async with LLMDInferenceSimRunner(model_name, *_sim_args(), port=get_free_port()) as sim:
+        result = await run_benchmark_minimal(
+            {
+                "data": {"type": "mock"},
+                "load": {
+                    "type": arrival,
+                    "stages": [{"rate": RATE, "duration": DURATION}],
+                    "num_workers": 2,
+                },
+                "api": {"type": "completion", "streaming": True},
+                "server": _server_block(sim, model_name),
+                "tokenizer": {"pretrained_model_name_or_path": str(model_path)},
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                        "per_stage": True,
+                        "per_request": True,
+                    },
+                },
+            },
+            timeout_sec=180,
+        )
+
+    entries = assert_successful_run(result, EXPECTED_RATE_REQUESTS)
+
+    stage = result.reports["stage_0_lifecycle_metrics.json"]["load_summary"]
+    assert stage["count"] == EXPECTED_RATE_REQUESTS
+    assert stage["requested_rate"] == RATE, f"stage echoed requested_rate {stage['requested_rate']}, configured {RATE}"
+
+    # (1) reportgen's derivation, against the same quantity recomputed from
+    # the raw per-request send times. Exact: it is the same arithmetic on the
+    # same data, so any drift here is a reportgen bug, not timing noise.
+    send_duration, recomputed_rate = observed_send_rate(entries)
+    assert stage["send_duration"] == pytest.approx(send_duration, rel=1e-9), (
+        f"reported send_duration {stage['send_duration']} != {send_duration} recomputed from per-request starts"
+    )
+    assert stage["achieved_rate"] == pytest.approx(recomputed_rate, rel=1e-9), (
+        f"reported achieved_rate {stage['achieved_rate']} != {recomputed_rate} recomputed from per-request starts"
+    )
+
+    # (2) the load-shape claim itself.
+    tolerance = rate_tolerance(EXPECTED_RATE_REQUESTS, arrival)
+    error = abs(recomputed_rate - RATE) / RATE
+    assert error <= tolerance, (
+        f"{arrival} stage delivered {recomputed_rate:.3f} req/s against a configured {RATE} req/s "
+        f"({error:.1%} off, tolerance {tolerance:.1%} for n={EXPECTED_RATE_REQUESTS})"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+@pytest.mark.parametrize(
+    ("concurrency", "num_workers"),
+    [
+        pytest.param(8, 2, id="c8_w2_divisible"),
+        # concurrency_level % num_workers != 0: workers get 3 and 2. The split
+        # arithmetic is unit-tested, but nothing has checked that the sum of
+        # the split semaphores is what actually goes on the wire.
+        pytest.param(5, 2, id="c5_w2_remainder"),
+    ],
+)
+async def test_delivered_concurrency_matches_configured_level(concurrency: int, num_workers: int):
+    """A fixed-concurrency stage must hold exactly `concurrency_level` in flight.
+
+    Note what the report does and does not give us here. `load_summary`
+    carries a `concurrency` field, but reportgen copies it straight off the
+    stage config, so asserting on it proves only that the value was threaded
+    through. The delivered value has to be reconstructed from the per-request
+    start and end timestamps; that reconstruction is the actual oracle and
+    `assert_delivered_concurrency` carries the reasoning for its window.
+
+    `achieved_rate` is not asserted for this load type: main.py rewrites a
+    concurrent stage to rate=num_requests, duration=1 to enqueue everything at
+    once, so `requested_rate` on a concurrent stage is a dispatch detail and
+    not a load-shape claim.
+    """
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+    num_requests = concurrency * ROUNDS
+
+    async with LLMDInferenceSimRunner(
+        model_name,
+        *_sim_args(
+            *("--time-to-first-token", str(SIM_TTFT_MS)),
+            *("--inter-token-latency", str(SIM_ITL_MS)),
+            # Deterministic sleeps: request duration must not jitter, or the
+            # length of the plateau moves with it.
+            *("--time-to-first-token-std-dev", "0"),
+            *("--inter-token-latency-std-dev", "0"),
+            *("--seed", "42"),
+        ),
+        port=get_free_port(),
+    ) as sim:
+        result = await run_benchmark_minimal(
+            {
+                "data": {
+                    "type": "synthetic",
+                    "input_distribution": {"type": "fixed", "min": 32, "max": 32, "mean": 32},
+                    "output_distribution": {
+                        "type": "fixed",
+                        "min": OUTPUT_TOKENS,
+                        "max": OUTPUT_TOKENS,
+                        "mean": OUTPUT_TOKENS,
+                    },
+                },
+                "load": {
+                    "type": "concurrent",
+                    "stages": [{"num_requests": num_requests, "concurrency_level": concurrency}],
+                    "num_workers": num_workers,
+                },
+                "api": {"type": "completion", "streaming": True},
+                "server": _server_block(sim, model_name),
+                "tokenizer": {"pretrained_model_name_or_path": str(model_path)},
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                        "per_stage": True,
+                        "per_request": True,
+                    },
+                },
+            },
+            timeout_sec=180,
+        )
+
+    entries = assert_successful_run(result, num_requests)
+
+    # Wiring check only, called out as such: this field is an echo of config.
+    stage = result.reports["stage_0_lifecycle_metrics.json"]["load_summary"]
+    assert stage["concurrency"] == concurrency, f"stage echoed concurrency {stage['concurrency']}, configured {concurrency}"
+
+    # The load-shape claim: what was actually in flight.
+    assert_delivered_concurrency(entries, concurrency)
+
+
+# --- Helper self-tests: prove the assertions can actually fail. -------------
+# Same guard as the golden accuracy suite: a load-shape assertion that cannot
+# go red is worse than no assertion, because it reads as coverage. These run
+# without the sim, so the reasoning stays checked even where the binary is
+# absent.
+
+
+def _closed_loop_entries(delivered: int, rounds: int, duration: float = 1.0) -> list[dict]:
+    """A perfect closed loop holding `delivered` requests in flight.
+
+    `delivered` slots run back to back for `rounds` rounds, every request
+    taking exactly `duration`, so in-flight is `delivered` throughout.
+    """
+    return [{"start_time": r * duration, "end_time": (r + 1) * duration} for r in range(rounds) for _ in range(delivered)]
+
+
+def test_rate_tolerance_is_a_function_of_n_and_arrival():
+    # Poisson tightens as 1/sqrt(n), constant as 1/n, so at equal n the
+    # Poisson budget is the looser of the two.
+    assert rate_tolerance(2_500, "poisson") == pytest.approx(0.08)  # 4/sqrt(n), above the floor
+    assert rate_tolerance(2_500, "constant") == pytest.approx(0.05)  # 12/n is below the floor here
+    assert rate_tolerance(2_500, "poisson") > rate_tolerance(2_500, "constant")
+    assert rate_tolerance(10_000, "poisson") < rate_tolerance(2_500, "poisson")
+    # The floor is a floor for both: no request count buys a tolerance under 5%.
+    assert rate_tolerance(10_000, "poisson") == pytest.approx(0.05)
+    with pytest.raises(ValueError, match="unknown arrival process"):
+        rate_tolerance(100, "lognormal")
+    with pytest.raises(ValueError, match="meaningless"):
+        rate_tolerance(1, "constant")
+
+
+def test_observed_send_rate_matches_reportgen_arithmetic():
+    entries = [{"start_time": t, "end_time": t + 0.5} for t in [0.0, 1.0, 2.0, 3.0]]
+    send_duration, rate = observed_send_rate(entries)
+    assert send_duration == pytest.approx(3.0)
+    # 4 requests spanning 3s: this is count/span, the same edge effect
+    # reportgen has, which is exactly why rate_tolerance accounts for it.
+    assert rate == pytest.approx(4.0 / 3.0)
+
+
+def test_inflight_reconstruction_counts_overlap():
+    segments = inflight_segments(
+        [
+            {"start_time": 0.0, "end_time": 3.0},
+            {"start_time": 1.0, "end_time": 2.0},
+        ]
+    )
+    assert segments == [(0.0, 1.0, 1), (1.0, 2.0, 2), (2.0, 3.0, 1)]
+    assert max_inflight(segments) == 2
+    assert mean_inflight(segments, (0.0, 3.0)) == pytest.approx(4.0 / 3.0)
+    assert fraction_at_level(segments, (0.0, 3.0), 2) == pytest.approx(1.0 / 3.0)
+
+
+def test_inflight_reconstruction_does_not_double_count_a_handoff():
+    # One request ending exactly as its replacement starts is one slot, not
+    # two: ties resolve ends before starts.
+    segments = inflight_segments(
+        [
+            {"start_time": 0.0, "end_time": 1.0},
+            {"start_time": 1.0, "end_time": 2.0},
+        ]
+    )
+    assert max_inflight(segments) == 1
+
+
+def test_plateau_window_excludes_ramp_up_and_drain():
+    entries = _closed_loop_entries(delivered=4, rounds=5)
+    # Fourth earliest start is still 0.0 (the pipeline fills instantly here),
+    # and the window closes at the last start, before the drain.
+    assert plateau_window(entries, 4) == (0.0, 4.0)
+    with pytest.raises(ValueError, match="need at least"):
+        plateau_window(_closed_loop_entries(delivered=4, rounds=1), 4)
+
+
+def test_delivered_concurrency_accepts_a_faithful_closed_loop():
+    assert_delivered_concurrency(_closed_loop_entries(delivered=8, rounds=6), 8)
+
+
+def test_delivered_concurrency_rejects_under_delivery():
+    # The #633 failure mode: a distribution bug throttles the run to
+    # concurrency_level - 1 and every existing e2e assertion still passes.
+    with pytest.raises(AssertionError, match="averaged"):
+        assert_delivered_concurrency(_closed_loop_entries(delivered=7, rounds=6), 8)
+
+
+def test_delivered_concurrency_rejects_over_delivery():
+    with pytest.raises(AssertionError, match="peaked at"):
+        assert_delivered_concurrency(_closed_loop_entries(delivered=9, rounds=6), 8)

--- a/e2e/utils/absorber.py
+++ b/e2e/utils/absorber.py
@@ -15,9 +15,11 @@
 
 Point any benchmark tool at the absorber and, when the run finishes, the list
 of recorded requests is exactly what that tool sent: how many, when each
-arrived, the prompt, ``max_tokens``, the ``stream`` / ``ignore_eos`` flags, and
-how many other requests were in progress at that moment. The tool-parity tests
-compare those recordings between tools. When two tools configured for "the
+arrived and when its reply finished, the prompt, ``max_tokens``, and the
+``stream`` / ``ignore_eos`` flags. The arrival/finish pairs feed the shared
+load-shape helpers in ``e2e/utils/load_shape.py``, which turn them into a
+request rate and an in-flight concurrency; the absorber itself only records.
+The tool-parity tests compare those recordings between tools. When two tools configured for "the
 same" workload differ, the difference shows up as a concrete request-level
 mismatch that names the setting responsible, rather than as a fuzzy gap in the
 latency numbers the tools print.
@@ -46,14 +48,27 @@ from aiohttp import web
 _FILLER_WORDS = ("alpha", "bravo", "carol", "delta", "echo", "fox", "golf", "hotel")
 
 
-@dataclass(frozen=True)
+@dataclass
 class AbsorbedRequest:
-    """One request exactly as the absorber received it, plus when and how busy the server was."""
+    """One request exactly as the absorber received it, plus when it arrived and when its reply finished.
+
+    The two timestamps are ``time.perf_counter()`` readings, so only differences
+    between them mean anything. Together they are the raw material for the
+    load-shape helpers in ``e2e/utils/load_shape.py`` (request rate, in-flight
+    concurrency); the absorber itself computes nothing from them.
+    """
 
     route: str  # "/v1/completions" or "/v1/chat/completions"
-    arrival_s: float  # time.perf_counter() when the request arrived; only differences between requests mean anything
-    in_flight_at_arrival: int  # how many requests were in progress at that moment, counting this one
+    arrival_s: float  # when the request arrived (before its body was read)
     body: Dict[str, Any]  # the request's JSON body, as sent
+    done_s: Optional[float] = None  # when the last byte of the reply was sent; None while the reply is still going
+
+    # The (start_time, end_time) pair in the shape e2e/utils/load_shape.py reads,
+    # so a list of these can go straight into its rate and concurrency helpers.
+    # Fails if the reply has not finished yet.
+    def lifecycle_entry(self) -> Dict[str, float]:
+        assert self.done_s is not None, "reply not finished; read requests only after the tool has exited"
+        return {"start_time": self.arrival_s, "end_time": self.done_s}
 
     @property
     def prompt_text(self) -> Optional[str]:
@@ -114,7 +129,6 @@ class AbsorberServer:
     requests: List[AbsorbedRequest] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        self._in_flight = 0
         self._runner: Optional[web.AppRunner] = None
 
     @property
@@ -148,15 +162,10 @@ class AbsorberServer:
         # Empty but valid Prometheus output, so tools that scrape metrics do not error.
         return web.Response(text="", content_type="text/plain")
 
-    # Records one request: timestamps it, notes how many are in flight, appends
-    # it to self.requests.
-    def _absorb(self, route: str, body: Dict[str, Any]) -> AbsorbedRequest:
-        absorbed = AbsorbedRequest(
-            route=route,
-            arrival_s=time.perf_counter(),
-            in_flight_at_arrival=self._in_flight,
-            body=body,
-        )
+    # Records one request with the arrival time taken by the caller, and appends
+    # it to self.requests. done_s is filled in later, when the reply is finished.
+    def _absorb(self, route: str, body: Dict[str, Any], arrival_s: float) -> AbsorbedRequest:
+        absorbed = AbsorbedRequest(route=route, arrival_s=arrival_s, body=body)
         self.requests.append(absorbed)
         return absorbed
 
@@ -180,15 +189,17 @@ class AbsorberServer:
     async def _handle_chat(self, request: web.Request) -> web.StreamResponse:
         return await self._respond(request, "/v1/chat/completions")
 
-    # Shared handler for both endpoints. Records the request, then replies with
-    # max_tokens (or default_output_tokens) chunks: streamed with pacing if the
-    # request said stream=true, otherwise as one JSON body after an equivalent
-    # total wait. The in-flight counter covers the whole reply.
+    # Shared handler for both endpoints. Takes the arrival time first, records
+    # the request, then replies with max_tokens (or default_output_tokens)
+    # chunks: streamed with pacing if the request said stream=true, otherwise
+    # as one JSON body after an equivalent total wait. Stamps done_s once the
+    # reply is finished (for a streamed reply, after the final "[DONE]" is
+    # written; for a one-piece reply, just before aiohttp writes it).
     async def _respond(self, request: web.Request, route: str) -> web.StreamResponse:
-        self._in_flight += 1
+        arrival_s = time.perf_counter()
+        body = await request.json()
+        absorbed = self._absorb(route, body, arrival_s)
         try:
-            body = await request.json()
-            absorbed = self._absorb(route, body)
             n_out = absorbed.max_tokens or self.default_output_tokens
             chunks = self._chunk_texts(n_out)
             usage = {
@@ -201,7 +212,7 @@ class AbsorberServer:
             await asyncio.sleep(self.ttft_s + self.itl_s * max(0, len(chunks) - 1))
             return web.json_response(self._unary_body(route, chunks, usage))
         finally:
-            self._in_flight -= 1
+            absorbed.done_s = time.perf_counter()
 
     # The fixed id/object/created/model fields every reply carries.
     def _envelope(self, route: str) -> Dict[str, Any]:

--- a/e2e/utils/absorber.py
+++ b/e2e/utils/absorber.py
@@ -11,23 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""OpenAI-compatible absorber: records the load a client offers it.
+"""A fake OpenAI-compatible server that records every request sent to it.
 
-The absorber is the oracle for the tool-parity tests: any benchmark tool is
-pointed at it, and afterwards the recorded requests ARE the workload that tool
-actually offered: request count, arrival times, prompt payloads, sampling
-flags, and how many requests were in flight at once. Divergence between two
-tools configured for "the same" workload shows up here as a diff over
-recorded requests, naming the knob that leaked, instead of as a noisy delta
-between the tools' reported metrics.
+Point any benchmark tool at the absorber and, when the run finishes, the list
+of recorded requests is exactly what that tool sent: how many, when each
+arrived, the prompt, ``max_tokens``, the ``stream`` / ``ignore_eos`` flags, and
+how many other requests were in progress at that moment. The tool-parity tests
+compare those recordings between tools. When two tools configured for "the
+same" workload differ, the difference shows up as a concrete request-level
+mismatch that names the setting responsible, rather than as a fuzzy gap in the
+latency numbers the tools print.
 
-It is deliberately NOT dumb: closed-loop clients issue their next request when
-the previous one finishes, so response pacing shapes the arrival process being
-measured. Responses therefore stream ``max_tokens`` chunks paced by a
-configured TTFT and inter-chunk interval. It is also NOT a token oracle: chunk
-text is arbitrary filler and the usage numbers it returns are naive counts.
-Token-accounting fidelity belongs to the golden sim (golden_sim.py) and the
-live vLLM tier, never to parity cases.
+Two things to know about the responses it sends back:
+
+- They are paced on purpose. Closed-loop tools (a fixed number of requests in
+  flight) send their next request only when the previous one finishes, so how
+  quickly the server answers changes the traffic pattern being measured. The
+  absorber therefore streams ``max_tokens`` chunks with a configurable wait
+  before the first chunk (TTFT) and between chunks (ITL).
+- They are not real tokens. Chunk text is filler words and the ``usage``
+  counts are rough. Anything about token accounting is tested elsewhere
+  (golden_sim.py and the live vLLM tier), never here.
 """
 
 import asyncio
@@ -44,16 +48,16 @@ _FILLER_WORDS = ("alpha", "bravo", "carol", "delta", "echo", "fox", "golf", "hot
 
 @dataclass(frozen=True)
 class AbsorbedRequest:
-    """One request exactly as the absorber received it."""
+    """One request exactly as the absorber received it, plus when and how busy the server was."""
 
     route: str  # "/v1/completions" or "/v1/chat/completions"
-    arrival_s: float  # perf_counter() at handler entry
-    in_flight_at_arrival: int  # concurrent requests the moment this one arrived, including it
-    body: Dict[str, Any]  # raw parsed JSON body
+    arrival_s: float  # time.perf_counter() when the request arrived; only differences between requests mean anything
+    in_flight_at_arrival: int  # how many requests were in progress at that moment, counting this one
+    body: Dict[str, Any]  # the request's JSON body, as sent
 
     @property
     def prompt_text(self) -> Optional[str]:
-        """The prompt as text, or None when it cannot be interpreted as text."""
+        """The prompt as one string (chat messages joined by newlines), or None if it is not text."""
         if self.route == "/v1/chat/completions":
             parts = []
             for message in self.body.get("messages", []):
@@ -70,7 +74,7 @@ class AbsorbedRequest:
 
     @property
     def prompt_token_ids(self) -> Optional[List[int]]:
-        """Pre-tokenized prompt ids, when the client sent ids instead of text."""
+        """The prompt as a list of token ids, when the tool sent ids instead of text; else None."""
         prompt = self.body.get("prompt")
         if isinstance(prompt, list) and prompt and all(isinstance(p, int) for p in prompt):
             return prompt
@@ -92,12 +96,13 @@ class AbsorbedRequest:
 
 @dataclass
 class AbsorberServer:
-    """Serves /v1/completions and /v1/chat/completions, recording every request.
+    """The fake server. Use as ``async with AbsorberServer(...) as s:``; afterwards ``s.requests`` is the recording.
 
-    ``ttft_s`` delays the first streamed chunk (or the whole unary response)
-    and ``itl_s`` paces subsequent chunks, so closed-loop clients see realistic
-    request durations. ``default_output_tokens`` bounds responses when a client
-    omits ``max_tokens``.
+    Answers on /v1/completions and /v1/chat/completions (plus /v1/models,
+    /health and /metrics so tools that probe those do not error). ``ttft_s`` is
+    the wait before the first chunk (or before a non-streaming reply) and
+    ``itl_s`` the wait between chunks. ``default_output_tokens`` is how many
+    chunks to send when the request has no ``max_tokens``.
     """
 
     port: int
@@ -140,9 +145,11 @@ class AbsorberServer:
         return web.Response(text="")
 
     async def _handle_metrics(self, request: web.Request) -> web.Response:
-        # An empty but valid exposition, so clients that scrape do not error.
+        # Empty but valid Prometheus output, so tools that scrape metrics do not error.
         return web.Response(text="", content_type="text/plain")
 
+    # Records one request: timestamps it, notes how many are in flight, appends
+    # it to self.requests.
     def _absorb(self, route: str, body: Dict[str, Any]) -> AbsorbedRequest:
         absorbed = AbsorbedRequest(
             route=route,
@@ -153,6 +160,8 @@ class AbsorberServer:
         self.requests.append(absorbed)
         return absorbed
 
+    # Rough prompt token count for the usage field: list length for token ids,
+    # word count for text. Not accurate, and nothing here relies on it being.
     def _naive_prompt_tokens(self, absorbed: AbsorbedRequest) -> int:
         ids = absorbed.prompt_token_ids
         if ids is not None:
@@ -160,6 +169,7 @@ class AbsorberServer:
         text = absorbed.prompt_text or ""
         return len(text.split())
 
+    # n filler chunks: " alpha", " bravo", ... cycling through _FILLER_WORDS.
     def _chunk_texts(self, n: int) -> List[str]:
         words = itertools.cycle(_FILLER_WORDS)
         return [f" {next(words)}" for _ in range(n)]
@@ -170,6 +180,10 @@ class AbsorberServer:
     async def _handle_chat(self, request: web.Request) -> web.StreamResponse:
         return await self._respond(request, "/v1/chat/completions")
 
+    # Shared handler for both endpoints. Records the request, then replies with
+    # max_tokens (or default_output_tokens) chunks: streamed with pacing if the
+    # request said stream=true, otherwise as one JSON body after an equivalent
+    # total wait. The in-flight counter covers the whole reply.
     async def _respond(self, request: web.Request, route: str) -> web.StreamResponse:
         self._in_flight += 1
         try:
@@ -189,10 +203,12 @@ class AbsorberServer:
         finally:
             self._in_flight -= 1
 
+    # The fixed id/object/created/model fields every reply carries.
     def _envelope(self, route: str) -> Dict[str, Any]:
         kind = "text_completion" if route == "/v1/completions" else "chat.completion"
         return {"id": "absorber-0", "object": kind, "created": int(time.time()), "model": self.model}
 
+    # One complete non-streaming reply with all chunks joined into one text.
     def _unary_body(self, route: str, chunks: List[str], usage: Dict[str, int]) -> Dict[str, Any]:
         text = "".join(chunks)
         if route == "/v1/completions":
@@ -201,6 +217,9 @@ class AbsorberServer:
             choice = {"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "length"}
         return {**self._envelope(route), "choices": [choice], "usage": usage}
 
+    # Server-sent-events reply: wait ttft_s, send the first chunk, then wait
+    # itl_s before each later chunk. Sends a final usage chunk only if the
+    # request asked for it (stream_options.include_usage), then "data: [DONE]".
     async def _stream(
         self,
         request: web.Request,

--- a/e2e/utils/absorber.py
+++ b/e2e/utils/absorber.py
@@ -1,0 +1,242 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenAI-compatible absorber: records the load a client offers it.
+
+The absorber is the oracle for the tool-parity tests: any benchmark tool is
+pointed at it, and afterwards the recorded requests ARE the workload that tool
+actually offered: request count, arrival times, prompt payloads, sampling
+flags, and how many requests were in flight at once. Divergence between two
+tools configured for "the same" workload shows up here as a diff over
+recorded requests, naming the knob that leaked, instead of as a noisy delta
+between the tools' reported metrics.
+
+It is deliberately NOT dumb: closed-loop clients issue their next request when
+the previous one finishes, so response pacing shapes the arrival process being
+measured. Responses therefore stream ``max_tokens`` chunks paced by a
+configured TTFT and inter-chunk interval. It is also NOT a token oracle: chunk
+text is arbitrary filler and the usage numbers it returns are naive counts.
+Token-accounting fidelity belongs to the golden sim (golden_sim.py) and the
+live vLLM tier, never to parity cases.
+"""
+
+import asyncio
+import itertools
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from aiohttp import web
+
+_FILLER_WORDS = ("alpha", "bravo", "carol", "delta", "echo", "fox", "golf", "hotel")
+
+
+@dataclass(frozen=True)
+class AbsorbedRequest:
+    """One request exactly as the absorber received it."""
+
+    route: str  # "/v1/completions" or "/v1/chat/completions"
+    arrival_s: float  # perf_counter() at handler entry
+    in_flight_at_arrival: int  # concurrent requests the moment this one arrived, including it
+    body: Dict[str, Any]  # raw parsed JSON body
+
+    @property
+    def prompt_text(self) -> Optional[str]:
+        """The prompt as text, or None when it cannot be interpreted as text."""
+        if self.route == "/v1/chat/completions":
+            parts = []
+            for message in self.body.get("messages", []):
+                content = message.get("content")
+                if isinstance(content, str):
+                    parts.append(content)
+            return "\n".join(parts)
+        prompt = self.body.get("prompt")
+        if isinstance(prompt, str):
+            return prompt
+        if isinstance(prompt, list) and all(isinstance(p, str) for p in prompt):
+            return "\n".join(prompt)
+        return None
+
+    @property
+    def prompt_token_ids(self) -> Optional[List[int]]:
+        """Pre-tokenized prompt ids, when the client sent ids instead of text."""
+        prompt = self.body.get("prompt")
+        if isinstance(prompt, list) and prompt and all(isinstance(p, int) for p in prompt):
+            return prompt
+        return None
+
+    @property
+    def max_tokens(self) -> Optional[int]:
+        value = self.body.get("max_tokens", self.body.get("max_completion_tokens"))
+        return int(value) if isinstance(value, int) else None
+
+    @property
+    def stream(self) -> bool:
+        return bool(self.body.get("stream", False))
+
+    @property
+    def ignore_eos(self) -> bool:
+        return bool(self.body.get("ignore_eos", False))
+
+
+@dataclass
+class AbsorberServer:
+    """Serves /v1/completions and /v1/chat/completions, recording every request.
+
+    ``ttft_s`` delays the first streamed chunk (or the whole unary response)
+    and ``itl_s`` paces subsequent chunks, so closed-loop clients see realistic
+    request durations. ``default_output_tokens`` bounds responses when a client
+    omits ``max_tokens``.
+    """
+
+    port: int
+    model: str
+    ttft_s: float = 0.04
+    itl_s: float = 0.005
+    default_output_tokens: int = 16
+    host: str = "127.0.0.1"
+    requests: List[AbsorbedRequest] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self._in_flight = 0
+        self._runner: Optional[web.AppRunner] = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def __aenter__(self) -> "AbsorberServer":
+        app = web.Application()
+        app.router.add_post("/v1/completions", self._handle_completions)
+        app.router.add_post("/v1/chat/completions", self._handle_chat)
+        app.router.add_get("/v1/models", self._handle_models)
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/metrics", self._handle_metrics)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    async def _handle_models(self, request: web.Request) -> web.Response:
+        return web.json_response({"object": "list", "data": [{"id": self.model, "object": "model"}]})
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        return web.Response(text="")
+
+    async def _handle_metrics(self, request: web.Request) -> web.Response:
+        # An empty but valid exposition, so clients that scrape do not error.
+        return web.Response(text="", content_type="text/plain")
+
+    def _absorb(self, route: str, body: Dict[str, Any]) -> AbsorbedRequest:
+        absorbed = AbsorbedRequest(
+            route=route,
+            arrival_s=time.perf_counter(),
+            in_flight_at_arrival=self._in_flight,
+            body=body,
+        )
+        self.requests.append(absorbed)
+        return absorbed
+
+    def _naive_prompt_tokens(self, absorbed: AbsorbedRequest) -> int:
+        ids = absorbed.prompt_token_ids
+        if ids is not None:
+            return len(ids)
+        text = absorbed.prompt_text or ""
+        return len(text.split())
+
+    def _chunk_texts(self, n: int) -> List[str]:
+        words = itertools.cycle(_FILLER_WORDS)
+        return [f" {next(words)}" for _ in range(n)]
+
+    async def _handle_completions(self, request: web.Request) -> web.StreamResponse:
+        return await self._respond(request, "/v1/completions")
+
+    async def _handle_chat(self, request: web.Request) -> web.StreamResponse:
+        return await self._respond(request, "/v1/chat/completions")
+
+    async def _respond(self, request: web.Request, route: str) -> web.StreamResponse:
+        self._in_flight += 1
+        try:
+            body = await request.json()
+            absorbed = self._absorb(route, body)
+            n_out = absorbed.max_tokens or self.default_output_tokens
+            chunks = self._chunk_texts(n_out)
+            usage = {
+                "prompt_tokens": self._naive_prompt_tokens(absorbed),
+                "completion_tokens": n_out,
+                "total_tokens": self._naive_prompt_tokens(absorbed) + n_out,
+            }
+            if absorbed.stream:
+                return await self._stream(request, route, chunks, body, usage)
+            await asyncio.sleep(self.ttft_s + self.itl_s * max(0, len(chunks) - 1))
+            return web.json_response(self._unary_body(route, chunks, usage))
+        finally:
+            self._in_flight -= 1
+
+    def _envelope(self, route: str) -> Dict[str, Any]:
+        kind = "text_completion" if route == "/v1/completions" else "chat.completion"
+        return {"id": "absorber-0", "object": kind, "created": int(time.time()), "model": self.model}
+
+    def _unary_body(self, route: str, chunks: List[str], usage: Dict[str, int]) -> Dict[str, Any]:
+        text = "".join(chunks)
+        if route == "/v1/completions":
+            choice: Dict[str, Any] = {"index": 0, "text": text, "finish_reason": "length"}
+        else:
+            choice = {"index": 0, "message": {"role": "assistant", "content": text}, "finish_reason": "length"}
+        return {**self._envelope(route), "choices": [choice], "usage": usage}
+
+    async def _stream(
+        self,
+        request: web.Request,
+        route: str,
+        chunks: List[str],
+        body: Dict[str, Any],
+        usage: Dict[str, int],
+    ) -> web.StreamResponse:
+        response = web.StreamResponse(
+            status=200,
+            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache", "Connection": "keep-alive"},
+        )
+        await response.prepare(request)
+
+        envelope = self._envelope(route)
+        if route == "/v1/chat/completions":
+            envelope["object"] = "chat.completion.chunk"
+
+        async def send(event: Dict[str, Any]) -> None:
+            await response.write(f"data: {json.dumps(event)}\n\n".encode("utf-8"))
+
+        await asyncio.sleep(self.ttft_s)
+        for i, text in enumerate(chunks):
+            if i > 0:
+                await asyncio.sleep(self.itl_s)
+            last = i == len(chunks) - 1
+            finish = "length" if last else None
+            if route == "/v1/completions":
+                choice: Dict[str, Any] = {"index": 0, "text": text, "finish_reason": finish}
+            else:
+                choice = {"index": 0, "delta": {"content": text}, "finish_reason": finish}
+            await send({**envelope, "choices": [choice]})
+
+        include_usage = bool((body.get("stream_options") or {}).get("include_usage"))
+        if include_usage:
+            await send({**envelope, "choices": [], "usage": usage})
+        await response.write(b"data: [DONE]\n\n")
+        await response.write_eof()
+        return response

--- a/e2e/utils/load_shape.py
+++ b/e2e/utils/load_shape.py
@@ -1,0 +1,206 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared load-shape assertions: was the configured load actually offered (#633).
+
+The golden accuracy helpers in ``utils.accuracy`` check the measurement side
+(what the tool reports about each response). These check the stimulus side:
+the request rate and the in-flight concurrency the load generator actually
+delivered.
+
+Everything here works off the raw ``start_time`` / ``end_time`` pairs in
+``per_request_lifecycle_metrics.json``, deliberately not off the numbers
+``summarize_requests`` prints, so the reconstruction is independent of
+reportgen and can be used to check reportgen's own derivation.
+
+Honest limits of this oracle, stated once so callers do not overclaim:
+
+- The timestamps are recorded by the client around its own send and receive,
+  so this is the load generator's view of what it offered. It catches a
+  generator that fails to keep up with its own schedule, a semaphore that
+  admits too few or too many requests, and a reportgen that derives the rate
+  wrongly. It cannot catch a bug in the timestamping itself.
+- A server that recorded arrivals independently would be a strictly stronger
+  oracle for the same claim. See the Status note on the PR for #633.
+"""
+
+import math
+from typing import Any, Dict, List, Sequence, Tuple
+
+# Piecewise-constant in-flight count: (segment start, segment end, in-flight).
+Segment = Tuple[float, float, int]
+
+
+def rate_tolerance(n: int, arrival: str) -> float:
+    """Relative tolerance on achieved_rate for a stage of ``n`` requests.
+
+    Sized from the arrival process rather than picked to make a run pass.
+
+    ``constant``: ``ConstantLoadTimer`` draws n exponential gaps and rescales
+    them so they sum to exactly ``duration``, so the schedule carries no
+    cumulative drift. The only stochastic term left in reportgen's
+    ``send_duration = max(start) - min(start)`` is the first gap, which n
+    points do not span (n points bound n-1 gaps). That gap is Exp(1/rate), so
+    the relative error is Exp(1)/n and P(error > k/n) = e^-k. k = 12 puts the
+    statistical false-failure rate near 1e-5.
+
+    ``poisson``: ``PoissonLoadTimer`` draws a Poisson(rate) count per second,
+    so the wall-clock time to emit n requests is a renewal time with standard
+    deviation sqrt(n)/rate against a mean of n/rate. The coefficient of
+    variation of the achieved rate is therefore 1/sqrt(n), and 4 sigma is
+    4/sqrt(n): tighten it by raising n, never by shrinking the multiplier.
+
+    Both are floored at 5% so ordinary scheduler and socket jitter on a busy
+    shared runner cannot fail the gate. At the request counts used by the e2e
+    tier the floor binds only for ``constant``.
+    """
+    if n < 2:
+        raise ValueError(f"a rate tolerance is meaningless for n={n} requests")
+    floor = 0.05
+    if arrival == "poisson":
+        return max(floor, 4.0 / math.sqrt(n))
+    if arrival == "constant":
+        return max(floor, 12.0 / n)
+    raise ValueError(f"unknown arrival process: {arrival!r}")
+
+
+def observed_send_rate(entries: Sequence[Dict[str, Any]]) -> Tuple[float, float]:
+    """Recompute (send_duration, achieved_rate) from raw per-request starts.
+
+    Mirrors ``summarize_requests`` exactly (count over the span of send
+    times), so the result can be diffed against the reported value to check
+    reportgen rather than to restate it.
+    """
+    starts = sorted(float(e["start_time"]) for e in entries)
+    if len(starts) < 2:
+        raise ValueError("need at least two requests to observe a send rate")
+    send_duration = starts[-1] - starts[0]
+    if send_duration <= 0:
+        raise ValueError("all requests share one send timestamp; no rate to observe")
+    return send_duration, len(starts) / send_duration
+
+
+def inflight_segments(entries: Sequence[Dict[str, Any]]) -> List[Segment]:
+    """Reconstruct the in-flight request count over time as a step function.
+
+    A sweep line over request starts and ends. Ends are applied before starts
+    at an identical timestamp, so a tie never credits an extra concurrent
+    slot: the reconstruction under-reports rather than over-reports.
+    """
+    events: List[Tuple[float, int]] = []
+    for entry in entries:
+        start = float(entry["start_time"])
+        end = float(entry["end_time"])
+        if end < start:
+            raise ValueError(f"request ends before it starts: {start} -> {end}")
+        events.append((start, 1))
+        events.append((end, -1))
+    events.sort(key=lambda ev: (ev[0], ev[1]))
+
+    segments: List[Segment] = []
+    inflight = 0
+    prev_t = events[0][0]
+    for t, delta in events:
+        if t > prev_t:
+            segments.append((prev_t, t, inflight))
+            prev_t = t
+        inflight += delta
+    return segments
+
+
+def max_inflight(segments: Sequence[Segment]) -> int:
+    return max((n for _, _, n in segments), default=0)
+
+
+def plateau_window(entries: Sequence[Dict[str, Any]], concurrency: int) -> Tuple[float, float]:
+    """Steady-state window of a closed-loop stage, derived not guessed.
+
+    Under a concurrency limit of C, request k cannot start until request k-C
+    has finished, so the pipeline is full from the C-th earliest start and
+    stays full until the last start, after which only the drain remains.
+    ``[C-th earliest start, latest start]`` therefore excludes ramp-up and
+    drain by construction, with no hand-tuned margin to tune away a failure.
+    """
+    if concurrency < 1:
+        raise ValueError(f"concurrency must be positive, got {concurrency}")
+    starts = sorted(float(e["start_time"]) for e in entries)
+    if len(starts) < 2 * concurrency:
+        raise ValueError(f"need at least 2*concurrency={2 * concurrency} requests for a plateau, got {len(starts)}")
+    return starts[concurrency - 1], starts[-1]
+
+
+def mean_inflight(segments: Sequence[Segment], window: Tuple[float, float]) -> float:
+    """Time-weighted mean in-flight count over ``window``.
+
+    Time weighted, not sample weighted: a run that sits at C for seconds and
+    dips to C-1 for microseconds between requests must not read as C-0.5.
+    """
+    lo, hi = window
+    if hi <= lo:
+        raise ValueError(f"empty window {window}")
+    weighted = 0.0
+    covered = 0.0
+    for seg_lo, seg_hi, n in segments:
+        a, b = max(seg_lo, lo), min(seg_hi, hi)
+        if b > a:
+            weighted += n * (b - a)
+            covered += b - a
+    if covered <= 0:
+        raise ValueError(f"no in-flight segments overlap window {window}")
+    return weighted / covered
+
+
+def fraction_at_level(segments: Sequence[Segment], window: Tuple[float, float], level: int) -> float:
+    """Fraction of ``window`` spent at exactly ``level`` in-flight requests."""
+    lo, hi = window
+    if hi <= lo:
+        raise ValueError(f"empty window {window}")
+    at_level = 0.0
+    covered = 0.0
+    for seg_lo, seg_hi, n in segments:
+        a, b = max(seg_lo, lo), min(seg_hi, hi)
+        if b > a:
+            covered += b - a
+            if n == level:
+                at_level += b - a
+    if covered <= 0:
+        raise ValueError(f"no in-flight segments overlap window {window}")
+    return at_level / covered
+
+
+def assert_delivered_concurrency(entries: Sequence[Dict[str, Any]], concurrency: int, *, slack: float = 0.5) -> None:
+    """Delivered in-flight concurrency must match the configured level.
+
+    Two claims, both against the configured level as the known-good value:
+
+    - never above it: the semaphore is an upper bound, so this is exact.
+    - within ``slack`` of it on time-weighted average across the plateau. The
+      default half-slot budget fails an off-by-one distribution bug (C-1 in
+      flight) for any C, while absorbing the sub-millisecond gap between one
+      request completing and its replacement being dispatched. Measured
+      against the sim at C=5 and C=8, that handoff costs about 0.04 of a slot
+      (roughly 96% of plateau time sits at exactly C), so the default leaves
+      an order of magnitude of headroom over real behaviour and still fails a
+      deficit of a whole slot.
+    """
+    segments = inflight_segments(entries)
+    window = plateau_window(entries, concurrency)
+    peak = max_inflight(segments)
+    assert peak <= concurrency, f"delivered concurrency peaked at {peak}, above the configured limit of {concurrency}"
+
+    mean = mean_inflight(segments, window)
+    held = fraction_at_level(segments, window, concurrency)
+    assert mean >= concurrency - slack, (
+        f"delivered concurrency averaged {mean:.3f} over the plateau, below the configured {concurrency} "
+        f"by more than {slack} (only {held:.1%} of plateau time was spent at exactly {concurrency})"
+    )

--- a/e2e/utils/vllm_bench.py
+++ b/e2e/utils/vllm_bench.py
@@ -11,24 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Run `vllm bench serve` against a server, for tool-parity comparison.
+"""Find (or install) vllm and run `vllm bench serve`, for the tool-parity tests.
 
-Design intent (per request): vllm is NOT a dependency of inference-perf. We
-instead clone a *pinned* vllm at test time and invoke its bench CLI, and we
-warn (loudly, non-fatally) if the pin has drifted too far from upstream so the
-comparison does not silently rot against a stale tool.
+vllm is not a dependency of inference-perf and this file does not make it one.
+Instead the tests use whatever vllm the environment provides, or optionally
+clone and install one specific pinned version into a throwaway venv. A warning
+is logged (never an error) if that pin has not been reviewed in a long time, so
+the comparison does not quietly go stale against an old vllm.
 
-Resolution order for *how* to invoke vllm, fastest first:
-  1. $VLLM_BENCH_BIN: path to an already-installed `vllm` executable. Skips
-     all clone/install work. The fast path for local iteration.
-  2. A cached, isolated venv under the e2e cache dir with the pinned vllm clone
-     installed into it. Heavy one-time setup (vllm pulls torch); cached across
-     runs. This is the CI path.
+Where the vllm executable comes from, tried in this order:
+  1. $VLLM_BENCH_BIN: path to a `vllm` you already have. Nothing to install.
+     Use this for local work and in CI.
+  2. $VLLM_BENCH_PROVISION=1: clone the pinned vllm and pip-install it (which
+     pulls in torch, so it is a large download) into a venv under a cache
+     directory. Reused on later runs.
+  3. Neither set: raise VllmUnavailable, which the tests turn into a skip.
 
-Any failure to provision vllm results in a SkipReason, so the parity test
-degrades gracefully (skips) exactly like the llm-d-inference-sim tests do when
-the sim is absent. It never hard-fails the suite on a missing tool.
+A missing vllm therefore skips the vllm-side tests. It never fails the suite,
+the same way the llm-d-inference-sim tests skip when the sim is absent.
 """
 
 from __future__ import annotations
@@ -49,26 +49,29 @@ logger = logging.getLogger(__name__)
 
 # --------------------------------------------------------------------------- pin
 #
-# Bump these together. VLLM_PIN_DATE is the date the pin was last reviewed and
-# drives the offline staleness warning (no network needed). The optional
-# upstream check (see warn_if_pin_stale) is best-effort on top of this.
+# Which vllm version the parity cases are written for. Bump these together.
+# VLLM_PIN_DATE is when someone last checked the pin; it drives the "this pin
+# is old" warning without any network access. warn_if_pin_stale can also
+# compare against GitHub's latest release, best-effort.
 #
-# The parity case files (cases/*/vllm-bench.args) were read off this exact tag,
-# whose tree is 6d8d0a24c02bfd84d46b3016b865a44f048ae84b. The flag semantics
-# they depend on live in vllm/benchmarks/serve.py and vllm/benchmarks/datasets.py
-# and have changed across vllm versions, so re-read both when bumping.
+# The case files (cases/*/vllm-bench.args) were written by reading this exact
+# tag (tree 6d8d0a24c02bfd84d46b3016b865a44f048ae84b). What each flag means is
+# defined in vllm/benchmarks/serve.py and vllm/benchmarks/datasets.py and has
+# changed between vllm versions, so re-read both files when bumping.
 VLLM_PINNED_REF = "v0.10.0"
-# Extra pip specs installed alongside the pinned vllm (space-separated; the CI
-# workflow greps this constant too). vllm leaves transformers unbounded above,
-# and transformers 5 removed PreTrainedTokenizerBase.all_special_tokens_extended,
-# which this vllm reads unconditionally in get_tokenizer() at bench startup
-# (vllm/transformers_utils/tokenizer.py). Review when bumping the pin.
+# Extra packages to pip-install next to the pinned vllm (space-separated; the
+# CI workflow reads this constant too). vllm does not cap its transformers
+# version, and transformers 5 removed a tokenizer attribute
+# (all_special_tokens_extended) that this vllm reads at bench startup, so
+# without this pin the run crashes before sending a request. Review when
+# bumping the vllm pin.
 VLLM_COMPAT_PINS = "transformers<5"
 VLLM_PIN_DATE = datetime.date(2026, 1, 15)
 VLLM_STALENESS_WARN_DAYS = 180
 VLLM_REPO_URL = "https://github.com/vllm-project/vllm.git"
 
-# Cache lives outside the repo tree by default; override for CI persistence.
+# Where the cloned vllm and its venv live. Outside the repo by default; set
+# VLLM_BENCH_CACHE_DIR to somewhere CI keeps between runs.
 _DEFAULT_CACHE = Path(os.environ.get("VLLM_BENCH_CACHE_DIR", Path(tempfile.gettempdir()) / "inference-perf-vllm-bench"))
 
 
@@ -82,16 +85,16 @@ class VllmBenchResult:
 
 
 class VllmUnavailable(Exception):
-    """Raised when vllm could not be provisioned; callers should pytest.skip."""
+    """No usable vllm was found or installed. The tests catch this and skip."""
 
 
 def warn_if_pin_stale(*, check_upstream: bool = False) -> None:
-    """Emit a warning if the pinned vllm ref looks out of date.
+    """Log a warning if the pinned vllm looks old. Never raises.
 
-    Offline check: how long since the pin was reviewed. Optional online check:
-    compare the pinned tag against GitHub's latest release. Both are advisory: a
-    stale pin still runs, it just gets a loud log line so the comparison does
-    not quietly drift against an old vllm.
+    Always: warn if VLLM_PIN_DATE is more than VLLM_STALENESS_WARN_DAYS ago.
+    With check_upstream=True: also ask GitHub for vllm's latest release and warn
+    if the pin is behind it (skipped quietly on any network problem). A stale
+    pin still runs; the warning is just so nobody forgets it exists.
     """
     age_days = (datetime.date.today() - VLLM_PIN_DATE).days
     if age_days > VLLM_STALENESS_WARN_DAYS:
@@ -105,7 +108,7 @@ def warn_if_pin_stale(*, check_upstream: bool = False) -> None:
 
     if not check_upstream:
         return
-    try:  # best-effort; never fail the test on a network hiccup
+    try:  # advisory only; a network problem here must not fail the test
         import urllib.request
 
         with urllib.request.urlopen("https://api.github.com/repos/vllm-project/vllm/releases/latest", timeout=5) as resp:
@@ -116,13 +119,13 @@ def warn_if_pin_stale(*, check_upstream: bool = False) -> None:
         logger.debug("upstream vllm staleness check skipped: %s", e)
 
 
-# Env vars that redirect a Python process's module resolution. The e2e suite
-# typically runs inside this repo's dev environment (nix devshell + venv, which
-# exports PYTHONPATH entries for its own interpreter), while vllm runs under a
-# separate interpreter. PYTHONPATH outranks the child's site-packages, so
-# inheriting these makes vllm import packages built for the wrong CPython ABI
-# (e.g. the devshell's torch) and crash on startup. LD_LIBRARY_PATH is left
-# alone: CI's hosted Python needs its entry to find libpython.
+# Environment variables that tell a Python process where to look for packages.
+# These tests usually run inside this repo's dev environment (nix devshell plus
+# venv), which sets PYTHONPATH for its own Python. vllm runs under a different
+# Python, and PYTHONPATH wins over that Python's own installed packages, so if
+# vllm inherited it, it would import this repo's torch (built for a different
+# Python) and crash on startup. So these are stripped from vllm's environment.
+# LD_LIBRARY_PATH is kept: CI's Python needs it to find libpython.
 _HOST_PYTHON_ENV_VARS = frozenset(
     {
         "PYTHONPATH",
@@ -136,19 +139,18 @@ _HOST_PYTHON_ENV_VARS = frozenset(
 
 
 def _isolated_env() -> Dict[str, str]:
-    """os.environ minus the vars that leak the host Python's packages into vllm's."""
+    """A copy of os.environ with _HOST_PYTHON_ENV_VARS removed."""
     return {k: v for k, v in os.environ.items() if k not in _HOST_PYTHON_ENV_VARS}
 
 
-# The `vllm` CLI cannot run `bench serve` on a machine with no accelerator:
-# main() eagerly builds every subparser, and the `vllm serve` (server) one
-# instantiates a default DeviceConfig, whose platform inference raises
-# "Failed to infer device type" when no device is present, which is true of
-# CI runners and GPU-less workstations. The bench serve code itself is a pure
-# HTTP client that never touches a device, so run it directly instead. This
-# shim reproduces exactly what the CLI subcommand does
-# (vllm/entrypoints/cli/benchmark/serve.py: add_cli_args + main), minus the
-# unrelated broken subparsers.
+# Why we do not just run `vllm bench serve`: on a machine with no GPU (CI
+# runners, most laptops) the `vllm` command crashes at startup with "Failed to
+# infer device type". That happens while it sets up the argument parser for
+# every subcommand, including `vllm serve`, which needs a GPU. `bench serve`
+# itself is only an HTTP client and never touches a GPU. So this tiny script
+# imports just the bench serve code and calls it the same way the CLI would
+# (see vllm/entrypoints/cli/benchmark/serve.py: add_cli_args + main), skipping
+# the broken parts.
 _BENCH_SERVE_SHIM = (
     "import argparse\n"
     "try:\n"
@@ -163,12 +165,12 @@ _BENCH_SERVE_SHIM = (
 
 
 def _bench_serve_cmd(vllm_bin: str, args: List[str]) -> List[str]:
-    """Build the argv for `vllm bench serve <args>` semantics.
+    """The command line to run: equivalent to `vllm bench serve <args>`.
 
-    Prefer the shim above under the vllm install's own interpreter (the
-    `python` sibling of the `vllm` executable, present in any venv or
-    setup-python install). Fall back to the real CLI when no sibling python
-    exists, e.g. if $VLLM_BENCH_BIN points at a wrapper script.
+    Preferred: run _BENCH_SERVE_SHIM with the `python` that sits next to the
+    `vllm` executable (any venv or setup-python install has one). Fallback:
+    the real `vllm bench serve` when there is no such python, for example when
+    $VLLM_BENCH_BIN points at a wrapper script.
     """
     resolved = shutil.which(vllm_bin) or vllm_bin
     python = Path(resolved).parent / "python"
@@ -183,20 +185,20 @@ def _run(cmd: List[str]) -> "subprocess.CompletedProcess[str]":
 
 
 def ensure_vllm_bench_bin(cache_dir: Optional[Path] = None) -> str:
-    """Return a path to a runnable `vllm` executable, or raise VllmUnavailable.
+    """Return the path of a runnable `vllm` executable, or raise VllmUnavailable.
 
-    Resolution:
-      1. $VLLM_BENCH_BIN -> use it directly (the path CI uses: a vllm installed
-         under a compatible interpreter). Fast, no build.
-      2. $VLLM_BENCH_PROVISION truthy -> opt in to the HEAVY path: clone the
-         pinned vllm and pip-install it (with torch) into a cached venv.
-      3. otherwise -> raise VllmUnavailable so the parity test skips cleanly.
+    Tried in order:
+      1. $VLLM_BENCH_BIN set -> use it as is (this is what CI does: it installs
+         vllm under a compatible Python and points here). Nothing to install.
+      2. $VLLM_BENCH_PROVISION set -> clone the pinned vllm and pip-install it
+         (with torch, so a multi-GB download) into a venv under cache_dir.
+         Reused if it already exists.
+      3. neither -> raise VllmUnavailable, so the tests skip.
 
-    The default is to skip, NOT to silently kick off a multi-GB build during a
-    normal `pdm run test:e2e`. The heavy path is also gated on interpreter
-    compatibility: vllm supports Python <=3.12, while this repo runs 3.14, so
-    the in-tree interpreter usually cannot build it, hence CI installs vllm
-    under a separate 3.12 and points $VLLM_BENCH_BIN at it.
+    The default is to skip rather than silently start a multi-GB install during
+    an ordinary `pdm run test:e2e`. Note vllm supports Python <=3.12 and this
+    repo runs 3.14, so option 2 usually also needs $VLLM_PYTHON pointed at a
+    3.12 interpreter; CI avoids that by using option 1.
     """
     override = os.environ.get("VLLM_BENCH_BIN")
     if override:
@@ -223,8 +225,8 @@ def ensure_vllm_bench_bin(cache_dir: Optional[Path] = None) -> str:
     if not shutil.which("git"):
         raise VllmUnavailable("git not available to clone vllm")
 
-    # vllm does not yet publish wheels for Python 3.14; let callers point at a
-    # compatible interpreter (e.g. python3.12) for the isolated venv.
+    # vllm does not build on Python 3.14 yet, so the venv is created with
+    # $VLLM_PYTHON (e.g. python3.12) when set.
     venv_python = os.environ.get("VLLM_PYTHON", "python")
 
     try:
@@ -235,8 +237,8 @@ def ensure_vllm_bench_bin(cache_dir: Optional[Path] = None) -> str:
         logger.info("creating isolated venv for vllm at %s (python=%s)", venv_dir, venv_python)
         _run([venv_python, "-m", "venv", str(venv_dir)])
         pip = str(venv_dir / "bin" / "pip")
-        # CPU-only client bench: no GPU needed to drive an OpenAI-compatible
-        # server. This is still a large install (torch); it is cached above.
+        # No GPU needed: bench serve is only an HTTP client. Still a large
+        # install because vllm pulls in torch; the venv is kept for next time.
         _run([pip, "install", "--upgrade", "pip"])
         _run([pip, "install", str(clone_dir), *VLLM_COMPAT_PINS.split()])
     except subprocess.CalledProcessError as e:
@@ -255,10 +257,11 @@ async def run_vllm_bench(
     result_filename: str = "vllm_bench_result.json",
     timeout_sec: Optional[int] = 300,
 ) -> VllmBenchResult:
-    """Invoke `vllm bench serve <args>` and parse its --save-result JSON.
+    """Run `vllm bench serve <args>` and return its exit status, output, and --save-result JSON.
 
-    `args` should already contain `--save-result --result-filename <path>`
-    (the harness appends these). We read that file back here.
+    `args` must already contain `--save-result --result-filename <path>` (the
+    parity test adds them); that file is read back into result_json. Runs in a
+    fresh temp dir unless work_dir is given, and is killed after timeout_sec.
     """
     wd = Path(work_dir) if work_dir else Path(tempfile.mkdtemp(prefix="vllm-bench-e2e-"))
     wd.mkdir(parents=True, exist_ok=True)
@@ -290,7 +293,7 @@ async def run_vllm_bench(
         except ProcessLookupError:
             pass
 
-    # --result-filename may be absolute (Scenario passes one); fall back to wd.
+    # result_filename may be absolute; if relative, it is inside the work dir.
     rf = Path(result_filename)
     result_path = rf if rf.is_absolute() else wd / rf
     result_json = None

--- a/e2e/utils/vllm_bench.py
+++ b/e2e/utils/vllm_bench.py
@@ -1,0 +1,309 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Run `vllm bench serve` against a server, for tool-parity comparison.
+
+Design intent (per request): vllm is NOT a dependency of inference-perf. We
+instead clone a *pinned* vllm at test time and invoke its bench CLI, and we
+warn (loudly, non-fatally) if the pin has drifted too far from upstream so the
+comparison does not silently rot against a stale tool.
+
+Resolution order for *how* to invoke vllm, fastest first:
+  1. $VLLM_BENCH_BIN: path to an already-installed `vllm` executable. Skips
+     all clone/install work. The fast path for local iteration.
+  2. A cached, isolated venv under the e2e cache dir with the pinned vllm clone
+     installed into it. Heavy one-time setup (vllm pulls torch); cached across
+     runs. This is the CI path.
+
+Any failure to provision vllm results in a SkipReason, so the parity test
+degrades gracefully (skips) exactly like the llm-d-inference-sim tests do when
+the sim is absent. It never hard-fails the suite on a missing tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- pin
+#
+# Bump these together. VLLM_PIN_DATE is the date the pin was last reviewed and
+# drives the offline staleness warning (no network needed). The optional
+# upstream check (see warn_if_pin_stale) is best-effort on top of this.
+#
+# The parity case files (cases/*/vllm-bench.args) were read off this exact tag,
+# whose tree is 6d8d0a24c02bfd84d46b3016b865a44f048ae84b. The flag semantics
+# they depend on live in vllm/benchmarks/serve.py and vllm/benchmarks/datasets.py
+# and have changed across vllm versions, so re-read both when bumping.
+VLLM_PINNED_REF = "v0.10.0"
+# Extra pip specs installed alongside the pinned vllm (space-separated; the CI
+# workflow greps this constant too). vllm leaves transformers unbounded above,
+# and transformers 5 removed PreTrainedTokenizerBase.all_special_tokens_extended,
+# which this vllm reads unconditionally in get_tokenizer() at bench startup
+# (vllm/transformers_utils/tokenizer.py). Review when bumping the pin.
+VLLM_COMPAT_PINS = "transformers<5"
+VLLM_PIN_DATE = datetime.date(2026, 1, 15)
+VLLM_STALENESS_WARN_DAYS = 180
+VLLM_REPO_URL = "https://github.com/vllm-project/vllm.git"
+
+# Cache lives outside the repo tree by default; override for CI persistence.
+_DEFAULT_CACHE = Path(os.environ.get("VLLM_BENCH_CACHE_DIR", Path(tempfile.gettempdir()) / "inference-perf-vllm-bench"))
+
+
+@dataclass
+class VllmBenchResult:
+    success: bool
+    timed_out: bool
+    return_code: int
+    stdout: str
+    result_json: Optional[Dict[str, Any]]  # parsed --save-result output, if produced
+
+
+class VllmUnavailable(Exception):
+    """Raised when vllm could not be provisioned; callers should pytest.skip."""
+
+
+def warn_if_pin_stale(*, check_upstream: bool = False) -> None:
+    """Emit a warning if the pinned vllm ref looks out of date.
+
+    Offline check: how long since the pin was reviewed. Optional online check:
+    compare the pinned tag against GitHub's latest release. Both are advisory: a
+    stale pin still runs, it just gets a loud log line so the comparison does
+    not quietly drift against an old vllm.
+    """
+    age_days = (datetime.date.today() - VLLM_PIN_DATE).days
+    if age_days > VLLM_STALENESS_WARN_DAYS:
+        logger.warning(
+            "vllm pin %s was last reviewed %d days ago (> %d). Consider bumping "
+            "VLLM_PINNED_REF and re-checking the bench CLI flags in the parity case files.",
+            VLLM_PINNED_REF,
+            age_days,
+            VLLM_STALENESS_WARN_DAYS,
+        )
+
+    if not check_upstream:
+        return
+    try:  # best-effort; never fail the test on a network hiccup
+        import urllib.request
+
+        with urllib.request.urlopen("https://api.github.com/repos/vllm-project/vllm/releases/latest", timeout=5) as resp:
+            latest = json.loads(resp.read()).get("tag_name")
+        if latest and latest != VLLM_PINNED_REF:
+            logger.warning("vllm pin %s is behind upstream latest release %s.", VLLM_PINNED_REF, latest)
+    except Exception as e:  # noqa: BLE001 - advisory only
+        logger.debug("upstream vllm staleness check skipped: %s", e)
+
+
+# Env vars that redirect a Python process's module resolution. The e2e suite
+# typically runs inside this repo's dev environment (nix devshell + venv, which
+# exports PYTHONPATH entries for its own interpreter), while vllm runs under a
+# separate interpreter. PYTHONPATH outranks the child's site-packages, so
+# inheriting these makes vllm import packages built for the wrong CPython ABI
+# (e.g. the devshell's torch) and crash on startup. LD_LIBRARY_PATH is left
+# alone: CI's hosted Python needs its entry to find libpython.
+_HOST_PYTHON_ENV_VARS = frozenset(
+    {
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONSTARTUP",
+        "NIX_PYTHONPATH",
+        "VIRTUAL_ENV",
+        "VIRTUAL_ENV_PROMPT",
+    }
+)
+
+
+def _isolated_env() -> Dict[str, str]:
+    """os.environ minus the vars that leak the host Python's packages into vllm's."""
+    return {k: v for k, v in os.environ.items() if k not in _HOST_PYTHON_ENV_VARS}
+
+
+# The `vllm` CLI cannot run `bench serve` on a machine with no accelerator:
+# main() eagerly builds every subparser, and the `vllm serve` (server) one
+# instantiates a default DeviceConfig, whose platform inference raises
+# "Failed to infer device type" when no device is present, which is true of
+# CI runners and GPU-less workstations. The bench serve code itself is a pure
+# HTTP client that never touches a device, so run it directly instead. This
+# shim reproduces exactly what the CLI subcommand does
+# (vllm/entrypoints/cli/benchmark/serve.py: add_cli_args + main), minus the
+# unrelated broken subparsers.
+_BENCH_SERVE_SHIM = (
+    "import argparse\n"
+    "try:\n"
+    "    from vllm.utils import FlexibleArgumentParser as Parser\n"
+    "except Exception:\n"
+    "    Parser = argparse.ArgumentParser\n"
+    "from vllm.benchmarks.serve import add_cli_args, main\n"
+    "parser = Parser(description='vllm bench serve (direct module invocation)')\n"
+    "add_cli_args(parser)\n"
+    "main(parser.parse_args())\n"
+)
+
+
+def _bench_serve_cmd(vllm_bin: str, args: List[str]) -> List[str]:
+    """Build the argv for `vllm bench serve <args>` semantics.
+
+    Prefer the shim above under the vllm install's own interpreter (the
+    `python` sibling of the `vllm` executable, present in any venv or
+    setup-python install). Fall back to the real CLI when no sibling python
+    exists, e.g. if $VLLM_BENCH_BIN points at a wrapper script.
+    """
+    resolved = shutil.which(vllm_bin) or vllm_bin
+    python = Path(resolved).parent / "python"
+    if python.exists():
+        return [str(python), "-c", _BENCH_SERVE_SHIM, *args]
+    return [vllm_bin, "bench", "serve", *args]
+
+
+def _run(cmd: List[str]) -> "subprocess.CompletedProcess[str]":
+    logger.debug("running: %s", " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, text=True, check=True, env=_isolated_env())
+
+
+def ensure_vllm_bench_bin(cache_dir: Optional[Path] = None) -> str:
+    """Return a path to a runnable `vllm` executable, or raise VllmUnavailable.
+
+    Resolution:
+      1. $VLLM_BENCH_BIN -> use it directly (the path CI uses: a vllm installed
+         under a compatible interpreter). Fast, no build.
+      2. $VLLM_BENCH_PROVISION truthy -> opt in to the HEAVY path: clone the
+         pinned vllm and pip-install it (with torch) into a cached venv.
+      3. otherwise -> raise VllmUnavailable so the parity test skips cleanly.
+
+    The default is to skip, NOT to silently kick off a multi-GB build during a
+    normal `pdm run test:e2e`. The heavy path is also gated on interpreter
+    compatibility: vllm supports Python <=3.12, while this repo runs 3.14, so
+    the in-tree interpreter usually cannot build it, hence CI installs vllm
+    under a separate 3.12 and points $VLLM_BENCH_BIN at it.
+    """
+    override = os.environ.get("VLLM_BENCH_BIN")
+    if override:
+        if shutil.which(override) or Path(override).exists():
+            return override
+        raise VllmUnavailable(f"$VLLM_BENCH_BIN set but not executable: {override}")
+
+    if not os.environ.get("VLLM_BENCH_PROVISION"):
+        raise VllmUnavailable(
+            "no vllm available: set $VLLM_BENCH_BIN to a vllm executable, or "
+            "$VLLM_BENCH_PROVISION=1 to clone+install the pinned vllm (heavy; "
+            "needs a Python <=3.12 interpreter via $VLLM_PYTHON)"
+        )
+
+    cache = cache_dir or _DEFAULT_CACHE
+    cache.mkdir(parents=True, exist_ok=True)
+    clone_dir = cache / f"vllm-{VLLM_PINNED_REF}"
+    venv_dir = cache / f"venv-{VLLM_PINNED_REF}"
+    vllm_bin = venv_dir / "bin" / "vllm"
+
+    if vllm_bin.exists():
+        return str(vllm_bin)
+
+    if not shutil.which("git"):
+        raise VllmUnavailable("git not available to clone vllm")
+
+    # vllm does not yet publish wheels for Python 3.14; let callers point at a
+    # compatible interpreter (e.g. python3.12) for the isolated venv.
+    venv_python = os.environ.get("VLLM_PYTHON", "python")
+
+    try:
+        if not clone_dir.exists():
+            logger.info("cloning pinned vllm %s (shallow) -> %s", VLLM_PINNED_REF, clone_dir)
+            _run(["git", "clone", "--depth", "1", "--branch", VLLM_PINNED_REF, VLLM_REPO_URL, str(clone_dir)])
+
+        logger.info("creating isolated venv for vllm at %s (python=%s)", venv_dir, venv_python)
+        _run([venv_python, "-m", "venv", str(venv_dir)])
+        pip = str(venv_dir / "bin" / "pip")
+        # CPU-only client bench: no GPU needed to drive an OpenAI-compatible
+        # server. This is still a large install (torch); it is cached above.
+        _run([pip, "install", "--upgrade", "pip"])
+        _run([pip, "install", str(clone_dir), *VLLM_COMPAT_PINS.split()])
+    except subprocess.CalledProcessError as e:
+        raise VllmUnavailable(f"failed to provision vllm: {e.stderr or e}") from e
+
+    if not vllm_bin.exists():
+        raise VllmUnavailable(f"vllm install completed but no executable at {vllm_bin}")
+    return str(vllm_bin)
+
+
+async def run_vllm_bench(
+    args: List[str],
+    *,
+    vllm_bin: str,
+    work_dir: Optional[Path] = None,
+    result_filename: str = "vllm_bench_result.json",
+    timeout_sec: Optional[int] = 300,
+) -> VllmBenchResult:
+    """Invoke `vllm bench serve <args>` and parse its --save-result JSON.
+
+    `args` should already contain `--save-result --result-filename <path>`
+    (the harness appends these). We read that file back here.
+    """
+    wd = Path(work_dir) if work_dir else Path(tempfile.mkdtemp(prefix="vllm-bench-e2e-"))
+    wd.mkdir(parents=True, exist_ok=True)
+
+    full = _bench_serve_cmd(vllm_bin, args)
+    logger.debug("starting vllm bench: %s", " ".join(full))
+    proc = await asyncio.create_subprocess_exec(
+        *full,
+        cwd=str(wd),
+        env=_isolated_env(),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    timed_out = False
+    return_code = -1
+    stdout = ""
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_sec)
+        stdout = out.decode()
+        assert proc.returncode is not None
+        return_code = proc.returncode
+    except asyncio.TimeoutError:
+        timed_out = True
+        return_code = -9
+        try:
+            proc.kill()
+            await proc.wait()
+        except ProcessLookupError:
+            pass
+
+    # --result-filename may be absolute (Scenario passes one); fall back to wd.
+    rf = Path(result_filename)
+    result_path = rf if rf.is_absolute() else wd / rf
+    result_json = None
+    if result_path.exists():
+        try:
+            result_json = json.loads(result_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning("vllm bench result file present but unparseable: %s", result_path)
+
+    return VllmBenchResult(
+        success=(return_code == 0 and not timed_out),
+        timed_out=timed_out,
+        return_code=return_code,
+        stdout=stdout,
+        result_json=result_json,
+    )

--- a/tests/required/config/test_yaml_configs.py
+++ b/tests/required/config/test_yaml_configs.py
@@ -65,10 +65,10 @@ NON_CONFIG_FILES = {
     "examples/tgi/docker-compose.yml": "docker-compose service definition",
     "examples/tgi/prometheus.yml": "Prometheus scrape config",
 }
-# Same idea as NON_CONFIG_FILES, for families of files whose membership grows by convention
-# rather than by edit. A drop-in test case directory must not require a Python change here
-# every time one is added, but the sibling inference-perf config in the same directory still
-# has to be schema-validated, so the exclusion has to be per-file rather than per-directory.
+# Like NON_CONFIG_FILES, but with wildcards, for groups of files that keep growing (e.g. one
+# per test case directory). Adding a new case directory must not need an edit here. It is a
+# per-file pattern rather than a whole-directory one because the inference-perf.yaml sitting
+# next to each expected.yaml still needs to be schema-checked.
 NON_CONFIG_GLOBS = {
     "e2e/tests/parity/cases/*/expected.yaml": "tool-parity case invariants, not inference-perf configs",
 }
@@ -83,6 +83,8 @@ def _tracked_yaml_files() -> List[str]:
     return sorted(p for p in out.split("\n") if p)
 
 
+# True if path matches any NON_CONFIG_GLOBS pattern, e.g.
+# "e2e/tests/parity/cases/a_fixed_rate/expected.yaml".
 def _matches_non_config_glob(path: str) -> bool:
     return any(fnmatch(path, pattern) for pattern in NON_CONFIG_GLOBS)
 

--- a/tests/required/config/test_yaml_configs.py
+++ b/tests/required/config/test_yaml_configs.py
@@ -32,6 +32,7 @@ stale config would validate cleanly while quietly losing the setting it meant to
 """
 
 import subprocess
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import List
 
@@ -64,6 +65,13 @@ NON_CONFIG_FILES = {
     "examples/tgi/docker-compose.yml": "docker-compose service definition",
     "examples/tgi/prometheus.yml": "Prometheus scrape config",
 }
+# Same idea as NON_CONFIG_FILES, for families of files whose membership grows by convention
+# rather than by edit. A drop-in test case directory must not require a Python change here
+# every time one is added, but the sibling inference-perf config in the same directory still
+# has to be schema-validated, so the exclusion has to be per-file rather than per-directory.
+NON_CONFIG_GLOBS = {
+    "e2e/tests/parity/cases/*/expected.yaml": "tool-parity case invariants, not inference-perf configs",
+}
 
 
 def _tracked_yaml_files() -> List[str]:
@@ -75,14 +83,20 @@ def _tracked_yaml_files() -> List[str]:
     return sorted(p for p in out.split("\n") if p)
 
 
+def _matches_non_config_glob(path: str) -> bool:
+    return any(fnmatch(path, pattern) for pattern in NON_CONFIG_GLOBS)
+
+
 def _is_config(path: str) -> bool:
     if path in CONFIG_FILES:
         return True
-    return any(path.startswith(f"{d}/") for d in CONFIG_DIRS) and path not in NON_CONFIG_FILES
+    if path in NON_CONFIG_FILES or _matches_non_config_glob(path):
+        return False
+    return any(path.startswith(f"{d}/") for d in CONFIG_DIRS)
 
 
 def _is_declared_non_config(path: str) -> bool:
-    if path in NON_CONFIG_FILES:
+    if path in NON_CONFIG_FILES or _matches_non_config_glob(path):
         return True
     return any(path.startswith(prefix) for prefix in NON_CONFIG_PREFIXES)
 
@@ -121,10 +135,11 @@ def test_every_tracked_yaml_is_classified(rel_path: str) -> None:
     """Every tracked YAML is either schema-validated or explicitly declared a non-config.
 
     If this fails for a file you just added, add it to CONFIG_DIRS/CONFIG_FILES if it is an
-    inference-perf config, or to NON_CONFIG_PREFIXES/NON_CONFIG_FILES with a reason if it is
-    not. Silently unvalidated config YAML is what this whole module exists to prevent.
+    inference-perf config, or to NON_CONFIG_PREFIXES/NON_CONFIG_FILES/NON_CONFIG_GLOBS with a
+    reason if it is not. Silently unvalidated config YAML is what this whole module exists to
+    prevent.
     """
     assert _is_config(rel_path) or _is_declared_non_config(rel_path), (
-        f"{rel_path} is neither validated as a config nor declared a non-config. "
-        "Add it to CONFIG_DIRS/CONFIG_FILES or NON_CONFIG_PREFIXES/NON_CONFIG_FILES."
+        f"{rel_path} is neither validated as a config nor declared a non-config. Add it to "
+        "CONFIG_DIRS/CONFIG_FILES or NON_CONFIG_PREFIXES/NON_CONFIG_FILES/NON_CONFIG_GLOBS."
     )


### PR DESCRIPTION
Part of #481. Runs inference-perf and `vllm bench serve` against the same recording server and asserts the two tools offered the same workload, which nothing in this repo checks today.

Row in #606: "End-to-end / Peer-benchmark skew (#481)", type `sim`.

**Stacked on #735** (`test/load-shape-accuracy-633`, `9b8c938`); its commit shows in this diff until it merges. Rate and concurrency here are computed by #735's `e2e/utils/load_shape.py`, so the e2e tier has one definition of each. #735 reads the client's own timestamps; this reads the server's.

## Why this is needed

Two recent skew reports were first read as inference-perf bugs and both decomposed into workload non-equivalence (the legacy `range_ratio` footgun, `0.0` meaning `Uniform[0, len]`; length-sampling, max-model-len and warmup deltas). Nothing could ask whether the two tools were even asked for the same thing.

**This harness never merge-gates, by design.** A delta can move from an inference-perf regression, a peer-tool change, or workload non-equivalence, and a gate cannot attribute which. The workload **mapping** is ours and asserted loudly; peer **results** are not ours and never asserted on.

## What the test does

- **The oracle is an absorber** (`e2e/utils/absorber.py`), an OpenAI-compatible aiohttp server that records every request (arrival, reply-finished, body) while streaming at a configured TTFT and inter-chunk interval. The recorded requests **are** the offered workload; no stored baseline.
- **Per tool, against `expected.yaml`:** exact request count, `max_tokens` multiset, `stream` and `ignore_eos` flags, per-request prompt tokens under the shared tokenizer (with tolerance), and either delivered rate within `rate_tolerance(n, arrival)` or delivered concurrency via `assert_delivered_concurrency` (never above C, time-weighted plateau mean within half a slot).
- **Tool against tool:** the same quantities compared directly; a failure names the knob that leaked.
- **No rate tolerance numbers.** Each tool declares its spacing (`tools.<tool>.arrival: constant|poisson`); the tolerance follows from the request count. Tightening a case means raising `num_requests`.
- **No reported-metric parity:** no TTFT, ITL or throughput number is asserted.
- **Warmup traffic is declared, not absorbed:** `leading_extra_requests` trims the earliest N arrivals for one tool; a nonzero value is itself a parity finding.

### The drop-in case contract (the reusable part)

```
e2e/tests/parity/cases/<name>/
  inference-perf.yaml   # verbatim config; harness overwrites only server.base_url + tokenizer path
  vllm-bench.args       # verbatim args, one per line, # comments ok; harness appends
                        # --base-url --model --tokenizer --save-result --result-filename
  expected.yaml         # invariants, absorber pacing, per-tool arrival + leading_extra_requests
```

Adding a case touches no Python. Starter cases: `a_fixed_rate` (40 QPS, 15s, 600 requests: the smallest count at which the Poisson side earns a useful 16% bound, matching #735) and `b_fixed_concurrency` (48 requests at concurrency 8).

## Verified against the pinned vllm source, not by running it

Read from tag `v0.10.0`: `benchmark()` always runs one warmup prompt first (`leading_extra_requests: 1`); `--random-range-ratio 0` gives fixed lengths; `--max-concurrency` is a semaphore; `--random-input-len` is reduced by the special-token count (hence `prompt_tokens_rel_tol`); `--request-rate` at default `--burstiness 1.0` is Poisson (`arrival: poisson`); `--backend` is vestigial, so **args files corrected** to `--endpoint-type openai`; `stream: true` is hardcoded, so `stream: false` is not expressible on the vllm leg. `transformers<5` is required (5.13 dropped `all_special_tokens_extended`).

## Status

Verified locally: `pdm run validate` clean; `pdm run test` **898 passed, 16 skipped**; `pdm run pytest e2e/tests/parity` **3 passed, 4 skipped**. Against the absorber: case `a` rate 40.01/s on a 5% budget; case `b` plateau mean 7.88 of 8 on a half-slot budget (the server sees the client's turnaround gap; client-side timestamps do not); C-1 and C+1 both fail.

**Not verified:**

- **The vllm leg has never been executed.** No vllm in this environment; all 4 skips are vllm-side. Source reading does not prove the run completes, that the absorber satisfies `vllm bench`'s parsing, or that both tools land inside tolerance.
- `prompt_tokens_rel_tol: 0.15` is sized by argument, not observation. `VLLM_PIN_DATE` still warns, deliberately.
- No CI wiring (and never merge-blocking when wired). `aiperf` not started.
