### PR TITLE
test: bounded termination and outage recovery

### DIFF
--- a/e2e/tests/test_sim_outage_then_recovery.py
+++ b/e2e/tests/test_sim_outage_then_recovery.py
@@ -106,6 +106,9 @@ RELATIVE_TOLERANCE = 1e-6
 _SIM_SUCCESS_RE = re.compile(r"^vllm:request_success(?:_total)?\{.*?\} (\d+)", re.MULTILINE)
 
 
+# One GET of the sim's /metrics. Returns the sum of every vllm:request_success(_total)
+# series (e.g. finish_reason="stop" 9 + finish_reason="length" 6 -> 15), or None if the
+# counter is not on the page yet.
 async def _sim_success_count(session: aiohttp.ClientSession, url: str) -> Optional[int]:
     """Reads the sim's cumulative successful-request count, summed over all
     finish_reason series. Returns None when the counter is absent: the sim
@@ -119,6 +122,9 @@ async def _sim_success_count(session: aiohttp.ClientSession, url: str) -> Option
     return sum(int(count) for count in counts)
 
 
+# Polls that sum every 0.2s until it reaches target (15 here, one full stage) and returns
+# it. Gives up after 120s with one of two messages: counter seen but short of target, or
+# counter never seen at all (no request completed, or the sim renamed the metric).
 async def _wait_for_sim_success_count(
     host: str,
     port: int,
@@ -161,10 +167,13 @@ async def _wait_for_sim_success_count(
             await asyncio.sleep(poll_sec)
 
 
+# end_time - start_time of one per-request record, in seconds.
 def _entry_latency(entry: Dict[str, Any]) -> float:
     return float(entry["end_time"]) - float(entry["start_time"])
 
 
+# Output tokens for one record: server_usage.completion_tokens if present, otherwise the
+# client-side output_tokens, otherwise 0. A failed request has no response_metrics, so 0.
 def _entry_output_tokens(entry: Dict[str, Any]) -> float:
     """Output tokens the report would attribute to this request: the
     server-reported completion_tokens when present, the client count otherwise.
@@ -176,15 +185,19 @@ def _entry_output_tokens(entry: Dict[str, Any]) -> float:
     return float(metrics.get("output_tokens") or 0)
 
 
+# Prompt tokens for one record from request_metrics.text.input_tokens, otherwise 0.
 def _entry_input_tokens(entry: Dict[str, Any]) -> float:
     request_metrics = ((entry.get("info") or {}).get("request_metrics") or {}).get("text") or {}
     return float(request_metrics.get("input_tokens") or 0)
 
 
+# actual must equal expected to within 1e-6 relative; `what` names the aggregate in the message.
 def _assert_close(actual: float, expected: float, what: str) -> None:
     assert actual == pytest.approx(expected, rel=RELATIVE_TOLERANCE), f"{what}: report says {actual}, recomputed {expected}"
 
 
+# The opposite: polluted must NOT equal clean to within 1e-6. Fails when the failed requests
+# would not have moved the number, because then the successes-only check proves nothing.
 def _assert_differs(polluted: float, clean: float, what: str) -> None:
     """The teeth of the successes-only check: if including the failed requests
     made no difference, the check proves nothing about which set was used."""
@@ -193,6 +206,10 @@ def _assert_differs(polluted: float, clean: float, what: str) -> None:
     )
 
 
+# Splits the 45 per-request records into 30 successes and 15 failures, checks no failure
+# carries response_metrics, then checks the summary's mean/max latency and total/mean output
+# and prompt tokens equal the same numbers recomputed from the 30 successes, and that
+# recomputing over all 45 gives different numbers.
 def _assert_aggregates_use_successes_only(summary: Dict[str, Any], per_request: List[Dict[str, Any]]) -> None:
     successes = [entry for entry in per_request if not entry.get("error")]
     failures = [entry for entry in per_request if entry.get("error")]
@@ -242,6 +259,10 @@ def _assert_aggregates_use_successes_only(summary: Dict[str, Any], per_request: 
     )
 
 
+# Three 15-request stages (5/s x 3s) 30s apart. The sim is killed once its /metrics shows
+# stage 0's 15 successes and restarted 52s later, before stage 2. Expects stage reports of
+# 0/15/0 failures and 15/0/15 successes, a 30-success/15-failure summary, 45 per-request
+# records, and summary aggregates that match the 30 successes only.
 @pytest.mark.asyncio
 @pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
 async def test_run_recovers_after_a_midrun_sim_outage():

--- a/e2e/tests/test_sim_outage_then_recovery.py
+++ b/e2e/tests/test_sim_outage_then_recovery.py
@@ -48,7 +48,7 @@ import asyncio
 import logging
 import re
 import statistics
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 import pytest
@@ -81,7 +81,11 @@ STAGE_INTERVAL = 30
 STAGE_OVERHEAD_SEC = 6
 
 # Extra slack before the restart, on top of "stage 1 must be over by now".
-RESTART_MARGIN_SEC = 8
+# The restart has to land inside the interval after stage 1: too early and the
+# revived sim catches the tail of stage 1, too late and stage 2 starts against
+# a dead port. Stage 1 overhead is the only uncertain term, so the margin sits
+# on the early side of the interval's midpoint rather than at its edge.
+RESTART_MARGIN_SEC = 13
 
 # Measured from the moment the kill completes. Stage 1 begins one interval
 # after stage 0 ends and takes duration + overhead, so waiting that out plus
@@ -94,17 +98,25 @@ RESTART_AFTER_KILL_SEC = STAGE_INTERVAL + STAGE_DURATION + STAGE_OVERHEAD_SEC + 
 # recomputed from the per-request records.
 RELATIVE_TOLERANCE = 1e-6
 
