### PR TITLE
ci: run the e2e job on ARM runners so the live oracle stops failing on a runner draw

### DIFF
--- a/.github/workflows/e2e_test-on-change.yml
+++ b/.github/workflows/e2e_test-on-change.yml
@@ -12,7 +12,15 @@ on:
 
 jobs:
   e2e-tests:
-    runs-on: ubuntu-latest
+    # ARM, not x86: the live-oracle step below starts a real vLLM CPU server,
+    # and the ubuntu-latest x86 pool hands out several CPU models, some of
+    # which cannot run it (AMD EPYC 9xxx VMs with AVX-512 masked by the
+    # hypervisor: vLLM's sampler is a Triton kernel that triton-cpu compiles
+    # for the host CPU name, znver4, so the worker traps on invalid opcode).
+    # That made the job red on a runner draw, not on a code change. GitHub's
+    # ARM pool is one CPU, so the same job on it is deterministic; there is
+    # no way to pin a CPU model within the x86 pool.
+    runs-on: ubuntu-24.04-arm
     env:
       VLLM_MODEL: facebook/opt-125m
     steps:
@@ -83,7 +91,7 @@ jobs:
           failed=""
           for v in $VLLM_VERSIONS; do
             if e2e/vllm_cpu_server.sh start "$v"; then
