### PR TITLE
fix: record a 200 that carries an error payload or nothing as a failure

### DIFF
--- a/docs/reports.md
+++ b/docs/reports.md
@@ -86,5 +86,5 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
 
 - **`load_summary`**: Details about the requested vs achieved load.
 - **`successes`**: Metrics for successful requests.
-- **`failures`**: Metrics for failed requests, including the per-label error breakdown.
+- **`failures`**: Metrics for failed requests, including the per-label error breakdown. A request fails on a non-200 status, on a transport error, or on a 200 whose body is not a completion: a body carrying a top-level `error` object (label `inbanderror`, `error_msg` is that object) or one with neither completion content nor `usage` (label `emptyresponseerror`). The body is kept as `response` in the per-request report either way.
 - **`goodput_metrics`**: (Optional) Goodput statistics if constraints were configured.

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -34,6 +34,7 @@ from inference_perf.payloads import (
     SyntheticImageSpec,
     SyntheticMp4VideoSpec,
 )
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError, in_band_error
 from inference_perf.apis.streaming_parser import parse_sse_stream
 from inference_perf.config import APIConfig, APIType
 from inference_perf.mediagen.pool import get_video_pool
@@ -564,6 +565,10 @@ class ChatCompletionAPIData(InferenceAPIData):
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
+            # A stream that carried neither content nor usage is not a completion
+            # (an error page or an empty stream behind a 200), not a zero-token one.
+            if not output_text and server_usage is None:
+                raise EmptyResponseError(raw_content)
             prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
             # with special tokens would add a BOS the server's completion_tokens
@@ -583,15 +588,21 @@ class ChatCompletionAPIData(InferenceAPIData):
             )
 
         data = await response.json()
+        # A 200 whose body is an error payload is that error, not a success.
+        if (error_payload := in_band_error(data)) is not None:
+            raise InBandError(error_payload)
         server_usage = data.get("usage")
-        prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
         choices = data.get("choices", [])
+        output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
+        # No content and no usage means the body is not a completion at all.
+        if not output_text and server_usage is None:
+            raise EmptyResponseError()
+        prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
         if len(choices) == 0:
             return InferenceInfo(
                 request_metrics=self._build_request_metrics(prompt_len, 0),
                 lora_adapter=lora_adapter,
             )
-        output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
         output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
         return InferenceInfo(
             request_metrics=self._build_request_metrics(prompt_len, output_len),

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -20,6 +20,7 @@ from inference_perf.apis import InferenceAPIData, InferenceInfo, UnaryResponseMe
 from inference_perf.payloads import RequestBody, RequestMetrics, Text
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.config import APIConfig, APIType
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError, in_band_error
 from inference_perf.apis.streaming_parser import parse_sse_stream
 
 
@@ -78,6 +79,10 @@ class CompletionAPIData(InferenceAPIData):
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("text")
             )
+            # A stream that carried neither content nor usage is not a completion
+            # (an error page or an empty stream behind a 200), not a zero-token one.
+            if not output_text and server_usage is None:
+                raise EmptyResponseError(raw_content)
 
             prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
@@ -99,15 +104,21 @@ class CompletionAPIData(InferenceAPIData):
             )
         else:
             data = await response.json()
+            # A 200 whose body is an error payload is that error, not a success.
+            if (error_payload := in_band_error(data)) is not None:
+                raise InBandError(error_payload)
             server_usage = data.get("usage")
-            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             choices = data.get("choices", [])
+            output_text = choices[0].get("text", "") if choices else ""
+            # No content and no usage means the body is not a completion at all.
+            if not output_text and server_usage is None:
+                raise EmptyResponseError()
+            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             if len(choices) == 0:
                 return InferenceInfo(
                     request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
                     lora_adapter=lora_adapter,
                 )