-# Regex matching the sim's cumulative successful-request counter. Mirrors the
-# parsing used in test_prometheus.py and test_sim_killed_midrun.py.
-_SIM_SUCCESS_RE = re.compile(r"vllm:request_success(?:_total)?\{.*?\} (\d+)")
+# Regex matching one series of the sim's cumulative successful-request
+# counter. Same metric as test_prometheus.py and test_sim_killed_midrun.py, but
+# summed over every label set below: the sim labels the counter by
+# finish_reason, so reading only the first series would plateau short of the
+# target whenever a stage mixes finish reasons.
+_SIM_SUCCESS_RE = re.compile(r"^vllm:request_success(?:_total)?\{.*?\} (\d+)", re.MULTILINE)
 
 
-async def _sim_success_count(session: aiohttp.ClientSession, url: str) -> int:
-    """Reads the sim's cumulative successful-request count, or 0 if unavailable."""
+async def _sim_success_count(session: aiohttp.ClientSession, url: str) -> Optional[int]:
+    """Reads the sim's cumulative successful-request count, summed over all
+    finish_reason series. Returns None when the counter is absent: the sim
+    only creates the series on the first successful request, so absence is
+    normal until stage 0 starts completing and is only suspicious if it lasts."""
     async with session.get(url) as resp:
         text = await resp.text()
