### PR TITLE
test: catch SGLang and TGI metric-name drift

### DIFF
--- a/.github/workflows/metric_name_drift.yml
+++ b/.github/workflows/metric_name_drift.yml
@@ -1,0 +1,214 @@
+# Periodic metric-name drift detection for SGLang and TGI (#669).
+#
+# inference-perf hardcodes the Prometheus metric names it queries per model
+# server. When an upstream server renames, removes or re-namespaces one,
+# nothing fails: the PromQL matches nothing, the report field comes back
+# empty, and a reader cannot tell "the server did not report this" from "we
+# asked for a name that no longer exists". #382 caught one such rename
+# (sglang:cache_hit_rate to sglang:token_usage) by hand.
+#
+# This job starts the LATEST release of each server, scrapes /metrics once,
+# and rewrites e2e/testdata/server_metric_families/<server>.txt. If the family
+# list changed it opens a pull request; if not it exits quietly. The pull
+# request then runs the normal checks in
+# e2e/tests/test_sglang_tgi_metric_names.py, so a name we still declare but
+# the server no longer exposes goes red on one attributable PR that somebody
+# owns, rather than on every open PR at once.
+#
+# Deliberately NOT merge blocking, and deliberately not on `pull_request`.
+# `latest` is a moving external dependency: if it gated merges, one upstream
+# rename would turn every open PR red at the same time, including the PR that
+# fixes it. Schedule plus manual dispatch is the correct contract, and it is
+# why this row does not block the release even though it lives in the live
+# tier.
+#
+# CAPACITY: both servers want an accelerator to start, and this project has no
+# runner with one yet (#641). Until it does, `runs-on` has nothing to point
+# at, so the job is gated on a repository variable: it stays skipped (not
+# queued forever, not failing every week) until somebody sets
+# METRIC_DRIFT_RUNNER to the label of a GPU runner with the NVIDIA container
+# toolkit installed. Setting that variable is the only step needed to turn
+# this on. Opening the refresh PR also needs the repository setting "Allow
+# GitHub Actions to create and approve pull requests".
+name: Metric-name drift (SGLang, TGI)
+
+on:
+  schedule:
+    # Mondays, early UTC. Weekly is enough: upstream releases are weeks apart
+    # and the fixture only has to be fresher than our next release.
+    - cron: '23 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      model:
+        description: Model both servers load. Small and ungated; generation quality is irrelevant, only metric registration is.
+        required: false
+        default: Qwen/Qwen2.5-0.5B-Instruct
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  capture:
+    # Never on forks (a fork has neither the runner nor anywhere useful to
+    # send the PR), and never before a runner exists (#641).
+    if: github.repository == 'kubernetes-sigs/inference-perf' && vars.METRIC_DRIFT_RUNNER != ''
+    runs-on: ${{ vars.METRIC_DRIFT_RUNNER }}
+    timeout-minutes: 60
+    # One job, one server, one pull request: a TGI rename must not be held up
+    # behind an SGLang server that failed to boot.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - server: sglang
+            image: docker.io/lmsysorg/sglang:latest
+            port: 30000
+            # SGLang exports nothing at all without --enable-metrics. The
+            # model flag comes last so the model name is appended as its own
+            # argument, never spliced into this string.
+            launch_args: python3 -m sglang.launch_server --host 0.0.0.0 --port 30000 --enable-metrics --model-path
+            warmup_body: '{"text":"1 2 3","sampling_params":{"max_new_tokens":4}}'
+          - server: tgi
+            image: ghcr.io/huggingface/text-generation-inference:latest
+            port: 80
+            launch_args: --model-id
+            warmup_body: '{"inputs":"1 2 3","parameters":{"max_new_tokens":4}}'
+    env:
+      MODEL: ${{ inputs.model || 'Qwen/Qwen2.5-0.5B-Instruct' }}
+      SERVER: ${{ matrix.server }}
+      FIXTURE: e2e/testdata/server_metric_families/${{ matrix.server }}.txt
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+
+      - name: Set up PDM
+        uses: pdm-project/setup-pdm@c6081998a653693a457d93c70b8007d979bc6741 # v4
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: pdm sync -d
+
+      - name: Start ${{ matrix.server }}
+        env:
+          IMAGE: ${{ matrix.image }}
+          PORT: ${{ matrix.port }}
+          LAUNCH_ARGS: ${{ matrix.launch_args }}
+        run: |
+          set -euo pipefail
+
+          # GPU runners are usually persistent, so never inherit a container
+          # from a previous run.
+          docker rm -f drift 2>/dev/null || true
+          docker pull "${IMAGE}"
+
+          # LAUNCH_ARGS is unquoted on purpose so it word-splits into
+          # arguments; it is a literal from this workflow file, not input.
+          docker run -d --name drift --gpus all --shm-size 8g \
+            -p "127.0.0.1:8080:${PORT}" \
+            -v "${HOME}/hf-cache:/data" -e HF_HOME=/data \
+            "${IMAGE}" ${LAUNCH_ARGS} "${MODEL}"
+
+          # Both images do a model download plus an engine warmup on first
+          # boot, so this deadline is generous. It is also what stands between
+          # a wedged boot and the job timeout.
+          for _ in $(seq 1 120); do
+            if curl -sf http://127.0.0.1:8080/health > /dev/null; then
+              echo "${SERVER} is ready"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::${SERVER} did not become ready"
+          exit 1
+
+      # Both servers register most metric families lazily, on first use, so a
+      # scrape of a freshly booted server under-reports. One real request is
+      # enough; no benchmark run is needed.
+      - name: Warm up ${{ matrix.server }}
+        env:
+          WARMUP_BODY: ${{ matrix.warmup_body }}
+        run: |
+          set -euo pipefail
+          curl -sf -X POST http://127.0.0.1:8080/generate \
+            -H 'Content-Type: application/json' \
+            -d "${WARMUP_BODY}" > /dev/null
+
+      # Writes only when the family list or the reported version differs from
+      # what is committed, so an unchanged metric surface leaves no diff and
+      # the step below has nothing to open.
+      - name: Capture metric-family fixture
+        run: |
+          set -euo pipefail
+          pdm run python scripts/capture_server_metric_names.py \
+            --server "${SERVER}" --base-url http://127.0.0.1:8080
+
+      - name: Collect server logs
+        if: always()
+        run: docker logs drift > "${SERVER}-server.log" 2>&1 || true
+
+      - name: Upload server logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.server }}-server-log
+          path: ${{ matrix.server }}-server.log
+
+      - name: Stop ${{ matrix.server }}
+        if: always()
+        run: docker rm -f drift 2>/dev/null || true
+
+      # A refresh PR, not a test failure: the diff is the finding, and the
+      # checks on the PR say whether it breaks anything we declare.
+      - name: Open a fixture-refresh pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- "${FIXTURE}"; then
+            echo "${SERVER} metric names unchanged; nothing to do."
+            exit 0
+          fi
+
+          VERSION="$(sed -n 's/^# version: //p' "${FIXTURE}")"
+          BRANCH="metric-drift/${SERVER}"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch -c "${BRANCH}"
+          git add "${FIXTURE}"
+          git commit -m "test: refresh ${SERVER} metric-name fixture (${VERSION})"
+          # Force push: the branch is a rolling snapshot of latest, so a
+          # second drift before the first PR merges should update that PR
+          # rather than stack a second one.
+          git push --force origin "${BRANCH}"
+
+          if gh pr view "${BRANCH}" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            echo "Existing PR for ${BRANCH} updated in place."
+            exit 0
+          fi
+
+          cat > pr-body.md <<EOF
+          Automated by .github/workflows/metric_name_drift.yml (#669).
+
+          The /metrics exposition of ${SERVER} ${VERSION} no longer matches the checked-in
+          fixture. The diff is the drift.
+
+          If a name inference-perf declares in get_prometheus_metric_metadata() disappeared,
+          e2e/tests/test_sglang_tgi_metric_names.py fails on this PR, and the declaration in
+          inference_perf/client/modelserver/${SERVER}_client.py needs updating in the same
+          change. If the checks are green, upstream added or removed metrics this project does
+          not query and the refresh can merge as is.
+          EOF
+
+          gh pr create \
+            --base main --head "${BRANCH}" \
+            --title "test: refresh ${SERVER} metric-name fixture (${VERSION})" \
+            --body-file pr-body.md

--- a/e2e/testdata/server_metric_families/sglang.txt
+++ b/e2e/testdata/server_metric_families/sglang.txt
@@ -1,0 +1,180 @@
+# sglang metric families, as inference-perf expects to find them on /metrics.
+#
+# provenance: upstream-source
+# server: sglang
+# version: v0.5.17
+# source: https://github.com/sgl-project/sglang/tree/v0.5.17/python/sglang (metric registrations, chiefly srt/observability/metrics_collector.py)
+# captured: 2026-08-17
+#
+# Regenerate against a running server:
+#   python scripts/capture_server_metric_names.py --server sglang \
+#     --base-url http://127.0.0.1:<port>
+#
+# UNVERIFIED AGAINST A LIVE SERVER. SGLang needs an accelerator to start, and
+# inference-perf has no runner with one yet (#641), so this snapshot was derived
+# by reading the pinned upstream registration code instead of by scraping a
+# running server. Derivation rule, reproducible by hand: every Gauge, Counter,
+# Histogram, Summary and GaugeHistogram construction under python/sglang/ at tag
+# v0.5.17 whose name literal starts with "sglang:". GaugeHistogram wraps a
+# prometheus_client Gauge (python/sglang/srt/utils/gauge_histogram.py), so it is
+# recorded as a gauge. prometheus_client's plain-text exposition appends _total
+# to counter family names; every SGLang counter already ends in _total, so the
+# registered name and the exposed family name coincide here.
+#
+# Two consequences of source derivation, both of which make this file a strict
+# SUPERSET of any single live exposition:
+#   - families gated on optional features (disaggregation, hicache, LoRA, spec
+#     decoding, grammar) are listed even though a default server never
+#     registers them;
+#   - metrics-registration is lazy in places, so a freshly started server
+#     exposes fewer families than it can register.
+# Anything asserting family-for-family equality against a live server must
+# therefore wait for a live-scrape regeneration. Run the scheduled workflow
+# (.github/workflows/metric_name_drift.yml) once a runner exists, or run
+# scripts/capture_server_metric_names.py by hand against your own server, and
+# commit the result; provenance flips to live-scrape and the equality check
+# stops skipping.
+sglang:backup_bandwidth histogram
+sglang:backup_pgs histogram
+sglang:backuped_tokens_total counter
+sglang:cache_hit_rate gauge
+sglang:cached_tokens_total counter
+sglang:context_len gauge
+sglang:cuda_graph_passes_total counter
+sglang:decode_sum_seq_lens gauge
+sglang:dp_cooperation_forward_execution_seconds_total counter
+sglang:dp_cooperation_realtime_tokens_total counter
+sglang:e2e_request_latency_seconds histogram
+sglang:encoder_cache_entries gauge
+sglang:encoder_cache_evictions_total counter
+sglang:encoder_cache_hit_files_total counter
+sglang:encoder_cache_hit_tokens_total counter
+sglang:encoder_cache_size_mb gauge
+sglang:encoder_cache_total_files_total counter
+sglang:encoder_cache_total_tokens_total counter
+sglang:encoder_dp_pending_requests gauge
+sglang:encoder_mm_items_per_batch histogram
+sglang:encoder_mm_items_per_request histogram
+sglang:encoder_model_forward_seconds histogram
+sglang:encoder_preprocess_seconds histogram
+sglang:encoder_queue_wait_seconds histogram
+sglang:encoder_request_e2e_latency_seconds histogram
+sglang:encoder_requests_received_total counter
+sglang:encoder_requests_total counter
+sglang:encoder_transfer_seconds histogram
+sglang:eplb_balancedness summary
+sglang:eplb_gpu_physical_count histogram
+sglang:estimated_flops_per_gpu_total counter
+sglang:estimated_read_bytes_per_gpu_total counter
+sglang:estimated_write_bytes_per_gpu_total counter
+sglang:evicted_tokens_total counter
+sglang:eviction_duration_seconds histogram
+sglang:failed_session_recoveries_total counter
+sglang:forward_execution_seconds_total counter
+sglang:full_token_usage gauge
+sglang:func_latency_seconds histogram
+sglang:fwd_occupancy gauge
+sglang:gen_throughput gauge
+sglang:generation_tokens_histogram histogram
+sglang:generation_tokens_total counter
+sglang:get_loads_duration_seconds histogram
+sglang:grammar_compilation_time_seconds histogram
+sglang:grammar_ebnf_size histogram
+sglang:grammar_schema_count histogram
+sglang:grammar_tree_traversal_time_avg histogram
+sglang:grammar_tree_traversal_time_max histogram
+sglang:graph_memory_usage_gb gauge
+sglang:hicache_host_total_tokens gauge
+sglang:hicache_host_used_tokens gauge
+sglang:http_requests_active gauge
+sglang:http_requests_total counter
+sglang:http_responses_total counter
+sglang:inter_token_latency_seconds histogram
+sglang:is_cuda_graph gauge
+sglang:kv_available_tokens gauge
+sglang:kv_cache_memory_usage_gb gauge
+sglang:kv_evictable_tokens gauge
+sglang:kv_transfer_alloc_ms histogram
+sglang:kv_transfer_bootstrap_ms histogram
+sglang:kv_transfer_latency_ms histogram
+sglang:kv_transfer_speed_gb_s histogram
+sglang:kv_transfer_total_mb histogram
+sglang:kv_used_tokens gauge
+sglang:load_back_duration_seconds histogram
+sglang:load_back_tokens_total counter
+sglang:lora_pool_slots_total gauge
+sglang:lora_pool_slots_used gauge
+sglang:lora_pool_utilization gauge
+sglang:mamba_available_tokens gauge
+sglang:mamba_evictable_tokens gauge
+sglang:mamba_usage gauge
+sglang:mamba_used_tokens gauge
+sglang:max_running_requests_under_SLO gauge
+sglang:max_total_num_tokens gauge
+sglang:max_total_num_tokens_swa gauge
+sglang:new_token_ratio gauge
+sglang:num_aborted_requests_total counter
+sglang:num_bootstrap_failed_reqs_total counter
+sglang:num_decode_prealloc_queue_reqs gauge
+sglang:num_decode_transfer_queue_reqs gauge
+sglang:num_grammar_aborted_total counter
+sglang:num_grammar_cache_hit_total counter
+sglang:num_grammar_queue_reqs gauge
+sglang:num_grammar_timeout_total counter
+sglang:num_grammar_total counter
+sglang:num_pages gauge
+sglang:num_paused_reqs gauge
+sglang:num_prefill_bootstrap_queue_reqs gauge
+sglang:num_prefill_inflight_queue_reqs gauge
+sglang:num_prefill_retries_total counter
+sglang:num_queue_reqs gauge
+sglang:num_requests_total counter
+sglang:num_retracted_input_tokens_total counter
+sglang:num_retracted_output_tokens_total counter
+sglang:num_retracted_reqs gauge
+sglang:num_retracted_requests_total counter
+sglang:num_running_reqs gauge
+sglang:num_so_requests_total counter
+sglang:num_streaming_sessions gauge
+sglang:num_transfer_failed_reqs_total counter
+sglang:num_unique_running_routing_keys gauge
+sglang:num_used_tokens gauge
+sglang:page_size gauge
+sglang:pending_prealloc_token_usage gauge
+sglang:per_stage_req_latency_seconds histogram
+sglang:prefetch_bandwidth histogram
+sglang:prefetch_pgs histogram
+sglang:prefetched_tokens_total counter
+sglang:prefill_delayer_outcomes_total counter
+sglang:prefill_delayer_wait_forward_passes histogram
+sglang:prefill_delayer_wait_seconds histogram
+sglang:process_cpu_seconds_total counter
+sglang:prompt_tokens_histogram histogram
+sglang:prompt_tokens_total counter
+sglang:queue_time_seconds histogram
+sglang:realtime_tokens_total counter
+sglang:routing_key_all_req_count gauge
+sglang:routing_key_running_req_count gauge
+sglang:routing_keys_active gauge
+sglang:spec_accept_length gauge
+sglang:spec_accept_rate gauge
+sglang:spec_block_accept_length gauge
+sglang:spec_cap_length gauge
+sglang:spec_num_draft_tokens gauge
+sglang:spec_num_steps gauge
+sglang:spec_verify_calls_total counter
+sglang:startup_available_gpu_memory_gb gauge
+sglang:startup_cuda_graph_time_seconds gauge
+sglang:startup_latency_breakdown_seconds_max gauge
+sglang:startup_time_seconds gauge
+sglang:streaming_session_held_tokens gauge
+sglang:swa_available_tokens gauge
+sglang:swa_evictable_tokens gauge
+sglang:swa_token_usage gauge
+sglang:swa_used_tokens gauge
+sglang:time_to_first_token_seconds histogram
+sglang:token_usage gauge
+sglang:uncached_prompt_tokens_histogram histogram
+sglang:utilization gauge
+sglang:weight_load_duration_seconds gauge
+sglang:weight_memory_usage_gb gauge

--- a/e2e/testdata/server_metric_families/tgi.txt
+++ b/e2e/testdata/server_metric_families/tgi.txt
@@ -1,0 +1,56 @@
+# tgi metric families, as inference-perf expects to find them on /metrics.
+#
+# provenance: upstream-source
+# server: tgi
+# version: v3.3.7
+# source: https://github.com/huggingface/text-generation-inference/tree/v3.3.7 (metrics macro invocations in router/src and backends/*/src)
+# captured: 2026-08-17
+#
+# Regenerate against a running server:
+#   python scripts/capture_server_metric_names.py --server tgi \
+#     --base-url http://127.0.0.1:<port>
+#
+# UNVERIFIED AGAINST A LIVE SERVER. Same reason and same caveats as the SGLang
+# fixture: derived from pinned upstream source, not scraped. Derivation rule:
+# every counter!/gauge!/histogram! and describe_counter!/describe_gauge!/
+# describe_histogram! macro invocation over **/*.rs at tag v3.3.7 whose first
+# argument is a "tgi_" string literal, with the type taken from the macro name.
+# TGI's exporter (metrics-exporter-prometheus) emits counter families under the
+# name as registered, with no _total suffix, which the repo's own Grafana
+# dashboard corroborates: assets/tgi_grafana.json queries tgi_request_success
+# directly.
+#
+# This is a strict superset of a live exposition: the metrics-rs recorder only
+# renders a family once something has recorded to it, so a server that has
+# served no request exposes almost nothing. It is also a superset of TGI's own
+# documented list (docs/source/reference/metrics.md at v3.3.7 tabulates 21 of
+# these 27; tgi_batch_concat, tgi_batch_concat_duration,
+# tgi_batch_inference_failure, tgi_batch_max_total_tokens, tgi_batch_total_tokens
+# and tgi_request_failure are registered but undocumented).
+tgi_batch_concat counter
+tgi_batch_concat_duration histogram
+tgi_batch_current_max_tokens gauge
+tgi_batch_current_size gauge
+tgi_batch_decode_duration histogram
+tgi_batch_filter_duration histogram
+tgi_batch_forward_duration histogram
+tgi_batch_inference_count counter
+tgi_batch_inference_duration histogram
+tgi_batch_inference_failure counter
+tgi_batch_inference_success counter
+tgi_batch_max_total_tokens gauge
+tgi_batch_next_size histogram
+tgi_batch_total_tokens gauge
+tgi_queue_size gauge
+tgi_request_count counter
+tgi_request_duration histogram
+tgi_request_failure counter
+tgi_request_generated_tokens histogram
+tgi_request_inference_duration histogram
+tgi_request_input_length histogram
+tgi_request_max_new_tokens histogram
+tgi_request_mean_time_per_token_duration histogram
+tgi_request_queue_duration histogram
+tgi_request_skipped_tokens histogram
+tgi_request_success counter
+tgi_request_validation_duration histogram

--- a/e2e/tests/test_sglang_tgi_metric_names.py
+++ b/e2e/tests/test_sglang_tgi_metric_names.py
@@ -1,0 +1,224 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Declared SGLang and TGI Prometheus metric names still exist upstream (#669).
+
+A stale metric name never errors. The PromQL query matches nothing, the
+report field comes back empty, and a reader cannot tell "the server did not
+report this" from "we asked for a name that no longer exists". #382 caught one
+such rename (``sglang:cache_hit_rate`` to ``sglang:token_usage``) by hand.
+
+The vLLM half of #669 (#697) pins releases and can start a real server on a
+plain CI runner in CPU mode. SGLang and TGI cannot: both want an accelerator,
+which this project has no runner for yet (#641). So this half is built the way
+#669 proposes instead, around a checked-in fixture that a scheduled job
+refreshes:
+
+1. ``test_declared_names_resolve_against_fixture`` (serverless, runs today in
+   the normal e2e job): every name the client declares must resolve against
+   the committed metric-family fixture for that server. This is the check that
+   catches a rename, and it needs no GPU because the fixture stands in for the
+   server.
+2. ``test_known_unresolved_are_still_unresolved`` (serverless): every entry in
+   the ``KNOWN_UNRESOLVED`` triage list must still be both declared and
+   unresolved. An allowlist that silently stops applying is how a gate rots,
+   so fixing a declaration turns this red and forces the entry to be deleted.
+3. ``test_exposed_families_match_fixture`` (live): the running server's
+   families equal the fixture exactly, which is what keeps the fixture honest.
+   Skips loudly while the fixture is source derived, because a source derived
+   fixture is a superset of any live exposition and equality is the wrong
+   oracle against it.
+4. ``test_declared_metric_names_exist`` (live): the end invariant itself,
+   declared names present in a real exposition.
+
+The live checks read ``E2E_SGLANG_BASE_URL`` / ``E2E_TGI_BASE_URL`` and skip
+when unset. Nothing here starts a server.
+
+Regenerating a fixture is ``scripts/capture_server_metric_names.py``, which
+the scheduled workflow (``.github/workflows/metric_name_drift.yml``) runs
+against the latest upstream release and turns into a pull request when the
+result differs. Capture and check share ``utils.server_metric_names``, so a
+committed fixture is by construction what these checks would have parsed.
+"""
+
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.server_metric_names import (
+    LIVE_SCRAPE,
+    PROVENANCES,
+    REQUIRED_HEADER_KEYS,
+    SERVERS,
+    ServerSpec,
+    declared_metrics,
+    exposed_names,
+    external_base_url,
+    fetch_text,
+    fixture_path,
+    is_exposed,
+    load_fixture,
+    parse_exposition,
+    resolves,
+)
+
+from inference_perf.config import APIConfig, APIType
+
+SERVER_IDS = sorted(SERVERS)
+
+# Declared names that do NOT resolve against the committed fixture, kept out of
+# the strict check so the rest of the surface stays gated, with the reason
+# written down so each is a triage item rather than a silent exception. Every
+# entry is asserted to still apply by test_known_unresolved_are_still_unresolved,
+# so none of these can rot into a permanent hole.
+KNOWN_UNRESOLVED: Dict[str, Dict[str, str]] = {
+    "sglang": {
+        # Found by this test, not by hand: SGLang registers no metric of this
+        # name anywhere in v0.5.17. The only occurrences left in that tree are
+        # a stale exposition sample in sgl-model-gateway/tests and the equally
+        # stale docs/docs/references/production_metrics.mdx dump. The live
+        # consequence is that summary_prometheus_metrics.json carries an empty
+        # time_per_output_token section for every SGLang run.
+        # sglang:inter_token_latency_seconds is the surviving per-token
+        # histogram and sglang_client already declares it as a custom metric,
+        # so the fix is a one-line swap in sglang_client.py. Doing it here
+        # would mix a client behaviour change into a test-only PR, so it is
+        # left for its own change with this entry as the repro.
+        "sglang:time_per_output_token_seconds": "not registered by SGLang v0.5.17; see #669",
+    },
+    "tgi": {},
+}
+
+
+def declared_for(spec: ServerSpec) -> Dict[str, str]:
+    """Metric base names -> type, as the server's client subclass declares them.
+
+    Only the declarations are read, never the tokenizer, so CustomTokenizer is
+    patched out to keep construction offline (same approach as
+    tests/required/client/metricsclient/test_prometheus_query_goldens.py).
+    """
+    with patch("inference_perf.client.modelserver.openai_client.CustomTokenizer"):
+        client = spec.client_cls(
+            metrics_collector=MagicMock(),
+            api_config=APIConfig(type=APIType.Completion, streaming=False),
+            uri="http://127.0.0.1:1",
+            model_name="meta-llama/Llama-3.1-8B-Instruct",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+    declared = declared_metrics(client.get_prometheus_metric_metadata(), spec.prefix)
+    assert declared, f"{spec.name} client declared no metric names"
+    return declared
+
+
+def live_metrics_text(spec: ServerSpec) -> str:
+    base_url = external_base_url(spec)
+    if not base_url:
+        pytest.skip(f"{spec.base_url_env} not set; no running {spec.name} to scrape")
+    return fetch_text(f"{base_url}/metrics")
+
+
+@pytest.mark.parametrize("server", SERVER_IDS)
+def test_fixture_header_is_complete(server: str) -> None:
+    # A fixture that does not say where it came from cannot be reviewed, and
+    # an unattributed fixture is exactly how a hand-written guess becomes a
+    # pinned expectation.
+    fixture = load_fixture(server)
+    missing = [key for key in REQUIRED_HEADER_KEYS if not fixture.header.get(key)]
+    assert not missing, f"{fixture_path(server).name} header is missing {missing}"
+    assert fixture.provenance in PROVENANCES, (
+        f"{fixture_path(server).name} declares unknown provenance {fixture.provenance!r}, expected one of {PROVENANCES}"
+    )
+    assert fixture.header["server"] == server
+    assert fixture.families, f"{fixture_path(server).name} lists no metric families"
+
+
+@pytest.mark.parametrize("server", SERVER_IDS)
+def test_declared_names_resolve_against_fixture(server: str) -> None:
+    spec = SERVERS[server]
+    fixture = load_fixture(server)
+    declared = declared_for(spec)
+    allowed = KNOWN_UNRESOLVED[server]
+
+    missing = sorted(
+        name
+        for name, metric_type in declared.items()
+        if name not in allowed and not resolves(name, metric_type, fixture.families)
+    )
+    assert not missing, (
+        f"{len(missing)}/{len(declared)} names declared by the {server} client do not resolve against "
+        f"{fixture_path(server).name} ({fixture.version}); a stale name produces a silently empty report "
+        f"field, so either fix the declaration or, if upstream really dropped it, add it to "
+        f"KNOWN_UNRESOLVED with the reason: {missing}"
+    )
+
+
+@pytest.mark.parametrize("server", SERVER_IDS)
+def test_known_unresolved_are_still_unresolved(server: str) -> None:
+    spec = SERVERS[server]
+    allowed = KNOWN_UNRESOLVED[server]
+    if not allowed:
+        pytest.skip(f"no known-unresolved declarations for {server}")
+    fixture = load_fixture(server)
+    declared = declared_for(spec)
+
+    undeclared = sorted(name for name in allowed if name not in declared)
+    assert not undeclared, f"{server} no longer declares {undeclared}; drop the KNOWN_UNRESOLVED entries"
+
+    now_resolving = sorted(name for name in allowed if resolves(name, declared[name], fixture.families))
+    assert not now_resolving, (
+        f"{server} declarations {now_resolving} now resolve against {fixture_path(server).name}; "
+        f"drop their KNOWN_UNRESOLVED entries so the strict check covers them again"
+    )
+
+
+@pytest.mark.parametrize("server", SERVER_IDS)
+def test_exposed_families_match_fixture(server: str) -> None:
+    spec = SERVERS[server]
+    fixture = load_fixture(server)
+    if fixture.provenance != LIVE_SCRAPE:
+        pytest.skip(
+            f"{fixture_path(server).name} provenance is {fixture.provenance!r}, not {LIVE_SCRAPE!r}: it was derived "
+            f"from pinned upstream source and is a superset of any live exposition, so family-for-family equality "
+            f"would fail for reasons that are not drift. Regenerate it with "
+            f"scripts/capture_server_metric_names.py against a running {server} and this check activates."
+        )
+    families = parse_exposition(live_metrics_text(spec), spec.prefix)
+    assert families, f"running {server} exposed no {spec.prefix}* metric families"
+
+    added = sorted(set(families) - set(fixture.families))
+    removed = sorted(set(fixture.families) - set(families))
+    retyped = sorted(n for n in set(fixture.families) & set(families) if fixture.families[n] != families[n])
+    assert not (added or removed or retyped), (
+        f"live {server} exposition diverges from {fixture_path(server).name} ({fixture.version}): "
+        f"added={added}, removed={removed}, retyped={retyped}. Regenerate the fixture with "
+        f"scripts/capture_server_metric_names.py and commit the diff."
+    )
+
+
+@pytest.mark.parametrize("server", SERVER_IDS)
+def test_declared_metric_names_exist(server: str) -> None:
+    spec = SERVERS[server]
+    names = exposed_names(live_metrics_text(spec))
+    declared = declared_for(spec)
+    allowed = KNOWN_UNRESOLVED[server]
+
+    missing = sorted(
+        name for name, metric_type in declared.items() if name not in allowed and not is_exposed(name, metric_type, names)
+    )
+    assert not missing, (
+        f"{len(missing)}/{len(declared)} names declared by the {server} client are absent from a real "
+        f"/metrics exposition (stale names produce silently empty report fields): {missing}"
+    )

--- a/e2e/tests/test_sglang_tgi_metric_names.py
+++ b/e2e/tests/test_sglang_tgi_metric_names.py
@@ -118,7 +118,7 @@ def declared_for(spec: ServerSpec) -> Dict[str, str]:
             max_tcp_connections=1,
             additional_filters=[],
         )
-    declared = declared_metrics(client.get_prometheus_metric_metadata(), spec.prefix)
+    declared = declared_metrics(client.get_prometheus_metric_metadata())
     assert declared, f"{spec.name} client declared no metric names"
     return declared
 
@@ -153,9 +153,7 @@ def test_declared_names_resolve_against_fixture(server: str) -> None:
     allowed = KNOWN_UNRESOLVED[server]
 
     missing = sorted(
-        name
-        for name, metric_type in declared.items()
-        if name not in allowed and not resolves(name, metric_type, fixture.families)
+        name for name, metric in declared.items() if name not in allowed and not resolves(metric, fixture.families)
     )
     assert not missing, (
         f"{len(missing)}/{len(declared)} names declared by the {server} client do not resolve against "
@@ -177,7 +175,7 @@ def test_known_unresolved_are_still_unresolved(server: str) -> None:
     undeclared = sorted(name for name in allowed if name not in declared)
     assert not undeclared, f"{server} no longer declares {undeclared}; drop the KNOWN_UNRESOLVED entries"
 
-    now_resolving = sorted(name for name in allowed if resolves(name, declared[name], fixture.families))
+    now_resolving = sorted(name for name in allowed if resolves(declared[name], fixture.families))
     assert not now_resolving, (
         f"{server} declarations {now_resolving} now resolve against {fixture_path(server).name}; "
         f"drop their KNOWN_UNRESOLVED entries so the strict check covers them again"
@@ -215,9 +213,7 @@ def test_declared_metric_names_exist(server: str) -> None:
     declared = declared_for(spec)
     allowed = KNOWN_UNRESOLVED[server]
 
-    missing = sorted(
-        name for name, metric_type in declared.items() if name not in allowed and not is_exposed(name, metric_type, names)
-    )
+    missing = sorted(name for name, metric in declared.items() if name not in allowed and not is_exposed(metric, names))
     assert not missing, (
         f"{len(missing)}/{len(declared)} names declared by the {server} client are absent from a real "
         f"/metrics exposition (stale names produce silently empty report fields): {missing}"

--- a/e2e/tests/test_vllm_cpu_metric_names.py
+++ b/e2e/tests/test_vllm_cpu_metric_names.py
@@ -45,6 +45,7 @@ what the check would have accepted.
 """
 
 import os
+from typing import Any
 
 import aiohttp
 import pytest
@@ -64,6 +65,7 @@ from utils.net import get_free_port
 from utils.testdata import extract_tarball
 from utils.vllm_server import DEFAULT_MODEL, VLLMServerRunner
 
+from inference_perf.client.modelserver.metrics.base import Metric
 from inference_perf.client.modelserver.vllm_client import vLLMModelServerClient
 from inference_perf.config import APIConfig, APIType, CustomTokenizerConfig
 from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
@@ -94,11 +96,27 @@ CONDITIONALLY_EXPOSED = {
     "vllm:prompt_tokens_recomputed",
 }
 
+# Declarations whose queries select nothing, with a fix already in flight. Kept
+# apart from CONDITIONALLY_EXPOSED because the reason is different: those names
+# are gated off on a stock server, these are simply queried under a name the
+# server does not use. Found by this check once it started asking what the
+# queries select rather than whether the declared name is findable (#669).
+#
+# The list cannot rot: test_known_unresolved_still_do_not_resolve fails the
+# moment an entry starts resolving, which forces it to be deleted.
+KNOWN_UNRESOLVED = {
+    "vllm:prompt_tokens": "queried bare; v0.26.0 exposes vllm:prompt_tokens_total. Fixed by #568",
+    "vllm:generation_tokens": "queried bare; v0.26.0 exposes vllm:generation_tokens_total. Fixed by #568",
+}
+
+# Names excluded from the strict checks for either reason.
+SKIPPED = CONDITIONALLY_EXPOSED | set(KNOWN_UNRESOLVED)
+
 GOLDEN_FILES = sorted(GOLDEN_DIR.glob("*.txt"))
 
 
-def _declared(base_url: str, model_name: str) -> dict[str, str]:
-    """Metric base names -> metric type, as declared by the vLLM client."""
+def _declared(base_url: str, model_name: str) -> dict[str, Metric[Any]]:
+    """Declared metric name -> the metric object, as declared by the vLLM client."""
     client = vLLMModelServerClient(
         metrics_collector=LocalRequestMetricCollector(),
         api_config=APIConfig(type=APIType.Completion),
@@ -134,14 +152,29 @@ def test_declared_names_resolve_against_goldens(golden_file) -> None:
     declared = _declared("http://127.0.0.1:1", DEFAULT_MODEL)
     assert declared, "vLLM client declared no metric names"
 
-    missing = sorted(
-        name
-        for name, metric_type in declared.items()
-        if name not in CONDITIONALLY_EXPOSED and not in_golden(name, metric_type, golden)
-    )
+    missing = sorted(name for name, metric in declared.items() if name not in SKIPPED and not in_golden(metric, golden))
     assert not missing, (
         f"{len(missing)}/{len(declared)} declared metric names do not resolve against {golden_file.name} "
         f"(stale names produce silently empty report fields): {missing}"
+    )
+
+
+@pytest.mark.parametrize("golden_file", GOLDEN_FILES, ids=lambda p: p.stem)
+def test_known_unresolved_still_do_not_resolve(golden_file) -> None:
+    # Guards the allowlist above. Each KNOWN_UNRESOLVED name must still be declared
+    # and must still fail to resolve; the moment #568 lands and vllm:prompt_tokens
+    # starts selecting vllm:prompt_tokens_total, this goes red and the entry has to
+    # be deleted. An allowlist that quietly stops applying is how a gate rots.
+    golden = load_golden(golden_file)
+    declared = _declared("http://127.0.0.1:1", DEFAULT_MODEL)
+
+    undeclared = sorted(name for name in KNOWN_UNRESOLVED if name not in declared)
+    assert not undeclared, f"no longer declared, drop the KNOWN_UNRESOLVED entries: {undeclared}"
+
+    now_resolving = sorted(name for name in KNOWN_UNRESOLVED if in_golden(declared[name], golden))
+    assert not now_resolving, (
+        f"{now_resolving} now resolve against {golden_file.name}; drop their KNOWN_UNRESOLVED "
+        f"entries so the strict check covers them again"
     )
 
 
@@ -182,11 +215,7 @@ async def test_declared_metric_names_exist():
         declared = _declared(server.base_url, server.model)
 
     assert declared, "vLLM client declared no metric names"
-    missing = sorted(
-        name
-        for name, metric_type in declared.items()
-        if name not in CONDITIONALLY_EXPOSED and not is_exposed(name, metric_type, names)
-    )
+    missing = sorted(name for name, metric in declared.items() if name not in SKIPPED and not is_exposed(metric, names))
     assert not missing, (
         f"{len(missing)}/{len(declared)} declared metric names absent from a real vLLM /metrics exposition "
         f"(stale names produce silently empty report fields): {missing}"

--- a/e2e/utils/metric_families.py
+++ b/e2e/utils/metric_families.py
@@ -33,27 +33,36 @@ mechanical companions of their family, and vLLM can toggle them via
 ``PROMETHEUS_DISABLE_CREATED_SERIES`` without any semantic change.
 """
 
-import re
 from pathlib import Path
-from typing import Dict, Set
+from typing import Any, Dict, Set
 
 from inference_perf.client.modelserver.metrics import CounterMetric, GaugeMetric, HistogramMetric
+from inference_perf.client.modelserver.metrics.base import Metric
 from inference_perf.client.modelserver.openai_client import OpenAIMetrics
 
 GOLDEN_DIR = Path(__file__).resolve().parents[1] / "testdata" / "vllm_metric_families"
 
-_BASE_NAME = re.compile(r"vllm:[A-Za-z0-9_]+")
 
+def declared_metrics(metadata: OpenAIMetrics) -> Dict[str, Metric[Any]]:
+    """Declared metric name -> the metric object, as declared by a client's metadata.
 
-def declared_metrics(metadata: OpenAIMetrics) -> Dict[str, str]:
-    """Metric base names -> prometheus type, as declared by a client's metadata."""
-    types = ((CounterMetric, "counter"), (GaugeMetric, "gauge"), (HistogramMetric, "histogram"))
-    declared: Dict[str, str] = {}
+    The metric itself is carried, not just its name and type, because it is the
+    only thing that knows which series its queries select (``candidate_names``).
+    The key stays the declared name so callers can key allowlists and failure
+    messages off exactly what appears in the client source.
+    """
+    declared: Dict[str, Metric[Any]] = {}
     for _field, metric in metadata:
-        metric_type = next(t for cls, t in types if isinstance(metric, cls))
-        for name in _BASE_NAME.findall(metric.metric_name):
-            declared[name] = metric_type
+        declared[metric.metric_name] = metric
     return declared
+
+
+def prometheus_type(metric: Metric[Any]) -> str:
+    """The exposition type a declared metric expects its family to carry."""
+    for cls, metric_type in ((CounterMetric, "counter"), (GaugeMetric, "gauge"), (HistogramMetric, "histogram")):
+        if isinstance(metric, cls):
+            return metric_type
+    raise TypeError(f"no prometheus type known for {type(metric).__name__}")
 
 
 def exposed_names(metrics_text: str) -> Set[str]:
@@ -79,25 +88,39 @@ def exposed_vllm_families(metrics_text: str) -> Dict[str, str]:
     return families
 
 
-def is_exposed(name: str, metric_type: str, names: Set[str]) -> bool:
-    """Whether a declared (name, type) is present in a live exposition's names.
+def provided_by_families(series: str, metric_type: str, families: Dict[str, str]) -> bool:
+    """Whether a family -> type map provides one series a query selects.
 
-    Presence is type-aware, mirroring what a Prometheus scrape stores: gauges
-    by bare name, counters by bare or ``_total``-suffixed name, histograms by
-    their ``_bucket``/``_count``/``_sum`` series.
+    A family map records what ``# TYPE`` declares, so counter and gauge series
+    are families in their own right, while ``_bucket``/``_count``/``_sum`` series
+    are produced by a histogram or summary family with the suffix stripped. That
+    second case also covers a counter declared straight onto a histogram's
+    ``_count`` series, which is valid PromQL and which SGLang's request count uses.
     """
-    if metric_type == "histogram":
-        return all(f"{name}{suffix}" in names for suffix in ("_bucket", "_count", "_sum"))
-    if metric_type == "counter":
-        return name in names or f"{name}_total" in names
-    return name in names
+    if families.get(series) == metric_type:
+        return True
+    for suffix in ("_bucket", "_count", "_sum"):
+        if series.endswith(suffix) and families.get(series[: -len(suffix)]) in ("histogram", "summary"):
+            return True
+    return False
 
 
-def in_golden(name: str, metric_type: str, golden: Dict[str, str]) -> bool:
-    """Whether a declared (name, type) resolves against a golden family map."""
-    if metric_type == "counter":
-        return golden.get(name) == "counter" or golden.get(f"{name}_total") == "counter"
-    return golden.get(name) == metric_type
+def is_exposed(metric: Metric[Any], names: Set[str]) -> bool:
+    """Whether every series this metric's queries select is in a live exposition.
+
+    An exposition lists real series names, so this is a plain subset test over the
+    metric's own candidate groups; nothing here needs to know how a counter or a
+    histogram is spelled.
+    """
+    return any(group <= names for group in metric.candidate_names())
+
+
+def in_golden(metric: Metric[Any], golden: Dict[str, str]) -> bool:
+    """Whether every series this metric's queries select resolves against a golden."""
+    metric_type = prometheus_type(metric)
+    return any(
+        all(provided_by_families(series, metric_type, golden) for series in group) for group in metric.candidate_names()
+    )
 
 
 def golden_path(release_tag: str) -> Path:

--- a/e2e/utils/server_metric_names.py
+++ b/e2e/utils/server_metric_names.py
@@ -1,0 +1,301 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prometheus metric-family bookkeeping for the SGLang and TGI drift checks (#669).
+
+Three representations of "which metrics exist" meet here, and this module
+converts between them:
+
+- **declared**: the (base name, type) pairs a client will query, read from its
+  ``get_prometheus_metric_metadata()``. Matching is by base name plus the
+  type's naming convention, never string equality, because a Prometheus type
+  decides which series a name actually produces.
+- **exposed**: what a live server's ``/metrics`` text contains.
+- **fixture**: the committed snapshot of a server's metric families
+  (``e2e/testdata/server_metric_families/<server>.txt``), which stands in for
+  a live server so the declared-vs-exposed check runs with no GPU.
+
+Unlike the vLLM half of #669, which pins releases and keeps one golden per
+pin, this half tracks whatever upstream calls ``latest``: there is exactly one
+fixture per server and the scheduled job rewrites it in place, so the review
+artifact is a diff of names rather than a new file.
+
+Fixture format: a header of ``# key: value`` lines followed by one
+``<family> <type>`` pair per line, sorted. Other ``#`` comments and blank
+lines are ignored. ``*_created`` series are dropped at capture time: they are
+prometheus_client per-series creation timestamps, mechanical companions of
+their family rather than metrics anyone declares.
+
+The header's ``provenance`` key is load bearing. ``live-scrape`` means the
+contents came off a running server's ``/metrics``. ``upstream-source`` means
+they were derived by reading the pinned upstream registration code, which is a
+strict superset of any single live exposition (it includes families gated on
+optional features, and families a server only registers once exercised). A
+check that needs family-for-family equality is only meaningful against
+``live-scrape`` and must skip otherwise.
+"""
+
+import json
+import os
+import re
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Set, Tuple, Type
+
+from inference_perf.client.modelserver.metrics import CounterMetric, GaugeMetric, HistogramMetric
+from inference_perf.client.modelserver.metrics.base import BaseMetrics
+from inference_perf.client.modelserver.openai_client import openAIModelServerClient
+from inference_perf.client.modelserver.sglang_client import SGlangModelServerClient
+from inference_perf.client.modelserver.tgi_client import TGImodelServerClient
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "testdata" / "server_metric_families"
+
+# Provenance values a fixture header may carry. See the module docstring.
+LIVE_SCRAPE = "live-scrape"
+UPSTREAM_SOURCE = "upstream-source"
+PROVENANCES = (LIVE_SCRAPE, UPSTREAM_SOURCE)
+
+# Header keys every fixture must carry, so a fixture can never be committed
+# without saying where its contents came from.
+REQUIRED_HEADER_KEYS = ("provenance", "server", "version", "source", "captured")
+
+# Series suffixes a histogram or summary family produces. A client may declare
+# one of these directly as a counter (SGLang counts requests off the latency
+# histogram's _count series), which is valid PromQL, so name resolution has to
+# recognise it.
+_AGGREGATE_SUFFIXES = ("_count", "_sum")
+
+
+@dataclass(frozen=True)
+class ServerSpec:
+    """Everything the drift checks and the capture script need per server."""
+
+    name: str
+    # Family-name prefix that identifies this server's own metrics. Everything
+    # else on /metrics (python_*, process_*, http_*) belongs to the runtime,
+    # not the server, and is not what this repo declares against.
+    prefix: str
+    client_cls: Type[openAIModelServerClient]
+    # Env var pointing at an already-running server, for the live checks.
+    base_url_env: str
+    # Endpoint returning a JSON object with a "version" key, used by the
+    # capture script to stamp the fixture with the release it scraped.
+    version_path: str
+    version_key: str
+
+
+SERVERS: Dict[str, ServerSpec] = {
+    "sglang": ServerSpec(
+        name="sglang",
+        prefix="sglang:",
+        client_cls=SGlangModelServerClient,
+        base_url_env="E2E_SGLANG_BASE_URL",
+        version_path="/server_info",
+        version_key="version",
+    ),
+    "tgi": ServerSpec(
+        name="tgi",
+        prefix="tgi_",
+        client_cls=TGImodelServerClient,
+        base_url_env="E2E_TGI_BASE_URL",
+        version_path="/info",
+        version_key="version",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Fixture:
+    """A parsed fixture file: its provenance header and its family -> type map."""
+
+    header: Dict[str, str]
+    families: Dict[str, str]
+
+    @property
+    def provenance(self) -> str:
+        return self.header.get("provenance", "")
+
+    @property
+    def version(self) -> str:
+        return self.header.get("version", "")
+
+
+def fixture_path(server: str) -> Path:
+    return FIXTURE_DIR / f"{server}.txt"
+
+
+def external_base_url(spec: ServerSpec) -> Optional[str]:
+    """The already-running server for this spec, or None.
+
+    There is deliberately no spawning runner here, unlike the vLLM half's
+    ``VLLMServerRunner``: SGLang and TGI both need an accelerator to start, so
+    until #641 provides one the only honest provisioning mode is "somebody
+    else started it and told us where". The live checks skip without it.
+    """
+    url = os.environ.get(spec.base_url_env, "").strip()
+    return url.rstrip("/") or None
+
+
+def fetch_text(url: str, timeout: float = 30.0) -> str:
+    if not url.startswith(("http://", "https://")):
+        raise ValueError(f"refusing to fetch non-http url: {url!r}")
+    # Scheme is checked above, so this never reaches file:// or similar.
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return str(resp.read().decode("utf-8"))
+
+
+def fetch_json(url: str, timeout: float = 30.0) -> Any:
+    return json.loads(fetch_text(url, timeout))
+
+
+def declared_metrics(metadata: BaseMetrics, prefix: str) -> Dict[str, str]:
+    """Metric base names -> prometheus type, as declared by a client's metadata.
+
+    A declared name is normally bare (``sglang:num_queue_reqs``) but the
+    counter type also accepts a version-spanning PromQL selector
+    (``{__name__=~"tgi_request_success(_total)?"}``), so base names are pulled
+    out by prefix rather than taken whole. A name that yields no base name at
+    all is kept verbatim: it cannot resolve against any fixture, and a
+    declaration this code cannot even parse is itself drift worth failing on.
+    """
+    types: Tuple[Tuple[type, str], ...] = (
+        (CounterMetric, "counter"),
+        (GaugeMetric, "gauge"),
+        (HistogramMetric, "histogram"),
+    )
+    base_name = re.compile(re.escape(prefix) + r"[A-Za-z0-9_]+")
+    declared: Dict[str, str] = {}
+    for _field, metric in metadata:
+        metric_type = next(t for cls, t in types if isinstance(metric, cls))
+        for name in base_name.findall(metric.metric_name) or [metric.metric_name]:
+            declared[name] = metric_type
+    return declared
+
+
+def parse_exposition(metrics_text: str, prefix: str) -> Dict[str, str]:
+    """The exposition's ``<prefix>*`` family -> type map, ``*_created`` dropped."""
+    families: Dict[str, str] = {}
+    for line in metrics_text.splitlines():
+        if not line.startswith(f"# TYPE {prefix}"):
+            continue
+        _, _, name, metric_type = line.split(" ", 3)
+        if not name.endswith("_created"):
+            families[name] = metric_type.strip()
+    return families
+
+
+def exposed_names(metrics_text: str) -> Set[str]:
+    """All family and sample names present in a /metrics exposition."""
+    names: Set[str] = set()
+    for line in metrics_text.splitlines():
+        if line.startswith("# TYPE ") or line.startswith("# HELP "):
+            names.add(line.split(" ")[2])
+        elif line and not line.startswith("#"):
+            names.add(line.split("{")[0].split(" ")[0])
+    return names
+
+
+def _aggregate_of(name: str) -> str:
+    """The family a ``_count``/``_sum`` series belongs to, or "" if not one."""
+    for suffix in _AGGREGATE_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return ""
+
+
+def resolves(name: str, metric_type: str, families: Dict[str, str]) -> bool:
+    """Whether a declared (name, type) resolves against a family -> type map.
+
+    Type aware, mirroring what a Prometheus scrape stores:
+
+    - gauges and histograms by exact family name and type;
+    - counters by exact name, by the ``_total``-suffixed name that
+      prometheus_client emits for a counter registered without it, or as the
+      ``_count``/``_sum`` series of a histogram or summary family.
+    """
+    if metric_type == "counter":
+        if families.get(name) == "counter" or families.get(f"{name}_total") == "counter":
+            return True
+        base = _aggregate_of(name)
+        return bool(base) and families.get(base) in ("histogram", "summary")
+    return families.get(name) == metric_type
+
+
+def is_exposed(name: str, metric_type: str, names: Set[str]) -> bool:
+    """Whether a declared (name, type) is present in a live exposition's names.
+
+    Presence is type aware for the same reason as ``resolves``: gauges by bare
+    name, counters by bare or ``_total``-suffixed name, histograms by their
+    ``_bucket``/``_count``/``_sum`` series.
+    """
+    if metric_type == "histogram":
+        return all(f"{name}{suffix}" in names for suffix in ("_bucket", "_count", "_sum"))
+    if metric_type == "counter":
+        return name in names or f"{name}_total" in names
+    return name in names
+
+
+def parse_fixture(text: str) -> Fixture:
+    header: Dict[str, str] = {}
+    families: Dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            body = line.lstrip("#").strip()
+            key, sep, value = body.partition(":")
+            if sep and key in REQUIRED_HEADER_KEYS:
+                header[key] = value.strip()
+            continue
+        name, _, metric_type = line.partition(" ")
+        families[name] = metric_type.strip()
+    return Fixture(header=header, families=families)
+
+
+def load_fixture(server: str) -> Fixture:
+    return parse_fixture(fixture_path(server).read_text(encoding="utf-8"))
+
+
+def format_fixture(
+    families: Dict[str, str],
+    *,
+    server: str,
+    version: str,
+    provenance: str,
+    source: str,
+    captured: str,
+    notes: str = "",
+) -> str:
+    """Render a fixture file. Capture and check share this format, so a
+    committed fixture is by construction what the checks would have parsed."""
+    if provenance not in PROVENANCES:
+        raise ValueError(f"unknown provenance {provenance!r}, expected one of {PROVENANCES}")
+    lines = [
+        f"# {server} metric families, as inference-perf expects to find them on /metrics.",
+        "#",
+        f"# provenance: {provenance}",
+        f"# server: {server}",
+        f"# version: {version}",
+        f"# source: {source}",
+        f"# captured: {captured}",
+        "#",
+        "# Regenerate against a running server:",
+        f"#   python scripts/capture_server_metric_names.py --server {server} \\",
+        "#     --base-url http://127.0.0.1:<port>",
+    ]
+    if notes:
+        lines += ["#"] + [f"# {line}".rstrip() for line in notes.strip("\n").splitlines()]
+    body = "".join(f"{name} {metric_type}\n" for name, metric_type in sorted(families.items()))
+    return "\n".join(lines) + "\n" + body

--- a/e2e/utils/server_metric_names.py
+++ b/e2e/utils/server_metric_names.py
@@ -47,14 +47,13 @@ check that needs family-for-family equality is only meaningful against
 
 import json
 import os
-import re
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Tuple, Type
+from typing import Any, Dict, Optional, Set, Type
 
 from inference_perf.client.modelserver.metrics import CounterMetric, GaugeMetric, HistogramMetric
-from inference_perf.client.modelserver.metrics.base import BaseMetrics
+from inference_perf.client.modelserver.metrics.base import BaseMetrics, Metric
 from inference_perf.client.modelserver.openai_client import openAIModelServerClient
 from inference_perf.client.modelserver.sglang_client import SGlangModelServerClient
 from inference_perf.client.modelserver.tgi_client import TGImodelServerClient
@@ -70,11 +69,11 @@ PROVENANCES = (LIVE_SCRAPE, UPSTREAM_SOURCE)
 # without saying where its contents came from.
 REQUIRED_HEADER_KEYS = ("provenance", "server", "version", "source", "captured")
 
-# Series suffixes a histogram or summary family produces. A client may declare
-# one of these directly as a counter (SGLang counts requests off the latency
-# histogram's _count series), which is valid PromQL, so name resolution has to
-# recognise it.
-_AGGREGATE_SUFFIXES = ("_count", "_sum")
+# Series suffixes produced by a histogram or summary family rather than being
+# families in their own right. A client may declare one directly as a counter
+# (SGLang counts requests off the latency histogram's _count series), which is
+# valid PromQL, so resolving a series against a family map has to recognise it.
+_AGGREGATE_SUFFIXES = ("_bucket", "_count", "_sum")
 
 
 @dataclass(frozen=True)
@@ -159,28 +158,26 @@ def fetch_json(url: str, timeout: float = 30.0) -> Any:
     return json.loads(fetch_text(url, timeout))
 
 
-def declared_metrics(metadata: BaseMetrics, prefix: str) -> Dict[str, str]:
-    """Metric base names -> prometheus type, as declared by a client's metadata.
+def declared_metrics(metadata: BaseMetrics) -> Dict[str, Metric[Any]]:
+    """Declared metric name -> the metric object, as declared by a client's metadata.
 
-    A declared name is normally bare (``sglang:num_queue_reqs``) but the
-    counter type also accepts a version-spanning PromQL selector
-    (``{__name__=~"tgi_request_success(_total)?"}``), so base names are pulled
-    out by prefix rather than taken whole. A name that yields no base name at
-    all is kept verbatim: it cannot resolve against any fixture, and a
-    declaration this code cannot even parse is itself drift worth failing on.
+    The metric is carried rather than its name and type because only the metric
+    knows which series its queries select (``candidate_names``). The server's
+    family prefix used to be needed here to pull base names out of a declaration;
+    the metric takes itself apart now, so nothing here has to know the prefix.
     """
-    types: Tuple[Tuple[type, str], ...] = (
-        (CounterMetric, "counter"),
-        (GaugeMetric, "gauge"),
-        (HistogramMetric, "histogram"),
-    )
-    base_name = re.compile(re.escape(prefix) + r"[A-Za-z0-9_]+")
-    declared: Dict[str, str] = {}
+    declared: Dict[str, Metric[Any]] = {}
     for _field, metric in metadata:
-        metric_type = next(t for cls, t in types if isinstance(metric, cls))
-        for name in base_name.findall(metric.metric_name) or [metric.metric_name]:
-            declared[name] = metric_type
+        declared[metric.metric_name] = metric
     return declared
+
+
+def prometheus_type(metric: Metric[Any]) -> str:
+    """The exposition type a declared metric expects its family to carry."""
+    for cls, metric_type in ((CounterMetric, "counter"), (GaugeMetric, "gauge"), (HistogramMetric, "histogram")):
+        if isinstance(metric, cls):
+            return metric_type
+    raise TypeError(f"no prometheus type known for {type(metric).__name__}")
 
 
 def parse_exposition(metrics_text: str, prefix: str) -> Dict[str, str]:
@@ -207,43 +204,47 @@ def exposed_names(metrics_text: str) -> Set[str]:
 
 
 def _aggregate_of(name: str) -> str:
-    """The family a ``_count``/``_sum`` series belongs to, or "" if not one."""
+    """The family a ``_bucket``/``_count``/``_sum`` series belongs to, or "" if not one."""
     for suffix in _AGGREGATE_SUFFIXES:
         if name.endswith(suffix):
             return name[: -len(suffix)]
     return ""
 
 
-def resolves(name: str, metric_type: str, families: Dict[str, str]) -> bool:
-    """Whether a declared (name, type) resolves against a family -> type map.
+def provided_by_families(series: str, metric_type: str, families: Dict[str, str]) -> bool:
+    """Whether a family -> type map provides one series a query selects.
 
-    Type aware, mirroring what a Prometheus scrape stores:
-
-    - gauges and histograms by exact family name and type;
-    - counters by exact name, by the ``_total``-suffixed name that
-      prometheus_client emits for a counter registered without it, or as the
-      ``_count``/``_sum`` series of a histogram or summary family.
+    A fixture records what ``# TYPE`` declares, so counter and gauge series are
+    families in their own right, while ``_bucket``/``_count``/``_sum`` series come
+    from a histogram or summary family with the suffix stripped.
     """
-    if metric_type == "counter":
-        if families.get(name) == "counter" or families.get(f"{name}_total") == "counter":
-            return True
-        base = _aggregate_of(name)
-        return bool(base) and families.get(base) in ("histogram", "summary")
-    return families.get(name) == metric_type
+    if families.get(series) == metric_type:
+        return True
+    base = _aggregate_of(series)
+    return bool(base) and families.get(base) in ("histogram", "summary")
 
 
-def is_exposed(name: str, metric_type: str, names: Set[str]) -> bool:
-    """Whether a declared (name, type) is present in a live exposition's names.
+def resolves(metric: Metric[Any], families: Dict[str, str]) -> bool:
+    """Whether every series this metric's queries select resolves against a fixture.
 
-    Presence is type aware for the same reason as ``resolves``: gauges by bare
-    name, counters by bare or ``_total``-suffixed name, histograms by their
-    ``_bucket``/``_count``/``_sum`` series.
+    The naming conventions (a counter spanning the optional ``_total`` suffix, a
+    histogram needing all three of its series) are not restated here: they come
+    from the metric's own ``candidate_names``, so this check cannot drift away
+    from what the client actually queries the way it did in #669.
     """
-    if metric_type == "histogram":
-        return all(f"{name}{suffix}" in names for suffix in ("_bucket", "_count", "_sum"))
-    if metric_type == "counter":
-        return name in names or f"{name}_total" in names
-    return name in names
+    metric_type = prometheus_type(metric)
+    return any(
+        all(provided_by_families(series, metric_type, families) for series in group) for group in metric.candidate_names()
+    )
+
+
+def is_exposed(metric: Metric[Any], names: Set[str]) -> bool:
+    """Whether every series this metric's queries select is in a live exposition.
+
+    An exposition lists real series names, so this is a plain subset test over the
+    metric's candidate groups.
+    """
+    return any(group <= names for group in metric.candidate_names())
 
 
 def parse_fixture(text: str) -> Fixture:

--- a/inference_perf/client/modelserver/metrics/base.py
+++ b/inference_perf/client/modelserver/metrics/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar
+from typing import Any, Callable, Dict, FrozenSet, Generic, Iterator, List, Optional, Sequence, Tuple, TypeVar
 from pydantic import BaseModel
 
 R = TypeVar("R", bound=BaseModel)
@@ -27,6 +27,24 @@ class Metric(ABC, Generic[R]):
 
         filters is the comma-joined label selector (e.g. "model_name='m'"), supplied by the
         owning container so it is not repeated on every metric.
+        """
+        ...
+
+    @abstractmethod
+    def candidate_names(self) -> Sequence[FrozenSet[str]]:
+        """The Prometheus series this metric's queries select.
+
+        Each frozenset is a group whose names must all exist for that group to be
+        satisfied, and the metric resolves if any group is satisfied. A histogram
+        needs all three of its `_bucket`/`_count`/`_sum` series, so it returns one
+        group of three; a counter that spans the exposition's optional `_total`
+        suffix accepts either form, so it returns two groups of one.
+
+        This lives next to get_queries so that a name-drift check can ask what the
+        queries actually select rather than restating the exposition's naming
+        conventions on its own. Restating them is how the two fell out of step:
+        the drift check accepted a counter declared as `X` because the server
+        exposed `X_total`, while the query only ever selected `X` (#669, #568).
         """
         ...
 

--- a/inference_perf/client/modelserver/metrics/counter/base.py
+++ b/inference_perf/client/modelserver/metrics/counter/base.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
+import re
+from typing import FrozenSet, List, Sequence
 from pydantic import BaseModel
 
 from ..base import Metric
@@ -32,6 +33,21 @@ class CounterMetric(Metric[CounterResult]):
 
     def __init__(self, metric_name: str) -> None:
         self.metric_name = metric_name
+
+    # The alternatives a `{__name__=~"X(_total)?"}` selector name spans. The selector is the
+    # only declaration form that reaches more than one series, so it is the only one that has
+    # to be taken apart to say what the queries select.
+    _SPANNING_SELECTOR = re.compile(r'^\{__name__=~"(?P<base>[^"(){}]+)\(_total\)\?"\}$')
+
+    def candidate_names(self) -> Sequence[FrozenSet[str]]:
+        # A plain name selects exactly itself: nothing in get_queries adds a `_total` suffix,
+        # so a counter declared bare against a server that suffixes its counters selects
+        # nothing at all. That is the gap this reports rather than papers over (#669).
+        match = self._SPANNING_SELECTOR.match(self.metric_name)
+        if not match:
+            return (frozenset({self.metric_name}),)
+        base = match.group("base")
+        return (frozenset({f"{base}_total"}), frozenset({base}))
 
     def _selector(self, filters: str) -> str:
         # A counter name may be a plain metric or a `{__name__=~"foo(_total)?"}` selector;

--- a/inference_perf/client/modelserver/metrics/gauge/base.py
+++ b/inference_perf/client/modelserver/metrics/gauge/base.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Dict, List
+from typing import Dict, FrozenSet, List, Sequence
 from pydantic import BaseModel
 
 from ..base import Metric
@@ -40,6 +40,10 @@ class GaugeMetric(Metric[GaugeResult]):
         if metric_name.startswith("{"):
             raise ValueError(f"GaugeMetric does not support `{{__name__=~...}}` selector metric names: {metric_name}")
         self.metric_name = metric_name
+
+    def candidate_names(self) -> Sequence[FrozenSet[str]]:
+        # A gauge is stored under its bare name, which is the only name its queries select.
+        return (frozenset({self.metric_name}),)
 
     def get_queries(self, duration: float, filters: str) -> List[str]:
         f, m = filters, self.metric_name

--- a/inference_perf/client/modelserver/metrics/histogram/base.py
+++ b/inference_perf/client/modelserver/metrics/histogram/base.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
+from typing import FrozenSet, List, Sequence
 
 from ..base import Metric
 from ..gauge.base import GaugeResult
@@ -31,6 +31,11 @@ class HistogramMetric(Metric[HistogramResult]):
         if metric_name.startswith("{"):
             raise ValueError(f"HistogramMetric does not support `{{__name__=~...}}` selector metric names: {metric_name}")
         self.metric_name = metric_name
+
+    def candidate_names(self) -> Sequence[FrozenSet[str]]:
+        # A histogram's queries select all three of its series, so all three must exist;
+        # one family missing its _bucket is drift, not a partially usable metric.
+        return (frozenset({f"{self.metric_name}{suffix}" for suffix in ("_bucket", "_count", "_sum")}),)
 
     def get_queries(self, duration: float, filters: str) -> List[str]:
         f, m = filters, self.metric_name

--- a/scripts/capture_server_metric_names.py
+++ b/scripts/capture_server_metric_names.py
@@ -1,0 +1,129 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rewrite a server's metric-family fixture from a running server (#669).
+
+Scrapes ``<base-url>/metrics``, keeps the family names and types that belong
+to the server itself, and writes them to
+``e2e/testdata/server_metric_families/<server>.txt`` with a header recording
+the release it came from. The scheduled drift workflow
+(``.github/workflows/metric_name_drift.yml``) runs this against the latest
+upstream release of SGLang and TGI and opens a pull request when the file
+changes; run it by hand against your own server to refresh a fixture out of
+band.
+
+Exits 0 whether or not the file changed. ``--check`` instead exits 1 on a
+difference without writing, for callers that only want to know.
+
+Two things to know before trusting the output:
+
+- Both servers register metric families lazily, so scrape only after the
+  server has served at least one request. The workflow does that warmup; a
+  by-hand run should too, or the capture will under-report.
+- The server must actually be exporting. SGLang needs ``--enable-metrics``.
+
+The parsing and formatting live in ``e2e/utils/server_metric_names.py``, the
+same module the drift checks read fixtures with, so a captured file is by
+construction what those checks would have parsed.
+"""
+
+import argparse
+import datetime
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+# The e2e helpers are not an installed package; e2e/ is what pytest puts on
+# sys.path for those tests, so put it there too rather than duplicating the
+# fixture format in a second place.
+sys.path.insert(0, str(REPO_ROOT / "e2e"))
+
+from utils.server_metric_names import (  # noqa: E402
+    LIVE_SCRAPE,
+    SERVERS,
+    ServerSpec,
+    fetch_json,
+    fetch_text,
+    fixture_path,
+    format_fixture,
+    parse_exposition,
+    parse_fixture,
+)
+
+
+def resolve_version(spec: ServerSpec, base_url: str) -> str:
+    """The running release, from the server's own version endpoint."""
+    payload = fetch_json(f"{base_url}{spec.version_path}")
+    version = payload.get(spec.version_key) if isinstance(payload, dict) else None
+    if not version:
+        raise SystemExit(f"{base_url}{spec.version_path} did not report a {spec.version_key!r}; pass --version explicitly")
+    return str(version)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--server", required=True, choices=sorted(SERVERS), help="which server's fixture to rewrite")
+    parser.add_argument("--base-url", required=True, help="base URL of a running server, e.g. http://127.0.0.1:30000")
+    parser.add_argument("--version", help="release tag to stamp; read from the server's version endpoint when omitted")
+    parser.add_argument("--output", type=Path, help="fixture path to write; defaults to the checked-in one")
+    parser.add_argument("--check", action="store_true", help="exit 1 if the fixture would change, and write nothing")
+    args = parser.parse_args()
+
+    spec = SERVERS[args.server]
+    base_url = args.base_url.rstrip("/")
+    version = args.version or resolve_version(spec, base_url)
+
+    families = parse_exposition(fetch_text(f"{base_url}/metrics"), spec.prefix)
+    if not families:
+        raise SystemExit(
+            f"{base_url}/metrics exposed no {spec.prefix}* families. The server may not have served a request yet, "
+            f"or metrics may be disabled (SGLang needs --enable-metrics). Refusing to write an empty fixture."
+        )
+
+    rendered = format_fixture(
+        families,
+        server=spec.name,
+        version=version,
+        provenance=LIVE_SCRAPE,
+        source=f"{base_url}/metrics",
+        captured=datetime.date.today().isoformat(),
+        notes=(
+            "Captured from a running server after at least one request, so this lists the families that\n"
+            "server actually exposed under its launch configuration, not every family it could register."
+        ),
+    )
+
+    path = args.output or fixture_path(spec.name)
+    # The header carries a capture date and a source URL that move on every
+    # run, so comparing whole files would report a change every week. Compare
+    # the family list and the reported version instead: those are the two
+    # things a reviewer of a refresh PR is being asked about.
+    previous = parse_fixture(path.read_text(encoding="utf-8")) if path.is_file() else None
+    changed = previous is None or previous.families != families or previous.version != version
+
+    if args.check:
+        print(f"{spec.name} {version}: {len(families)} families, {'CHANGED' if changed else 'unchanged'}")
+        return 1 if changed else 0
+
+    if not changed:
+        print(f"{path} already matches {spec.name} {version} ({len(families)} families); left untouched")
+        return 0
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rendered, encoding="utf-8")
+    print(f"wrote {path} ({len(families)} families from {spec.name} {version})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/required/client/metricsclient/test_prometheus_client.py
+++ b/tests/required/client/metricsclient/test_prometheus_client.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Iterator, List, Tuple
+from typing import Any, Dict, FrozenSet, Iterator, List, Sequence, Tuple
 import pytest
 from pydantic import ValidationError
 from unittest.mock import patch
@@ -128,6 +128,9 @@ def test_get_model_server_metrics_rejects_wrong_result_type() -> None:
 
         def get_queries(self, duration: float, filters: str) -> List[str]:
             return ["q"]
+
+        def candidate_names(self) -> Sequence[FrozenSet[str]]:
+            return (frozenset({self.metric_name}),)
 
         def parse(self, results: List[float]) -> CounterResult:
             return CounterResult(total=1.0)

--- a/tests/required/client/modelserver/test_openai_client.py
+++ b/tests/required/client/modelserver/test_openai_client.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import FrozenSet, Sequence
+
 import pytest
 import asyncio
 import aiohttp
@@ -309,6 +311,9 @@ def test_openai_metrics_iteration_yields_each_field_once() -> None:
 
         def get_queries(self, duration: float, filters: str) -> list[str]:
             return []
+
+        def candidate_names(self) -> Sequence[FrozenSet[str]]:
+            return (frozenset({self.metric_name}),)
 
         def parse(self, results: list[float]) -> CounterResult:
             return CounterResult()

--- a/tests/required/client/modelserver/test_result_types.py
+++ b/tests/required/client/modelserver/test_result_types.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
+from typing import Any, List
 
 import pytest
 
+from inference_perf.client.modelserver.metrics.base import Metric
 from inference_perf.client.modelserver.metrics import (
     CounterMetric,
     CounterResult,
@@ -103,3 +104,55 @@ def test_gauge_and_histogram_reject_name_selectors() -> None:
     for metric_type in (GaugeMetric, HistogramMetric):
         with pytest.raises(ValueError, match="selector"):
             metric_type(metric_name='{__name__=~"vllm:foo(_total)?"}')
+
+
+def test_candidate_names_are_the_series_each_metric_actually_queries() -> None:
+    # The anti-drift invariant: whatever candidate_names() reports must literally
+    # appear in the metric's own get_queries() output. A gauge "vllm:queue" says
+    # [{"vllm:queue"}] and queries avg_over_time(vllm:queue{...}); a histogram
+    # "vllm:lat" says [{"vllm:lat_bucket","vllm:lat_count","vllm:lat_sum"}] and
+    # queries all three. If someone changes a query builder without changing the
+    # names it advertises, this test is what goes red.
+    #
+    # The `{__name__=~"X(_total)?"}` counter form is deliberately not in this list:
+    # it spells its alternatives as a regex, so "vllm:request_success_total" is
+    # never literally in the query text and containment cannot judge it. Its own
+    # test below pins it instead.
+    metrics: List[Metric[Any]] = [
+        CounterMetric("vllm:prompt_tokens"),
+        GaugeMetric("vllm:num_requests_waiting"),
+        HistogramMetric("vllm:e2e_request_latency_seconds"),
+    ]
+    for metric in metrics:
+        queries = " ".join(metric.get_queries(60.0, "model_name='m'"))
+        advertised = {name for group in metric.candidate_names() for name in group}
+        assert advertised, f"{metric.metric_name} advertises no candidate names"
+        unqueried = sorted(name for name in advertised if name not in queries)
+        assert not unqueried, f"{metric.metric_name} advertises {unqueried} but never queries them"
+
+
+def test_counter_candidate_names_report_a_plain_name_as_selecting_only_itself() -> None:
+    # CounterMetric("vllm:prompt_tokens") builds increase(vllm:prompt_tokens{...}),
+    # with no _total suffix anywhere, so it selects exactly one series. Reporting
+    # the bare name alone is what lets a drift check notice that a server exposing
+    # only vllm:prompt_tokens_total leaves this query matching nothing (#669).
+    assert CounterMetric("vllm:prompt_tokens").candidate_names() == (frozenset({"vllm:prompt_tokens"}),)
+
+
+def test_counter_candidate_names_span_both_forms_for_a_selector_name() -> None:
+    # A `{__name__=~"X(_total)?"}` declaration selects either exact form, so it
+    # reports two single-name groups: satisfying either one resolves the metric.
+    names = CounterMetric('{__name__=~"vllm:request_success(_total)?"}').candidate_names()
+    assert names == (frozenset({"vllm:request_success_total"}), frozenset({"vllm:request_success"}))
+
+
+def test_histogram_candidate_names_require_all_three_series_together() -> None:
+    # HistogramMetric("vllm:lat") queries _sum, _count and _bucket, so all three
+    # go in ONE group: a family exposing _sum and _count but no _bucket is drift,
+    # not a metric that half works.
+    assert HistogramMetric("vllm:lat").candidate_names() == (frozenset({"vllm:lat_bucket", "vllm:lat_count", "vllm:lat_sum"}),)
+
+
+def test_gauge_candidate_names_are_the_bare_name() -> None:
+    # GaugeMetric("vllm:kv_cache_usage_perc") queries the bare name and nothing else.
+    assert GaugeMetric("vllm:kv_cache_usage_perc").candidate_names() == (frozenset({"vllm:kv_cache_usage_perc"}),)


### PR DESCRIPTION
Part of #669 (SGLang/TGI half; the vLLM half is #697). Row in #606: "Metric-name drift, SGLang/TGI (#669)", e2e table, type `live`.

## Why

A stale metric name never errors: the query matches nothing and the field in `summary_prometheus_metrics.json` comes back absent or zero, indistinguishable from a server that did not report it. #382 carries one instance (`sglang:cache_hit_rate` renamed to `sglang:token_usage`), caught by hand.

**This PR found three more.**

`sglang:time_per_output_token_seconds`, declared by `sglang_client.py`, is registered nowhere in SGLang v0.5.17, so every SGLang run emits an empty `time_per_output_token` section. `sglang:inter_token_latency_seconds` is the surviving histogram, so the fix is small; it is deliberately not in this test-only PR, the `KNOWN_UNRESOLVED` entry being its repro.

`vllm:prompt_tokens` and `vllm:generation_tokens` are queried under their bare names while v0.26.0 exposes only the `_total` forms, so `prompt_len` and `output_len` have read 0 against a stock server on any Prometheus. #568 fixes the query side.

## Name resolution now comes from the metrics

Both checks decided whether a declared name resolves by restating the exposition's naming conventions (a counter matches `X` or `X_total`) in the test util, a second copy of what `Metric.get_queries` implements. The copies drifted, which is how the vLLM pair passed #697's check while selecting nothing.

`Metric.candidate_names()` now reports the series a metric's queries select, as groups OR'd with the names in a group AND'd, and both checks ask the metric instead of restating the rules. The utils keep only the series to family/type mapping, which is genuinely fixture-format knowledge, and `is_exposed` collapses to a subset test.

This adds scope: `inference_perf/client/modelserver/metrics/` (one abstract method, three implementations) and #697's `e2e/utils/metric_families.py`. Two test stubs implement the new method.

The two vLLM names go on `KNOWN_UNRESOLVED`, kept apart from `CONDITIONALLY_EXPOSED` (gated off on a stock server) because the reason differs, and guarded by `test_known_unresolved_still_do_not_resolve`, which fails once they resolve. Verified by simulating #568's `CounterMetric`: the guard fires. So this need not stack on #568, and #568 cannot leave a stale entry behind.

## What the tests do

`e2e/tests/test_sglang_tgi_metric_names.py`, five checks over both servers. Serverless: every declared name resolves against `e2e/testdata/server_metric_families/<server>.txt`; each `KNOWN_UNRESOLVED` entry is still declared and unresolved; each fixture states provenance, server, version, source, capture date. Live: the server's families equal the fixture, and declared names exist in a real exposition.

The oracle is the names the server publishes, so provenance lives in the fixture. Both carry `provenance: upstream-source`, derived by reading pinned upstream registration code (SGLang v0.5.17, 144 families; TGI v3.3.7, 27 families), **not verified against a live server**. A source-derived set is a superset of any live exposition, so the family-equality check skips until a live scrape lands.

Supporting: `scripts/capture_server_metric_names.py`, and `.github/workflows/metric_name_drift.yml` (weekly plus dispatch, no `pull_request` trigger, gated on a `METRIC_DRIFT_RUNNER` variable, so it never gates a PR).

## Status

`pdm run validate` clean. `tests/required` plus both drift modules: 666 passed, 13 skipped.

Not verified: fixture contents have never been compared to a live SGLang or TGI (both need an accelerator); the scheduled workflow has never run; live checks need `E2E_SGLANG_BASE_URL` / `E2E_TGI_BASE_URL` and skip without them.