-            output_text = choices[0].get("text", "")
             output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             self.model_response = output_text
             return InferenceInfo(

--- a/inference_perf/apis/response_errors.py
+++ b/inference_perf/apis/response_errors.py
@@ -1,0 +1,78 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What a 200 can carry that is not a completion.
+
+A non-200 status is a failure by construction. A 200 is only a success if its
+body actually is a completion: some servers and proxies answer 200 and put the
+failure in the body, and a body with no content and no ``usage`` says nothing at
+all. Both used to be recorded as zero-token successes (#713). The exceptions here
+are raised by ``process_response`` on such bodies so the client records the
+request as failed, with the body preserved, the same way it does for a stream
+that breaks partway (``StreamInterruptedError``).
+"""
+
+import json
+from typing import Any, Optional
+
+
+class InvalidResponseError(Exception):
+    """A 200 response whose body is not a completion.
+
+    Unlike ``StreamInterruptedError`` this is raised after the body was read: the
+    transport succeeded, the payload is what failed. ``raw_content`` is the body
+    as received, so the client can record what the server actually sent. Streaming
+    callers pass the bytes read so far; unary callers leave it empty because the
+    client already holds the body it handed to ``process_response``.
+    """
+
+    def __init__(self, message: str, raw_content: str = "") -> None:
+        super().__init__(message)
+        self.raw_content = raw_content
+
+
+class InBandError(InvalidResponseError):
+    """The body carries a top-level ``error`` where a completion was expected.
+
+    ``str(exc)`` is the error payload's JSON text, so it lands in ``error_msg``
+    in the same shape as a non-200 body and reportgen's ``parse_error_message``
+    pulls the server's message out of it unchanged.
+    """
+
+
+class EmptyResponseError(InvalidResponseError):
+    """The body parsed as a completion but yielded no content and no ``usage``.
+
+    A response with neither has nothing that could be measured, and a well-formed
+    empty completion always carries ``usage``: it is mandatory in a unary
+    completion body, and every streaming request asks for it with
+    ``stream_options.include_usage``.
+    """
+
+    def __init__(self, raw_content: str = "") -> None:
+        super().__init__("200 response with no completion content and no usage", raw_content)
+
+
+def in_band_error(data: Any) -> Optional[str]:
+    """Return the JSON text of ``data`` if it is a body or SSE frame carrying a
+    top-level ``error``, else None.
+
+    Only a top-level key counts. That is the shape every server family uses for
+    an error it delivers in-band: the OpenAI ``{"error": {...}}`` object (vLLM and
+    SGLang emit it mid-stream), TGI's ``{"error": "...", "error_type": ...}``
+    string form, and Anthropic's ``{"type": "error", "error": {...}}`` event.
+    """
+    if isinstance(data, dict) and data.get("error"):
+        return json.dumps(data)
+    return None

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -25,6 +25,8 @@ from typing import Any, Callable, List, Optional, Tuple
 
 from aiohttp import ClientResponse
 
+from inference_perf.apis.response_errors import InBandError, in_band_error
+
 
 class StreamInterruptedError(Exception):
     """Raised when an SSE stream fails partway through being read.
@@ -72,6 +74,12 @@ async def parse_sse_stream(
           (e.g. OpenAI trailing `{"choices":[],"usage":{...}}` or Anthropic
           `message.usage`/`message_delta.usage`). None if the server didn't
           emit usage.
+
+    Raises:
+        InBandError: a frame carried a top-level ``error`` payload (a 200 whose
+            failure is in the body). The rest of the stream is still read so
+            the exception's ``raw_content`` holds the whole body.
+        StreamInterruptedError: the stream broke before it ended.
     """
     output_text = ""
     chunk_times: List[float] = []
@@ -79,6 +87,11 @@ async def parse_sse_stream(
     raw_content = b""
     response_chunks: List[str] = []
     server_usage: Optional[dict[str, Any]] = None
+    # First in-band error payload seen. Reading continues past it so the raw
+    # body is complete and the connection drains normally; the raise happens
+    # once the stream ends. If the stream breaks after it, the error payload
+    # is still the failure worth reporting, not the transport symptom.
+    error_payload: Optional[str] = None
 
     try:
         async for chunk in response.content.iter_any():
@@ -96,6 +109,8 @@ async def parse_sse_stream(
                             break
                         try:
                             data = json.loads(data_str)
+                            if error_payload is None:
+                                error_payload = in_band_error(data)
                             usage = data.get("usage")
                             if not isinstance(usage, dict):
                                 message_data = data.get("message")
@@ -116,6 +131,11 @@ async def parse_sse_stream(
         # connection, or a proxy that 200s then sends an error page). Re-raise
         # with the bytes received so far attached so the caller can still record
         # what the server actually sent instead of an empty response body.
+        if error_payload is not None:
+            raise InBandError(error_payload, raw_content.decode("utf-8", errors="ignore")) from e
         raise StreamInterruptedError(e, raw_content.decode("utf-8", errors="ignore")) from e
+
+    if error_payload is not None:
+        raise InBandError(error_payload, raw_content.decode("utf-8", errors="ignore"))
 
     return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -23,6 +23,7 @@ from inference_perf.apis import (
     StreamedResponseMetrics,
 )
 from inference_perf.apis.anthropic_messages import ANTHROPIC_VERSION, parse_anthropic_content
+from inference_perf.apis.response_errors import InvalidResponseError
 from inference_perf.apis.streaming_parser import StreamInterruptedError
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.utils import CustomTokenizer
@@ -505,6 +506,12 @@ class openAIModelServerClientSession(ModelServerClientSession):
                                 original_error = read_error.original
                                 if read_error.raw_content:
                                     response_content = read_error.raw_content
+                            # A 200 whose body is not a completion (an in-band
+                            # error payload, or no content and no usage) is
+                            # reported under its own type; the body it carries
+                            # is the evidence, so keep it as the response.
+                            elif isinstance(read_error, InvalidResponseError) and read_error.raw_content:
+                                response_content = read_error.raw_content
                             error = ErrorResponseInfo(
                                 error_msg=str(original_error),
                                 error_type=type(original_error).__name__,

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
+import json
 import logging
 from typing import Any, AsyncGenerator, Iterator, List, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,7 @@ from aiohttp import ClientResponse
 from inference_perf.apis import UnaryResponseMetrics
 from inference_perf.apis import chat as chat_module
 from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError
 from inference_perf.config import APIType
 from inference_perf.payloads import (
     ImageRepresentation,
@@ -178,6 +180,47 @@ async def test_process_response_streaming_uses_server_prompt_tokens() -> None:
     info = await data.process_response(response, _make_config(streaming=True), tokenizer)
 
     assert info.request_metrics.text.input_tokens == 17
+
+
+# Unary 200 whose body is `{"error": {...}}` (the #713 shape). Must raise
+# InBandError carrying that body as its message rather than return a zero-token
+# InferenceInfo through the empty-choices early return.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_in_band_error_body_raises() -> None:
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")])
+    body = {"error": {"message": "upstream unavailable", "type": "server_error", "code": 503}}
+    response = MagicMock()
+    response.json = AsyncMock(return_value=body)
+
+    with pytest.raises(InBandError) as exc_info:
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+    assert json.loads(str(exc_info.value)) == body
+
+
+# Unary 200 whose body is `{}`: no choices, no usage. Must raise EmptyResponseError.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_no_choices_no_usage_raises() -> None:
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")])
+    response = MagicMock()
+    response.json = AsyncMock(return_value={})
+
+    with pytest.raises(EmptyResponseError):
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+
+# Streaming 200 whose frames are a role-only delta and [DONE]: no content, no
+# usage. Must raise EmptyResponseError with the raw stream attached.
+@pytest.mark.asyncio
+async def test_process_response_streaming_no_content_no_usage_raises() -> None:
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")])
+    sse = b'data: {"choices": [{"delta": {"role": "assistant"}}]}\n\ndata: [DONE]\n\n'
+    response = cast(ClientResponse, _FakeStreamingResponse([sse]))
+
+    with pytest.raises(EmptyResponseError) as exc_info:
+        await data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+    assert exc_info.value.raw_content == sse.decode()
 
 
 def _reset_multimodal_progress_state() -> None:

--- a/tests/required/apis/test_completion.py
+++ b/tests/required/apis/test_completion.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from typing import AsyncGenerator, List, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -19,6 +20,7 @@ from aiohttp import ClientResponse
 
 from inference_perf.apis import ChatCompletionAPIData, ChatMessage, UnaryResponseMetrics
 from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError
 from inference_perf.config import APIType
 
 
@@ -235,3 +237,62 @@ async def test_process_response_streaming_falls_back_without_server_usage() -> N
     info = await data.process_response(response, _make_config(streaming=True), tokenizer)
 
     assert info.request_metrics.text.input_tokens == 3
+
+
+# Unary 200 whose body is `{"error": {...}}` and nothing else. Must raise
+# InBandError carrying that body as its message instead of returning a
+# zero-token InferenceInfo.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_in_band_error_body_raises() -> None:
+    """The #713 unary shape: a proxy that answers 200 with an OpenAI error object.
+    Before, the empty `choices` early-return recorded it as a success."""
+    data = CompletionAPIData(prompt="hi")
+    body = {"error": {"message": "upstream unavailable", "type": "server_error", "code": 503}}
+    response = MagicMock()
+    response.json = AsyncMock(return_value=body)
+
+    with pytest.raises(InBandError) as exc_info:
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+    assert json.loads(str(exc_info.value)) == body
+
+
+# Unary 200 whose body is `{}`: no choices, no usage, no error. Must raise
+# EmptyResponseError. The sibling test above with `{"choices": [], "usage": {...}}`
+# still returns an InferenceInfo, so usage is what separates the two.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_no_choices_no_usage_raises() -> None:
+    data = CompletionAPIData(prompt="hi")
+    response = MagicMock()
+    response.json = AsyncMock(return_value={})
+
+    with pytest.raises(EmptyResponseError):
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+
+# Streaming 200 whose only frame is [DONE]: no content, no usage. Must raise
+# EmptyResponseError with the raw stream attached, not return output_tokens=0.
+@pytest.mark.asyncio
+async def test_process_response_streaming_no_content_no_usage_raises() -> None:
+    data = CompletionAPIData(prompt="hi")
+    response = cast(ClientResponse, _FakeStreamingResponse([b"data: [DONE]\n\n"]))
+
+    with pytest.raises(EmptyResponseError) as exc_info:
+        await data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+    assert exc_info.value.raw_content == "data: [DONE]\n\n"
+
+
+# Streaming 200 with no content but a usage frame saying completion_tokens=0.
+# That is a legitimate empty completion: must return an InferenceInfo, not raise.
+@pytest.mark.asyncio
+async def test_process_response_streaming_no_content_with_usage_is_a_success() -> None:
+    data = CompletionAPIData(prompt="hi")
+    sse = b'data: {"choices": [], "usage": {"prompt_tokens": 3, "completion_tokens": 0}}\n\ndata: [DONE]\n\n'
+    response = cast(ClientResponse, _FakeStreamingResponse([sse]))
+
+    info = await data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+    assert info.request_metrics.text.input_tokens == 3
+    assert info.response_metrics is not None
+    assert info.response_metrics.server_usage == {"prompt_tokens": 3, "completion_tokens": 0}

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from typing import Any, AsyncGenerator, Optional
 from unittest.mock import Mock
+from inference_perf.apis.response_errors import InBandError
 from inference_perf.apis.streaming_parser import parse_sse_stream, StreamInterruptedError
 import pytest
 
@@ -136,3 +138,88 @@ async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
     # The bytes received before the break are retained, not discarded.
     assert "Hello" in err.raw_content
     assert "world" in err.raw_content
+
+
+# Builds a fake aiohttp response whose body is the given SSE chunks, optionally
+# raising `broken_by` after the last one, and returns it with the standard chat
+# delta extractor.
+def _stream(chunks: list[bytes], broken_by: Optional[Exception] = None) -> tuple[Mock, Any]:
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+        if broken_by is not None:
+            raise broken_by
+
+    mock_content.iter_any = mock_iter_any
+
+    def extract_content(data: dict[str, Any]) -> Optional[str]:
+        return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
+
+    return mock_response, extract_content
+
+
+# One content frame, then a `{"error": {...}}` frame, then [DONE], all delivered
+# cleanly. Must raise InBandError whose message is the error frame's JSON and whose
+# raw_content is the whole stream, [DONE] included, rather than return "Hello".
+@pytest.mark.asyncio
+async def test_parse_sse_stream_raises_on_in_band_error_frame() -> None:
+    """A 200 stream that carries its failure as a frame (the #713 shape, what vLLM
+    and SGLang emit when generation fails mid-stream) is that failure, not a short
+    success. The stream is read to the end first so raw_content is the full body."""
+    error_frame = b'{"error": {"message": "The model is overloaded", "type": "server_error", "code": 503}}'
+    mock_response, extract_content = _stream(
+        [
+            b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+            b"data: " + error_frame + b"\n\n",
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    with pytest.raises(InBandError) as exc_info:
+        await parse_sse_stream(mock_response, extract_content)
+
+    err = exc_info.value
+    assert json.loads(str(err)) == json.loads(error_frame)
+    assert "Hello" in err.raw_content
+    assert "[DONE]" in err.raw_content, "the stream must be drained before raising"
+
+
+# An error frame followed by a dropped connection. The in-band error must win over
+# the transport error: InBandError, not StreamInterruptedError, and the raw body
+# still holds the frame.
+@pytest.mark.asyncio
+async def test_parse_sse_stream_in_band_error_wins_over_a_later_break() -> None:
+    """When the server says why it failed and then drops the connection, the reason
+    is what belongs in the report; the break is a symptom."""
+    error_frame = b'{"error": {"message": "engine died", "type": "server_error"}}'
+    mock_response, extract_content = _stream(
+        [b"data: " + error_frame + b"\n\n"], broken_by=ConnectionResetError("Response payload is not completed")
+    )
+
+    with pytest.raises(InBandError) as exc_info:
+        await parse_sse_stream(mock_response, extract_content)
+
+    assert json.loads(str(exc_info.value)) == json.loads(error_frame)
+    assert "engine died" in exc_info.value.raw_content
+
+
+# A normal frame that happens to carry `"error": null` next to its choices. Must
+# parse as a plain "Hello" success: only a truthy top-level error counts.
+@pytest.mark.asyncio
+async def test_parse_sse_stream_ignores_null_error_field() -> None:
+    mock_response, extract_content = _stream(
+        [
+            b'data: {"choices": [{"delta": {"content": "Hello"}}], "error": null}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    output_text, chunk_times, _, response_chunks, server_usage = await parse_sse_stream(mock_response, extract_content)
+
+    assert output_text == "Hello"
+    assert len(chunk_times) == len(response_chunks) == 1
+    assert server_usage is None

--- a/tests/required/integration/fake_truncating_server.py
+++ b/tests/required/integration/fake_truncating_server.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A fake model server that 200s and then breaks the stream, for the
+integration tier.
+
+The sim cannot fail on cue, so the truncated-stream condition has to be
+induced. This speaks raw HTTP/1.1 rather than going through an server
+framework because the failure being reproduced *is* a protocol-level lie: the
+response declares a ``Content-Length`` larger than the body it actually sends
+and then half-closes. aiohttp raises a real ``ClientPayloadError`` when the
+connection ends early, so tests exercise the client's genuine exception path
+instead of a patched-in exception (the #606 Integration tier's "fake the
+conditions, never the oracle" principle).
+"""
+
+import asyncio
+from types import TracebackType
+from typing import List, Optional, Type
+
+
+class TruncatingSSEServer:
+    """Serves a 200 SSE response that stops short of its declared length.
+
+    ``events`` are the JSON payloads to emit as ``data:`` frames before the
+    break; pass an empty list to break before any body byte is sent.
+    ``sent_body`` records exactly what went out on the wire so a test can
+    assert the client preserved that text and not an approximation of it.
+    """
+
+    def __init__(self, events: List[str], missing_bytes: int = 64) -> None:
+        self.events = events
+        # How far the declared Content-Length overshoots what we actually
+        # write. Any positive value triggers the client-side error.
+        self.missing_bytes = missing_bytes
+        self.sent_body = ""
+        self._server: Optional[asyncio.AbstractServer] = None
+        self.port = 0
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def __aenter__(self) -> "TruncatingSSEServer":
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+        return self
+
+    async def __aexit__(
+        self, exc_type: Optional[Type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
+    ) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    @staticmethod
+    async def _drain_request(reader: asyncio.StreamReader) -> None:
+        """Read the full request so the client's own write completes cleanly and
+        the only failure under test is the response-side truncation."""
+        header = await reader.readuntil(b"\r\n\r\n")
+        content_length = 0
+        for line in header.split(b"\r\n"):
+            if line.lower().startswith(b"content-length:"):
+                content_length = int(line.split(b":", 1)[1])
+        if content_length:
+            await reader.readexactly(content_length)
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await self._drain_request(reader)
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+            writer.close()
+            return
+
+        body = "".join(f"data: {event}\n\n" for event in self.events)
+        encoded = body.encode()
+        headers = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/event-stream\r\n"
+            # The lie: promise more than we are going to send.
+            f"Content-Length: {len(encoded) + self.missing_bytes}\r\n"
+            "\r\n"
+        )
+        writer.write(headers.encode() + encoded)
+        await writer.drain()
+        self.sent_body = body
+        # Half-close so the partial body is delivered and *then* the stream
+        # ends early. An abrupt reset here would surface as a connection error
+        # rather than the incomplete-payload case #531 describes.
+        if writer.can_write_eof():
+            writer.write_eof()
+        writer.close()

--- a/tests/required/integration/fake_truncating_server.py
+++ b/tests/required/integration/fake_truncating_server.py
@@ -22,6 +22,10 @@ and then half-closes. aiohttp raises a real ``ClientPayloadError`` when the
 connection ends early, so tests exercise the client's genuine exception path
 instead of a patched-in exception (the #606 Integration tier's "fake the
 conditions, never the oracle" principle).
+
+With ``missing_bytes=0`` the server keeps its promise and the body arrives
+complete, which is the condition #713 needs: a well-formed 200 whose *payload*
+is the failure (an in-band error frame, or nothing at all).
 """
 
 import asyncio
@@ -36,13 +40,26 @@ class TruncatingSSEServer:
     break; pass an empty list to break before any body byte is sent.
     ``sent_body`` records exactly what went out on the wire so a test can
     assert the client preserved that text and not an approximation of it.
+
+    ``body`` replaces the SSE framing with a verbatim body (a unary JSON
+    response, say) and ``content_type`` labels it; ``events`` is ignored then.
     """
 
-    def __init__(self, events: List[str], missing_bytes: int = 64) -> None:
+    def __init__(
+        self,
+        events: List[str],
+        missing_bytes: int = 64,
+        *,
+        body: Optional[str] = None,
+        content_type: str = "text/event-stream",
+    ) -> None:
         self.events = events
         # How far the declared Content-Length overshoots what we actually
-        # write. Any positive value triggers the client-side error.
+        # write. Any positive value triggers the client-side error; 0 delivers
+        # the body complete.
         self.missing_bytes = missing_bytes
+        self.body = body
+        self.content_type = content_type
         self.sent_body = ""
         self._server: Optional[asyncio.AbstractServer] = None
         self.port = 0
@@ -82,12 +99,12 @@ class TruncatingSSEServer:
             writer.close()
             return
 
-        body = "".join(f"data: {event}\n\n" for event in self.events)
+        body = self.body if self.body is not None else "".join(f"data: {event}\n\n" for event in self.events)
         encoded = body.encode()
         headers = (
             "HTTP/1.1 200 OK\r\n"
-            "Content-Type: text/event-stream\r\n"
-            # The lie: promise more than we are going to send.
+            f"Content-Type: {self.content_type}\r\n"
+            # The lie (when missing_bytes > 0): promise more than we are going to send.
             f"Content-Length: {len(encoded) + self.missing_bytes}\r\n"
             "\r\n"
         )

--- a/tests/required/integration/openai_client_harness.py
+++ b/tests/required/integration/openai_client_harness.py
@@ -1,0 +1,86 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Drives one request through the real ``openAIModelServerClient`` against a
+fake server and hands back the ``RequestLifecycleMetric`` it recorded.
+
+Shared by the integration tests that fake a misbehaving server (#531, #713):
+they differ in what the server sends, not in how the client is driven.
+"""
+
+import time
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+from inference_perf.apis import InferenceAPIData, RequestLifecycleMetric
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
+from inference_perf.config import APIConfig, APIType
+from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+
+
+class ConcreteOpenAIClient(openAIModelServerClient):
+    """openAIModelServerClient is abstract only in the two methods below, and
+    neither participates in the request path under test."""
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion]
+
+    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
+        raise NotImplementedError("no server metrics are scraped in the integration tier")
+
+
+# A tokenizer stand-in that counts whitespace-separated words, so no Hub download.
+def make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+# Sends one request (a 16-token completion by default) through the real client to
+# `base_url` with the given API config, and returns the single metric the client
+# recorded for it. Fails if the client recorded zero or several metrics.
+async def run_request_against(
+    base_url: str,
+    api_config: Optional[APIConfig] = None,
+    data: Optional[InferenceAPIData] = None,
+) -> RequestLifecycleMetric:
+    """One request through the real client, returning the metric it recorded."""
+    collector = LocalRequestMetricCollector()
+    # The client builds a CustomTokenizer, which would otherwise fetch from the
+    # Hub; token counts are irrelevant to these tests, only the response body is.
+    with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
+        client = ConcreteOpenAIClient(
+            metrics_collector=collector,
+            api_config=api_config or APIConfig(type=APIType.Completion, streaming=True),
+            uri=base_url,
+            model_name="fake-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+
+    session = client.new_session()
+    try:
+        await session.process_request(
+            data or CompletionAPIData(prompt="the quick brown fox", max_tokens=16),
+            stage_id=0,
+            scheduled_time=time.perf_counter(),
+        )
+    finally:
+        await session.close()
+
+    metrics = collector.get_metrics()
+    assert len(metrics) == 1, "the client must record exactly one metric for one request"
+    return metrics[0]

--- a/tests/required/integration/test_in_band_error_200.py
+++ b/tests/required/integration/test_in_band_error_200.py
@@ -1,0 +1,176 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for issue #713 (#606 Integration tier, per-change lane).
+
+A 200 is only a success if its body is a completion. Some servers and proxies
+answer ``200 OK`` and put the failure in the body; before #713 such a request
+was recorded as a success with ``output_tokens: 0`` and counted toward
+throughput, with nothing in the report pointing at the cause.
+
+These tests drive the real client against a fake that returns a *complete*,
+well-formed 200 (the ``Content-Length`` is honest, nothing breaks) whose
+payload is either an error object or nothing at all, in both the streaming and
+the unary path, and assert the request lands in the failure bucket with the
+body preserved. No model server needed.
+"""
+
+import json
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from fake_truncating_server import TruncatingSSEServer
+from openai_client_harness import run_request_against
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
+from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
+from inference_perf.reportgen.base import ReportGenerator
+
+# The OpenAI error object as vLLM and SGLang emit it mid-stream and as a proxy
+# might return it whole. `code` inside the payload says 503; the transport says 200.
+ERROR_PAYLOAD: Dict[str, Any] = {
+    "error": {"message": "The model is overloaded, retry later", "type": "server_error", "code": 503}
+}
+ERROR_FRAME = json.dumps(ERROR_PAYLOAD)
+
+
+# Runs the summary and per-request reports over one metric and returns
+# (summary contents, per-request entries), so each test skips that plumbing.
+async def generate_reports(metric: RequestLifecycleMetric) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    config = MagicMock()
+    config.tokenizer = None
+    config.model_dump = MagicMock(return_value={})
+    generator = ReportGenerator(
+        metrics_client=None,
+        metrics_collector=MagicMock(get_metrics=MagicMock(return_value=[metric])),
+        config=config,
+    )
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=0.0,
+        duration=1.0,
+        model_server_metrics=BaseMetrics(),
+        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
+    )
+    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(summary=True, per_request=True))
+
+    reports = await generator.generate_reports(report_config, runtime_parameters)
+
+    summary = [r for r in reports if r.name == "summary_lifecycle_metrics"]
+    per_request = [r for r in reports if r.name == "per_request_lifecycle_metrics"]
+    assert len(summary) == 1 and len(per_request) == 1
+    return summary[0].contents, per_request[0].contents
+
+
+# Streaming completion (default) and streaming chat against a complete 200 whose
+# only data frame is the error object, followed by [DONE]. Both must record a
+# failure of type InBandError whose error_msg is that object, with the whole
+# body (frame and [DONE]) as response_data.
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("api_config", "data"),
+    [
+        pytest.param(APIConfig(type=APIType.Completion, streaming=True), None, id="completion"),
+        pytest.param(
+            APIConfig(type=APIType.Chat, streaming=True),
+            ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")], max_tokens=16),
+            id="chat",
+        ),
+    ],
+)
+async def test_streaming_in_band_error_frame_is_a_failure(api_config: APIConfig, data: Any) -> None:
+    """The #713 streaming shape. The stream is complete and well-formed, so no
+    transport error fires; the payload alone has to make this a failure."""
+    async with TruncatingSSEServer([ERROR_FRAME, "[DONE]"], missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url, api_config, data)
+        sent_body = server.sent_body
+
+    assert metric.error is not None, "a 200 carrying an error payload must be recorded as a failure"
+    assert metric.error.error_type == "InBandError"
+    assert json.loads(metric.error.error_msg) == ERROR_PAYLOAD, "error_msg must be the server's error object"
+    assert metric.response_data == sent_body, "the whole body must be preserved, framing included"
+    assert "[DONE]" in (metric.response_data or "")
+
+
+# Streaming completion against a complete 200 whose only frame is [DONE]: no
+# content, no usage. Must record an EmptyResponseError failure with the body kept.
+@pytest.mark.asyncio
+async def test_streaming_empty_stream_is_a_failure() -> None:
+    """A stream that says nothing is not a zero-token completion. Before #713 this
+    was a success with output_tokens 0 and an empty response."""
+    async with TruncatingSSEServer(["[DONE]"], missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url)
+        sent_body = server.sent_body
+
+    assert metric.error is not None
+    assert metric.error.error_type == "EmptyResponseError"
+    assert metric.response_data == sent_body == "data: [DONE]\n\n"
+
+
+# Unary completion against a complete 200 whose JSON body is the error object.
+# Must record an InBandError failure whose error_msg is that object and whose
+# response_data is the body as sent.
+@pytest.mark.asyncio
+async def test_unary_in_band_error_body_is_a_failure() -> None:
+    """The #713 unary shape: a proxy that answers 200 with an OpenAI error object.
+    The client reads the body before process_response, so it is the client's own
+    copy that must survive as response_data."""
+    async with TruncatingSSEServer([], missing_bytes=0, body=ERROR_FRAME, content_type="application/json") as server:
+        metric = await run_request_against(server.base_url, APIConfig(type=APIType.Completion, streaming=False))
+
+    assert metric.error is not None
+    assert metric.error.error_type == "InBandError"
+    assert json.loads(metric.error.error_msg) == ERROR_PAYLOAD
+    assert metric.response_data == ERROR_FRAME
+
+
+# Unary completion against a complete 200 whose body is `{}`. Must record an
+# EmptyResponseError failure with response_data == "{}".
+@pytest.mark.asyncio
+async def test_unary_empty_body_is_a_failure() -> None:
+    async with TruncatingSSEServer([], missing_bytes=0, body="{}", content_type="application/json") as server:
+        metric = await run_request_against(server.base_url, APIConfig(type=APIType.Completion, streaming=False))
+
+    assert metric.error is not None
+    assert metric.error.error_type == "EmptyResponseError"
+    assert metric.response_data == "{}"
+
+
+# End of the chain: the in-band error request must show up in the summary as
+# failures.count == 1 under the "inbanderror" label carrying the server's
+# message, successes.count == 0, and the per-request entry must carry both the
+# error and the raw body.
+@pytest.mark.asyncio
+async def test_in_band_error_lands_in_the_failure_bucket_of_the_report() -> None:
+    """What #713 is about: the request must not count toward throughput, and the
+    report has to say why it failed."""
+    async with TruncatingSSEServer([ERROR_FRAME, "[DONE]"], missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url)
+        sent_body = server.sent_body
+
+    summary, entries = await generate_reports(metric)
+
+    assert summary["successes"]["count"] == 0
+    assert summary["failures"]["count"] == 1
+    by_label = summary["failures"]["by_label"]
+    assert list(by_label) == ["inbanderror"], by_label
+    assert by_label["inbanderror"]["count"] == 1
+    assert by_label["inbanderror"]["messages"][0]["message"] == ERROR_PAYLOAD["error"]["message"]
+
+    assert len(entries) == 1
+    assert entries[0]["error"]["error_type"] == "InBandError"
+    assert entries[0]["response"] == sent_body

--- a/tests/required/integration/test_streaming_failure_body.py
+++ b/tests/required/integration/test_streaming_failure_body.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration test for issue #531 (#606 Integration tier, per-change lane).
+
+#530 fixed the bug: ``parse_sse_stream`` now wraps a mid-stream failure in
+``StreamInterruptedError`` carrying the bytes read so far, and
+``process_request`` recovers them into ``response_data`` so the per-request
+report still shows what the server sent. Nothing gates that recovery, and an
+ungated fix is how #410 reached the #564 postmortem.
+
+These tests drive the real client against a fake that returns 200, writes
+valid SSE frames, then ends the connection short of its declared
+``Content-Length``. That is the reproduction described in #531, and it raises a
+genuine ``aiohttp.ClientPayloadError`` inside the client, so the recovery
+branch is exercised through the real exception path rather than a patched-in
+one.
+"""
+
+import time
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fake_truncating_server import TruncatingSSEServer
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
+from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
+from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+from inference_perf.reportgen.base import ReportGenerator
+
+# Two well-formed frames, so a break after them leaves a body that is both
+# non-empty and recognizably SSE.
+EVENTS = [
+    '{"choices":[{"text":"Hello "}]}',
+    '{"choices":[{"text":"world "}]}',
+]
+
+
+class _ConcreteOpenAIClient(openAIModelServerClient):
+    """openAIModelServerClient is abstract only in the two methods below, and
+    neither participates in the streaming path under test."""
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion]
+
+    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
+        raise NotImplementedError("no server metrics are scraped in the integration tier")
+
+
+def make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+async def run_request_against(server: TruncatingSSEServer) -> RequestLifecycleMetric:
+    """One streaming completion through the real client, returning the metric
+    the client recorded for it."""
+    collector = LocalRequestMetricCollector()
+    # The client builds a CustomTokenizer, which would otherwise fetch from the
+    # Hub; token counts are irrelevant to this test, only the response body is.
+    with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
+        client = _ConcreteOpenAIClient(
+            metrics_collector=collector,
+            api_config=APIConfig(type=APIType.Completion, streaming=True),
+            uri=server.base_url,
+            model_name="fake-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+
+    session = client.new_session()
+    try:
+        await session.process_request(
+            CompletionAPIData(prompt="the quick brown fox", max_tokens=16),
+            stage_id=0,
+            scheduled_time=time.perf_counter(),
+        )
+    finally:
+        await session.close()
+
+    metrics = collector.get_metrics()
+    assert len(metrics) == 1, "the client must record exactly one metric for one request"
+    return metrics[0]
+
+
+@pytest.mark.asyncio
+async def test_partial_body_is_preserved_when_the_stream_breaks() -> None:
+    """The #531 regression: bytes received before the break must reach
+    response_data, byte for byte."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+
+    assert metric.response_data == server.sent_body, "the partial body must be preserved exactly as sent"
+    # Guards against a future "fix" that stores the parsed text instead: the
+    # value has to be the raw wire bytes, framing included, or it is useless
+    # for diagnosing a malformed stream.
+    assert "data: " in (metric.response_data or ""), "response_data must hold raw SSE framing, not reassembled output"
+    assert "Hello " in (metric.response_data or "")
+
+
+@pytest.mark.asyncio
+async def test_underlying_exception_is_reported_not_the_wrapper() -> None:
+    """StreamInterruptedError is plumbing. The report must name the error the
+    client actually hit, or the bucket in build_error_counts is useless."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+
+    assert metric.error is not None, "a broken stream must be recorded as a failure"
+    assert metric.error.error_type == "ClientPayloadError"
+    assert metric.error.error_type != "StreamInterruptedError"
+
+
+@pytest.mark.asyncio
+async def test_break_before_any_body_byte_leaves_the_response_empty() -> None:
+    """The empty-raw_content branch: with nothing received there is nothing to
+    preserve, and the 200 path must not fall through to the placeholder text
+    the non-200 path writes."""
+    async with TruncatingSSEServer([]) as server:
+        metric = await run_request_against(server)
+
+    assert metric.response_data == ""
+    assert metric.error is not None
+    assert metric.error.error_type == "ClientPayloadError"
+    assert "Failed to read response text" not in (metric.response_data or "")
+
+
+@pytest.mark.asyncio
+async def test_per_request_report_carries_the_partial_body() -> None:
+    """End of the chain: the preserved bytes have to survive into
+    per_request_lifecycle_metrics, which is the escape hatch #531 is about."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+        sent_body = server.sent_body
+
+    config = MagicMock()
+    config.tokenizer = None
+    config.model_dump = MagicMock(return_value={})
+    generator = ReportGenerator(
+        metrics_client=None,
+        metrics_collector=MagicMock(get_metrics=MagicMock(return_value=[metric])),
+        config=config,
+    )
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=0.0,
+        duration=1.0,
+        model_server_metrics=BaseMetrics(),
+        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
+    )
+    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(per_request=True))
+
+    reports = await generator.generate_reports(report_config, runtime_parameters)
+
+    per_request = [report for report in reports if report.name == "per_request_lifecycle_metrics"]
+    assert len(per_request) == 1, "per_request: true must emit the per-request report"
+    entries: List[Dict[str, Any]] = per_request[0].contents
+    assert len(entries) == 1
+    assert entries[0]["response"] == sent_body, "the per-request entry must carry the partial body, not an empty string"
+    assert entries[0]["error"]["error_type"] == "ClientPayloadError"

