### PR TITLE
[PENDING: #694] test: worker count matrix and collector equivalence

### DIFF
--- a/e2e/tests/test_worker_matrix_smoke.py
+++ b/e2e/tests/test_worker_matrix_smoke.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sim-backed worker-matrix smoke test (#632, #606 e2e tier).
+
+One multi-stage run at a pinned worker count against llm-d-inference-sim, with
+the token-accounting helpers from ``utils/accuracy.py`` attached.
+
+Why it exists: the Integration matrix in
+``tests/required/integration/test_worker_matrix.py`` drives the same worker
+architecture against an in-process fake server. That is faster and more
+controllable, but it is only worth trusting if a real server agrees. This test
+is the cross-check on the two properties the fake is least able to vouch for,
+because both are about the worker processes rather than about the HTTP
+exchange:
+
+- worker teardown: the CLI must exit 0 with every worker joined, rather than
+  leaving a daemon child behind or hanging on the stage barrier at the end of a
+  multi-stage run (#469)
+- the liveness check: ``run_stage`` polls ``Worker.is_alive()`` and aborts the
+  stage if a worker died. It must never fire on a healthy run, or the matrix
+  is measuring an aborted stage and calling it a pass (#593)
+
+Ground truth is the sim's own ``usage`` accounting: ``ignore_eos`` plus a
+degenerate output distribution pins exactly ``OUTPUT_TOKENS`` generated tokens
+per request, and the sim streams one token per chunk, so both are asserted
+exactly. The condition (server timing, worker count, stage layout) is
+configured; the oracle (the server's token counts) is not.
+
+Client-side re-tokenization is deliberately NOT held to zero tolerance here.
+The sim generates from a word bank and the pinned gemma tokenizer re-splits
+some of those words, so the client count legitimately runs a token or two above
+the server's (measured 0 to 2 over this fixture). Exact client/server agreement
+needs a server whose text is built from known token ids, which is what #631's
+golden sim and #627's real vLLM provide; asserting it here would be pinning the
+tokenizer, not the worker matrix.
+
+Retired once the Integration fake has proved out, per the #606 row.
+"""
+
+import pytest
+
+from utils.accuracy import (
+    assert_output_token_accounting,
+    assert_streaming_bookkeeping,
+    assert_successful_run,
+    server_completion_tokens,
+    ttft,
+)
+from utils.benchmark import run_benchmark_minimal
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
+from utils.net import get_free_port
+from utils.testdata import extract_tarball
+
+TEST_MODEL_NAME = "google/gemma-3-270m"
+TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+
+# Pinned, not inherited from cpu_count(). The default num_workers is
+# max(1, cpu_count()), so an unpinned run tests whichever cell the runner
+# happens to have; N > 1 is the cell that exercises work distribution across
+# workers on top of the multiprocessing machinery itself.
+PINNED_N = 4
+
+RATE = 4
+DURATION = 3
+NUM_STAGES = 2
+REQUESTS_PER_STAGE = RATE * DURATION
+EXPECTED_REQUESTS = REQUESTS_PER_STAGE * NUM_STAGES
+
+# Deterministic server timing, std-dev 0, so the sim sleeps at least these
+# durations and TTFT has a hard floor.
+TTFT_SEC = 0.2
+ITL_SEC = 0.05
+OUTPUT_TOKENS = 8
+
+# Slack on the client's re-tokenization of the sim's word bank (see the module
+# docstring). Loose on purpose: it is a sanity bound, not the token oracle.
+CLIENT_RETOKENIZATION_SLACK = 3
+
+# The liveness check in run_stage. If this appears, a worker died and the stage
+# was cut short, so every count below would be measuring an aborted run.
+WORKER_DEATH_LOG = "A worker process died unexpectedly!"
+
+
+def _exact_length_distribution(tokens: int) -> dict:
+    """A degenerate length distribution: every request gets exactly `tokens`."""
+    return {"min": tokens, "max": tokens, "mean": tokens, "std_dev": 0, "total_count": 100}
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+async def test_multi_stage_run_at_pinned_worker_count():
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+
+    async with LLMDInferenceSimRunner(
+        TEST_MODEL_NAME,
+        *("--time-to-first-token", str(int(TTFT_SEC * 1000))),
+        *("--inter-token-latency", str(int(ITL_SEC * 1000))),
+        *("--time-to-first-token-std-dev", "0"),
+        *("--inter-token-latency-std-dev", "0"),
+        # PINNED_N workers each dispatch concurrently; the default
+        # max-num-seqs of 5 would queue them and inflate TTFT past its floor.
+        *("--max-num-seqs", "64"),
+        *("--seed", "42"),
+        port=get_free_port(),
+    ) as sim:
+        result = await run_benchmark_minimal(
+            {
+                "api": {"type": "completion", "streaming": True},
+                "data": {
+                    "type": "random",
+                    "input_distribution": _exact_length_distribution(8),
+                    "output_distribution": _exact_length_distribution(OUTPUT_TOKENS),
+                },
+                "load": {
+                    "type": "constant",
+                    "interval": 1,
+                    "stages": [{"rate": RATE, "duration": DURATION} for _ in range(NUM_STAGES)],
+                    "num_workers": PINNED_N,
+                },
+                "server": {
+                    "type": "vllm",
+                    "model_name": TEST_MODEL_NAME,
+                    "base_url": f"http://{sim.host}:{sim.port}",
+                    "ignore_eos": True,
+                },
+                "tokenizer": {"pretrained_model_name_or_path": str(model_path)},
+                "report": {
+                    "request_lifecycle": {
+                        "summary": True,
+                        "per_stage": True,
+                        "per_request": True,
+                    },
+                },
+            },
+            timeout_sec=240,
+        )
+
+    # Clean teardown: a run that leaves a worker wedged on the stage barrier
+    # times out here rather than returning a non-zero code, and either way the
+    # helper refuses the report.
+    entries = assert_successful_run(result, EXPECTED_REQUESTS)
+    assert WORKER_DEATH_LOG not in result.stdout, (
+        f"the worker liveness check fired, so at least one stage was aborted:\n{result.stdout}"
+    )
+
+    # Both stages ran and both carried their own load. A stage-barrier
+    # regression shows up here as a missing stage report or an empty one, well
+    # before it shows up as a wrong aggregate.
+    for stage_id in range(NUM_STAGES):
+        stage_report_name = f"stage_{stage_id}_lifecycle_metrics.json"
+        assert stage_report_name in result.reports, f"missing {stage_report_name} in {sorted(result.reports)}"
+        stage_report = result.reports[stage_report_name]
+        assert stage_report["successes"]["count"] == REQUESTS_PER_STAGE, (
+            f"stage {stage_id} reported {stage_report['successes']['count']} successes, expected {REQUESTS_PER_STAGE}"
+        )
+        assert stage_report["failures"]["count"] == 0
+
+    # Token accounting, per request, against the server's own usage counts.
+    # PINNED_N workers each build their own tokenizer and their own HTTP
+    # session, so a worker that came up misconfigured shows up as a
+    # per-request break rather than as a shifted average.
+    for entry in entries:
+        # Exact: the server generated exactly OUTPUT_TOKENS, and streamed them
+        # one per chunk, for every request from every worker.
+        assert server_completion_tokens(entry) == OUTPUT_TOKENS
+        assert_streaming_bookkeeping(entry, expected_chunks=OUTPUT_TOKENS)
+        # Bounded: client re-tokenization drift, see the module docstring.
+        assert_output_token_accounting(entry, expected=OUTPUT_TOKENS, tolerance=CLIENT_RETOKENIZATION_SLACK)
+        # The streamed timestamps have to survive the trip back from the
+        # worker: a dropped or defaulted first-chunk time reads as a TTFT
+        # below the floor the sim enforces.
+        assert ttft(entry) >= TTFT_SEC, f"TTFT {ttft(entry):.4f}s is below the sim's configured {TTFT_SEC}s"
+
+    summary = result.reports["summary_lifecycle_metrics.json"]["successes"]
+    assert summary["output_tokens"]["total"] == EXPECTED_REQUESTS * OUTPUT_TOKENS

--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -266,11 +266,18 @@ async def parse_anthropic_stream_response(
     response: ClientResponse,
 ) -> tuple[str, dict[str, Any], list[float], str, list[str], dict[str, Any] | None]:
     extract_content, build_output_message = _build_anthropic_stream_handlers()
-    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+    parsed = await parse_sse_stream(
         response,
         extract_content=extract_content,
     )
-    return output_text, build_output_message(output_text), chunk_times, raw_content, response_chunks, server_usage
+    return (
+        parsed.output_text,
+        build_output_message(parsed.output_text),
+        parsed.chunk_times,
+        parsed.raw_content,
+        parsed.response_chunks,
+        parsed.server_usage,
+    )
 
 
 class AnthropicMessagesAPIData(InferenceAPIData):

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -36,6 +36,12 @@ class StreamedResponseMetrics(ResponseMetrics):
     response_chunks: List[str] = []
     chunk_times: List[float] = []
     output_token_times: List[float] = []
+    # Reasoning-channel chunks (delta.reasoning_content / delta.reasoning) are
+    # tracked separately from content: they anchor TTFT, since the server
+    # starts generating at the first reasoning token, but stay out of
+    # output-length, TPOT, and ITL, which remain content-based. See #559.
+    reasoning_chunks: List[str] = []
+    reasoning_chunk_times: List[float] = []
 
 
 class InferenceInfo(BaseModel):

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -561,25 +561,36 @@ class ChatCompletionAPIData(InferenceAPIData):
         self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: Optional[str] = None
     ) -> InferenceInfo:
         if config.streaming:
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
+            parsed = await parse_sse_stream(
+                response,
+                extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content"),
+                # Reasoning models stream thinking on a separate delta field
+                # (reasoning_content on vLLM/DeepSeek, reasoning on some
+                # gateways) before any content. Captured apart from content so
+                # TTFT sees it while output_len/TPOT/ITL don't (#559).
+                extract_reasoning=lambda data: (
+                    data.get("choices", [{}])[0].get("delta", {}).get("reasoning_content")
+                    or data.get("choices", [{}])[0].get("delta", {}).get("reasoning")
+                ),
             )
-            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
+            prompt_len = self._resolve_prompt_tokens(parsed.server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
             # with special tokens would add a BOS the server's completion_tokens
             # never contains.
-            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
+            output_len = tokenizer.count_tokens(parsed.output_text, add_special_tokens=False)
             return InferenceInfo(
                 request_metrics=self._build_request_metrics(prompt_len, output_len),
                 response_metrics=StreamedResponseMetrics(
-                    response_chunks=response_chunks,
-                    chunk_times=chunk_times,
+                    response_chunks=parsed.response_chunks,
+                    chunk_times=parsed.chunk_times,
                     output_tokens=output_len,
-                    output_token_times=chunk_times,
-                    server_usage=server_usage,
+                    output_token_times=parsed.chunk_times,
+                    server_usage=parsed.server_usage,
+                    reasoning_chunks=parsed.reasoning_chunks,
+                    reasoning_chunk_times=parsed.reasoning_chunk_times,
                 ),
                 lora_adapter=lora_adapter,
-                extra_info={"raw_response": raw_content},
+                extra_info={"raw_response": parsed.raw_content},
             )
 
         data = await response.json()

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -75,27 +75,25 @@ class CompletionAPIData(InferenceAPIData):
     ) -> InferenceInfo:
         if config.streaming:
             # Use shared streaming parser with completion-specific content extraction
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=lambda data: data.get("choices", [{}])[0].get("text")
-            )
+            parsed = await parse_sse_stream(response, extract_content=lambda data: data.get("choices", [{}])[0].get("text"))
 
-            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
+            prompt_len = self._resolve_prompt_tokens(parsed.server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
             # with special tokens would add a BOS the server's completion_tokens
             # never contains.
-            output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
-            self.model_response = output_text
+            output_len = tokenizer.count_tokens(parsed.output_text, add_special_tokens=False)
+            self.model_response = parsed.output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
                 response_metrics=StreamedResponseMetrics(
-                    response_chunks=response_chunks,
-                    chunk_times=chunk_times,
+                    response_chunks=parsed.response_chunks,
+                    chunk_times=parsed.chunk_times,
                     output_tokens=output_len,
-                    output_token_times=chunk_times,
-                    server_usage=server_usage,
+                    output_token_times=parsed.chunk_times,
+                    server_usage=parsed.server_usage,
                 ),
                 lora_adapter=lora_adapter,
-                extra_info={"raw_response": raw_content},
+                extra_info={"raw_response": parsed.raw_content},
             )
         else:
             data = await response.json()

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -21,9 +21,42 @@ LLM APIs, reducing code duplication across different API types.
 
 import json
 import time
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, NamedTuple, Optional
 
 from aiohttp import ClientResponse
+
+
+class ParsedSSEStream(NamedTuple):
+    """Result of ``parse_sse_stream``, split by generation channel.
+
+    Content and reasoning are tracked separately so downstream metrics can
+    anchor TTFT to the first generated token of either channel while keeping
+    output-length, TPOT, and ITL content-based (#559): reasoning is "thinking",
+    not user-facing output, but the server starts generating at the first
+    reasoning token.
+    """
+
+    # Concatenated delta.content text.
+    output_text: str
+    # Timestamps for content-bearing chunks only. Role-only deltas, usage-only
+    # chunks, [DONE] signals, and unparseable messages are excluded so they
+    # don't corrupt downstream TPOT/TTFT/ITL.
+    chunk_times: List[float]
+    # The raw string content of the entire stream.
+    raw_content: str
+    # Raw JSON strings of content-bearing chunks, 1:1 with chunk_times.
+    response_chunks: List[str]
+    # Merged `usage` fields from chunks that carried one (e.g. OpenAI trailing
+    # `{"choices":[],"usage":{...}}` or Anthropic `message.usage` /
+    # `message_delta.usage`). None if the server didn't emit usage.
+    server_usage: Optional[dict[str, Any]]
+    # Concatenated reasoning-channel text, when extract_reasoning is given.
+    reasoning_text: str
+    # Raw JSON strings of reasoning-bearing chunks, 1:1 with
+    # reasoning_chunk_times.
+    reasoning_chunks: List[str]
+    # Timestamps for reasoning-bearing chunks only.
+    reasoning_chunk_times: List[float]
 
 
 class StreamInterruptedError(Exception):
@@ -43,8 +76,10 @@ class StreamInterruptedError(Exception):
 
 
 async def parse_sse_stream(
-    response: ClientResponse, extract_content: Callable[[dict[str, Any]], Optional[str]]
-) -> Tuple[str, List[float], str, List[str], Optional[dict[str, Any]]]:
+    response: ClientResponse,
+    extract_content: Callable[[dict[str, Any]], Optional[str]],
+    extract_reasoning: Optional[Callable[[dict[str, Any]], Optional[str]]] = None,
+) -> ParsedSSEStream:
     """
     Parse Server-Sent Events (SSE) stream and extract content.
 
@@ -58,20 +93,15 @@ async def parse_sse_stream(
         extract_content: Function to extract text content from parsed JSON data.
                         Should return the text content or None if not found.
                         Example: lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
+        extract_reasoning: Optional function to extract reasoning-channel text
+                        (e.g. delta.reasoning_content) from parsed JSON data.
+                        Chunks bearing reasoning but no content are recorded in
+                        the reasoning_* fields of the result, not in
+                        chunk_times/response_chunks, so content-based metrics
+                        are unaffected.
 
     Returns:
-        Tuple of (output_text, chunk_times, raw_content, response_chunks, server_usage):
-        - output_text: The concatenated text content from all chunks
-        - chunk_times: Timestamps for content-bearing chunks only. Role-only
-          deltas, usage-only chunks, [DONE] signals, and unparseable messages
-          are excluded so they don't corrupt downstream TPOT/TTFT/ITL.
-        - raw_content: The raw string content of the stream
-        - response_chunks: Raw JSON strings of content-bearing chunks, 1:1 with
-          chunk_times.
-        - server_usage: Merged `usage` fields from chunks that carried one
-          (e.g. OpenAI trailing `{"choices":[],"usage":{...}}` or Anthropic
-          `message.usage`/`message_delta.usage`). None if the server didn't
-          emit usage.
+        A ParsedSSEStream; see its field comments.
     """
     output_text = ""
     chunk_times: List[float] = []
@@ -79,6 +109,9 @@ async def parse_sse_stream(
     raw_content = b""
     response_chunks: List[str] = []
     server_usage: Optional[dict[str, Any]] = None
+    reasoning_text = ""
+    reasoning_chunks: List[str] = []
+    reasoning_chunk_times: List[float] = []
 
     try:
         async for chunk in response.content.iter_any():
@@ -107,6 +140,10 @@ async def parse_sse_stream(
                                 output_text += content
                                 chunk_times.append(message_time)
                                 response_chunks.append(data_str.decode("utf-8", errors="ignore"))
+                            elif extract_reasoning is not None and (reasoning := extract_reasoning(data)):
+                                reasoning_text += reasoning
+                                reasoning_chunk_times.append(message_time)
+                                reasoning_chunks.append(data_str.decode("utf-8", errors="ignore"))
                         except (json.JSONDecodeError, IndexError):
                             continue
                 if done:
@@ -118,4 +155,13 @@ async def parse_sse_stream(
         # what the server actually sent instead of an empty response body.
         raise StreamInterruptedError(e, raw_content.decode("utf-8", errors="ignore")) from e
 
-    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage
+    return ParsedSSEStream(
+        output_text=output_text,
+        chunk_times=chunk_times,
+        raw_content=raw_content.decode("utf-8", errors="ignore"),
+        response_chunks=response_chunks,
+        server_usage=server_usage,
+        reasoning_text=reasoning_text,
+        reasoning_chunks=reasoning_chunks,
+        reasoning_chunk_times=reasoning_chunk_times,
+    )

--- a/inference_perf/datagen/replay/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay/replay_graph_session_datagen.py
@@ -890,9 +890,24 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 content = delta.get("content")
                 return str(content) if content is not None else None
 
-            text_content, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-                response, extract_content=_extract_streaming_content
+            parsed = await parse_sse_stream(
+                response,
+                extract_content=_extract_streaming_content,
+                # Reasoning text itself is accumulated above (which also covers
+                # chunks carrying both channels); this extractor is what gets
+                # reasoning-only chunks timestamped so TTFT can see them (#559).
+                extract_reasoning=lambda data: (
+                    data.get("choices", [{}])[0].get("delta", {}).get("reasoning_content")
+                    or data.get("choices", [{}])[0].get("delta", {}).get("reasoning")
+                ),
             )
+            text_content, chunk_times, response_chunks, server_usage = (
+                parsed.output_text,
+                parsed.chunk_times,
+                parsed.response_chunks,
+                parsed.server_usage,
+            )
+            raw_content = parsed.raw_content
 
             # Combine reasoning_content with text_content in output_text (used for token count)
             reasoning_text = "".join(reasoning_content_chunks) if reasoning_content_chunks else ""
@@ -930,6 +945,8 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     output_tokens=output_len,
                     output_token_times=chunk_times,
                     server_usage=server_usage,
+                    reasoning_chunks=parsed.reasoning_chunks,
+                    reasoning_chunk_times=parsed.reasoning_chunk_times,
                 ),
                 lora_adapter=lora_adapter,
                 output_text=output_text or None,

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -554,6 +554,21 @@ def summarize_requests(
             # Do not overwrite output_tokens with the per-chunk sum. Keep the API layer's whole-message
             # count_tokens value, and surface the exact server count as `output_tokens`. See #564.
 
+            # The server's completion_tokens counts reasoning tokens too, so the
+            # client-side accounting must include them or every reasoning-model
+            # request would flag as mismatched. They stay out of
+            # output_token_times: reasoning anchors TTFT only (#559).
+            for chunk_str in m.info.response_metrics.reasoning_chunks:
+                try:
+                    data = json.loads(chunk_str)
+                    if choices := data.get("choices"):
+                        delta = choices[0].get("delta", {})
+                        reasoning = delta.get("reasoning_content") or delta.get("reasoning")
+                        if reasoning:
+                            accumulated_tokens += tokenizer.count_tokens(reasoning, add_special_tokens=False)
+                except json.JSONDecodeError:
+                    continue
+
             if expected_output_tokens is not None and accumulated_tokens != expected_output_tokens:
                 mismatched_requests += 1
 
@@ -564,13 +579,33 @@ def summarize_requests(
         else:
             ntpot_values.append(0.0)
 
-        # Check if streamable: Must have more than 1 output token timestamp
+        # Check if streamable: must have more than 1 timestamped generation
+        # event across both channels.
         response_metrics = m.info.response_metrics
-        if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
-            # TTFT: First Token Time - Start Time
-            ttft = response_metrics.output_token_times[0] - m.start_time
-            ttft_values.append(ttft)
+        if isinstance(response_metrics, StreamedResponseMetrics):
+            first_token_candidates = [
+                times[0] for times in (response_metrics.output_token_times, response_metrics.reasoning_chunk_times) if times
+            ]
+            ttft_streamable = len(response_metrics.output_token_times) + len(response_metrics.reasoning_chunk_times) > 1
+        else:
+            first_token_candidates = []
+            ttft_streamable = False
 
+        if ttft_streamable and first_token_candidates:
+            # TTFT: First Token Time - Start Time, where the first token is the
+            # first generated token of ANY channel (#559): reasoning models
+            # stream reasoning deltas before (and, when the output budget is
+            # exhausted, instead of) content, and the server generates from the
+            # first reasoning token (vllm:time_to_first_token counts it).
+            # Anchoring to content would inflate TTFT by the whole
+            # reasoning-decode phase, or yield null when no content ever
+            # arrives. TPOT and ITL stay content-based below: reasoning is
+            # "thinking", not user-facing output.
+            ttft_values.append(min(first_token_candidates) - m.start_time)
+        else:
+            ttft_values.append(None)
+
+        if isinstance(response_metrics, StreamedResponseMetrics) and len(response_metrics.output_token_times) > 1:
             # TPOT: (Last Token Time - First Token Time) / (Num Output Tokens - 1)
             duration = response_metrics.output_token_times[-1] - response_metrics.output_token_times[0]
             tpot_output_tokens = effective_output_tokens(response_metrics, use_server_output_tokens)
@@ -591,8 +626,7 @@ def summarize_requests(
             else:
                 itl_values.append(None)
         else:
-            # Not streamable, so TTFT and TPOT are undefined
-            ttft_values.append(None)
+            # No streamed content, so TPOT and ITL are undefined
             tpot_values.append(None)
             itl_values.append(None)
 

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -39,21 +39,19 @@ async def test_parse_sse_stream() -> None:
     def extract_content(data: dict[str, Any]) -> Optional[str]:
         return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
 
-    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
-        mock_response, extract_content
-    )
+    parsed = await parse_sse_stream(mock_response, extract_content)
 
-    assert output_text == "Hello world"
-    assert len(chunk_times) == 2
-    assert "Hello" in raw_content
-    assert "world" in raw_content
-    assert "[DONE]" in raw_content
-    assert len(response_chunks) == 2
-    assert "Hello" in response_chunks[0]
-    assert "world" in response_chunks[1]
+    assert parsed.output_text == "Hello world"
+    assert len(parsed.chunk_times) == 2
+    assert "Hello" in parsed.raw_content
+    assert "world" in parsed.raw_content
+    assert "[DONE]" in parsed.raw_content
+    assert len(parsed.response_chunks) == 2
+    assert "Hello" in parsed.response_chunks[0]
+    assert "world" in parsed.response_chunks[1]
     # response_chunks and chunk_times must stay in lockstep — reportgen zips them with strict=True.
-    assert len(chunk_times) == len(response_chunks)
-    assert server_usage is None
+    assert len(parsed.chunk_times) == len(parsed.response_chunks)
+    assert parsed.server_usage is None
 
 
 @pytest.mark.asyncio
@@ -87,15 +85,15 @@ async def test_parse_sse_stream_timestamps_only_content_events() -> None:
     def extract_content(data: dict[str, Any]) -> Optional[str]:
         return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
 
-    output_text, chunk_times, _, response_chunks, server_usage = await parse_sse_stream(mock_response, extract_content)
+    parsed = await parse_sse_stream(mock_response, extract_content)
 
-    assert output_text == "Hello world"
-    assert len(chunk_times) == 2, (
-        f"expected 2 timestamps for content-bearing chunks, got {len(chunk_times)} "
+    assert parsed.output_text == "Hello world"
+    assert len(parsed.chunk_times) == 2, (
+        f"expected 2 timestamps for content-bearing chunks, got {len(parsed.chunk_times)} "
         "(role-only, usage, or [DONE] events leaking into chunk_times)"
     )
-    assert len(response_chunks) == len(chunk_times), "response_chunks must stay 1:1 aligned with chunk_times"
-    assert server_usage == {"prompt_tokens": 5, "completion_tokens": 2}, (
+    assert len(parsed.response_chunks) == len(parsed.chunk_times), "response_chunks must stay 1:1 aligned with chunk_times"
+    assert parsed.server_usage == {"prompt_tokens": 5, "completion_tokens": 2}, (
         "usage info from a content-less chunk should still be surfaced separately"
     )
 
@@ -136,3 +134,108 @@ async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
     # The bytes received before the break are retained, not discarded.
     assert "Hello" in err.raw_content
     assert "world" in err.raw_content
+
+
+def extract_delta_content(data: dict[str, Any]) -> Optional[str]:
+    return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
+
+
+def extract_delta_reasoning(data: dict[str, Any]) -> Optional[str]:
+    delta = data.get("choices", [{}])[0].get("delta", {})
+    return delta.get("reasoning_content") or delta.get("reasoning")  # type: ignore[no-any-return]
+
+
+def make_response(chunks: list[bytes]) -> Mock:
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+
+    mock_content.iter_any = mock_iter_any
+    return mock_response
+
+
+REASONING_THEN_CONTENT_CHUNKS = [
+    b'data: {"choices": [{"delta": {"role": "assistant"}}]}\n\n',
+    b'data: {"choices": [{"delta": {"reasoning_content": "Let me"}}]}\n\n',
+    b'data: {"choices": [{"delta": {"reasoning_content": " think."}}]}\n\n',
+    b'data: {"choices": [{"delta": {"content": "The answer"}}]}\n\n',
+    b'data: {"choices": [{"delta": {"content": " is 4."}}]}\n\n',
+    b"data: [DONE]\n\n",
+]
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_tracked_separately_from_content() -> None:
+    """Reasoning models (gpt-oss, DeepSeek-R1, QwQ) stream delta.reasoning_content
+    before delta.content. The channels must stay separate (#559): reasoning
+    timestamps anchor TTFT, while output_text (the basis for output_len) and
+    chunk_times (the basis for TPOT/ITL) must remain content-only so reasoning
+    doesn't count as user-facing output."""
+    parsed = await parse_sse_stream(
+        make_response(REASONING_THEN_CONTENT_CHUNKS), extract_delta_content, extract_delta_reasoning
+    )
+
+    assert parsed.output_text == "The answer is 4."
+    assert parsed.reasoning_text == "Let me think."
+    assert len(parsed.chunk_times) == 2
+    assert len(parsed.response_chunks) == 2
+    assert len(parsed.reasoning_chunk_times) == 2
+    # reasoning_chunks and reasoning_chunk_times stay 1:1, mirroring the content lists.
+    assert len(parsed.reasoning_chunks) == len(parsed.reasoning_chunk_times)
+    assert all("reasoning_content" in chunk for chunk in parsed.reasoning_chunks)
+    # Reasoning arrived before content, so its timestamps must precede content's:
+    # this ordering is what lets reportgen anchor TTFT to the reasoning channel.
+    assert parsed.reasoning_chunk_times[0] <= parsed.chunk_times[0]
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_field_variant() -> None:
+    """Some OpenAI-compatible servers name the channel delta.reasoning rather
+    than delta.reasoning_content; both must be recognized."""
+    chunks = [
+        b'data: {"choices": [{"delta": {"reasoning": "Step 1."}}]}\n\n',
+        b'data: {"choices": [{"delta": {"content": "Result."}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    parsed = await parse_sse_stream(make_response(chunks), extract_delta_content, extract_delta_reasoning)
+
+    assert parsed.output_text == "Result."
+    assert parsed.reasoning_text == "Step 1."
+    assert len(parsed.reasoning_chunk_times) == 1
+    assert len(parsed.chunk_times) == 1
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_only_stream() -> None:
+    """When the output budget is exhausted mid-reasoning (max_tokens below the
+    reasoning length), the stream ends with no content chunk at all. The
+    reasoning channel must still be captured: it is the only TTFT anchor such
+    a request has (#559's null-TTFT case)."""
+    chunks = [
+        b'data: {"choices": [{"delta": {"reasoning_content": "Thinking"}}]}\n\n',
+        b'data: {"choices": [{"delta": {"reasoning_content": " hard"}}]}\n\n',
+        b"data: [DONE]\n\n",
+    ]
+    parsed = await parse_sse_stream(make_response(chunks), extract_delta_content, extract_delta_reasoning)
+
+    assert parsed.output_text == ""
+    assert parsed.reasoning_text == "Thinking hard"
+    assert len(parsed.chunk_times) == 0
+    assert len(parsed.reasoning_chunk_times) == 2
+
+
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reasoning_ignored_without_extractor() -> None:
+    """Callers that pass no extract_reasoning (e.g. the completions API) must
+    see exactly the pre-#559 behavior: reasoning chunks contribute nothing."""
+    parsed = await parse_sse_stream(make_response(REASONING_THEN_CONTENT_CHUNKS), extract_delta_content)
+
+    assert parsed.output_text == "The answer is 4."
+    assert parsed.reasoning_text == ""
+    assert len(parsed.chunk_times) == 2
+    assert parsed.reasoning_chunks == []
+    assert parsed.reasoning_chunk_times == []

--- a/tests/required/integration/fake_openai_server.py
+++ b/tests/required/integration/fake_openai_server.py
@@ -1,0 +1,113 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""In-process OpenAI-compatible streaming fake for the integration tier.
+
+The sim-backed e2e tier (llm-d-inference-sim) exercises realistic server
+behavior, but the sim cannot emit reasoning-channel deltas or pace chunks on
+cue. This fake serves a scripted SSE event sequence over real HTTP with
+controlled per-event delays, and records a timestamp for every chunk it
+actually sent, so tests can assert client-side metrics against the server's
+own timeline rather than against configured intent (the #606 Integration
+tier's "fake the conditions, never the oracle" principle).
+"""
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import List, Optional, Type
+
+from aiohttp import web
+
+
+@dataclass(frozen=True)
+class StreamEvent:
+    """One scripted SSE delta: which channel carries the text and how long the
+    server waits before sending it."""
+
+    channel: str  # "reasoning" | "content"
+    text: str
+    delay_before: float = 0.0
+
+
+@dataclass
+class ServedStream:
+    """What the fake actually did for one request.
+
+    Timestamps are ``perf_counter()`` stamped immediately after each event was
+    written and drained. The client can only observe a chunk at or after its
+    send stamp (same clock, same process), so these bound TTFT assertions
+    tightly without trusting ``asyncio.sleep`` accuracy.
+    """
+
+    reasoning_send_times: List[float] = field(default_factory=list)
+    content_send_times: List[float] = field(default_factory=list)
+
+
+class FakeOpenAIServer:
+    """Serves /v1/chat/completions, streaming the configured script for every
+    request. Use as an async context manager; ``url`` is the endpoint."""
+
+    def __init__(self, script: List[StreamEvent], completion_tokens: Optional[int] = None) -> None:
+        self.script = script
+        # Emitted as a trailing usage chunk (stream_options.include_usage
+        # style) when set.
+        self.completion_tokens = completion_tokens
+        self.served: List[ServedStream] = []
+        self._runner: Optional[web.AppRunner] = None
+        self.port = 0
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1/chat/completions"
+
+    async def __aenter__(self) -> "FakeOpenAIServer":
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", self._handle)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        self.port = self._runner.addresses[0][1]
+        return self
+
+    async def __aexit__(
+        self, exc_type: Optional[Type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
+    ) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    async def _handle(self, request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse(headers={"Content-Type": "text/event-stream"})
+        await response.prepare(request)
+        record = ServedStream()
+        self.served.append(record)
+        for event in self.script:
+            if event.delay_before > 0:
+                await asyncio.sleep(event.delay_before)
+            key = "reasoning_content" if event.channel == "reasoning" else "content"
+            payload = {"choices": [{"delta": {key: event.text}}]}
+            await response.write(f"data: {json.dumps(payload)}\n\n".encode())
+            stamp = time.perf_counter()
+            if event.channel == "reasoning":
+                record.reasoning_send_times.append(stamp)
+            else:
+                record.content_send_times.append(stamp)
+        if self.completion_tokens is not None:
+            usage = {"choices": [], "usage": {"completion_tokens": self.completion_tokens}}
+            await response.write(f"data: {json.dumps(usage)}\n\n".encode())
+        await response.write(b"data: [DONE]\n\n")
+        await response.write_eof()
+        return response

--- a/tests/required/integration/test_reasoning_ttft_integration.py
+++ b/tests/required/integration/test_reasoning_ttft_integration.py
@@ -1,0 +1,117 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration test for issue #559 (#606 Integration tier, per-change lane).
+
+Drives the full client pipeline (real HTTP request, real SSE wire bytes,
+real timing) against an in-process fake reasoning model and asserts that
+reported TTFT anchors to the first reasoning token, using the server's own
+send timestamps as the oracle. The unit tests in tests/test_reasoning_ttft.py
+pin the arithmetic with synthetic timestamps; this test pins the wiring: that
+a reasoning delta on the wire actually reaches the TTFT calculation.
+"""
+
+import time
+from typing import Tuple
+from unittest.mock import MagicMock
+
+import aiohttp
+import pytest
+
+from fake_openai_server import FakeOpenAIServer, ServedStream, StreamEvent
+
+from inference_perf.apis.base import RequestLifecycleMetric, StreamedResponseMetrics
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.config import APIConfig, APIType
+from inference_perf.reportgen.base import ResponsesSummary, summarize_requests
+
+
+def make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+async def run_request(server: FakeOpenAIServer) -> Tuple[ResponsesSummary, RequestLifecycleMetric, ServedStream, float]:
+    """One benchmark request against the fake, through the real parse and
+    summarize path. Returns (summary, metric, what the server did, start)."""
+    tokenizer = make_tokenizer()
+    config = APIConfig(type=APIType.Chat, streaming=True)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="prompt")], max_tokens=100)
+
+    async with aiohttp.ClientSession() as session:
+        start = time.perf_counter()
+        async with session.post(server.url, json={}) as response:
+            info = await data.process_response(response, config, tokenizer)
+        end = time.perf_counter()
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=start, start_time=start, end_time=end, request_data="prompt", info=info, error=None
+    )
+    return summarize_requests([metric], [50], tokenizer=tokenizer), metric, server.served[-1], start
+
+
+@pytest.mark.asyncio
+async def test_ttft_anchors_to_first_reasoning_token_on_the_wire() -> None:
+    """The inflated-TTFT case: reasoning streams promptly, content only after a
+    long reasoning phase. TTFT must land at the first reasoning chunk, not be
+    inflated by the reasoning-decode phase to the first content chunk."""
+    reasoning_phase = [StreamEvent("reasoning", "Let me", 0.02), StreamEvent("reasoning", " think.", 0.02)]
+    # The pause before content is the reasoning-decode phase TTFT must NOT
+    # include. Large relative to loopback parse latency so the bound is robust.
+    content_phase = [StreamEvent("content", "The answer", 0.35), StreamEvent("content", " is 4.", 0.02)]
+
+    async with FakeOpenAIServer(reasoning_phase + content_phase, completion_tokens=7) as server:
+        result, metric, served, start = await run_request(server)
+
+    ttft_summary = result.successes["latency"]["time_to_first_token"]
+    assert ttft_summary is not None
+    ttft = ttft_summary["mean"]
+    # The client cannot observe a chunk before the server sent it (same
+    # perf_counter clock, same process), so TTFT is at least the first
+    # reasoning send offset...
+    assert ttft >= served.reasoning_send_times[0] - start - 1e-6
+    # ...and anchoring to reasoning means it must come in strictly before the
+    # first content chunk was even sent. Pre-#559 this read ~0.4s, not ~0.02s.
+    assert ttft < served.content_send_times[0] - start
+
+    # Output length stays content-based: reasoning is thinking, not output.
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    assert metric.info.response_metrics.output_tokens == 4  # "The answer is 4."
+    # Client accounting (content + reasoning) matches the server's
+    # completion_tokens, so the mismatch detector stays quiet.
+    assert result.successes["token_count_mismatches"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ttft_reported_when_output_budget_exhausted_mid_reasoning() -> None:
+    """The null-TTFT case: max_tokens below the reasoning length means the
+    stream ends while still in the reasoning channel, so no content token ever
+    arrives. TTFT must still be reported; TPOT and ITL stay undefined."""
+    script = [
+        StreamEvent("reasoning", "Thinking", 0.02),
+        StreamEvent("reasoning", " quite", 0.02),
+        StreamEvent("reasoning", " hard", 0.02),
+    ]
+
+    async with FakeOpenAIServer(script, completion_tokens=3) as server:
+        result, metric, served, start = await run_request(server)
+
+    ttft_summary = result.successes["latency"]["time_to_first_token"]
+    assert ttft_summary is not None, "reasoning-only stream must yield a TTFT, not null"
+    assert ttft_summary["mean"] >= served.reasoning_send_times[0] - start - 1e-6
+
+    assert result.successes["latency"]["time_per_output_token"] is None
+    assert result.successes["latency"]["inter_token_latency"] is None
+    assert isinstance(metric.info.response_metrics, StreamedResponseMetrics)
+    assert metric.info.response_metrics.output_tokens == 0

--- a/tests/required/integration/test_worker_matrix.py
+++ b/tests/required/integration/test_worker_matrix.py
@@ -1,0 +1,447 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Worker-count matrix for issue #632 (#606 Integration tier, per-change lane).
+
+``num_workers`` is not a scaling knob, it selects between two execution
+architectures: 0 runs the whole benchmark on one in-process asyncio loop
+through ``LocalRequestMetricCollector``, and > 0 runs the ``mp_run`` path with
+real worker processes, per-worker queues, shared counters, a stage barrier and
+``MultiprocessRequestMetricCollector``. Every motivating bug (#589, #590, #469,
+#593) lives in that process machinery rather than in the server, so this file
+fakes the server and keeps the processes real: the load runs against the
+in-process ``FakeOpenAIServer`` over loopback, which child workers reach exactly
+like any other HTTP endpoint.
+
+The oracle is the fake server's own record of what it served. Whatever the
+architecture, the number of requests the client accounts for must equal the
+number the server actually handled, and the per-request token accounting must
+be identical in every cell. That invariant is what a lost, duplicated or
+silently dropped worker result breaks.
+
+Start-method agnostic on purpose. Nothing here asserts on, or configures, the
+multiprocessing start method: this file is meant to gate #526 (fork ->
+forkserver), so it has to pass identically before and after that switch. What
+it does assert is the property #526 depends on, that the worker payload
+survives a pickle round trip (#589), which holds under either method.
+
+Everything driving real processes is wrapped in ``asyncio.wait_for``: a
+barrier-quorum regression (#469) hangs rather than fails, and a bounded wait
+turns that hang into a test failure instead of a stuck CI job.
+
+Standing finding: the ``num_workers = 0`` cell is marked xfail because it
+currently crashes about half the time. See IN_PROCESS_ZIP_BUG below for the
+mechanism. The cell is kept rather than dropped, because a matrix that omits
+the failing cell is exactly how #590 stayed open.
+"""
+
+import asyncio
+import pickle
+import time
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from fake_openai_server import FakeOpenAIServer, StreamEvent
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.client.modelserver.base import ModelServerClient
+from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
+from inference_perf.client.modelserver.metrics import CounterMetric, GaugeMetric, HistogramMetric
+from inference_perf.client.modelserver.otel_instrumentation import get_otel_instrumentation
+from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType, LoadConfig, LoadType, StandardLoadStage
+from inference_perf.datagen.synthetic.mock_datagen import MockDataGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.metrics.request_collector import (
+    LocalRequestMetricCollector,
+    MultiprocessRequestMetricCollector,
+    RequestMetricCollector,
+)
+from inference_perf.reportgen.base import ResponsesSummary, summarize_requests
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+# N is pinned rather than inherited from cpu_count(), which is what makes a CI
+# run test a known cell instead of whichever cell the runner happens to have.
+PINNED_N = 4
+
+RATE = 8
+DURATION = 1
+NUM_STAGES = 2
+REQUESTS_PER_STAGE = RATE * DURATION
+
+PERCENTILES = [50.0, 90.0]
+
+# Generous but finite. A healthy cell finishes in well under 20s; this only has
+# to be small enough that a deadlock fails the job rather than wedging it.
+RUN_TIMEOUT_SEC = 180.0
+
+# One scripted response, four single-word content chunks. Word-per-chunk keeps
+# the whitespace tokenizer below exact: four chunks, four tokens, and the
+# concatenation re-counts to the same four, so token_count_mismatches stays 0
+# and any per-cell divergence is a real divergence.
+RESPONSE_SCRIPT = [
+    StreamEvent("content", "alpha", 0.01),
+    StreamEvent("content", " beta", 0.01),
+    StreamEvent("content", " gamma", 0.01),
+    StreamEvent("content", " delta", 0.01),
+]
+EXPECTED_OUTPUT_TOKENS = 4
+
+# How many requests the collector-equivalence comparison drives. Small: the
+# comparison is exact, so more requests buy nothing but wall time.
+EQUIVALENCE_REQUESTS = 8
+
+# Found by this test. The in-process (num_workers = 0) dispatch loop walks
+# zip(datagen.get_data(), time_generator, strict=True) and relies on breaking
+# out at the stage deadline before the finite timer runs out. ConstantLoadTimer
+# normalizes its intervals to sum to exactly the stage duration, so the last
+# scheduled time lands on the deadline and whether the loop breaks first is
+# decided by float rounding. When it does not, the timer is exhausted and
+# strict=True raises "zip() argument 2 is shorter than argument 1" out of the
+# TaskGroup, failing the stage. Reproduced 4 and 5 times out of 10 runs, across
+# two rate/duration settings. Introduced in #388, and exactly the #590 shape: a
+# crash that exists only in the num_workers = 0 cell, which nothing in CI runs.
+# The marker below comes off (and turns strict) once that is fixed.
+IN_PROCESS_ZIP_BUG = (
+    "num_workers=0 stage dispatch raises ValueError from zip(strict=True) when the timer is fully consumed (#590 family)"
+)
+
+
+class WhitespaceTokenizer(CustomTokenizer):
+    """Counts whitespace-delimited words, with no model download.
+
+    Deliberately does not call ``CustomTokenizer.__init__``: that pulls a
+    HuggingFace tokenizer, which the per-change lane cannot depend on. Token
+    fidelity is not what this file is testing (#631 and #697 own that); what
+    matters here is that the count is deterministic and identical in every
+    cell, so a difference between cells is attributable to the process
+    machinery.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
+        return len(text.split())
+
+    def get_tokenizer(self) -> Any:
+        return None
+
+
+class FakeServerClient(openAIModelServerClient):
+    """The production OpenAI client, pointed at the in-process fake.
+
+    Only the constructor is replaced, and only to skip building a
+    ``CustomTokenizer`` from the hub. Request-body construction, the aiohttp
+    session, SSE parsing, response accounting and the ``record_metric`` call
+    are all the shipped code path, which is what makes the collector
+    comparison below meaningful.
+    """
+
+    def __init__(self, metrics_collector: RequestMetricCollector, api_config: APIConfig, uri: str) -> None:
+        ModelServerClient.__init__(self, api_config, None)
+        self.uri = uri
+        self.model_name = "fake-model"
+        self.max_completion_tokens = 30
+        self.ignore_eos = True
+        self.metrics_collector = metrics_collector
+        self.max_tcp_connections = 100
+        self.additional_filters: List[str] = []
+        self.api_key: Optional[str] = None
+        self.cert_path: Optional[str] = None
+        self.key_path: Optional[str] = None
+        self.lora_config = None
+        self.otel = get_otel_instrumentation()
+        self.tokenizer = WhitespaceTokenizer()
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Completion, APIType.Chat]
+
+    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
+        return OpenAIMetrics(
+            filters=[],
+            prompt_tokens=CounterMetric("fake:prompt_tokens"),
+            output_tokens=CounterMetric("fake:generation_tokens"),
+            requests=CounterMetric("fake:request_success"),
+            request_latency=HistogramMetric("fake:e2e_request_latency_seconds"),
+            queue_length=GaugeMetric("fake:num_requests_waiting"),
+            time_per_output_token=HistogramMetric("fake:time_per_output_token_seconds"),
+        )
+
+
+def make_load_config(num_workers: int) -> LoadConfig:
+    return LoadConfig(
+        type=LoadType.CONSTANT,
+        num_workers=num_workers,
+        worker_max_concurrency=16,
+        interval=0,
+        stages=[StandardLoadStage(rate=RATE, duration=DURATION) for _ in range(NUM_STAGES)],
+        base_seed=42,
+    )
+
+
+def make_datagen(api_config: APIConfig) -> MockDataGenerator:
+    return MockDataGenerator(api_config, DataConfig(type=DataGenType.Mock), None)
+
+
+async def run_cell(num_workers: int) -> tuple[List[RequestLifecycleMetric], int]:
+    """Run the configured multi-stage load in one matrix cell.
+
+    Returns the collected metrics and the number of requests the fake server
+    actually served, which is the oracle the metrics are checked against.
+    """
+    api_config = APIConfig(type=APIType.Chat, streaming=True)
+    collector: RequestMetricCollector = (
+        LocalRequestMetricCollector() if num_workers == 0 else MultiprocessRequestMetricCollector()
+    )
+
+    async with FakeOpenAIServer(RESPONSE_SCRIPT, completion_tokens=EXPECTED_OUTPUT_TOKENS) as server:
+        client = FakeServerClient(collector, api_config, f"http://127.0.0.1:{server.port}")
+        load_gen = LoadGenerator(make_datagen(api_config), make_load_config(num_workers))
+        try:
+            async with collector.start():
+                # A stage-barrier quorum bug (#469) deadlocks rather than
+                # failing, so the whole run is bounded.
+                await asyncio.wait_for(load_gen.run(client), timeout=RUN_TIMEOUT_SEC)
+        finally:
+            await load_gen.stop()
+            await client.close()
+        served = len(server.served)
+
+    return collector.get_metrics(), served
+
+
+async def drive_requests(collector: RequestMetricCollector, count: int) -> int:
+    """Send ``count`` real requests through the real client, concurrently.
+
+    Deliberately bypasses the load generator. The collector comparison below
+    needs one fixed body of load, and the stage dispatch loops add scheduling
+    variance (and, on the in-process path, the defect described in
+    IN_PROCESS_ZIP_BUG) that has nothing to do with the collectors. The
+    request path, the wire format and the metric construction are still the
+    real ones. Returns what the server served.
+    """
+    api_config = APIConfig(type=APIType.Chat, streaming=True)
+    async with FakeOpenAIServer(RESPONSE_SCRIPT, completion_tokens=EXPECTED_OUTPUT_TOKENS) as server:
+        client = FakeServerClient(collector, api_config, f"http://127.0.0.1:{server.port}")
+        data_stream = make_datagen(api_config).get_data()
+        requests = [next(data_stream) for _ in range(count)]
+        try:
+            scheduled = time.perf_counter()
+            await asyncio.gather(*(client.process_request(request, 0, scheduled) for request in requests))
+        finally:
+            await client.close()
+        return len(server.served)
+
+
+def summarize(metrics: List[RequestLifecycleMetric]) -> ResponsesSummary:
+    return summarize_requests(metrics, PERCENTILES, tokenizer=WhitespaceTokenizer())
+
+
+def output_token_values(metrics: List[RequestLifecycleMetric]) -> List[int]:
+    """Per-request output token counts, sorted, so two collectors can be
+    compared without depending on the order they reassembled the metrics in."""
+    values: List[int] = []
+    for metric in metrics:
+        response_metrics = metric.info.response_metrics
+        assert response_metrics is not None
+        assert response_metrics.output_tokens is not None
+        values.append(response_metrics.output_tokens)
+    return sorted(values)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "num_workers",
+    [
+        pytest.param(
+            0,
+            marks=pytest.mark.xfail(strict=False, reason=IN_PROCESS_ZIP_BUG),
+            id="workers-0",
+        ),
+        pytest.param(1, id="workers-1"),
+        pytest.param(PINNED_N, id=f"workers-{PINNED_N}"),
+    ],
+)
+async def test_worker_matrix_accounts_every_served_request(num_workers: int) -> None:
+    """Each cell of the matrix must account for exactly what the server served.
+
+    This is the invariant that survives the architectural difference between
+    the cells. It fails if a worker result is lost crossing the queue, counted
+    twice, or produced by a worker that died silently (#593), and it fails on
+    the in-process path too (#590), which no CI run exercises today.
+    """
+    metrics, served = await run_cell(num_workers)
+
+    assert served > 0, "the fake server handled no requests at all"
+    assert len(metrics) == served, f"collected {len(metrics)} metrics for {served} served requests"
+
+    errored = [m for m in metrics if m.error is not None]
+    assert not errored, f"{len(errored)}/{len(metrics)} requests errored, first: {errored[0].error}"
+
+    # Both stages must have run and both must have delivered load.
+    by_stage: Dict[int, int] = {}
+    for metric in metrics:
+        assert metric.stage_id is not None, "a recorded metric lost its stage id"
+        by_stage[metric.stage_id] = by_stage.get(metric.stage_id, 0) + 1
+    assert sorted(by_stage) == list(range(NUM_STAGES)), f"expected one bucket per stage, got {sorted(by_stage)}"
+    for stage_id in range(NUM_STAGES):
+        if num_workers == 0:
+            # The in-process dispatch loop stops at the stage deadline instead
+            # of enqueueing a fixed count, so how many of the scheduled
+            # requests it gets out depends on how loaded the machine is. Only
+            # the mp path has an exact expected count.
+            assert 0 < by_stage[stage_id] <= REQUESTS_PER_STAGE, (
+                f"stage {stage_id} delivered {by_stage[stage_id]} requests, expected 1 to {REQUESTS_PER_STAGE}"
+            )
+        else:
+            assert by_stage[stage_id] == REQUESTS_PER_STAGE, (
+                f"stage {stage_id} delivered {by_stage[stage_id]} requests, expected {REQUESTS_PER_STAGE}"
+            )
+
+    # Per-request token accounting is identical in every cell: the response is
+    # scripted, so any drift here is the process machinery mangling a metric
+    # on its way back, not the server.
+    for metric in metrics:
+        assert metric.info.response_metrics is not None
+        assert metric.info.response_metrics.output_tokens == EXPECTED_OUTPUT_TOKENS
+
+    summary = summarize(metrics)
+    assert summary.successes["count"] == len(metrics)
+    assert summary.failures["count"] == 0
+    assert summary.successes["token_count_mismatches"] == 0
+    assert summary.successes["output_tokens"]["total"] == float(len(metrics) * EXPECTED_OUTPUT_TOKENS)
+    # Latency must actually have been measured on every path, including
+    # through the queue: a null TTFT here means the streamed timestamps did
+    # not survive the trip.
+    assert summary.successes["latency"]["time_to_first_token"] is not None
+    assert summary.successes["latency"]["inter_token_latency"] is not None
+
+
+@pytest.mark.asyncio
+async def test_collectors_agree_on_identical_load() -> None:
+    """``LocalRequestMetricCollector`` and ``MultiprocessRequestMetricCollector``
+    must produce equivalent aggregates for identical load.
+
+    "Identical" is made literal: one real batch of requests against the fake
+    produces the metrics, then the same metric objects go through both
+    collectors, with the multiprocess one fed from a real child process so its
+    queue, its pickling and its drain-on-sentinel protocol are all exercised.
+    Any difference in the aggregates is therefore attributable to the
+    collector, not to two runs having drawn different request timings. The
+    matrix test above is what covers real workers feeding the multiprocess
+    collector end to end; this one isolates the transport.
+
+    What is compared, and why the split:
+
+    - EXACT: request counts, failure counts, token totals and the per-request
+      token values. These are integers copied verbatim through the queue, so
+      any difference at all is a transport bug.
+    - TOLERANCE: the latency summaries. The values themselves are copied
+      verbatim too, but the multiprocess collector reassembles them in queue
+      arrival order rather than record order, and ``np.mean`` over a permuted
+      list of floats can differ in the last bits. Bit-exactness would be an
+      assertion about float summation order, not about the collector, so the
+      comparison is to within a nanosecond, far below any real distortion
+      (#566 was a K-fold ITL deflation).
+    - STRUCTURAL: which latency fields are present versus None. A collector
+      that dropped the streamed timestamps would keep the counts intact and
+      silently turn TTFT into None, so presence is asserted separately from
+      value.
+    """
+    local = LocalRequestMetricCollector()
+    served = await drive_requests(local, EQUIVALENCE_REQUESTS)
+    assert served == EQUIVALENCE_REQUESTS
+    metrics = local.get_metrics()
+    assert len(metrics) == EQUIVALENCE_REQUESTS
+
+    multiprocess = MultiprocessRequestMetricCollector()
+    async with multiprocess.start():
+        # Feeding from a child process is the point: recording in-process
+        # would compare a list against itself and never exercise the
+        # cross-process transport that #632 is about.
+        await asyncio.wait_for(_feed_from_child_process(multiprocess, metrics), timeout=RUN_TIMEOUT_SEC)
+
+    local_metrics = metrics
+    mp_metrics = multiprocess.get_metrics()
+    assert len(mp_metrics) == len(local_metrics), "multiprocess collector lost or duplicated a metric in transit"
+
+    local_summary = summarize(local_metrics)
+    mp_summary = summarize(mp_metrics)
+
+    # --- exact ---
+    assert mp_summary.successes["count"] == local_summary.successes["count"]
+    assert mp_summary.failures["count"] == local_summary.failures["count"]
+    assert mp_summary.load_summary["count"] == local_summary.load_summary["count"]
+    assert mp_summary.successes["token_count_mismatches"] == local_summary.successes["token_count_mismatches"]
+    assert mp_summary.successes["output_tokens"]["total"] == local_summary.successes["output_tokens"]["total"]
+    assert mp_summary.successes["prompt_tokens"]["total"] == local_summary.successes["prompt_tokens"]["total"]
+    assert output_token_values(mp_metrics) == output_token_values(local_metrics)
+
+    # --- structural, then tolerance ---
+    for field in ("request_latency", "time_to_first_token", "time_per_output_token", "inter_token_latency"):
+        local_field = local_summary.successes["latency"][field]
+        mp_field = mp_summary.successes["latency"][field]
+        assert (local_field is None) == (mp_field is None), f"{field} is defined on one collector but not the other"
+        if local_field is None:
+            continue
+        assert sorted(local_field) == sorted(mp_field), f"{field} summaries have different keys"
+        for key, value in local_field.items():
+            assert mp_field[key] == pytest.approx(value, abs=1e-9), f"{field}.{key} differs between collectors"
+
+
+def _record_all(collector: MultiprocessRequestMetricCollector, metrics: List[RequestLifecycleMetric]) -> None:
+    """Child-process entrypoint: replay metrics into the collector's queue.
+
+    Module level and importable by name so it survives a start method that
+    pickles the target instead of inheriting it.
+    """
+    for metric in metrics:
+        collector.record_metric(metric)
+
+
+async def _feed_from_child_process(
+    collector: MultiprocessRequestMetricCollector, metrics: List[RequestLifecycleMetric]
+) -> None:
+    import multiprocessing as mp
+
+    process = mp.Process(target=_record_all, args=(collector, metrics), daemon=True)
+    process.start()
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, process.join)
+    assert process.exitcode == 0, f"metric-feeding child exited with {process.exitcode}"
+
+
+def test_worker_payload_survives_a_pickle_round_trip() -> None:
+    """The datagen and client a worker receives must be picklable (#589).
+
+    Under today's default start method the payload is inherited rather than
+    pickled, so nothing in CI would notice it becoming unpicklable until #526
+    switches workers to forkserver and every mp run breaks at once. Asserting
+    the property directly keeps the guard independent of which start method is
+    in force, which is the whole point of this file gating #526.
+
+    Narrow by design: it pins the payload this file builds, not the real
+    tokenizer-backed datagens, whose forkserver behavior #526 covers in its own
+    e2e.
+    """
+    api_config = APIConfig(type=APIType.Chat, streaming=True)
+    datagen = make_datagen(api_config)
+    client = FakeServerClient(LocalRequestMetricCollector(), api_config, "http://127.0.0.1:1")
+
+    restored_datagen = pickle.loads(pickle.dumps(datagen))
+    assert next(restored_datagen.get_data()) is not None
+
+    restored_client = pickle.loads(pickle.dumps(client))
+    assert restored_client.uri == client.uri
+    assert restored_client.tokenizer.count_tokens("one two three") == 3

--- a/tests/test_reasoning_ttft.py
+++ b/tests/test_reasoning_ttft.py
@@ -1,0 +1,202 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for issue #559.
+
+Reasoning models emit reasoning-channel tokens before (and, when the output
+budget is exhausted, instead of) any content token. Pre-#559 only
+delta.content chunks were timestamped, so time_to_first_token was inflated to
+time-to-first-CONTENT (prefill plus the entire reasoning-decode phase), and
+null when the stream ended while still in the reasoning channel.
+
+TTFT must anchor to the first generated token of ANY channel, matching
+server-side metrics (vllm:time_to_first_token). TPOT, ITL, and output-length
+stay content-based: reasoning is "thinking", not user-facing output.
+"""
+
+from typing import AsyncGenerator, List, Optional, cast
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import ClientResponse
+
+from inference_perf.apis.base import InferenceInfo, RequestLifecycleMetric, StreamedResponseMetrics
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.config import APIConfig, APIType
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.reportgen.base import summarize_requests
+
+
+def make_streamed_metric(
+    start_time: float,
+    end_time: float,
+    output_token_times: List[float],
+    reasoning_chunk_times: Optional[List[float]] = None,
+    output_tokens: int = 0,
+) -> RequestLifecycleMetric:
+    """A successful streamed request with synthetic timestamps, bypassing the
+    chunk re-parse (no tokenizer is passed to summarize_requests) so the TTFT
+    arithmetic is tested against exact, controlled inputs."""
+    return RequestLifecycleMetric(
+        scheduled_time=start_time,
+        start_time=start_time,
+        end_time=end_time,
+        request_data="prompt",
+        info=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=1)),
+            response_metrics=StreamedResponseMetrics(
+                output_tokens=output_tokens,
+                output_token_times=output_token_times,
+                reasoning_chunk_times=reasoning_chunk_times or [],
+            ),
+        ),
+        error=None,
+    )
+
+
+def test_ttft_anchors_to_reasoning_not_first_content() -> None:
+    """The inflated case: reasoning starts at t=2.0 but content only at t=5.0.
+    Pre-#559 TTFT reported 4.0s (time-to-first-content, i.e. prefill + the
+    whole reasoning-decode phase); it must report 1.0s, the first generated
+    token. ITL and TPOT keep ignoring the reasoning channel."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=6.0,
+        output_token_times=[5.0, 5.1, 5.2],
+        reasoning_chunk_times=[2.0, 2.5],
+        output_tokens=3,
+    )
+    result = summarize_requests([metric], [50])
+
+    ttft = result.successes["latency"]["time_to_first_token"]
+    assert ttft is not None
+    assert ttft["mean"] == pytest.approx(1.0)
+    # ITL only spans content gaps (5.0->5.1->5.2); the 2.5s reasoning->content
+    # gap must not appear in it.
+    itl = result.successes["latency"]["inter_token_latency"]
+    assert itl is not None
+    assert itl["max"] == pytest.approx(0.1)
+
+
+def test_ttft_defined_for_reasoning_only_stream() -> None:
+    """The null case: the output budget is exhausted mid-reasoning so no
+    content token ever arrives. Pre-#559 TTFT was null; it must report the
+    first reasoning token, while TPOT and ITL stay undefined (no content)."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=4.0,
+        output_token_times=[],
+        reasoning_chunk_times=[2.0, 2.5, 3.0],
+    )
+    result = summarize_requests([metric], [50])
+
+    ttft = result.successes["latency"]["time_to_first_token"]
+    assert ttft is not None, "reasoning-only stream must still yield a TTFT"
+    assert ttft["mean"] == pytest.approx(1.0)
+    assert result.successes["latency"]["time_per_output_token"] is None
+    assert result.successes["latency"]["inter_token_latency"] is None
+
+
+def test_ttft_unchanged_for_content_only_stream() -> None:
+    """Non-reasoning responses must keep the exact pre-#559 semantics."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=6.0,
+        output_token_times=[3.0, 3.2, 3.4],
+        output_tokens=3,
+    )
+    result = summarize_requests([metric], [50])
+
+    ttft = result.successes["latency"]["time_to_first_token"]
+    assert ttft is not None
+    assert ttft["mean"] == pytest.approx(2.0)
+
+
+def test_ttft_undefined_below_two_generation_events() -> None:
+    """A single timestamped event across both channels is indistinguishable
+    from a unary response, so TTFT stays undefined, matching the pre-#559
+    guard against single-event streams."""
+    metric = make_streamed_metric(
+        start_time=1.0,
+        end_time=4.0,
+        output_token_times=[],
+        reasoning_chunk_times=[2.0],
+    )
+    result = summarize_requests([metric], [50])
+
+    assert result.successes["latency"]["time_to_first_token"] is None
+
+
+def _build_reasoning_sse(reasoning_texts: List[str], content_texts: List[str], completion_tokens: int) -> bytes:
+    parts = [f'data: {{"choices":[{{"delta":{{"reasoning_content":"{t}"}}}}]}}\n\n'.encode() for t in reasoning_texts]
+    parts += [f'data: {{"choices":[{{"delta":{{"content":"{t}"}}}}]}}\n\n'.encode() for t in content_texts]
+    parts.append(f'data: {{"choices":[],"usage":{{"completion_tokens":{completion_tokens}}}}}\n\n'.encode())
+    parts.append(b"data: [DONE]\n\n")
+    return b"".join(parts)
+
+
+class FakeStreamingResponse:
+    """Minimal aiohttp ClientResponse stand-in that yields preset SSE bytes."""
+
+    def __init__(self, body: bytes) -> None:
+        self.status = 200
+        self.content = MagicMock()
+
+        async def iter_any() -> AsyncGenerator[bytes, None]:
+            yield body
+
+        self.content.iter_any = iter_any
+
+
+@pytest.mark.asyncio
+async def test_pipeline_output_len_content_only_and_accounting_includes_reasoning() -> None:
+    """Full pipeline (SSE bytes -> process_response -> summarize_requests):
+    client output_len must count content tokens only, while the token-count
+    mismatch check must include reasoning tokens, since the server's
+    completion_tokens counts them. With a tokenizer matching the server the
+    request must therefore NOT flag as mismatched."""
+    reasoning_texts = ["think one two", " three four"]  # 5 tokens
+    content_texts = ["answer is", " four ok"]  # 4 tokens
+    sse = _build_reasoning_sse(reasoning_texts, content_texts, completion_tokens=9)
+
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+
+    config = APIConfig(type=APIType.Chat, streaming=True)
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="prompt")], max_tokens=100)
+    info = await data.process_response(cast(ClientResponse, FakeStreamingResponse(sse)), config, tokenizer)
+
+    assert isinstance(info.response_metrics, StreamedResponseMetrics)
+    # output_tokens (client) is content-only: reasoning is not user-facing output.
+    assert info.response_metrics.output_tokens == 4
+    assert len(info.response_metrics.reasoning_chunks) == 2
+    assert len(info.response_metrics.chunk_times) == 2
+
+    metric = RequestLifecycleMetric(
+        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="prompt", info=info, error=None
+    )
+    result = summarize_requests([metric], [50], tokenizer=tokenizer)
+    assert result.successes["token_count_mismatches"] == 0
+
+    # The capped variant: no content at all, TTFT still defined end-to-end.
+    capped_sse = _build_reasoning_sse(["think one two", "three four"], [], completion_tokens=5)
+    capped_info = await data.process_response(cast(ClientResponse, FakeStreamingResponse(capped_sse)), config, tokenizer)
+    assert isinstance(capped_info.response_metrics, StreamedResponseMetrics)
+    assert capped_info.response_metrics.output_tokens == 0
+
+    capped_metric = RequestLifecycleMetric(
+        scheduled_time=0.0, start_time=0.0, end_time=10.0, request_data="prompt", info=capped_info, error=None
+    )
+    capped_result = summarize_requests([capped_metric], [50], tokenizer=tokenizer)
+    assert capped_result.successes["latency"]["time_to_first_token"] is not None
+    assert capped_result.successes["token_count_mismatches"] == 0


### PR DESCRIPTION
Part of #632. `num_workers` = 0 / 1 / N is now driven end to end with real worker processes against an in-process fake server, and `LocalRequestMetricCollector` vs `MultiprocessRequestMetricCollector` aggregates are compared field by field for one fixed body of load. Neither was asserted anywhere before.

Rows in #606: Integration / **Worker matrix (#632)**; e2e / **Worker matrix smoke (#632)**, type `sim`.

## Why this is needed

`num_workers` selects between two execution architectures, and every motivating bug is process machinery: #589 (datagen not picklable), #590 (crash only on the `num_workers = 0` path, which nothing in CI runs), #469 (barrier hang), #593 (no diagnostics on worker crash). The default is `max(1, cpu_count())`, so CI exercises whichever cell the runner has. #526 and #305 change spawn semantics here and need a gate.

## What the test does

**Integration, `tests/required/integration/test_worker_matrix.py` (per-change).**

- **Faked:** the server only. `FakeOpenAIServer` (from #694) streams a fixed four-chunk script over loopback. Everything else (worker processes, barrier, the shipped OpenAI client, its SSE parsing) is real; only the client constructor is swapped.
- **Oracle:** the fake server's own record of what it served. In all three cells, requests the client accounts for must equal requests the server handled; mp cells also get an exact per-stage count.
- **Collector equivalence:** the same metric objects go through both collectors, the multiprocess one fed from a real child process. Exact for counts and token values; structural for which latency fields are `None`; within 1e-9 for latency summaries (arrival-order float summation).
- **Start-method agnostic** (passes before and after #526); asserts what #526 depends on directly: the worker payload survives a pickle round trip (#589). Verified under `fork` and `forkserver`. Real-process work is under `asyncio.wait_for`, so a barrier regression (#469) fails instead of hanging CI. N is pinned at 4.

**e2e, `e2e/tests/test_worker_matrix_smoke.py` (sim, at-merge).**

One two-stage run at pinned N against `llm-d-inference-sim`, covering **worker teardown** (CLI exits 0, every worker joined) and **the liveness check** (`run_stage` polls `Worker.is_alive()`). Ground truth is the sim's own `usage`: `ignore_eos` plus a degenerate output distribution pins exactly 8 tokens and 8 chunks per request, plus a TTFT floor. Client re-tokenization measures 0 to 2 tokens above the server, so that is not held to zero here.

## Found while writing this: the `num_workers = 0` path crashes about half the time

`LoadGenerator.run()` walks `zip(self.datagen.get_data(), time_generator, strict=True)` and relies on breaking at the stage deadline before the timer runs out. `ConstantLoadTimer` normalizes intervals to sum to exactly the stage duration, so the last scheduled time lands **on** the deadline and float rounding decides; when the loop loses, `strict=True` raises `ValueError: zip() argument 2 is shorter than argument 1`. Reproduced 4 and 5 of 10 runs. Introduced in #388. The 0 cell is `xfail(strict=False)` and kept, because omitting the failing cell is how #590 stayed open. Fix belongs in its own change (#638 norm).

Side note for #526 and #589: Python 3.14 defaults to `forkserver`, and on 3.14 the existing e2e suite already fails six sim cases with the #589 `cannot pickle 'itertools.cycle'` error, independent of #526.

## Status

Stacked on **#694** (`ec600b2`), source of `fake_openai_server.py`; the diff shrinks to two new files once it merges.

Verified locally: `pdm run validate` clean; `pdm run test` 889 passed, 15 skipped, 1 xfailed (the 0 cell flips to xpassed on some runs); e2e smoke test 3/3 against a real sim v0.6.1 (skips when the sim is not on `PATH`).

Not verified: the smoke test failed once under `pdm run test:e2e -n auto` (all 24 requests `ClientConnectorError`) but passes standalone and at `-n 3`; likely local contention, unproven.