-              # A red release must name what it resolved to; latest-x86_64
+              # A red release must name what it resolved to; latest
               # points at a different release over time.
               {
                 echo "### $v resolved to"

--- a/e2e/testdata/vllm_metric_families/v0.26.0.txt
+++ b/e2e/testdata/vllm_metric_families/v0.26.0.txt
@@ -1,4 +1,4 @@
-# vllm:* metric families exposed by vllm-openai-cpu:v0.26.0-x86_64 under the
+# vllm:* metric families exposed by vllm-openai-cpu:v0.26.0 under the
 # e2e launch config (e2e/vllm_cpu_server.sh), captured after one warmup
 # request. Regenerate against a freshly started server of this release:
 #   e2e/vllm_cpu_server.sh start <release-tag>

--- a/e2e/vllm_cpu_server.sh
+++ b/e2e/vllm_cpu_server.sh
@@ -24,8 +24,8 @@
 #
 # Release tags come from e2e/vllm_releases.txt. Local repro of the CI slice:
 #
-#   e2e/vllm_cpu_server.sh start v0.26.0-x86_64
-#   E2E_VLLM_BASE_URL=http://127.0.0.1:8000 E2E_VLLM_VERSION=v0.26.0-x86_64 \
+#   e2e/vllm_cpu_server.sh start v0.26.0
+#   E2E_VLLM_BASE_URL=http://127.0.0.1:8000 E2E_VLLM_VERSION=v0.26.0 \
 #     pdm run test:e2e:live
 #   e2e/vllm_cpu_server.sh stop
 #

--- a/e2e/vllm_releases.txt
+++ b/e2e/vllm_releases.txt
@@ -1,11 +1,13 @@
 # The vLLM releases the live-oracle e2e slice gates against: tags of
 # docker.io/vllm/vllm-openai-cpu, one per line; comments and blank lines are
-# ignored. The e2e-tests CI job starts a real server of every listed release
+# ignored. Use the multi-arch tags (v0.26.0, latest), not the -x86_64 or
+# -arm64 forms: they resolve to the same per-arch images, so one table serves
+# CI (ARM runners) and local repro on any host. The e2e-tests CI job starts a real server of every listed release
 # (via e2e/vllm_cpu_server.sh) and runs the full live-oracle slice
 # (e2e/tests/test_vllm_*.py) against each one, all merge-blocking.
 #
 # Add a release when it starts to matter to a deployment we care about;
-# prune entries aggressively once they stop mattering. latest-x86_64 floats
+# prune entries aggressively once they stop mattering. latest floats
 # with upstream, so a new release's drift surfaces here before, not at, the
 # next pin bump.
 #
@@ -13,10 +15,10 @@
 # (e2e/testdata/vllm_metric_families/<tag>.txt): adding a pin means also
 # capturing its golden (see a golden's header for the two commands), and the
 # serverless slice then holds the client's declarations against every pin
-# without a server. latest-x86_64 deliberately has no golden; its live slice
+# without a server. latest deliberately has no golden; its live slice
 # is where upstream metric drift goes red first. When declarations and a
 # release genuinely diverge, that red forces the explicit choice:
 # version-aware query declarations (#669) or pruning the entry.
 
-v0.26.0-x86_64
-latest-x86_64
+v0.26.0
+latest

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
       {
         systems = [
           "x86_64-linux"
+          "aarch64-linux" # the e2e-tests CI job runs on GitHub's ARM runners
         ];
         flake = {
           lib = {


### PR DESCRIPTION
**The e2e job goes red on a runner draw, not on a code change, and the fix is to draw from a pool with one CPU.** `ubuntu-latest` hands out several x86 CPU models, and about half of them today are AMD EPYC 9xxx VMs with AVX-512 masked by the hypervisor. `vllm-openai-cpu` cannot start there: its sampler is a Triton kernel that triton-cpu compiles for the host CPU *name* (znver4, an AVX-512 part), so the worker traps on invalid opcode in the first forward pass and the live oracle never becomes healthy. That put `main` red twice today (#699, #715) and failed 10 of the 25 e2e runs in one PR batch, on branches sharing no code.

## Why not fix it in place

There is no knob. On five bad draws, six candidate settings all died at the same point: baseline, `TORCHINDUCTOR_CPP_SIMDLEN=256`, `VLLM_CPU_SGL_KERNEL=1`, `TRITON_CPU_BACKEND=0`, `--compilation-config custom_ops none`, `--dtype float32`. In source: vLLM v0.26.0 calls `gumbel_sample` unconditionally (greedy included), and triton-cpu's compiler has no target-CPU override. GitHub exposes no way to pin a CPU model within the x86 pool. The alternative was a runner-SKU check plus an auto-rerun workflow (this PR's first version); it worked, but it is a denylist tied to today's fleet and adds machinery to a job that should be simple.

GitHub's ARM hosted runners are one CPU. Six probe shards all drew a Neoverse-N2, and the same job there is deterministic.

## What this changes

- `e2e-tests`: `runs-on: ubuntu-24.04-arm`, with the reason in a comment.
- `flake.nix`: `aarch64-linux` added to `systems`, so `nix develop` works there.
- `e2e/vllm_releases.txt`: the multi-arch tags `v0.26.0` and `latest` instead of the `-x86_64` forms. They resolve to the same per-arch images (digest-checked against `-x86_64` and `-arm64`), so one table serves CI on ARM and local repro on any host.
- Metric-family golden renamed `v0.26.0-x86_64.txt` to `v0.26.0.txt`; contents unchanged.

No SKU check, no rerun workflow, no CPU names anywhere but the comment.

## Verified

The full `E2E Test on change` job on my fork at this commit, on `ubuntu-24.04-arm`, against the last green x86 run on `main`:

```
                     x86 (good draw)          ARM
sim suite            35 passed, 18 skipped    35 passed, 18 skipped
live v0.26.0         11 passed                11 passed
live latest          10 passed, 1 skipped     10 passed, 1 skipped
server healthy       ~8 min                   ~60 s
whole job            24m47                    16m14
```

Identical counts. The arm64 image exposes the same 36 `vllm:*` metric families as the committed golden, checked on all six probe shards.

## Tradeoffs

- The oracle now runs on ARM, which is not where most deployments run. What it checks (tokenizer, `usage` accounting, `/metrics` exposition) is architecture-independent, and the identical results above are the evidence, but the arm64 vLLM CPU build is a separate build and could diverge from x86 in ways this job would not see.
- The ARM pool queued this run about 5 minutes before starting; the x86 pool starts in seconds. That is well inside what the faster job gives back.
- `latest` and `v0.26.0` on x86 dev machines now resolve to the x86 images automatically; anyone pinning `-x86_64` locally should drop the suffix.

Part of #703.