--- a/tests/required/integration/test_streaming_failure_body.py
+++ b/tests/required/integration/test_streaming_failure_body.py
@@ -27,22 +27,17 @@ branch is exercised through the real exception path rather than a patched-in
 one.
 """
 
-import time
 from typing import Any, Dict, List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from fake_truncating_server import TruncatingSSEServer
+from openai_client_harness import run_request_against
 
-from inference_perf.apis import RequestLifecycleMetric
-from inference_perf.apis.completion import CompletionAPIData
-from inference_perf.client.modelserver import openai_client as openai_client_module
 from inference_perf.client.modelserver.metrics import BaseMetrics
-from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
 from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
-from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
-from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+from inference_perf.config import ReportConfig, RequestLifecycleMetricsReportConfig
 from inference_perf.reportgen.base import ReportGenerator
 
 # Two well-formed frames, so a break after them leaves a body that is both
@@ -53,61 +48,12 @@ EVENTS = [
 ]
 
 
-class _ConcreteOpenAIClient(openAIModelServerClient):
-    """openAIModelServerClient is abstract only in the two methods below, and
-    neither participates in the streaming path under test."""
-
-    def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Chat, APIType.Completion]
-
-    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
-        raise NotImplementedError("no server metrics are scraped in the integration tier")
-
-
-def make_tokenizer() -> MagicMock:
-    tokenizer = MagicMock()
-    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
-    return tokenizer
-
-
-async def run_request_against(server: TruncatingSSEServer) -> RequestLifecycleMetric:
-    """One streaming completion through the real client, returning the metric
-    the client recorded for it."""
-    collector = LocalRequestMetricCollector()
-    # The client builds a CustomTokenizer, which would otherwise fetch from the
-    # Hub; token counts are irrelevant to this test, only the response body is.
-    with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
-        client = _ConcreteOpenAIClient(
-            metrics_collector=collector,
-            api_config=APIConfig(type=APIType.Completion, streaming=True),
-            uri=server.base_url,
-            model_name="fake-model",
-            tokenizer_config=None,
-            max_tcp_connections=1,
-            additional_filters=[],
-        )
-
-    session = client.new_session()
-    try:
-        await session.process_request(
-            CompletionAPIData(prompt="the quick brown fox", max_tokens=16),
-            stage_id=0,
-            scheduled_time=time.perf_counter(),
-        )
-    finally:
-        await session.close()
-
-    metrics = collector.get_metrics()
-    assert len(metrics) == 1, "the client must record exactly one metric for one request"
-    return metrics[0]
-
-
 @pytest.mark.asyncio
 async def test_partial_body_is_preserved_when_the_stream_breaks() -> None:
     """The #531 regression: bytes received before the break must reach
     response_data, byte for byte."""
     async with TruncatingSSEServer(EVENTS) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
 
     assert metric.response_data == server.sent_body, "the partial body must be preserved exactly as sent"
     # Guards against a future "fix" that stores the parsed text instead: the
@@ -122,7 +68,7 @@ async def test_underlying_exception_is_reported_not_the_wrapper() -> None:
     """StreamInterruptedError is plumbing. The report must name the error the
     client actually hit, or the bucket in build_error_counts is useless."""
     async with TruncatingSSEServer(EVENTS) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
 
     assert metric.error is not None, "a broken stream must be recorded as a failure"
     assert metric.error.error_type == "ClientPayloadError"
@@ -135,7 +81,7 @@ async def test_break_before_any_body_byte_leaves_the_response_empty() -> None:
     preserve, and the 200 path must not fall through to the placeholder text
     the non-200 path writes."""
     async with TruncatingSSEServer([]) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
 
     assert metric.response_data == ""
     assert metric.error is not None