-    match = _SIM_SUCCESS_RE.search(text)
-    return int(match.group(1)) if match else 0
+    counts = _SIM_SUCCESS_RE.findall(text)
+    if not counts:
+        return None
+    return sum(int(count) for count in counts)
 
 
 async def _wait_for_sim_success_count(
@@ -123,17 +135,29 @@ async def _wait_for_sim_success_count(
     url = f"http://{host}:{port}/metrics"
     loop = asyncio.get_event_loop()
     deadline = loop.time() + timeout_sec
+    last_seen: Optional[int] = None
     async with aiohttp.ClientSession() as session:
         while True:
             try:
                 count = await _sim_success_count(session, url)
             except Exception as e:
                 logger.debug(f"polling sim metrics failed: {e}, retrying...")
-                count = 0
-            if count >= target:
-                return count
+                count = None
+            if count is not None:
+                last_seen = count
+                if count >= target:
+                    return count
             if loop.time() > deadline:
-                raise TimeoutError(f"sim did not reach {target} successes within {timeout_sec}s (last={count})")
+                # Two different failures share this timeout: the sim served
+                # the counter but it never reached target, or the counter never
+                # appeared at all, which points at a renamed metric (or a sim
+                # that never answered) rather than at the load.
+                if last_seen is not None:
+                    raise TimeoutError(f"sim did not reach {target} successes within {timeout_sec}s (last={last_seen})")
+                raise TimeoutError(
+                    f"vllm:request_success(_total) never appeared in {url} within {timeout_sec}s: "
+                    "either no request completed or the sim renamed the counter"
+                )
             await asyncio.sleep(poll_sec)
 
 

--- a/e2e/tests/test_sim_outage_then_recovery.py
+++ b/e2e/tests/test_sim_outage_then_recovery.py
@@ -1,0 +1,317 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end test covering a simulator outage that the run recovers from.
+
+The scenario, over three equal stages: stage 0 runs against a live sim and
+succeeds, the sim is killed during the interval that follows, stage 1 runs into
+a dead port and fails outright, a fresh sim is started on the same port during
+the next interval, and stage 2 succeeds against it.
+
+``test_sim_killed_midrun.py`` (#583) already covers the terminal case where the
+sim never comes back. Recovery is the harder half and the one #620 calls out:
+after an outage the run keeps going with reused client state, so stale state
+would show up as failures leaking into the recovered stage, or as a summary
+whose latency and token aggregates were polluted by the requests that failed.
+
+What is asserted:
+
+- failures are confined to the outage stage: stage 0 and stage 2 report zero
+  failures, stage 1 reports nothing but failures;
+- the post-recovery stage really succeeds, at full count, against the restarted
+  sim;
+- the run-wide latency and token aggregates are computed from the successful
+  requests only. Recomputing them from the per-request report is the oracle,
+  and the same numbers recomputed over every request (successes and failures)
+  must differ, so the check cannot pass vacuously.
+
+"Fake the conditions, never the oracle": only the outage is staged, by stopping
+and restarting the real simulator. Every asserted number comes from the
+generated reports, checked against the per-request records the same run
+produced.
+
+Requires `llm-d-inference-sim` in PATH (see test_llm_d_inference_sim.py). If it
+is missing, the test is skipped automatically.
+"""
+
+import asyncio
+import logging
+import re
+import statistics
+from typing import Any, Dict, List
+
+import aiohttp
+import pytest
+
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
+from utils.benchmark import run_benchmark_minimal
+from utils.net import get_free_port
+from utils.testdata import extract_tarball
+
+logger = logging.getLogger(__name__)
+
+TEST_MODEL_NAME = "google/gemma-3-270m"
+TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+
+# Three equal stages: live, dead, live again.
+STAGE_RATE = 5
+STAGE_DURATION = 3
+REQUESTS_PER_STAGE = STAGE_RATE * STAGE_DURATION
+NUM_STAGES = 3
+
+# A long inter-stage interval is what makes the outage line up with stage 1
+# exactly. Both the kill and the restart have to land inside an interval, and
+# the only observable clock the test shares with the benchmark is the sim's own
+# metrics counter, which goes away with the sim.
+STAGE_INTERVAL = 30
+
+# What a stage costs on top of its configured duration: run_stage offsets
+# dispatch by one second, polls for completion at one second granularity, then
+# drains its queue. Rounded well up so a loaded machine still fits.
+STAGE_OVERHEAD_SEC = 6
+
+# Extra slack before the restart, on top of "stage 1 must be over by now".
+RESTART_MARGIN_SEC = 8
+
+# Measured from the moment the kill completes. Stage 1 begins one interval
+# after stage 0 ends and takes duration + overhead, so waiting that out plus
+# the margin puts the restart inside the interval that follows stage 1, with
+# roughly STAGE_INTERVAL - RESTART_MARGIN_SEC still to spare before stage 2
+# begins.
+RESTART_AFTER_KILL_SEC = STAGE_INTERVAL + STAGE_DURATION + STAGE_OVERHEAD_SEC + RESTART_MARGIN_SEC
+
+# Floating point slack when comparing a report aggregate to the same aggregate
+# recomputed from the per-request records.
+RELATIVE_TOLERANCE = 1e-6
+
+# Regex matching the sim's cumulative successful-request counter. Mirrors the
+# parsing used in test_prometheus.py and test_sim_killed_midrun.py.
+_SIM_SUCCESS_RE = re.compile(r"vllm:request_success(?:_total)?\{.*?\} (\d+)")
+
+
+async def _sim_success_count(session: aiohttp.ClientSession, url: str) -> int:
+    """Reads the sim's cumulative successful-request count, or 0 if unavailable."""
+    async with session.get(url) as resp:
+        text = await resp.text()
+    match = _SIM_SUCCESS_RE.search(text)
+    return int(match.group(1)) if match else 0
+
+
+async def _wait_for_sim_success_count(
+    host: str,
+    port: int,
+    target: int,
+    timeout_sec: float = 120,
+    poll_sec: float = 0.2,
+) -> int:
+    """Polls the sim's /metrics endpoint until it reports at least `target`
+    successful requests. Synchronizing on the sim's own counter rather than a
+    fixed sleep is what makes the kill deterministic: stage 0 contains exactly
+    `target` requests, so the counter plateaus there for the whole interval
+    that follows.
+    """
+    url = f"http://{host}:{port}/metrics"
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout_sec
+    async with aiohttp.ClientSession() as session:
+        while True:
+            try:
+                count = await _sim_success_count(session, url)
+            except Exception as e:
+                logger.debug(f"polling sim metrics failed: {e}, retrying...")
+                count = 0
+            if count >= target:
+                return count
+            if loop.time() > deadline:
+                raise TimeoutError(f"sim did not reach {target} successes within {timeout_sec}s (last={count})")
+            await asyncio.sleep(poll_sec)
+
+
+def _entry_latency(entry: Dict[str, Any]) -> float:
+    return float(entry["end_time"]) - float(entry["start_time"])
+
+
+def _entry_output_tokens(entry: Dict[str, Any]) -> float:
+    """Output tokens the report would attribute to this request: the
+    server-reported completion_tokens when present, the client count otherwise.
+    Mirrors summarize_output_token_usage."""
+    metrics = (entry.get("info") or {}).get("response_metrics") or {}
+    usage = metrics.get("server_usage") or {}
+    if usage.get("completion_tokens") is not None:
+        return float(usage["completion_tokens"])
+    return float(metrics.get("output_tokens") or 0)
+
+
+def _entry_input_tokens(entry: Dict[str, Any]) -> float:
+    request_metrics = ((entry.get("info") or {}).get("request_metrics") or {}).get("text") or {}
+    return float(request_metrics.get("input_tokens") or 0)
+
+
+def _assert_close(actual: float, expected: float, what: str) -> None:
+    assert actual == pytest.approx(expected, rel=RELATIVE_TOLERANCE), f"{what}: report says {actual}, recomputed {expected}"
+
+
+def _assert_differs(polluted: float, clean: float, what: str) -> None:
+    """The teeth of the successes-only check: if including the failed requests
+    made no difference, the check proves nothing about which set was used."""
+    assert polluted != pytest.approx(clean, rel=RELATIVE_TOLERANCE), (
+        f"{what}: including failures changes nothing, this assertion cannot detect pollution"
+    )
+
+
+def _assert_aggregates_use_successes_only(summary: Dict[str, Any], per_request: List[Dict[str, Any]]) -> None:
+    successes = [entry for entry in per_request if not entry.get("error")]
+    failures = [entry for entry in per_request if entry.get("error")]
+    assert len(successes) == (NUM_STAGES - 1) * REQUESTS_PER_STAGE
+    assert len(failures) == REQUESTS_PER_STAGE
+
+    # A failed request must not carry response metrics at all: that is the
+    # structural reason its latency and tokens cannot reach the aggregates.
+    for entry in failures:
+        assert not (entry.get("info") or {}).get("response_metrics"), (
+            f"a failed request carries response_metrics: {entry.get('error')}"
+        )
+
+    latencies = [_entry_latency(entry) for entry in successes]
+    _assert_close(
+        summary["successes"]["latency"]["request_latency"]["mean"],
+        statistics.fmean(latencies),
+        "mean request latency",
+    )
+    _assert_close(
+        summary["successes"]["latency"]["request_latency"]["max"],
+        max(latencies),
+        "max request latency",
+    )
+    _assert_differs(
+        statistics.fmean([_entry_latency(entry) for entry in per_request]),
+        statistics.fmean(latencies),
+        "mean request latency",
+    )
+
+    output_tokens = [_entry_output_tokens(entry) for entry in successes]
+    _assert_close(summary["successes"]["output_tokens"]["total"], sum(output_tokens), "total output tokens")
+    _assert_close(summary["successes"]["output_tokens"]["mean"], statistics.fmean(output_tokens), "mean output tokens")
+    _assert_differs(
+        statistics.fmean([_entry_output_tokens(entry) for entry in per_request]),
+        statistics.fmean(output_tokens),
+        "mean output tokens",
+    )
+
+    input_tokens = [_entry_input_tokens(entry) for entry in successes]
+    _assert_close(summary["successes"]["prompt_tokens"]["total"], sum(input_tokens), "total prompt tokens")
+    _assert_close(summary["successes"]["prompt_tokens"]["mean"], statistics.fmean(input_tokens), "mean prompt tokens")
+    _assert_differs(
+        statistics.fmean([_entry_input_tokens(entry) for entry in per_request]),
+        statistics.fmean(input_tokens),
+        "mean prompt tokens",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+async def test_run_recovers_after_a_midrun_sim_outage():
+    """Kills the sim after stage 0, lets stage 1 fail against the dead port,
+    restarts the sim before stage 2, and asserts the failures stayed inside
+    stage 1 while the aggregates stayed clean."""
+    model_name = TEST_MODEL_NAME
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+    port = get_free_port()
+
+    load = {
+        "type": "constant",
+        "interval": STAGE_INTERVAL,
+        "stages": [{"rate": STAGE_RATE, "duration": STAGE_DURATION} for _ in range(NUM_STAGES)],
+        "num_workers": 2,
+    }
+
+    config = {
+        "data": {"type": "mock"},
+        "load": load,
+        "api": {
+            "type": "completion",
+            "streaming": True,
+        },
+        "server": {
+            "type": "vllm",
+            "model_name": model_name,
+            "base_url": f"http://127.0.0.1:{port}",
+            "ignore_eos": True,
+        },
+        "tokenizer": {
+            "pretrained_model_name_or_path": str(model_path),
+        },
+        "report": {
+            "request_lifecycle": {
+                "summary": True,
+                "per_stage": True,
+                "per_request": True,
+            },
+        },
+    }
+
+    first_sim = LLMDInferenceSimRunner(model_name, port=port)
+    await first_sim.__aenter__()
+    second_sim = LLMDInferenceSimRunner(model_name, port=port)
+
+    bench_task = asyncio.create_task(run_benchmark_minimal(config))
+    try:
+        # Stage 0's requests have all succeeded, so the run is in the interval
+        # before stage 1: a safe window to take the sim away.
+        await _wait_for_sim_success_count(first_sim.host, first_sim.port, REQUESTS_PER_STAGE)
+        await first_sim.__aexit__(None, None, None)
+
+        # Nothing is listening now, so there is no counter to synchronize on.
+        # Wait out stage 1 and restart inside the interval that follows it.
+        await asyncio.sleep(RESTART_AFTER_KILL_SEC)
+        await second_sim.__aenter__()
+
+        result = await bench_task
+    finally:
+        # Safety net: both sims dead and the benchmark drained even if the
+        # sequence above raised part way through.
+        for sim in (first_sim, second_sim):
+            if sim._proc is not None and sim._proc.returncode is None:
+                await sim.__aexit__(None, None, None)
+        if not bench_task.done():
+            bench_task.cancel()
+            try:
+                await bench_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    assert result.success, f"Benchmark did not complete cleanly:\n{result.stdout}"
+    assert result.reports, "No reports generated from benchmark"
+
+    # Failures confined to the outage window.
+    expected_failures = {0: 0, 1: REQUESTS_PER_STAGE, 2: 0}
+    for stage_id, failures in expected_failures.items():
+        stage_report = result.reports.get(f"stage_{stage_id}_lifecycle_metrics.json")
+        assert stage_report, f"Missing report for stage {stage_id}"
+        assert stage_report["failures"]["count"] == failures, (
+            f"stage {stage_id} reported {stage_report['failures']['count']} failures, expected {failures}. "
+            "If stage 1 is not the only failing stage, the outage window drifted off the stage boundaries."
+        )
+        assert stage_report["successes"]["count"] == REQUESTS_PER_STAGE - failures, (
+            f"stage {stage_id} reported {stage_report['successes']['count']} successes, "
+            f"expected {REQUESTS_PER_STAGE - failures}"
+        )
+
+    summary_report = result.reports["summary_lifecycle_metrics.json"]
+    assert summary_report["successes"]["count"] == (NUM_STAGES - 1) * REQUESTS_PER_STAGE
+    assert summary_report["failures"]["count"] == REQUESTS_PER_STAGE
+
+    per_request = result.reports["per_request_lifecycle_metrics.json"]
+    assert len(per_request) == NUM_STAGES * REQUESTS_PER_STAGE, "Unexpected number of requests in report"
+
+    _assert_aggregates_use_successes_only(summary_report, per_request)

--- a/tests/required/integration/test_dead_server_termination.py
+++ b/tests/required/integration/test_dead_server_termination.py
@@ -114,6 +114,8 @@ EXPECTED_REPORTS = (
 )
 
 
+# Stands in for the HuggingFace tokenizer so building the client needs no Hub download.
+# count_tokens("a b c") -> 3; nothing in these tests actually calls it.
 class _StubTokenizer(CustomTokenizer):
     """Stands in for the HuggingFace-backed tokenizer the client builds in
     __init__, which would otherwise fetch from the Hub.
@@ -132,6 +134,8 @@ class _StubTokenizer(CustomTokenizer):
         return len(text.split()) if text else 0
 
 
+# A real vLLMModelServerClient at uri: non-streaming completion API, 2 TCP connections,
+# request_timeout=2.0s, with the stub tokenizer patched in for the constructor only.
 def _build_client(uri: str, collector: MultiprocessRequestMetricCollector) -> vLLMModelServerClient:
     api_config = APIConfig(type=APIType.Completion, streaming=False)
     with patch.object(openai_client_module, "CustomTokenizer", return_value=_StubTokenizer()):
@@ -147,6 +151,8 @@ def _build_client(uri: str, collector: MultiprocessRequestMetricCollector) -> vL
         )
 
 
+# The Config the ReportGenerator reads: one constant stage of 4 requests over 1s, 2 workers,
+# request_timeout=2.0s, all three request-lifecycle reports switched on.
 def _build_config() -> Config:
     """The config object the ReportGenerator reads. Its report section asks for
     all three request-lifecycle reports, which is what the run must still
@@ -172,6 +178,9 @@ def _build_config() -> Config:
     )
 
 
+# Joins each worker against a shared 15s budget and returns their exit codes: 0 = clean,
+# None = still running, negative = killed by a signal. Runs before LoadGenerator.stop() so a
+# wedged worker is reported rather than terminated away.
 def _await_worker_exits(load_gen: LoadGenerator) -> List[Optional[int]]:
     """Give every worker ``WORKER_EXIT_GRACE_SEC`` in total to exit by itself and
     report the exit codes.
@@ -186,6 +195,9 @@ def _await_worker_exits(load_gen: LoadGenerator) -> List[Optional[int]]:
     return [worker.exitcode for worker in load_gen.workers]
 
 
+# Runs one full stage (4 requests, 2 workers, 2s timeout) at uri under a 60s wait_for, then
+# generates the reports. Returns (elapsed seconds, the 4 recorded metrics,
+# {report name: contents}, worker exit codes).
 async def _run_against(uri: str) -> Tuple[float, List[RequestLifecycleMetric], Dict[str, Any], List[Optional[int]]]:
     """Drive one full stage at ``uri`` and return
 
@@ -222,6 +234,8 @@ async def _run_against(uri: str) -> Tuple[float, List[RequestLifecycleMetric], D
     return elapsed, collector.get_metrics(), reports, worker_exitcodes
 
 
+# Exactly 4 metrics, each with an error and no response_metrics. Returns the sorted distinct
+# error_type names, e.g. ["ClientConnectorError"].
 def _assert_every_request_failed(metrics: List[RequestLifecycleMetric]) -> List[str]:
     """Every request must carry an error, and none may look like a success.
     Returns the distinct error types seen."""
@@ -242,6 +256,8 @@ def _assert_every_request_failed(metrics: List[RequestLifecycleMetric]) -> List[
     return sorted(error_types)
 
 
+# summary, stage_0 and per_request reports all present; per_request has 4 entries, all with
+# an error; summary and stage_0 both say successes=0 and failures=4.
 def _assert_reports_are_complete(reports: Dict[str, Any]) -> None:
     """All three request-lifecycle reports exist, and both summaries agree that
     nothing succeeded and everything failed."""
@@ -260,6 +276,7 @@ def _assert_reports_are_complete(reports: Dict[str, Any]) -> None:
         )
 
 
+# Exactly 2 exit codes and every one is 0: no worker was still running or had to be signalled.
 def _assert_no_worker_wedged(worker_exitcodes: List[Optional[int]]) -> None:
     """Every worker exited on its own, cleanly.
 
@@ -273,6 +290,9 @@ def _assert_no_worker_wedged(worker_exitcodes: List[Optional[int]]) -> None:
     )
 
 
+# 4 requests at a port with no listener. The run ends in under 60s (a few seconds in
+# practice), all 4 fail with error_type ClientConnectorError only (never TimeoutError), the
+# three reports say 0 successes / 4 failures, and both workers exit 0.
 @pytest.mark.asyncio
 async def test_run_terminates_when_nothing_is_listening() -> None:
     """Case (a): the endpoint's port has no listener, so every connect is
@@ -290,6 +310,9 @@ async def test_run_terminates_when_nothing_is_listening() -> None:
     _assert_no_worker_wedged(worker_exitcodes)
 
 
+# No load, no server. A client built with request_timeout=2.0 must show
+# session.timeout.total == 2.0; one built with no request_timeout must show
+# aiohttp.client.DEFAULT_TIMEOUT (300s total).
 @pytest.mark.asyncio
 async def test_configured_request_timeout_reaches_the_aiohttp_session() -> None:
     """The wiring the unresponsive-server case rests on: ``request_timeout``
@@ -334,6 +357,9 @@ async def test_configured_request_timeout_reaches_the_aiohttp_session() -> None:
         await default_session.close()
 
 
+# 4 requests at a listener that accepts and never answers. The run ends in under 60s, all 4
+# fail with error_type TimeoutError only, the fake accepted between 1 and 4 connections (no
+# retries), the three reports say 0 successes / 4 failures, and both workers exit 0.
 @pytest.mark.asyncio
 async def test_run_terminates_when_the_server_never_responds() -> None:
     """Case (b): the endpoint accepts the connection and never answers. Only

--- a/tests/required/integration/test_dead_server_termination.py
+++ b/tests/required/integration/test_dead_server_termination.py
@@ -1,0 +1,356 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bounded termination against a dead endpoint (#620, #606 Integration tier).
+
+Two ways an endpoint can be dead, both driven through the real client, the real
+worker processes and the real report generator:
+
+1. nothing listening on the port, so every connect is refused at the transport
+   layer;
+2. a listener that accepts the connection and never writes a response byte, so
+   only the client's own timeout can end the request.
+
+What is asserted in both cases: the run terminates in bounded time, no request
+is retried, every request lands in the reports as a failure, all three
+request-lifecycle reports are still produced, and no worker process is left
+alive holding a half-open connection.
+
+Why it is worth asserting: nothing in the suite today checks that the client
+times out at all. ``LoadConfig.request_timeout`` defaults to ``None``, which
+means ``openAIModelServerClientSession`` passes ``aiohttp.helpers.sentinel``
+instead of a ``ClientTimeout``, so an unresponsive server is bounded only by
+aiohttp's own default. ``LoadGenerator.mp_run`` calls ``run_stage`` without a
+timeout argument, so its "wait until all requests are finished" loop has no
+deadline of its own: if a request never completes, the stage never ends. The
+client timeout is the only thing standing between an unresponsive server and a
+run that never returns, and that is what these tests pin down.
+
+Both tests configure a small explicit ``request_timeout`` so they run fast. The
+bound they assert (``RUN_BOUND_SEC``) sits far above the configured timeout and
+far below aiohttp's default total timeout, so a regression that drops the
+configured timeout on the floor fails the bound rather than passing slowly.
+
+Note on scope: the hang in #469 is a barrier futex in the process machinery and
+is unrelated to the client-side timeout path exercised here.
+
+"Fake the conditions, never the oracle": the fakes supply only the failure
+condition (a closed port, a silent listener). Every asserted value comes from
+the production path, either the metrics the real client recorded or the reports
+the real ``ReportGenerator`` produced.
+"""
+
+import asyncio
+import time
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import aiohttp.client
+import pytest
+
+from unresponsive_server import UnresponsiveServer, reserve_unbound_port
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.vllm_client import vLLMModelServerClient
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    Config,
+    DataConfig,
+    DataGenType,
+    LoadConfig,
+    LoadType,
+    ReportConfig,
+    RequestLifecycleMetricsReportConfig,
+    StandardLoadStage,
+)
+from inference_perf.datagen import MockDataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
+from inference_perf.reportgen.base import ReportGenerator
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+# One stage of REQUESTS requests, dispatched at REQUESTS per second.
+REQUESTS = 4
+NUM_WORKERS = 2
+
+# Small enough that an unresponsive server is abandoned quickly, large enough
+# that a loaded CI machine does not trip it on a connect that would have
+# succeeded.
+REQUEST_TIMEOUT_SEC = 2.0
+
+# The bounded-termination oracle. run_stage adds a one second dispatch offset
+# and polls at one second granularity, so a correct run costs roughly
+# REQUEST_TIMEOUT_SEC plus a few seconds of scheduling. Anything near
+# aiohttp's five minute default total timeout, or an unbounded wait, blows
+# through this.
+RUN_BOUND_SEC = 60.0
+
+# How long a worker gets to notice the stop signal and exit on its own once the
+# run is over. A worker still wedged on a socket does not come back at all, so
+# the exact value only has to be comfortably longer than a clean shutdown.
+WORKER_EXIT_GRACE_SEC = 15.0
+
+# Guard against the assertions passing on a run that never sent anything.
+MIN_EXPECTED_ERROR_TYPES = 1
+
+EXPECTED_REPORTS = (
+    "summary_lifecycle_metrics",
+    "stage_0_lifecycle_metrics",
+    "per_request_lifecycle_metrics",
+)
+
+
+class _StubTokenizer(CustomTokenizer):
+    """Stands in for the HuggingFace-backed tokenizer the client builds in
+    __init__, which would otherwise fetch from the Hub.
+
+    Nothing here is ever called: on a pure transport failure the client never
+    reaches ``process_failure`` bodies that tokenize, and
+    ``CompletionAPIData.process_failure`` is a no-op. It is a module-level
+    class rather than a Mock because the client is pickled into the worker
+    processes under the forkserver start method.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
+        return len(text.split()) if text else 0
+
+
+def _build_client(uri: str, collector: MultiprocessRequestMetricCollector) -> vLLMModelServerClient:
+    api_config = APIConfig(type=APIType.Completion, streaming=False)
+    with patch.object(openai_client_module, "CustomTokenizer", return_value=_StubTokenizer()):
+        return vLLMModelServerClient(
+            metrics_collector=collector,
+            api_config=api_config,
+            uri=uri,
+            model_name="dead-server-model",
+            tokenizer_config=None,
+            max_tcp_connections=NUM_WORKERS,
+            additional_filters=[],
+            timeout=REQUEST_TIMEOUT_SEC,
+        )
+
+
+def _build_config() -> Config:
+    """The config object the ReportGenerator reads. Its report section asks for
+    all three request-lifecycle reports, which is what the run must still
+    produce with zero successful requests."""
+    return Config(
+        api=APIConfig(type=APIType.Completion, streaming=False),
+        data=DataConfig(type=DataGenType.Mock),
+        load=LoadConfig(
+            type=LoadType.CONSTANT,
+            interval=0,
+            num_workers=NUM_WORKERS,
+            worker_max_concurrency=REQUESTS,
+            request_timeout=REQUEST_TIMEOUT_SEC,
+            stages=[StandardLoadStage(rate=REQUESTS, duration=1)],
+        ),
+        report=ReportConfig(
+            request_lifecycle=RequestLifecycleMetricsReportConfig(
+                summary=True,
+                per_stage=True,
+                per_request=True,
+            )
+        ),
+    )
+
+
+def _await_worker_exits(load_gen: LoadGenerator) -> List[Optional[int]]:
+    """Give every worker ``WORKER_EXIT_GRACE_SEC`` in total to exit by itself and
+    report the exit codes.
+
+    Deliberately done before ``LoadGenerator.stop()``, which escalates to
+    ``terminate()``: a worker that only dies on SIGTERM is exactly the wedged
+    worker this is looking for, and stop() would hide it.
+    """
+    deadline = time.monotonic() + WORKER_EXIT_GRACE_SEC
+    for worker in load_gen.workers:
+        worker.join(timeout=max(0.0, deadline - time.monotonic()))
+    return [worker.exitcode for worker in load_gen.workers]
+
+
+async def _run_against(uri: str) -> Tuple[float, List[RequestLifecycleMetric], Dict[str, Any], List[Optional[int]]]:
+    """Drive one full stage at ``uri`` and return
+
+    (elapsed seconds, recorded metrics, {report name: contents}, worker exit codes).
+
+    The whole run is wrapped in ``asyncio.wait_for`` so a client that never
+    gives up surfaces as a test failure instead of a hung suite.
+    """
+    config = _build_config()
+    collector = MultiprocessRequestMetricCollector()
+    client = _build_client(uri, collector)
+    datagen = MockDataGenerator(config.api, config.data, None)
+    load_gen = LoadGenerator(datagen, config.load)
+
+    start = time.perf_counter()
+    try:
+        async with collector.start():
+            await asyncio.wait_for(load_gen.mp_run(client), timeout=RUN_BOUND_SEC)
+        elapsed = time.perf_counter() - start
+        worker_exitcodes = _await_worker_exits(load_gen)
+    finally:
+        await load_gen.stop()
+
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=start,
+        duration=elapsed,
+        model_server_metrics=BaseMetrics(),
+        stages=load_gen.stage_runtime_info,
+    )
+    reportgen = ReportGenerator(metrics_client=None, metrics_collector=collector, config=config)
+    report_files = await reportgen.generate_reports(config.report, runtime_parameters)
+    reports = {report.name: report.contents for report in report_files}
+
+    return elapsed, collector.get_metrics(), reports, worker_exitcodes
+
+
+def _assert_every_request_failed(metrics: List[RequestLifecycleMetric]) -> List[str]:
+    """Every request must carry an error, and none may look like a success.
+    Returns the distinct error types seen."""
+    assert len(metrics) == REQUESTS, f"expected {REQUESTS} recorded requests, got {len(metrics)}"
+
+    error_types = set()
+    for metric in metrics:
+        assert metric.error is not None, "a request against a dead endpoint was recorded without an error"
+        error_types.add(metric.error.error_type)
+        # A failed request must not carry response metrics: those feed the
+        # latency and token aggregates, which must be computed from successful
+        # requests only.
+        assert metric.info is None or metric.info.response_metrics is None, (
+            f"failed request carries response_metrics: {metric.info}"
+        )
+
+    assert len(error_types) >= MIN_EXPECTED_ERROR_TYPES, "no error types recorded, the run sent nothing"
+    return sorted(error_types)
+
+
+def _assert_reports_are_complete(reports: Dict[str, Any]) -> None:
+    """All three request-lifecycle reports exist, and both summaries agree that
+    nothing succeeded and everything failed."""
+    for name in EXPECTED_REPORTS:
+        assert name in reports, f"missing {name}, have {sorted(reports)}"
+
+    per_request = reports["per_request_lifecycle_metrics"]
+    assert len(per_request) == REQUESTS, f"per-request report has {len(per_request)} entries, expected {REQUESTS}"
+    assert all(entry["error"] for entry in per_request), "per-request report shows a request without an error"
+
+    for name in ("summary_lifecycle_metrics", "stage_0_lifecycle_metrics"):
+        summary = reports[name]
+        assert summary["successes"]["count"] == 0, f"{name} reports a success against a dead endpoint"
+        assert summary["failures"]["count"] == REQUESTS, (
+            f"{name} reports {summary['failures']['count']} failures, expected {REQUESTS}"
+        )
+
+
+def _assert_no_worker_wedged(worker_exitcodes: List[Optional[int]]) -> None:
+    """Every worker exited on its own, cleanly.
+
+    ``None`` means the process was still running when the grace period ran out,
+    a negative code means it had to be signalled: both are a worker that the
+    dead endpoint left holding a connection it could not let go of.
+    """
+    assert len(worker_exitcodes) == NUM_WORKERS, f"expected {NUM_WORKERS} workers, saw {len(worker_exitcodes)}"
+    assert all(code == 0 for code in worker_exitcodes), (
+        f"workers did not exit cleanly on their own, exit codes: {worker_exitcodes}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_terminates_when_nothing_is_listening() -> None:
+    """Case (a): the endpoint's port has no listener, so every connect is
+    refused. The run must end quickly with N failures and complete reports."""
+    port = reserve_unbound_port()
+    elapsed, metrics, reports, worker_exitcodes = await _run_against(f"http://127.0.0.1:{port}")
+
+    assert elapsed < RUN_BOUND_SEC, f"run took {elapsed:.1f}s against a closed port"
+    error_types = _assert_every_request_failed(metrics)
+    # A refused connect is an aiohttp connector error, never a timeout: if the
+    # client is waiting out the timeout on a connection that was refused
+    # immediately, that is a bug worth catching here.
+    assert error_types == ["ClientConnectorError"], f"unexpected error types on a refused connect: {error_types}"
+    _assert_reports_are_complete(reports)
+    _assert_no_worker_wedged(worker_exitcodes)
+
+
+@pytest.mark.asyncio
+async def test_configured_request_timeout_reaches_the_aiohttp_session() -> None:
+    """The wiring the unresponsive-server case rests on: ``request_timeout``
+    from the load config has to arrive at the aiohttp session as a total
+    timeout, and with nothing configured the client applies none of its own.
+
+    The second half is not a bug report, it is the documented default: with
+    ``request_timeout`` unset the only bound on a request to a server that
+    never answers is aiohttp's own default, which is two orders of magnitude
+    longer than any timeout a benchmark would choose. Pinning it here means a
+    change to that default is visible rather than silent.
+    """
+    collector = MultiprocessRequestMetricCollector()
+
+    configured = _build_client("http://127.0.0.1:1", collector)
+    session = configured.new_session()
+    try:
+        assert isinstance(session, openai_client_module.openAIModelServerClientSession)
+        assert session.session.timeout.total == REQUEST_TIMEOUT_SEC, (
+            f"configured request_timeout did not reach the session: {session.session.timeout}"
+        )
+    finally:
+        await session.close()
+
+    with patch.object(openai_client_module, "CustomTokenizer", return_value=_StubTokenizer()):
+        unconfigured = vLLMModelServerClient(
+            metrics_collector=collector,
+            api_config=APIConfig(type=APIType.Completion, streaming=False),
+            uri="http://127.0.0.1:1",
+            model_name="dead-server-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+    default_session = unconfigured.new_session()
+    try:
+        assert isinstance(default_session, openai_client_module.openAIModelServerClientSession)
+        assert default_session.session.timeout == aiohttp.client.DEFAULT_TIMEOUT, (
+            f"with no request_timeout the client must fall through to aiohttp's default, got {default_session.session.timeout}"
+        )
+    finally:
+        await default_session.close()
+
+
+@pytest.mark.asyncio
+async def test_run_terminates_when_the_server_never_responds() -> None:
+    """Case (b): the endpoint accepts the connection and never answers. Only
+    the configured client timeout can end these requests, so this is the test
+    that fails if the timeout is not applied."""
+    async with UnresponsiveServer() as server:
+        elapsed, metrics, reports, worker_exitcodes = await _run_against(server.base_url)
+        connections = server.connections
+
+    assert elapsed < RUN_BOUND_SEC, f"run took {elapsed:.1f}s against an unresponsive server"
+    error_types = _assert_every_request_failed(metrics)
+    assert error_types == ["TimeoutError"], f"unresponsive server produced {error_types}, expected the client timeout"
+
+    # No retry loop: each request may open at most one connection, and aiohttp
+    # is free to reuse one, so more accepted connections than requests means
+    # something dialed again after giving up.
+    assert 0 < connections <= REQUESTS, f"fake server accepted {connections} connections for {REQUESTS} requests"
+
+    _assert_reports_are_complete(reports)
+    _assert_no_worker_wedged(worker_exitcodes)

--- a/tests/required/integration/unresponsive_server.py
+++ b/tests/required/integration/unresponsive_server.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Two ways for a model server endpoint to be dead, as controllable fakes.
+
+``UnresponsiveServer`` is the "hang instead of crash" condition from #620: the
+TCP handshake completes, the request bytes are accepted, and not one response
+byte is ever written back. Nothing on the server side will ever end such a
+request, so only the client's own timeout can, which is what makes it the right
+fake for asserting that the timeout exists.
+
+``reserve_unbound_port`` is the complementary condition: a port that is
+guaranteed to have been free, with nothing listening on it, so every connect
+attempt is refused at the transport layer.
+
+Deliberately minimal: no HTTP parsing, no aiohttp, no response shaping. The
+fake supplies the failure condition, the assertions come from the real client
+and the real reports.
+"""
+
+import asyncio
+import socket
+from types import TracebackType
+from typing import List, Optional, Type
+
+
+def reserve_unbound_port(host: str = "127.0.0.1") -> int:
+    """Return a TCP port that had nothing listening on it a moment ago.
+
+    Binds an ephemeral port, reads the number the OS assigned, then closes the
+    socket so the port is free again. There is an inherent race: between the
+    close and the moment the test connects, something else on the machine could
+    claim the same port. The window is tiny and the OS does not immediately
+    recycle ephemeral ports, so in practice a connect to this port is refused.
+    This is the same tradeoff ``e2e/utils/net.py:get_free_port`` documents; it
+    is repeated here rather than imported because ``e2e/utils`` is only on the
+    import path for the e2e tier.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, 0))
+        port: int = sock.getsockname()[1]
+    return port
+
+
+class UnresponsiveServer:
+    """Accepts TCP connections, reads whatever arrives, never writes a byte.
+
+    Counting accepted connections is what lets a caller tell a single timed-out
+    attempt apart from a retry loop: N requests that each connect once produce
+    at most N connections, while a client that retries on timeout produces more.
+    """
+
+    def __init__(self, host: str = "127.0.0.1") -> None:
+        self.host = host
+        self.port = 0
+        self.connections = 0
+        self._server: Optional[asyncio.AbstractServer] = None
+        self._writers: List[asyncio.StreamWriter] = []
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        self.connections += 1
+        self._writers.append(writer)
+        try:
+            # Keep draining so the client's send never blocks on a full receive
+            # buffer, and so this coroutine parks until the peer goes away.
+            # read() returns b"" at EOF, which is the only way out.
+            while await reader.read(4096):
+                pass
+        except (ConnectionResetError, asyncio.CancelledError):
+            pass
+
+    async def __aenter__(self) -> "UnresponsiveServer":
+        self._server = await asyncio.start_server(self._handle, self.host, 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        for writer in self._writers:
+            try:
+                writer.close()
+            except Exception:  # noqa: BLE001 - teardown must not mask the test's own failure
+                pass
+        self._writers.clear()
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None

--- a/tests/required/integration/unresponsive_server.py
+++ b/tests/required/integration/unresponsive_server.py
@@ -34,6 +34,8 @@ from types import TracebackType
 from typing import List, Optional, Type
 
 
+# Returns a port number (e.g. 41234) that was free a moment ago and has nothing listening
+# on it, so a connect to 127.0.0.1:<port> is refused.
 def reserve_unbound_port(host: str = "127.0.0.1") -> int:
     """Return a TCP port that had nothing listening on it a moment ago.
 
@@ -53,6 +55,9 @@ def reserve_unbound_port(host: str = "127.0.0.1") -> int:
     return port
 
 
+# async-with fake: listens on an ephemeral 127.0.0.1 port, accepts every connection, reads
+# and discards whatever arrives, never writes a byte back. .connections counts accepts,
+# .base_url is http://127.0.0.1:<port>.
 class UnresponsiveServer:
     """Accepts TCP connections, reads whatever arrives, never writes a byte.
 
@@ -72,6 +77,7 @@ class UnresponsiveServer:
     def base_url(self) -> str:
         return f"http://{self.host}:{self.port}"
 
+    # Per-connection handler: bumps .connections, then drains the socket until the peer closes.
     async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         self.connections += 1
         self._writers.append(writer)
@@ -84,11 +90,13 @@ class UnresponsiveServer:
         except (ConnectionResetError, asyncio.CancelledError):
             pass
 
+    # Starts listening on port 0 and records the port the OS assigned.
     async def __aenter__(self) -> "UnresponsiveServer":
         self._server = await asyncio.start_server(self._handle, self.host, 0)
         self.port = self._server.sockets[0].getsockname()[1]
         return self
 
+    # Closes every accepted connection, then the listener.
     async def __aexit__(
         self,
         exc_type: Optional[Type[BaseException]],


### PR DESCRIPTION
Part of #620 (closed, consolidated into #606). Asserts that a run against a dead endpoint ends in bounded time with every request recorded as a failure and all three lifecycle reports written, and that a run whose simulator dies and returns keeps failures inside the outage stage and its aggregates clean.

Rows in #606: Integration / "Bounded termination (#620)"; e2e sim / "Outage then recovery (#620)".

## Why this is needed

Nothing in the suite asserts the client times out. `LoadConfig.request_timeout` defaults to `None` (the session then gets `aiohttp.helpers.sentinel`, not a `ClientTimeout`), and `mp_run` calls `run_stage` with no timeout, so nothing else bounds a stage; the client timeout is the only thing between an unresponsive server and a run that never returns. On the sim side, #583 covers a terminal outage but not recovery, where reused client state across a stage boundary would silently corrupt later stages.

## What each file tests

Three files, four tests. Integration cases run the real client, workers and `ReportGenerator`; only the failure is faked. `tests/required/integration/` is new, also created by #694 and #712 with different files.

**`tests/required/integration/test_dead_server_termination.py`**

- `test_run_terminates_when_nothing_is_listening`
  - Setup: ephemeral port bound, read and closed; every connect refused.
  - Asserts: run finishes inside `RUN_BOUND_SEC`; all N requests are failures with no response metrics; all three lifecycle reports show 0 successes and N failures; every worker exits 0 before `LoadGenerator.stop()` escalates to SIGTERM.
- `test_run_terminates_when_the_server_never_responds`
  - Setup: the `unresponsive_server.py` fake accepts, drains the request, writes nothing back, so only the client timeout can end it.
  - Asserts: same as above, plus accepted-connection count equals N (no retries).
- `test_configured_request_timeout_reaches_the_aiohttp_session`
  - Setup: no load run; builds a client with `request_timeout` set, then unset.
  - Asserts: set reaches aiohttp as a total `ClientTimeout`; unset falls through to `aiohttp.client.DEFAULT_TIMEOUT`.

**`tests/required/integration/unresponsive_server.py`**

- Helper, no tests: `reserve_unbound_port()` and the `asyncio.start_server` fake used by the two tests above.

**`e2e/tests/test_sim_outage_then_recovery.py`**

- `test_run_recovers_after_a_midrun_sim_outage`
  - Setup: #583 harness pattern, three equal stages; sim killed after stage 0 (synchronized on its own `vllm:request_success` counter, so deterministic), stage 1 into the dead port, fresh `LLMDInferenceSimRunner` on the same port before stage 2.
  - Asserts: failures confined to stage 1; stage 2 succeeds at full count; run-wide latency and token aggregates equal the same aggregates recomputed from successful per-request records only, and differ with failures included.

## Status

Based on `upstream/main` at 7bfbaed.

**No product gap on the Integration row.** All five assertions hold on main once an explicit `request_timeout` is configured, so nothing is `xfail`. Reviewer note: with it unset, a server that accepts and never answers is bounded only by aiohttp's `DEFAULT_TIMEOUT`, 300 seconds per request. Pinned by a test, not changed here.

Verified locally: `pdm run validate` clean; the three integration tests pass under forkserver and fork; `pdm run test` 891 passed, 16 skipped. CI green, e2e job included (`test_run_recovers_after_a_midrun_sim_outage` passed).

Timing most needs review: with the sim gone there is no counter to synchronize on, so the restart is a fixed wait (interval plus stage duration plus margin, documented at the top of the file); if it drifts into the wrong stage the per-stage assertion says so.