@@ -148,7 +94,7 @@ async def test_per_request_report_carries_the_partial_body() -> None:
     """End of the chain: the preserved bytes have to survive into
     per_request_lifecycle_metrics, which is the escape hatch #531 is about."""
     async with TruncatingSSEServer(EVENTS) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
         sent_body = server.sent_body
 
     config = MagicMock()


### PR DESCRIPTION
Fixes #713

Stacked on #712 (its commit `a4e6823` is the first one here) because the integration test extends its fake server; rebases to one commit once #712 merges.

### What was wrong

A 200 was counted as a success whatever its body held. Some servers and proxies answer 200 and put the failure in the body: vLLM and SGLang emit `data: {"error": {...}}` when generation fails mid-stream, and a proxy can return the OpenAI error object whole. Both landed in the success bucket with `output_tokens: 0`. Streaming: `extract_content` returned `None` on the error frame, so `parse_sse_stream` skipped it and returned normally. Unary: the empty-`choices` early return. The summary counted them toward throughput and the per-request entry showed an empty `response` and no `error`, so nothing pointed at the cause.

### What changes

Two rules, raised from `process_response` as exceptions and handled by the client the way a broken stream already is (`StreamInterruptedError`, #530): the request is recorded as failed, the body is kept as `response_data`.

- **`InBandError`**: the body, or any SSE frame, carries a top-level `error`. That is the shape every server family uses in-band (OpenAI object, TGI string form, Anthropic `error` event). `error_msg` is the error object's JSON, the same shape as a non-200 body, so `parse_error_message` in reportgen pulls the server's message out unchanged and the summary shows it under `failures.by_label.inbanderror`. The parser drains the stream before raising, so the raw body is complete and the connection closes cleanly; if the stream breaks after the error frame, the in-band error still wins over the transport symptom.
- **`EmptyResponseError`**: the body yields no completion content and no `usage`. A well-formed empty completion always carries `usage` (mandatory in a unary body; every stream asks for it with `stream_options.include_usage`), so this only fires on bodies that are not completions: an error page or an empty stream behind a 200, `{}`.

The `InBandError` rule lives in the shared parser, so Anthropic and trace-replay streams get it too. The empty rule is applied in the completion and chat APIs only. `{"choices": [], "usage": {...}}` keeps its existing early return: `usage` is what separates it.

Open question from the issue, decided here as **unconditional** rather than opt-in: a usage-less empty completion from a server that ignores `include_usage` would be recorded as `EmptyResponseError`. I could not name a current server that does that, the error message says exactly why, and the raw body is in the report. If too strict, a config toggle is the alternative.

### Tests

- Unit: parser (error frame raises with the full body attached, error frame then broken connection reports the in-band error, `"error": null` is ignored), completion and chat (in-band body, `{}`, empty stream, and empty stream with usage staying a success).
- Integration (#606 per-change lane): the real client against #712's fake server serving a complete, well-formed 200 (`missing_bytes=0`, honest `Content-Length`) whose only frame is the error payload, or `[DONE]` alone, in the streaming and unary paths, through to the report: `failures.count == 1`, `successes.count == 0`, label `inbanderror` carrying the server's message, per-request entry with the error and the raw body. All 14 new tests fail on `main`.
- The fake gains `missing_bytes=0` and a verbatim-body mode; the client harness moves out of #712's test into `openai_client_harness.py`, shared by both files.

`pdm run validate` clean, 918 passed locally. The sim e2e tier was not run here; the sim always emits `usage`, so the empty rule should not fire there.

Not covered, still #655: a stream that ends cleanly but short of `max_tokens` carries `choices` and `usage`, so neither rule fires. That needs `finish_reason`.
