### PR TITLE
[PENDING: #744] fix: record a clean but short completion under ignore_eos as a failure

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -275,7 +275,7 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--server.type` | Enum (vllm, sglang, tgi, mock) | Type of model server being benchmarked. |
 | `--server.model_name` | str | Model name sent in each request. Auto-detected from the server if unset. |
 | `--server.base_url` | str | Base URL of the model server, e.g. 'http://localhost:8000'. |
-| `--server.ignore_eos` | boolean | Ask the server to keep generating past the end-of-sequence token so outputs hit the requested length. |
+| `--server.ignore_eos` | boolean | Ask the server to keep generating past the end-of-sequence token so outputs hit the requested length. A completion that then delivers fewer output tokens than its max_tokens is recorded as a failure (TruncatedResponseError). Set false for servers that ignore this field. |
 | `--server.api_key` | str | API key sent as a bearer token with each request. |
 | `--server.cert_path` | str | Path to a client TLS certificate file. |
 | `--server.key_path` | str | Path to the private key for the client TLS certificate. |

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -86,5 +86,5 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
 
 - **`load_summary`**: Details about the requested vs achieved load.
 - **`successes`**: Metrics for successful requests.
-- **`failures`**: Metrics for failed requests, including the per-label error breakdown.
+- **`failures`**: Metrics for failed requests, including the per-label error breakdown. A request fails on a non-200 status, on a transport error, or on a 200 whose body is not a completion: a body carrying a top-level `error` object (label `inbanderror`, `error_msg` is that object) or one with neither completion content nor `usage` (label `emptyresponseerror`). The body is kept as `response` in the per-request report either way.
 - **`goodput_metrics`**: (Optional) Goodput statistics if constraints were configured.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -34,7 +34,12 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
     "throughput": {
       "requests_per_sec": 1.02,
       "total_tokens_per_sec": 676.12
-    }
+    },
+    "finish_reasons": {
+      "length": 478,
+      "stop": 2
+    },
+    "output_shortfalls": 2
   },
   "failures": {
     "count": 3,
@@ -85,6 +90,8 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
 ### Key Sections
 
 - **`load_summary`**: Details about the requested vs achieved load.
-- **`successes`**: Metrics for successful requests.
-- **`failures`**: Metrics for failed requests, including the per-label error breakdown. A request fails on a non-200 status, on a transport error, or on a 200 whose body is not a completion: a body carrying a top-level `error` object (label `inbanderror`, `error_msg` is that object) or one with neither completion content nor `usage` (label `emptyresponseerror`). The body is kept as `response` in the per-request report either way.
+- **`successes`**: Metrics for successful requests. Two fields describe whether those requests ran to the length they asked for:
+  - `finish_reasons`: how many successful requests ended with each reason the server reported, verbatim (OpenAI `finish_reason`: `stop`, `length`, `tool_calls`, ...; Anthropic `stop_reason`: `end_turn`, `max_tokens`, ...). `length` and `max_tokens` mean the requested budget was delivered; anything else means the server halted on its own. Requests whose server reported no reason are not counted.
+  - `output_shortfalls`: how many successful requests delivered fewer output tokens than their `max_tokens` asked for. Delivered means the server's own `usage.completion_tokens` when it reported one, otherwise the client-side count. Without `ignore_eos` a shortfall is usually the model emitting EOS as intended, which is why it is an observation here rather than a failure.
+- **`failures`**: Metrics for failed requests, including the per-label error breakdown. A request fails on a non-200 status, on a transport error, or on a 200 whose body is not a completion: a body carrying a top-level `error` object (label `inbanderror`, `error_msg` is that object) or one with neither completion content nor `usage` (label `emptyresponseerror`). With `server.ignore_eos: true` (the default) a completion that delivered fewer output tokens than its `max_tokens` is also a failure (label `truncatedresponseerror`, `error_msg` names delivered-of-requested and the `finish_reason`): the server was asked to generate the full length and did not, whether it stopped early or capped the request. A server that ignores the `ignore_eos` field will report every natural stop this way; set `ignore_eos: false` for it. The body is kept as `response` in the per-request report in every case, and each per-request entry records the request's `max_tokens` alongside `info.response_metrics.finish_reason`.
 - **`goodput_metrics`**: (Optional) Goodput statistics if constraints were configured.

--- a/e2e/tests/test_golden_accuracy_sim.py
+++ b/e2e/tests/test_golden_accuracy_sim.py
@@ -155,7 +155,13 @@ async def test_golden_accuracy(tokenizer_key: str, api_type: str, streaming: boo
                     "type": "vllm",
                     "model_name": "golden-model",
                     "base_url": f"http://{sim.host}:{sim.port}",
-                    "ignore_eos": True,
+                    # The golden sim serves each case's n_tokens regardless of the
+                    # request's max_tokens (the mock datagen sends the client
+                    # default, 30). Under ignore_eos the 16- and 24-token cases
+                    # would rightly be classed as truncated (#655); this fixture
+                    # measures tokenization fidelity, not length compliance, so it
+                    # does not claim ignore_eos.
+                    "ignore_eos": False,
                 },
                 "tokenizer": {"pretrained_model_name_or_path": tokenizer_path},
                 "report": {

--- a/e2e/tests/test_metrics_fidelity.py
+++ b/e2e/tests/test_metrics_fidelity.py
@@ -158,6 +158,11 @@ async def test_streaming_metrics_match_simulated_ground_truth(ttft_sec: float, i
     assert output_tokens["total"] == num_requests * output_tokens_per_request
     distribution_stats = {k: v for k, v in output_tokens.items() if k != "total"}
     assert set(distribution_stats.values()) == {float(output_tokens_per_request)}, distribution_stats
+    # Same ground truth seen through the #655 fields: every request ran to its
+    # budget, so the sim reports finish_reason "length" on all of them and no
+    # request fell short of its max_tokens.
+    assert successes["finish_reasons"] == {"length": num_requests}
+    assert successes["output_shortfalls"] == 0
     # Input-side usage is plumbed through too. Its exact value is the sim's own
     # tokenization of the random prompts, which this test cannot predict.
     assert successes["prompt_tokens"]["total"] > 0

--- a/e2e/tests/test_output_length_sim.py
+++ b/e2e/tests/test_output_length_sim.py
@@ -1,0 +1,131 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+End-to-end check of the requested-versus-delivered output length fields (#655)
+against llm-d-inference-sim, extending the ground-truth pattern of #614.
+
+The sim honours ``ignore_eos``: with it on, every response runs to exactly
+``max_tokens`` and reports ``finish_reason: length``; with it off, it stops at
+a random earlier point and reports ``finish_reason: stop``. That gives two
+known outcomes for the same config:
+
+- ``ignore_eos: true``: no request is short, so ``finish_reasons`` is all
+  ``length``, ``output_shortfalls`` is 0 and nothing is reclassified as failed.
+- ``ignore_eos: false``: short responses are legitimate. They stay successes,
+  ``finish_reasons`` shows the ``stop`` bucket, and ``output_shortfalls`` equals
+  the number of requests whose server-reported ``completion_tokens`` fell
+  below the ``max_tokens`` recorded on their per-request entry, which is the
+  cross-check between the two report files.
+
+The truncation *failure* (short under ``ignore_eos``) is a condition the sim
+does not produce on its own, so it lives in the Integration tier against a
+fake (tests/required/integration/test_truncated_response.py) per the #606
+"fake the conditions, never the oracle" rule.
+"""
+
+import pytest
+from utils.llm_d_inference_sim import LLMDInferenceSimRunner
+from utils.benchmark import run_benchmark_minimal
+from utils.net import get_free_port
+from utils.testdata import extract_tarball
+
+TEST_MODEL_NAME = "google/gemma-3-270m"
+TEST_MODEL_TARBALL = "e2e/testdata/models/google_gemma-3-270m.tar.gz"
+MAX_TOKENS = 40
+
+
+# Pins every request's max_tokens to `tokens` through the random datagen's
+# output distribution (a degenerate distribution: min == max == mean).
+def _exact_length_distribution(tokens: int) -> dict:
+    return {"min": tokens, "max": tokens, "mean": tokens, "std_dev": 0, "total_count": 100}
+
+
+# Runs 10 streaming completion requests (rate 2 for 5s) against the sim with the
+# given ignore_eos and max_tokens 40, and returns the summary and per-request
+# reports. Fails if the run itself failed or produced no reports.
+async def _run(ignore_eos: bool) -> tuple[dict, list]:
+    model_path = extract_tarball(TEST_MODEL_TARBALL)
+    async with LLMDInferenceSimRunner(
+        TEST_MODEL_NAME,
+        *("--time-to-first-token", "20"),
+        *("--inter-token-latency", "5"),
+        *("--max-num-seqs", "64"),
+        *("--seed", "42"),
+        port=get_free_port(),
+    ) as sim:
+        result = await run_benchmark_minimal(
+            {
+                "api": {"type": "completion", "streaming": True},
+                "data": {
+                    "type": "random",
+                    "input_distribution": _exact_length_distribution(8),
+                    "output_distribution": _exact_length_distribution(MAX_TOKENS),
+                },
+                "load": {"type": "constant", "stages": [{"rate": 2, "duration": 5}], "num_workers": 2},
+                "server": {
+                    "type": "vllm",
+                    "model_name": TEST_MODEL_NAME,
+                    "base_url": f"http://{sim.host}:{sim.port}",
+                    "ignore_eos": ignore_eos,
+                },
+                "tokenizer": {"pretrained_model_name_or_path": str(model_path)},
+                "report": {"request_lifecycle": {"summary": True, "per_stage": False, "per_request": True}},
+            }
+        )
+    assert result.success, "Benchmark failed"
+    assert result.reports, "No reports generated from benchmark"
+    return result.reports["summary_lifecycle_metrics.json"], result.reports["per_request_lifecycle_metrics.json"]
+
+
+# ignore_eos on, max_tokens 40 on all 10 requests: the sim delivers exactly 40
+# with finish_reason "length" every time, so failures == 0, successes == 10,
+# finish_reasons == {"length": 10}, output_shortfalls == 0, and every per-request
+# entry records max_tokens 40 with completion_tokens 40.
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+async def test_full_budget_under_ignore_eos_reports_length_and_no_shortfall():
+    summary, per_request = await _run(ignore_eos=True)
+
+    assert summary["failures"]["count"] == 0
+    assert summary["successes"]["count"] == len(per_request) == 10
+    assert summary["successes"]["finish_reasons"] == {"length": 10}
+    assert summary["successes"]["output_shortfalls"] == 0
+    for entry in per_request:
+        assert entry["max_tokens"] == MAX_TOKENS
+        assert entry["info"]["response_metrics"]["server_usage"]["completion_tokens"] == MAX_TOKENS
+        assert entry["info"]["response_metrics"]["finish_reason"] == "length"
+
+
+# ignore_eos off, same config: the sim stops early at random, so short responses
+# are legitimate and stay successes (failures == 0). Every request carries a
+# finish_reason (buckets sum to 10, keys within {"stop", "length"}), and
+# output_shortfalls equals the number of per-request entries whose server
+# completion_tokens is below their recorded max_tokens (40), which with 10
+# random-length responses is at least 1.
+@pytest.mark.asyncio
+@pytest.mark.skipif(not LLMDInferenceSimRunner.is_available(), reason="local environment missing llm-d-inference-sim")
+async def test_early_stops_without_ignore_eos_stay_successes_and_are_counted():
+    summary, per_request = await _run(ignore_eos=False)
+
+    assert summary["failures"]["count"] == 0
+    assert summary["successes"]["count"] == len(per_request) == 10
+    finish_reasons = summary["successes"]["finish_reasons"]
+    assert set(finish_reasons) <= {"stop", "length"}, finish_reasons
+    assert sum(finish_reasons.values()) == 10
+
+    short = [e for e in per_request if e["info"]["response_metrics"]["server_usage"]["completion_tokens"] < e["max_tokens"]]
+    assert all(e["max_tokens"] == MAX_TOKENS for e in per_request)
+    assert len(short) >= 1, "the sim produced no early stop in 10 requests; the ignore_eos=false path is untested"
+    assert summary["successes"]["output_shortfalls"] == len(short)

--- a/inference_perf/apis/anthropic_messages.py
+++ b/inference_perf/apis/anthropic_messages.py
@@ -264,13 +264,21 @@ def _build_anthropic_stream_handlers() -> tuple[Callable[[dict[str, Any]], str |
 
 async def parse_anthropic_stream_response(
     response: ClientResponse,
-) -> tuple[str, dict[str, Any], list[float], str, list[str], dict[str, Any] | None]:
+) -> tuple[str, dict[str, Any], list[float], str, list[str], dict[str, Any] | None, str | None]:
     extract_content, build_output_message = _build_anthropic_stream_handlers()
-    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+    output_text, chunk_times, raw_content, response_chunks, server_usage, stop_reason = await parse_sse_stream(
         response,
         extract_content=extract_content,
     )
-    return output_text, build_output_message(output_text), chunk_times, raw_content, response_chunks, server_usage
+    return (
+        output_text,
+        build_output_message(output_text),
+        chunk_times,
+        raw_content,
+        response_chunks,
+        server_usage,
+        stop_reason,
+    )
 
 
 class AnthropicMessagesAPIData(InferenceAPIData):
@@ -314,6 +322,7 @@ class AnthropicMessagesAPIData(InferenceAPIData):
                 raw_content,
                 response_chunks,
                 server_usage,
+                stop_reason,
             ) = await parse_anthropic_stream_response(response)
             input_tokens = (server_usage or {}).get("input_tokens")
             output_tokens = (server_usage or {}).get("output_tokens")
@@ -330,6 +339,7 @@ class AnthropicMessagesAPIData(InferenceAPIData):
                     output_tokens=output_len,
                     output_token_times=chunk_times,
                     server_usage=server_usage,
+                    finish_reason=stop_reason,
                 ),
                 lora_adapter=lora_adapter,
                 extra_info={"raw_response": raw_content, "output_message": output_message, "output_text": output_text},
@@ -350,7 +360,7 @@ class AnthropicMessagesAPIData(InferenceAPIData):
             request_metrics=RequestMetrics(
                 text=Text(input_tokens=int(input_tokens) if input_tokens is not None else self._count_prompt_tokens(tokenizer))
             ),
-            response_metrics=UnaryResponseMetrics(output_tokens=output_len),
+            response_metrics=UnaryResponseMetrics(output_tokens=output_len, finish_reason=data.get("stop_reason")),
             lora_adapter=lora_adapter,
             extra_info=extra_info,
         )

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -26,6 +26,24 @@ class ResponseMetrics(BaseModel):
     # Last-seen `usage` dict reported by the server (streaming: the trailing
     # usage chunk; non-streaming: the response body's `usage`).
     server_usage: Optional[dict[str, Any]] = None
+    # Why the server stopped generating, verbatim as it reported it: OpenAI's
+    # `finish_reason` (`stop`, `length`, `tool_calls`, ...) or Anthropic's
+    # `stop_reason` (`end_turn`, `max_tokens`, ...). `length`/`max_tokens` mean
+    # the requested budget was delivered; anything else means the server
+    # halted on its own. None when the server did not report one.
+    finish_reason: Optional[str] = None
+
+    def delivered_output_tokens(self) -> int:
+        """Output tokens the server actually produced.
+
+        The server's own ``usage.completion_tokens`` when it reported one, since
+        that is an exact count; otherwise the client-side re-tokenization in
+        ``output_tokens``, which is an approximation (#564).
+        """
+        completion_tokens = self.server_usage.get("completion_tokens") if self.server_usage else None
+        if isinstance(completion_tokens, (int, float)) and not isinstance(completion_tokens, bool):
+            return int(completion_tokens)
+        return self.output_tokens
 
 
 class UnaryResponseMetrics(ResponseMetrics):
@@ -71,6 +89,10 @@ class RequestLifecycleMetric(BaseModel):
     response_data: Optional[str] = None
     info: InferenceInfo
     error: Optional[ErrorResponseInfo]
+    # The `max_tokens` the request body asked for, so requested-versus-delivered
+    # output length is computable at report time. None when the body carried no
+    # `max_tokens` (a replay whose trace omits it, or a client that never set one).
+    max_tokens: Optional[int] = None
 
     ttft_slo_sec: Optional[float] = None
     tpot_slo_sec: Optional[float] = None

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -34,6 +34,7 @@ from inference_perf.payloads import (
     SyntheticImageSpec,
     SyntheticMp4VideoSpec,
 )
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError, in_band_error
 from inference_perf.apis.streaming_parser import parse_sse_stream
 from inference_perf.config import APIConfig, APIType
 from inference_perf.mediagen.pool import get_video_pool
@@ -564,6 +565,10 @@ class ChatCompletionAPIData(InferenceAPIData):
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
+            # A stream that carried neither content nor usage is not a completion
+            # (an error page or an empty stream behind a 200), not a zero-token one.
+            if not output_text and server_usage is None:
+                raise EmptyResponseError(raw_content)
             prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
             # with special tokens would add a BOS the server's completion_tokens
@@ -583,15 +588,21 @@ class ChatCompletionAPIData(InferenceAPIData):
             )
 
         data = await response.json()
+        # A 200 whose body is an error payload is that error, not a success.
+        if (error_payload := in_band_error(data)) is not None:
+            raise InBandError(error_payload)
         server_usage = data.get("usage")
-        prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
         choices = data.get("choices", [])
+        output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
+        # No content and no usage means the body is not a completion at all.
+        if not output_text and server_usage is None:
+            raise EmptyResponseError()
+        prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
         if len(choices) == 0:
             return InferenceInfo(
                 request_metrics=self._build_request_metrics(prompt_len, 0),
                 lora_adapter=lora_adapter,
             )
-        output_text = "".join([choice.get("message", {}).get("content", "") for choice in choices])
         output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
         return InferenceInfo(
             request_metrics=self._build_request_metrics(prompt_len, output_len),

--- a/inference_perf/apis/chat.py
+++ b/inference_perf/apis/chat.py
@@ -35,7 +35,7 @@ from inference_perf.payloads import (
     SyntheticMp4VideoSpec,
 )
 from inference_perf.apis.response_errors import EmptyResponseError, InBandError, in_band_error
-from inference_perf.apis.streaming_parser import parse_sse_stream
+from inference_perf.apis.streaming_parser import finish_reason_of, parse_sse_stream
 from inference_perf.config import APIConfig, APIType
 from inference_perf.mediagen.pool import get_video_pool
 from inference_perf.mediagen.synthesis import generate_jpeg_bytes, generate_mp4_bytes, generate_png_bytes, generate_wav_bytes
@@ -562,7 +562,7 @@ class ChatCompletionAPIData(InferenceAPIData):
         self, response: ClientResponse, config: APIConfig, tokenizer: CustomTokenizer, lora_adapter: Optional[str] = None
     ) -> InferenceInfo:
         if config.streaming:
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+            output_text, chunk_times, raw_content, response_chunks, server_usage, finish_reason = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
             )
             # A stream that carried neither content nor usage is not a completion
@@ -582,6 +582,7 @@ class ChatCompletionAPIData(InferenceAPIData):
                     output_tokens=output_len,
                     output_token_times=chunk_times,
                     server_usage=server_usage,
+                    finish_reason=finish_reason,
                 ),
                 lora_adapter=lora_adapter,
                 extra_info={"raw_response": raw_content},
@@ -606,6 +607,8 @@ class ChatCompletionAPIData(InferenceAPIData):
         output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
         return InferenceInfo(
             request_metrics=self._build_request_metrics(prompt_len, output_len),
-            response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=server_usage),
+            response_metrics=UnaryResponseMetrics(
+                output_tokens=output_len, server_usage=server_usage, finish_reason=finish_reason_of(data)
+            ),
             lora_adapter=lora_adapter,
         )

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -21,7 +21,7 @@ from inference_perf.payloads import RequestBody, RequestMetrics, Text
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.config import APIConfig, APIType
 from inference_perf.apis.response_errors import EmptyResponseError, InBandError, in_band_error
-from inference_perf.apis.streaming_parser import parse_sse_stream
+from inference_perf.apis.streaming_parser import finish_reason_of, parse_sse_stream
 
 
 class CompletionAPIData(InferenceAPIData):
@@ -76,7 +76,7 @@ class CompletionAPIData(InferenceAPIData):
     ) -> InferenceInfo:
         if config.streaming:
             # Use shared streaming parser with completion-specific content extraction
-            output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+            output_text, chunk_times, raw_content, response_chunks, server_usage, finish_reason = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("text")
             )
             # A stream that carried neither content nor usage is not a completion
@@ -98,6 +98,7 @@ class CompletionAPIData(InferenceAPIData):
                     output_tokens=output_len,
                     output_token_times=chunk_times,
                     server_usage=server_usage,
+                    finish_reason=finish_reason,
                 ),
                 lora_adapter=lora_adapter,
                 extra_info={"raw_response": raw_content},
@@ -123,6 +124,8 @@ class CompletionAPIData(InferenceAPIData):
             self.model_response = output_text
             return InferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
-                response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=server_usage),
+                response_metrics=UnaryResponseMetrics(
+                    output_tokens=output_len, server_usage=server_usage, finish_reason=finish_reason_of(data)
+                ),
                 lora_adapter=lora_adapter,
             )

--- a/inference_perf/apis/completion.py
+++ b/inference_perf/apis/completion.py
@@ -20,6 +20,7 @@ from inference_perf.apis import InferenceAPIData, InferenceInfo, UnaryResponseMe
 from inference_perf.payloads import RequestBody, RequestMetrics, Text
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.config import APIConfig, APIType
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError, in_band_error
 from inference_perf.apis.streaming_parser import parse_sse_stream
 
 
@@ -78,6 +79,10 @@ class CompletionAPIData(InferenceAPIData):
             output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
                 response, extract_content=lambda data: data.get("choices", [{}])[0].get("text")
             )
+            # A stream that carried neither content nor usage is not a completion
+            # (an error page or an empty stream behind a 200), not a zero-token one.
+            if not output_text and server_usage is None:
+                raise EmptyResponseError(raw_content)
 
             prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             # Generated text is a continuation, not a sequence start: counting it
@@ -99,15 +104,21 @@ class CompletionAPIData(InferenceAPIData):
             )
         else:
             data = await response.json()
+            # A 200 whose body is an error payload is that error, not a success.
+            if (error_payload := in_band_error(data)) is not None:
+                raise InBandError(error_payload)
             server_usage = data.get("usage")
-            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             choices = data.get("choices", [])
+            output_text = choices[0].get("text", "") if choices else ""
+            # No content and no usage means the body is not a completion at all.
+            if not output_text and server_usage is None:
+                raise EmptyResponseError()
+            prompt_len = self._resolve_prompt_tokens(server_usage, tokenizer)
             if len(choices) == 0:
                 return InferenceInfo(
                     request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
                     lora_adapter=lora_adapter,
                 )
-            output_text = choices[0].get("text", "")
             output_len = tokenizer.count_tokens(output_text, add_special_tokens=False)
             self.model_response = output_text
             return InferenceInfo(

--- a/inference_perf/apis/response_errors.py
+++ b/inference_perf/apis/response_errors.py
@@ -21,6 +21,13 @@ all. Both used to be recorded as zero-token successes (#713). The exceptions her
 are raised by ``process_response`` on such bodies so the client records the
 request as failed, with the body preserved, the same way it does for a stream
 that breaks partway (``StreamInterruptedError``).
+
+A completion can also be well-formed and still not be what was asked for: under
+``ignore_eos`` the server is told to generate the full ``max_tokens``, so a
+cleanly closed response that delivers fewer is a truncation, not a short answer
+(#655). ``TruncatedResponseError`` is that case; the client records it after
+``process_response`` returns, since only the client holds the request body and
+so knows both its ``max_tokens`` and whether it carried ``ignore_eos: true``.
 """
 
 import json
@@ -76,3 +83,32 @@ def in_band_error(data: Any) -> Optional[str]:
     if isinstance(data, dict) and data.get("error"):
         return json.dumps(data)
     return None
+
+
+class TruncatedResponseError(InvalidResponseError):
+    """A completion that delivered fewer output tokens than ``max_tokens`` asked
+    for while ``ignore_eos`` was set.
+
+    ``ignore_eos`` is documented as "keep generating past the end-of-sequence
+    token so outputs hit the requested length", so under it a shortfall has no
+    legitimate cause: the server stopped early (``finish_reason`` other than
+    ``length``) or capped the request below what was asked (``length`` with
+    fewer tokens, e.g. a ``max_model_len`` cap). Either way the run did not
+    exercise the configured output length, and counting the request as a success
+    would silently depress the output-length distribution the way #564 did.
+
+    Detection uses the server's own ``usage.completion_tokens`` when it reported
+    one and the client-side count otherwise (``ResponseMetrics.delivered_output_tokens``).
+    Without ``ignore_eos`` a short response is often the model emitting EOS as
+    intended, so the same shortfall is reported as an observation
+    (``successes.output_shortfalls``) rather than a failure.
+    """
+
+    def __init__(self, delivered: int, requested: int, finish_reason: Optional[str]) -> None:
+        super().__init__(
+            f"delivered {delivered} of {requested} requested output tokens with ignore_eos set"
+            f" (finish_reason={finish_reason if finish_reason is not None else 'unreported'})"
+        )
+        self.delivered = delivered
+        self.requested = requested
+        self.finish_reason = finish_reason

--- a/inference_perf/apis/response_errors.py
+++ b/inference_perf/apis/response_errors.py
@@ -1,0 +1,78 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What a 200 can carry that is not a completion.
+
+A non-200 status is a failure by construction. A 200 is only a success if its
+body actually is a completion: some servers and proxies answer 200 and put the
+failure in the body, and a body with no content and no ``usage`` says nothing at
+all. Both used to be recorded as zero-token successes (#713). The exceptions here
+are raised by ``process_response`` on such bodies so the client records the
+request as failed, with the body preserved, the same way it does for a stream
+that breaks partway (``StreamInterruptedError``).
+"""
+
+import json
+from typing import Any, Optional
+
+
+class InvalidResponseError(Exception):
+    """A 200 response whose body is not a completion.
+
+    Unlike ``StreamInterruptedError`` this is raised after the body was read: the
+    transport succeeded, the payload is what failed. ``raw_content`` is the body
+    as received, so the client can record what the server actually sent. Streaming
+    callers pass the bytes read so far; unary callers leave it empty because the
+    client already holds the body it handed to ``process_response``.
+    """
+
+    def __init__(self, message: str, raw_content: str = "") -> None:
+        super().__init__(message)
+        self.raw_content = raw_content
+
+
+class InBandError(InvalidResponseError):
+    """The body carries a top-level ``error`` where a completion was expected.
+
+    ``str(exc)`` is the error payload's JSON text, so it lands in ``error_msg``
+    in the same shape as a non-200 body and reportgen's ``parse_error_message``
+    pulls the server's message out of it unchanged.
+    """
+
+
+class EmptyResponseError(InvalidResponseError):
+    """The body parsed as a completion but yielded no content and no ``usage``.
+
+    A response with neither has nothing that could be measured, and a well-formed
+    empty completion always carries ``usage``: it is mandatory in a unary
+    completion body, and every streaming request asks for it with
+    ``stream_options.include_usage``.
+    """
+
+    def __init__(self, raw_content: str = "") -> None:
+        super().__init__("200 response with no completion content and no usage", raw_content)
+
+
+def in_band_error(data: Any) -> Optional[str]:
+    """Return the JSON text of ``data`` if it is a body or SSE frame carrying a
+    top-level ``error``, else None.
+
+    Only a top-level key counts. That is the shape every server family uses for
+    an error it delivers in-band: the OpenAI ``{"error": {...}}`` object (vLLM and
+    SGLang emit it mid-stream), TGI's ``{"error": "...", "error_type": ...}``
+    string form, and Anthropic's ``{"type": "error", "error": {...}}`` event.
+    """
+    if isinstance(data, dict) and data.get("error"):
+        return json.dumps(data)
+    return None

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -28,6 +28,27 @@ from aiohttp import ClientResponse
 from inference_perf.apis.response_errors import InBandError, in_band_error
 
 
+def finish_reason_of(data: dict[str, Any]) -> Optional[str]:
+    """The server's stated reason for ending generation carried by one parsed
+    body or SSE frame, or None if this one carries none.
+
+    OpenAI-shaped payloads put it at ``choices[0].finish_reason`` (null on every
+    streamed chunk but the last content-bearing one); Anthropic puts
+    ``stop_reason`` on the unary body and inside the ``message_delta`` event's
+    ``delta``. The value is returned verbatim, so ``length`` and ``max_tokens``
+    are the two spellings of "the requested budget was delivered".
+    """
+    choices = data.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        reason = choices[0].get("finish_reason")
+        if reason:
+            return str(reason)
+    for holder in (data, data.get("delta")):
+        if isinstance(holder, dict) and holder.get("stop_reason"):
+            return str(holder["stop_reason"])
+    return None
+
+
 class StreamInterruptedError(Exception):
     """Raised when an SSE stream fails partway through being read.
 
@@ -46,7 +67,7 @@ class StreamInterruptedError(Exception):
 
 async def parse_sse_stream(
     response: ClientResponse, extract_content: Callable[[dict[str, Any]], Optional[str]]
-) -> Tuple[str, List[float], str, List[str], Optional[dict[str, Any]]]:
+) -> Tuple[str, List[float], str, List[str], Optional[dict[str, Any]], Optional[str]]:
     """
     Parse Server-Sent Events (SSE) stream and extract content.
 
@@ -62,7 +83,7 @@ async def parse_sse_stream(
                         Example: lambda data: data.get("choices", [{}])[0].get("delta", {}).get("content")
 
     Returns:
-        Tuple of (output_text, chunk_times, raw_content, response_chunks, server_usage):
+        Tuple of (output_text, chunk_times, raw_content, response_chunks, server_usage, finish_reason):
         - output_text: The concatenated text content from all chunks
         - chunk_times: Timestamps for content-bearing chunks only. Role-only
           deltas, usage-only chunks, [DONE] signals, and unparseable messages
@@ -74,6 +95,9 @@ async def parse_sse_stream(
           (e.g. OpenAI trailing `{"choices":[],"usage":{...}}` or Anthropic
           `message.usage`/`message_delta.usage`). None if the server didn't
           emit usage.
+        - finish_reason: the last non-null reason the server gave for ending
+          generation (OpenAI `choices[0].finish_reason`, Anthropic
+          `message_delta.delta.stop_reason`), verbatim. None if it never sent one.
 
     Raises:
         InBandError: a frame carried a top-level ``error`` payload (a 200 whose
@@ -87,6 +111,7 @@ async def parse_sse_stream(
     raw_content = b""
     response_chunks: List[str] = []
     server_usage: Optional[dict[str, Any]] = None
+    finish_reason: Optional[str] = None
     # First in-band error payload seen. Reading continues past it so the raw
     # body is complete and the connection drains normally; the raise happens
     # once the stream ends. If the stream breaks after it, the error payload
@@ -118,6 +143,8 @@ async def parse_sse_stream(
                                     usage = message_data.get("usage")
                             if isinstance(usage, dict):
                                 server_usage = {**(server_usage or {}), **usage}
+                            if reason := finish_reason_of(data):
+                                finish_reason = reason
                             if content := extract_content(data):
                                 output_text += content
                                 chunk_times.append(message_time)
@@ -138,4 +165,11 @@ async def parse_sse_stream(
     if error_payload is not None:
         raise InBandError(error_payload, raw_content.decode("utf-8", errors="ignore"))
 
-    return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage
+    return (
+        output_text,
+        chunk_times,
+        raw_content.decode("utf-8", errors="ignore"),
+        response_chunks,
+        server_usage,
+        finish_reason,
+    )

--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -25,6 +25,8 @@ from typing import Any, Callable, List, Optional, Tuple
 
 from aiohttp import ClientResponse
 
+from inference_perf.apis.response_errors import InBandError, in_band_error
+
 
 class StreamInterruptedError(Exception):
     """Raised when an SSE stream fails partway through being read.
@@ -72,6 +74,12 @@ async def parse_sse_stream(
           (e.g. OpenAI trailing `{"choices":[],"usage":{...}}` or Anthropic
           `message.usage`/`message_delta.usage`). None if the server didn't
           emit usage.
+
+    Raises:
+        InBandError: a frame carried a top-level ``error`` payload (a 200 whose
+            failure is in the body). The rest of the stream is still read so
+            the exception's ``raw_content`` holds the whole body.
+        StreamInterruptedError: the stream broke before it ended.
     """
     output_text = ""
     chunk_times: List[float] = []
@@ -79,6 +87,11 @@ async def parse_sse_stream(
     raw_content = b""
     response_chunks: List[str] = []
     server_usage: Optional[dict[str, Any]] = None
+    # First in-band error payload seen. Reading continues past it so the raw
+    # body is complete and the connection drains normally; the raise happens
+    # once the stream ends. If the stream breaks after it, the error payload
+    # is still the failure worth reporting, not the transport symptom.
+    error_payload: Optional[str] = None
 
     try:
         async for chunk in response.content.iter_any():
@@ -96,6 +109,8 @@ async def parse_sse_stream(
                             break
                         try:
                             data = json.loads(data_str)
+                            if error_payload is None:
+                                error_payload = in_band_error(data)
                             usage = data.get("usage")
                             if not isinstance(usage, dict):
                                 message_data = data.get("message")
@@ -116,6 +131,11 @@ async def parse_sse_stream(
         # connection, or a proxy that 200s then sends an error page). Re-raise
         # with the bytes received so far attached so the caller can still record
         # what the server actually sent instead of an empty response body.
+        if error_payload is not None:
+            raise InBandError(error_payload, raw_content.decode("utf-8", errors="ignore")) from e
         raise StreamInterruptedError(e, raw_content.decode("utf-8", errors="ignore")) from e
+
+    if error_payload is not None:
+        raise InBandError(error_payload, raw_content.decode("utf-8", errors="ignore"))
 
     return output_text, chunk_times, raw_content.decode("utf-8", errors="ignore"), response_chunks, server_usage

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -23,7 +23,7 @@ from inference_perf.apis import (
     StreamedResponseMetrics,
 )
 from inference_perf.apis.anthropic_messages import ANTHROPIC_VERSION, parse_anthropic_content
-from inference_perf.apis.response_errors import InvalidResponseError
+from inference_perf.apis.response_errors import InvalidResponseError, TruncatedResponseError
 from inference_perf.apis.streaming_parser import StreamInterruptedError
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.utils import CustomTokenizer
@@ -188,6 +188,21 @@ class openAIModelServerClient(ModelServerClient):
             return []
 
 
+def _truncation_error(info: InferenceInfo, max_tokens: Optional[int]) -> Optional[ErrorResponseInfo]:
+    """The failure to record when a completion delivered fewer output tokens than
+    ``max_tokens`` asked for, or None when it delivered the budget or the pair
+    is not comparable (no ``max_tokens`` on the request, or a response the API
+    layer produced no metrics for, such as a body with no ``choices``)."""
+    metrics = info.response_metrics
+    if metrics is None or max_tokens is None:
+        return None
+    delivered = metrics.delivered_output_tokens()
+    if delivered >= max_tokens:
+        return None
+    exc = TruncatedResponseError(delivered, max_tokens, metrics.finish_reason)
+    return ErrorResponseInfo(error_msg=str(exc), error_type=type(exc).__name__)
+
+
 def _update_headers_case_insensitive(target: dict[str, str], source: dict[str, str]) -> None:
     for k, v in source.items():
         k_lower = k.lower()
@@ -261,9 +276,8 @@ class openAIModelServerClientSession(ModelServerClientSession):
                     tpot = total_decode_time / num_decode_tokens if num_decode_tokens > 0 else 0
                     otel_response_info["time_per_output_token"] = tpot
 
-            # Add finish reason from extra_info if available
-            if "finish_reason" in info.extra_info:
-                otel_response_info["finish_reason"] = info.extra_info["finish_reason"]
+            if inner and inner.finish_reason is not None:
+                otel_response_info["finish_reason"] = inner.finish_reason
 
             # Extract input and output following GenAI semantic conventions
             try:
@@ -402,6 +416,16 @@ class openAIModelServerClientSession(ModelServerClientSession):
                 headers[session_token_header] = session_token
 
         request_data = json.dumps(payload)
+        # What the request asked for, kept on the metric so requested-versus-
+        # delivered output length is computable at report time (#655). Every API
+        # family here spells it max_tokens. Whether the body actually told the
+        # server to ignore EOS is read from the body too, not the client setting:
+        # Anthropic bodies never carry the field, and the trace replay turns it
+        # off per request for tool calls, so those must not be held to it.
+        requested_max_tokens = payload.get("max_tokens")
+        if not isinstance(requested_max_tokens, int) or isinstance(requested_max_tokens, bool):
+            requested_max_tokens = None
+        asked_to_ignore_eos = payload.get("ignore_eos") is True
 
         # Determine operation name based on API type
         if self.client.api_config.type == APIType.Chat:
@@ -543,6 +567,13 @@ class openAIModelServerClientSession(ModelServerClientSession):
 
             end_time = time.perf_counter()
 
+            # Under ignore_eos the server was told to generate the full
+            # max_tokens, so a completion that delivered fewer is a truncation
+            # (#655), not a short answer: reclassify it as failed. The parsed
+            # metrics and body stay on the record as the evidence.
+            if info is not None and error is None and asked_to_ignore_eos:
+                error = _truncation_error(info, requested_max_tokens)
+
             # Record OTEL metrics
             self._record_otel_metrics(
                 span=span,
@@ -576,6 +607,7 @@ class openAIModelServerClientSession(ModelServerClientSession):
             response_data=response_content,
             info=info,
             error=error,
+            max_tokens=requested_max_tokens,
             start_time=start,
             end_time=end_time,
             scheduled_time=scheduled_time,

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -23,6 +23,7 @@ from inference_perf.apis import (
     StreamedResponseMetrics,
 )
 from inference_perf.apis.anthropic_messages import ANTHROPIC_VERSION, parse_anthropic_content
+from inference_perf.apis.response_errors import InvalidResponseError
 from inference_perf.apis.streaming_parser import StreamInterruptedError
 from inference_perf.payloads import RequestMetrics, Text
 from inference_perf.utils import CustomTokenizer
@@ -505,6 +506,12 @@ class openAIModelServerClientSession(ModelServerClientSession):
                                 original_error = read_error.original
                                 if read_error.raw_content:
                                     response_content = read_error.raw_content
+                            # A 200 whose body is not a completion (an in-band
+                            # error payload, or no content and no usage) is
+                            # reported under its own type; the body it carries
+                            # is the evidence, so keep it as the response.
+                            elif isinstance(read_error, InvalidResponseError) and read_error.raw_content:
+                                response_content = read_error.raw_content
                             error = ErrorResponseInfo(
                                 error_msg=str(original_error),
                                 error_type=type(original_error).__name__,

--- a/inference_perf/config/client/modelserver/config.py
+++ b/inference_perf/config/client/modelserver/config.py
@@ -33,7 +33,11 @@ class ModelServerClientConfig(StrictBaseModel):
     base_url: str = Field(description="Base URL of the model server, e.g. 'http://localhost:8000'.")
     ignore_eos: bool = Field(
         default=True,
-        description="Ask the server to keep generating past the end-of-sequence token so outputs hit the requested length.",
+        description=(
+            "Ask the server to keep generating past the end-of-sequence token so outputs hit the requested length. "
+            "A completion that then delivers fewer output tokens than its max_tokens is recorded as a failure "
+            "(TruncatedResponseError). Set false for servers that ignore this field."
+        ),
     )
     api_key: Optional[str] = Field(default=None, description="API key sent as a bearer token with each request.")
     cert_path: Optional[str] = Field(default=None, description="Path to a client TLS certificate file.")

--- a/inference_perf/datagen/replay/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay/replay_graph_session_datagen.py
@@ -53,7 +53,7 @@ from inference_perf.apis.anthropic_messages import (
 )
 from inference_perf.apis.chat import ChatMessage
 from inference_perf.payloads import RequestMetrics, Text
-from inference_perf.apis.streaming_parser import parse_sse_stream
+from inference_perf.apis.streaming_parser import finish_reason_of, parse_sse_stream
 from inference_perf.config import APIConfig, APIType, DataConfig, SessionReplayConfig
 from inference_perf.config.datagen.replay import BadToolCallHandling
 from inference_perf.datagen.base import LazyLoadDataMixin, SessionGenerator
@@ -890,7 +890,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 content = delta.get("content")
                 return str(content) if content is not None else None
 
-            text_content, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+            text_content, chunk_times, raw_content, response_chunks, server_usage, finish_reason = await parse_sse_stream(
                 response, extract_content=_extract_streaming_content
             )
 
@@ -930,6 +930,7 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                     output_tokens=output_len,
                     output_token_times=chunk_times,
                     server_usage=server_usage,
+                    finish_reason=finish_reason,
                 ),
                 lora_adapter=lora_adapter,
                 output_text=output_text or None,
@@ -975,7 +976,9 @@ class SessionChatCompletionAPIData(ChatCompletionAPIData):
                 output_len = tokenizer.count_tokens(output_text + tc_text)
             info = SessionInferenceInfo(
                 request_metrics=RequestMetrics(text=Text(input_tokens=prompt_len)),
-                response_metrics=UnaryResponseMetrics(output_tokens=output_len, server_usage=server_usage),
+                response_metrics=UnaryResponseMetrics(
+                    output_tokens=output_len, server_usage=server_usage, finish_reason=finish_reason_of(data)
+                ),
                 lora_adapter=lora_adapter,
                 output_text=output_text or None,
                 output_message=output_message,
@@ -1105,6 +1108,7 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
                 raw_content,
                 response_chunks,
                 server_usage,
+                stop_reason,
             ) = await parse_anthropic_stream_response(response)
             input_tokens = (server_usage or {}).get("input_tokens")
             output_tokens = (server_usage or {}).get("output_tokens")
@@ -1123,6 +1127,7 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
                     output_tokens=output_len,
                     output_token_times=chunk_times,
                     server_usage=server_usage,
+                    finish_reason=stop_reason,
                 ),
                 lora_adapter=lora_adapter,
                 extra_info={"raw_response": raw_content, "output_message": output_message, "output_text": output_text},
@@ -1142,7 +1147,7 @@ class SessionAnthropicMessagesAPIData(SessionChatCompletionAPIData):
                         else count_anthropic_prompt_tokens(self.messages, tokenizer, self.tool_definitions)
                     )
                 ),
-                response_metrics=UnaryResponseMetrics(output_tokens=output_len),
+                response_metrics=UnaryResponseMetrics(output_tokens=output_len, finish_reason=data.get("stop_reason")),
                 lora_adapter=lora_adapter,
                 extra_info={
                     "stop_reason": data.get("stop_reason"),

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -507,8 +507,21 @@ def summarize_requests(
     inter_token_latencies: List[float] = []
 
     mismatched_requests = 0
+    # Why the server said it stopped, and how often it stopped short of what the
+    # request asked for (#655). Both are observations over the success bucket:
+    # without ignore_eos a short response is usually the model emitting EOS as
+    # intended, so a shortfall is worth seeing, not a failure. Under ignore_eos
+    # the client has already moved shortfalls to the failure bucket
+    # (TruncatedResponseError), so anything counted here got past that rule.
+    finish_reason_counts: dict[str, int] = defaultdict(int)
+    output_shortfalls = 0
     for m in all_successful:
         request_latency_values.append(m.end_time - m.start_time)
+        if (response_metrics := m.info.response_metrics) is not None:
+            if response_metrics.finish_reason is not None:
+                finish_reason_counts[response_metrics.finish_reason] += 1
+            if isinstance(m.max_tokens, int) and response_metrics.delivered_output_tokens() < m.max_tokens:
+                output_shortfalls += 1
 
         # Process raw chunks if present and tokenizer is available
         if (
@@ -700,6 +713,8 @@ def summarize_requests(
         ),
         "output_tokens": summarize_output_token_usage(all_successful, percentiles),
         "token_count_mismatches": mismatched_requests,
+        "finish_reasons": dict(sorted(finish_reason_counts.items(), key=lambda kv: (-kv[1], kv[0]))),
+        "output_shortfalls": output_shortfalls,
     }
     if goodput_metrics:
         successes_dict["goodput_metrics"] = goodput_metrics
@@ -831,6 +846,7 @@ class ReportGenerator:
                         "end_time": metric.end_time,
                         "request": metric.request_data,
                         "response": metric.response_data,
+                        "max_tokens": metric.max_tokens,
                         "info": metric.info.model_dump() if metric.info else None,
                         "error": metric.error.model_dump() if metric.error else None,
                     }

--- a/tests/required/apis/test_anthropic_messages.py
+++ b/tests/required/apis/test_anthropic_messages.py
@@ -143,6 +143,7 @@ async def test_anthropic_messages_process_response_uses_anthropic_usage() -> Non
     assert info.request_metrics.text.input_tokens == 3
     assert info.response_metrics is not None
     assert info.response_metrics.output_tokens == 5
+    assert info.response_metrics.finish_reason == "end_turn"
     assert info.extra_info["stop_reason"] == "end_turn"
 
 
@@ -170,6 +171,8 @@ async def test_anthropic_messages_streaming_preserves_usage_across_events() -> N
     assert info.response_metrics is not None
     assert info.response_metrics.output_tokens == 5
     assert info.response_metrics.server_usage == {"input_tokens": 3, "output_tokens": 5}
+    # The message_delta event's stop_reason is the Anthropic spelling of finish_reason.
+    assert info.response_metrics.finish_reason == "end_turn"
     assert info.extra_info["output_text"] == "hello back"
     assert info.extra_info["output_message"] == {"role": "assistant", "content": "hello back"}
 

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import base64
+import json
 import logging
 from typing import Any, AsyncGenerator, Iterator, List, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -22,6 +23,7 @@ from aiohttp import ClientResponse
 from inference_perf.apis import UnaryResponseMetrics
 from inference_perf.apis import chat as chat_module
 from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError
 from inference_perf.config import APIType
 from inference_perf.payloads import (
     ImageRepresentation,
@@ -178,6 +180,47 @@ async def test_process_response_streaming_uses_server_prompt_tokens() -> None:
     info = await data.process_response(response, _make_config(streaming=True), tokenizer)
 
     assert info.request_metrics.text.input_tokens == 17
+
+
+# Unary 200 whose body is `{"error": {...}}` (the #713 shape). Must raise
+# InBandError carrying that body as its message rather than return a zero-token
+# InferenceInfo through the empty-choices early return.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_in_band_error_body_raises() -> None:
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")])
+    body = {"error": {"message": "upstream unavailable", "type": "server_error", "code": 503}}
+    response = MagicMock()
+    response.json = AsyncMock(return_value=body)
+
+    with pytest.raises(InBandError) as exc_info:
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+    assert json.loads(str(exc_info.value)) == body
+
+
+# Unary 200 whose body is `{}`: no choices, no usage. Must raise EmptyResponseError.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_no_choices_no_usage_raises() -> None:
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")])
+    response = MagicMock()
+    response.json = AsyncMock(return_value={})
+
+    with pytest.raises(EmptyResponseError):
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+
+# Streaming 200 whose frames are a role-only delta and [DONE]: no content, no
+# usage. Must raise EmptyResponseError with the raw stream attached.
+@pytest.mark.asyncio
+async def test_process_response_streaming_no_content_no_usage_raises() -> None:
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")])
+    sse = b'data: {"choices": [{"delta": {"role": "assistant"}}]}\n\ndata: [DONE]\n\n'
+    response = cast(ClientResponse, _FakeStreamingResponse([sse]))
+
+    with pytest.raises(EmptyResponseError) as exc_info:
+        await data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+    assert exc_info.value.raw_content == sse.decode()
 
 
 def _reset_multimodal_progress_state() -> None:

--- a/tests/required/apis/test_chat.py
+++ b/tests/required/apis/test_chat.py
@@ -415,3 +415,35 @@ async def test_materialize_pre_encoded_image_webp_mime() -> None:
     payload = await data.to_request_body(effective_model_name="gpt-vlm", max_tokens=10, ignore_eos=False, streaming=False)
     image_blocks = [c for c in payload["messages"][0]["content"] if c.get("type") == "image_url"]
     assert image_blocks[0]["image_url"]["url"].startswith("data:image/webp;base64,")
+
+
+# Unary chat body whose choice finished with "tool_calls" and streamed chat whose
+# last delta frame carries finish_reason "length": each must land verbatim on
+# response_metrics.finish_reason ("tool_calls" and "length" respectively).
+@pytest.mark.asyncio
+async def test_process_response_records_finish_reason_unary_and_streaming() -> None:
+    data = ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")])
+    tokenizer = _make_tokenizer()
+
+    response = MagicMock()
+    response.json = AsyncMock(
+        return_value={
+            "choices": [{"message": {"content": "calling"}, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        }
+    )
+    info = await data.process_response(response, _make_config(streaming=False), tokenizer)
+    assert info.response_metrics is not None
+    assert info.response_metrics.finish_reason == "tool_calls"
+
+    sse = (
+        b'data: {"choices": [{"delta": {"content": "hello"}, "finish_reason": null}]}\n\n'
+        b'data: {"choices": [{"delta": {}, "finish_reason": "length"}]}\n\n'
+        b'data: {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 1}}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    info = await data.process_response(
+        cast(ClientResponse, _FakeStreamingResponse([sse])), _make_config(streaming=True), tokenizer
+    )
+    assert info.response_metrics is not None
+    assert info.response_metrics.finish_reason == "length"

--- a/tests/required/apis/test_completion.py
+++ b/tests/required/apis/test_completion.py
@@ -296,3 +296,54 @@ async def test_process_response_streaming_no_content_with_usage_is_a_success() -
     assert info.request_metrics.text.input_tokens == 3
     assert info.response_metrics is not None
     assert info.response_metrics.server_usage == {"prompt_tokens": 3, "completion_tokens": 0}
+
+
+# Unary completion body with choices[0].finish_reason "length" and usage. The
+# returned response_metrics must carry finish_reason "length" and
+# delivered_output_tokens() must be the server's completion_tokens (16), not the
+# client count of the two-word text.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_records_finish_reason() -> None:
+    data = CompletionAPIData(prompt="hi", max_tokens=16)
+    response = MagicMock()
+    response.json = AsyncMock(
+        return_value={
+            "choices": [{"text": "hello there", "finish_reason": "length"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 16},
+        }
+    )
+
+    info = await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+    assert info.response_metrics is not None
+    assert info.response_metrics.finish_reason == "length"
+    assert info.response_metrics.delivered_output_tokens() == 16
+
+
+# Streamed completion: two content frames, the last carrying finish_reason
+# "stop", then a usage frame with completion_tokens 2. response_metrics must
+# carry finish_reason "stop" and delivered_output_tokens() == 2. A stream whose
+# frames never set finish_reason (second call) leaves it None and
+# delivered_output_tokens() falls back to the client count of the text (1).
+@pytest.mark.asyncio
+async def test_process_response_streaming_records_finish_reason() -> None:
+    data = CompletionAPIData(prompt="hi", max_tokens=16)
+    sse = (
+        b'data: {"choices": [{"text": "hello", "finish_reason": null}]}\n\n'
+        b'data: {"choices": [{"text": " there", "finish_reason": "stop"}]}\n\n'
+        b'data: {"choices": [], "usage": {"prompt_tokens": 1, "completion_tokens": 2}}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    response = cast(ClientResponse, _FakeStreamingResponse([sse]))
+
+    info = await data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+    assert info.response_metrics is not None
+    assert info.response_metrics.finish_reason == "stop"
+    assert info.response_metrics.delivered_output_tokens() == 2
+
+    bare = cast(ClientResponse, _FakeStreamingResponse([b'data: {"choices": [{"text": "hello"}]}\n\ndata: [DONE]\n\n']))
+    info = await data.process_response(bare, _make_config(streaming=True), _make_tokenizer())
+    assert info.response_metrics is not None
+    assert info.response_metrics.finish_reason is None
+    assert info.response_metrics.delivered_output_tokens() == 1

--- a/tests/required/apis/test_completion.py
+++ b/tests/required/apis/test_completion.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from typing import AsyncGenerator, List, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -19,6 +20,7 @@ from aiohttp import ClientResponse
 
 from inference_perf.apis import ChatCompletionAPIData, ChatMessage, UnaryResponseMetrics
 from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.apis.response_errors import EmptyResponseError, InBandError
 from inference_perf.config import APIType
 
 
@@ -235,3 +237,62 @@ async def test_process_response_streaming_falls_back_without_server_usage() -> N
     info = await data.process_response(response, _make_config(streaming=True), tokenizer)
 
     assert info.request_metrics.text.input_tokens == 3
+
+
+# Unary 200 whose body is `{"error": {...}}` and nothing else. Must raise
+# InBandError carrying that body as its message instead of returning a
+# zero-token InferenceInfo.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_in_band_error_body_raises() -> None:
+    """The #713 unary shape: a proxy that answers 200 with an OpenAI error object.
+    Before, the empty `choices` early-return recorded it as a success."""
+    data = CompletionAPIData(prompt="hi")
+    body = {"error": {"message": "upstream unavailable", "type": "server_error", "code": 503}}
+    response = MagicMock()
+    response.json = AsyncMock(return_value=body)
+
+    with pytest.raises(InBandError) as exc_info:
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+    assert json.loads(str(exc_info.value)) == body
+
+
+# Unary 200 whose body is `{}`: no choices, no usage, no error. Must raise
+# EmptyResponseError. The sibling test above with `{"choices": [], "usage": {...}}`
+# still returns an InferenceInfo, so usage is what separates the two.
+@pytest.mark.asyncio
+async def test_process_response_non_streaming_no_choices_no_usage_raises() -> None:
+    data = CompletionAPIData(prompt="hi")
+    response = MagicMock()
+    response.json = AsyncMock(return_value={})
+
+    with pytest.raises(EmptyResponseError):
+        await data.process_response(response, _make_config(streaming=False), _make_tokenizer())
+
+
+# Streaming 200 whose only frame is [DONE]: no content, no usage. Must raise
+# EmptyResponseError with the raw stream attached, not return output_tokens=0.
+@pytest.mark.asyncio
+async def test_process_response_streaming_no_content_no_usage_raises() -> None:
+    data = CompletionAPIData(prompt="hi")
+    response = cast(ClientResponse, _FakeStreamingResponse([b"data: [DONE]\n\n"]))
+
+    with pytest.raises(EmptyResponseError) as exc_info:
+        await data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+    assert exc_info.value.raw_content == "data: [DONE]\n\n"
+
+
+# Streaming 200 with no content but a usage frame saying completion_tokens=0.
+# That is a legitimate empty completion: must return an InferenceInfo, not raise.
+@pytest.mark.asyncio
+async def test_process_response_streaming_no_content_with_usage_is_a_success() -> None:
+    data = CompletionAPIData(prompt="hi")
+    sse = b'data: {"choices": [], "usage": {"prompt_tokens": 3, "completion_tokens": 0}}\n\ndata: [DONE]\n\n'
+    response = cast(ClientResponse, _FakeStreamingResponse([sse]))
+
+    info = await data.process_response(response, _make_config(streaming=True), _make_tokenizer())
+
+    assert info.request_metrics.text.input_tokens == 3
+    assert info.response_metrics is not None
+    assert info.response_metrics.server_usage == {"prompt_tokens": 3, "completion_tokens": 0}

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -16,7 +16,7 @@ import json
 from typing import Any, AsyncGenerator, Optional
 from unittest.mock import Mock
 from inference_perf.apis.response_errors import InBandError
-from inference_perf.apis.streaming_parser import parse_sse_stream, StreamInterruptedError
+from inference_perf.apis.streaming_parser import finish_reason_of, parse_sse_stream, StreamInterruptedError
 import pytest
 
 
@@ -41,7 +41,7 @@ async def test_parse_sse_stream() -> None:
     def extract_content(data: dict[str, Any]) -> Optional[str]:
         return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
 
-    output_text, chunk_times, raw_content, response_chunks, server_usage = await parse_sse_stream(
+    output_text, chunk_times, raw_content, response_chunks, server_usage, finish_reason = await parse_sse_stream(
         mock_response, extract_content
     )
 
@@ -56,6 +56,8 @@ async def test_parse_sse_stream() -> None:
     # response_chunks and chunk_times must stay in lockstep — reportgen zips them with strict=True.
     assert len(chunk_times) == len(response_chunks)
     assert server_usage is None
+    # No frame carried choices[0].finish_reason, so none is reported.
+    assert finish_reason is None
 
 
 @pytest.mark.asyncio
@@ -89,7 +91,7 @@ async def test_parse_sse_stream_timestamps_only_content_events() -> None:
     def extract_content(data: dict[str, Any]) -> Optional[str]:
         return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
 
-    output_text, chunk_times, _, response_chunks, server_usage = await parse_sse_stream(mock_response, extract_content)
+    output_text, chunk_times, _, response_chunks, server_usage, _ = await parse_sse_stream(mock_response, extract_content)
 
     assert output_text == "Hello world"
     assert len(chunk_times) == 2, (
@@ -218,8 +220,69 @@ async def test_parse_sse_stream_ignores_null_error_field() -> None:
         ]
     )
 
-    output_text, chunk_times, _, response_chunks, server_usage = await parse_sse_stream(mock_response, extract_content)
+    output_text, chunk_times, _, response_chunks, server_usage, _ = await parse_sse_stream(mock_response, extract_content)
 
     assert output_text == "Hello"
     assert len(chunk_times) == len(response_chunks) == 1
     assert server_usage is None
+
+
+# A vLLM-shaped stream: two content frames with finish_reason null, a third
+# content frame carrying finish_reason "length", then the usage-only frame with
+# empty choices, then [DONE]. Must report finish_reason "length" alongside the
+# text "Hello world!" and the usage dict, and stay at 3 content chunks.
+@pytest.mark.asyncio
+async def test_parse_sse_stream_reports_last_finish_reason() -> None:
+    mock_response, extract_content = _stream(
+        [
+            b'data: {"choices": [{"delta": {"content": "Hello"}, "finish_reason": null}]}\n\n',
+            b'data: {"choices": [{"delta": {"content": " world"}, "finish_reason": null}]}\n\n',
+            b'data: {"choices": [{"delta": {"content": "!"}, "finish_reason": "length"}]}\n\n',
+            b'data: {"choices": [], "usage": {"prompt_tokens": 4, "completion_tokens": 3, "total_tokens": 7}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    output_text, chunk_times, _, response_chunks, server_usage, finish_reason = await parse_sse_stream(
+        mock_response, extract_content
+    )
+
+    assert output_text == "Hello world!"
+    assert len(chunk_times) == len(response_chunks) == 3
+    assert server_usage == {"prompt_tokens": 4, "completion_tokens": 3, "total_tokens": 7}
+    assert finish_reason == "length"
+
+
+# The finish_reason arrives on its own frame after the last content (an empty
+# delta with finish_reason "stop"), as some servers send it. Must still be
+# reported as "stop", and that reason-only frame must not count as content.
+@pytest.mark.asyncio
+async def test_parse_sse_stream_finish_reason_on_a_content_free_frame() -> None:
+    mock_response, extract_content = _stream(
+        [
+            b'data: {"choices": [{"delta": {"content": "Hi"}, "finish_reason": null}]}\n\n',
+            b'data: {"choices": [{"delta": {}, "finish_reason": "stop"}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    output_text, chunk_times, _, response_chunks, _, finish_reason = await parse_sse_stream(mock_response, extract_content)
+
+    assert output_text == "Hi"
+    assert len(chunk_times) == len(response_chunks) == 1
+    assert finish_reason == "stop"
+
+
+# finish_reason_of on single payloads: an OpenAI unary body with
+# choices[0].finish_reason "stop" gives "stop"; an Anthropic unary body with
+# stop_reason "max_tokens" gives "max_tokens"; an Anthropic message_delta frame
+# with delta.stop_reason "end_turn" gives "end_turn"; a chunk whose
+# finish_reason is null, a usage-only frame with empty choices, and an error
+# payload all give None.
+def test_finish_reason_of_reads_openai_and_anthropic_shapes() -> None:
+    assert finish_reason_of({"choices": [{"text": "x", "finish_reason": "stop"}]}) == "stop"
+    assert finish_reason_of({"type": "message", "stop_reason": "max_tokens", "content": []}) == "max_tokens"
+    assert finish_reason_of({"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {}}) == "end_turn"
+    assert finish_reason_of({"choices": [{"delta": {"content": "x"}, "finish_reason": None}]}) is None
+    assert finish_reason_of({"choices": [], "usage": {"completion_tokens": 3}}) is None
+    assert finish_reason_of({"error": {"message": "boom"}}) is None

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from typing import Any, AsyncGenerator, Optional
 from unittest.mock import Mock
+from inference_perf.apis.response_errors import InBandError
 from inference_perf.apis.streaming_parser import parse_sse_stream, StreamInterruptedError
 import pytest
 
@@ -136,3 +138,88 @@ async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
     # The bytes received before the break are retained, not discarded.
     assert "Hello" in err.raw_content
     assert "world" in err.raw_content
+
+
+# Builds a fake aiohttp response whose body is the given SSE chunks, optionally
+# raising `broken_by` after the last one, and returns it with the standard chat
+# delta extractor.
+def _stream(chunks: list[bytes], broken_by: Optional[Exception] = None) -> tuple[Mock, Any]:
+    mock_response = Mock()
+    mock_content = Mock()
+    mock_response.content = mock_content
+
+    async def mock_iter_any() -> AsyncGenerator[bytes, None]:
+        for chunk in chunks:
+            yield chunk
+        if broken_by is not None:
+            raise broken_by
+
+    mock_content.iter_any = mock_iter_any
+
+    def extract_content(data: dict[str, Any]) -> Optional[str]:
+        return data.get("choices", [{}])[0].get("delta", {}).get("content")  # type: ignore[no-any-return]
+
+    return mock_response, extract_content
+
+
+# One content frame, then a `{"error": {...}}` frame, then [DONE], all delivered
+# cleanly. Must raise InBandError whose message is the error frame's JSON and whose
+# raw_content is the whole stream, [DONE] included, rather than return "Hello".
+@pytest.mark.asyncio
+async def test_parse_sse_stream_raises_on_in_band_error_frame() -> None:
+    """A 200 stream that carries its failure as a frame (the #713 shape, what vLLM
+    and SGLang emit when generation fails mid-stream) is that failure, not a short
+    success. The stream is read to the end first so raw_content is the full body."""
+    error_frame = b'{"error": {"message": "The model is overloaded", "type": "server_error", "code": 503}}'
+    mock_response, extract_content = _stream(
+        [
+            b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+            b"data: " + error_frame + b"\n\n",
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    with pytest.raises(InBandError) as exc_info:
+        await parse_sse_stream(mock_response, extract_content)
+
+    err = exc_info.value
+    assert json.loads(str(err)) == json.loads(error_frame)
+    assert "Hello" in err.raw_content
+    assert "[DONE]" in err.raw_content, "the stream must be drained before raising"
+
+
+# An error frame followed by a dropped connection. The in-band error must win over
+# the transport error: InBandError, not StreamInterruptedError, and the raw body
+# still holds the frame.
+@pytest.mark.asyncio
+async def test_parse_sse_stream_in_band_error_wins_over_a_later_break() -> None:
+    """When the server says why it failed and then drops the connection, the reason
+    is what belongs in the report; the break is a symptom."""
+    error_frame = b'{"error": {"message": "engine died", "type": "server_error"}}'
+    mock_response, extract_content = _stream(
+        [b"data: " + error_frame + b"\n\n"], broken_by=ConnectionResetError("Response payload is not completed")
+    )
+
+    with pytest.raises(InBandError) as exc_info:
+        await parse_sse_stream(mock_response, extract_content)
+
+    assert json.loads(str(exc_info.value)) == json.loads(error_frame)
+    assert "engine died" in exc_info.value.raw_content
+
+
+# A normal frame that happens to carry `"error": null` next to its choices. Must
+# parse as a plain "Hello" success: only a truthy top-level error counts.
+@pytest.mark.asyncio
+async def test_parse_sse_stream_ignores_null_error_field() -> None:
+    mock_response, extract_content = _stream(
+        [
+            b'data: {"choices": [{"delta": {"content": "Hello"}}], "error": null}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+    )
+
+    output_text, chunk_times, _, response_chunks, server_usage = await parse_sse_stream(mock_response, extract_content)
+
+    assert output_text == "Hello"
+    assert len(chunk_times) == len(response_chunks) == 1
+    assert server_usage is None

--- a/tests/required/client/modelserver/backend_client_suite.py
+++ b/tests/required/client/modelserver/backend_client_suite.py
@@ -126,7 +126,9 @@ class FakeStreamingResponse:
         return content
 
 
-def make_client(backend: Backend, api_config: APIConfig, api_key: Optional[str] = None) -> openAIModelServerClient:
+def make_client(
+    backend: Backend, api_config: APIConfig, api_key: Optional[str] = None, ignore_eos: bool = True
+) -> openAIModelServerClient:
     with patch("inference_perf.client.modelserver.openai_client.CustomTokenizer", StubTokenizer):
         return backend.client_cls(
             metrics_collector=MagicMock(),
@@ -137,6 +139,7 @@ def make_client(backend: Backend, api_config: APIConfig, api_key: Optional[str] 
             max_tcp_connections=4,
             additional_filters=[],
             api_key=api_key,
+            ignore_eos=ignore_eos,
         )
 
 
@@ -248,9 +251,15 @@ class BackendClientSuite:
 
     # --- Request payload serialization ---
 
+    # The canned replies below carry 5 or 6 tokens against the client's default
+    # max_tokens of 30. Under ignore_eos that shortfall is a truncation (#655), so
+    # these two success-path tests run with ignore_eos off, which is what the
+    # config would truthfully say about a server that stops early.
     @pytest.mark.asyncio
     async def test_streaming_completion_request_serialization(self) -> None:
-        client = make_client(self.backend, APIConfig(type=APIType.Completion, streaming=True), api_key="test-key")
+        client = make_client(
+            self.backend, APIConfig(type=APIType.Completion, streaming=True), api_key="test-key", ignore_eos=False
+        )
         response = FakeStreamingResponse([sse_stream(self.backend.completion_stream).encode()])
         session = await make_session(client, response)
 
@@ -265,17 +274,18 @@ class BackendClientSuite:
             "model": MODEL,
             "prompt": COMPLETION_PROMPT,
             "max_tokens": 30,
-            "ignore_eos": True,
+            "ignore_eos": False,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
         metric = recorded_metric(client)
         assert metric.error is None
         assert metric.info.response_metrics.output_tokens == 5
+        assert metric.max_tokens == 30
 
     @pytest.mark.asyncio
     async def test_non_streaming_chat_request_serialization(self) -> None:
-        client = make_client(self.backend, APIConfig(type=APIType.Chat, streaming=False))
+        client = make_client(self.backend, APIConfig(type=APIType.Chat, streaming=False), ignore_eos=False)
         response = FakeUnaryResponse(json.dumps(self.backend.chat_response))
         session = await make_session(client, response)
 
@@ -289,12 +299,13 @@ class BackendClientSuite:
             "model": MODEL,
             "messages": [{"role": "user", "content": CHAT_PROMPT}],
             "max_tokens": 30,
-            "ignore_eos": True,
+            "ignore_eos": False,
             "stream": False,
         }
         metric = recorded_metric(client)
         assert metric.error is None
         assert metric.info.response_metrics.output_tokens == 6
+        assert metric.max_tokens == 30
 
     # --- Response parsing: error paths ---
 

--- a/tests/required/integration/fake_truncating_server.py
+++ b/tests/required/integration/fake_truncating_server.py
@@ -1,0 +1,102 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A fake model server that 200s and then breaks the stream, for the
+integration tier.
+
+The sim cannot fail on cue, so the truncated-stream condition has to be
+induced. This speaks raw HTTP/1.1 rather than going through an server
+framework because the failure being reproduced *is* a protocol-level lie: the
+response declares a ``Content-Length`` larger than the body it actually sends
+and then half-closes. aiohttp raises a real ``ClientPayloadError`` when the
+connection ends early, so tests exercise the client's genuine exception path
+instead of a patched-in exception (the #606 Integration tier's "fake the
+conditions, never the oracle" principle).
+"""
+
+import asyncio
+from types import TracebackType
+from typing import List, Optional, Type
+
+
+class TruncatingSSEServer:
+    """Serves a 200 SSE response that stops short of its declared length.
+
+    ``events`` are the JSON payloads to emit as ``data:`` frames before the
+    break; pass an empty list to break before any body byte is sent.
+    ``sent_body`` records exactly what went out on the wire so a test can
+    assert the client preserved that text and not an approximation of it.
+    """
+
+    def __init__(self, events: List[str], missing_bytes: int = 64) -> None:
+        self.events = events
+        # How far the declared Content-Length overshoots what we actually
+        # write. Any positive value triggers the client-side error.
+        self.missing_bytes = missing_bytes
+        self.sent_body = ""
+        self._server: Optional[asyncio.AbstractServer] = None
+        self.port = 0
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def __aenter__(self) -> "TruncatingSSEServer":
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        self.port = self._server.sockets[0].getsockname()[1]
+        return self
+
+    async def __aexit__(
+        self, exc_type: Optional[Type[BaseException]], exc: Optional[BaseException], tb: Optional[TracebackType]
+    ) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    @staticmethod
+    async def _drain_request(reader: asyncio.StreamReader) -> None:
+        """Read the full request so the client's own write completes cleanly and
+        the only failure under test is the response-side truncation."""
+        header = await reader.readuntil(b"\r\n\r\n")
+        content_length = 0
+        for line in header.split(b"\r\n"):
+            if line.lower().startswith(b"content-length:"):
+                content_length = int(line.split(b":", 1)[1])
+        if content_length:
+            await reader.readexactly(content_length)
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await self._drain_request(reader)
+        except (asyncio.IncompleteReadError, asyncio.LimitOverrunError):
+            writer.close()
+            return
+
+        body = "".join(f"data: {event}\n\n" for event in self.events)
+        encoded = body.encode()
+        headers = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/event-stream\r\n"
+            # The lie: promise more than we are going to send.
+            f"Content-Length: {len(encoded) + self.missing_bytes}\r\n"
+            "\r\n"
+        )
+        writer.write(headers.encode() + encoded)
+        await writer.drain()
+        self.sent_body = body
+        # Half-close so the partial body is delivered and *then* the stream
+        # ends early. An abrupt reset here would surface as a connection error
+        # rather than the incomplete-payload case #531 describes.
+        if writer.can_write_eof():
+            writer.write_eof()
+        writer.close()

--- a/tests/required/integration/fake_truncating_server.py
+++ b/tests/required/integration/fake_truncating_server.py
@@ -22,6 +22,10 @@ and then half-closes. aiohttp raises a real ``ClientPayloadError`` when the
 connection ends early, so tests exercise the client's genuine exception path
 instead of a patched-in exception (the #606 Integration tier's "fake the
 conditions, never the oracle" principle).
+
+With ``missing_bytes=0`` the server keeps its promise and the body arrives
+complete, which is the condition #713 needs: a well-formed 200 whose *payload*
+is the failure (an in-band error frame, or nothing at all).
 """
 
 import asyncio
@@ -36,13 +40,26 @@ class TruncatingSSEServer:
     break; pass an empty list to break before any body byte is sent.
     ``sent_body`` records exactly what went out on the wire so a test can
     assert the client preserved that text and not an approximation of it.
+
+    ``body`` replaces the SSE framing with a verbatim body (a unary JSON
+    response, say) and ``content_type`` labels it; ``events`` is ignored then.
     """
 
-    def __init__(self, events: List[str], missing_bytes: int = 64) -> None:
+    def __init__(
+        self,
+        events: List[str],
+        missing_bytes: int = 64,
+        *,
+        body: Optional[str] = None,
+        content_type: str = "text/event-stream",
+    ) -> None:
         self.events = events
         # How far the declared Content-Length overshoots what we actually
-        # write. Any positive value triggers the client-side error.
+        # write. Any positive value triggers the client-side error; 0 delivers
+        # the body complete.
         self.missing_bytes = missing_bytes
+        self.body = body
+        self.content_type = content_type
         self.sent_body = ""
         self._server: Optional[asyncio.AbstractServer] = None
         self.port = 0
@@ -82,12 +99,12 @@ class TruncatingSSEServer:
             writer.close()
             return
 
-        body = "".join(f"data: {event}\n\n" for event in self.events)
+        body = self.body if self.body is not None else "".join(f"data: {event}\n\n" for event in self.events)
         encoded = body.encode()
         headers = (
             "HTTP/1.1 200 OK\r\n"
-            "Content-Type: text/event-stream\r\n"
-            # The lie: promise more than we are going to send.
+            f"Content-Type: {self.content_type}\r\n"
+            # The lie (when missing_bytes > 0): promise more than we are going to send.
             f"Content-Length: {len(encoded) + self.missing_bytes}\r\n"
             "\r\n"
         )

--- a/tests/required/integration/openai_client_harness.py
+++ b/tests/required/integration/openai_client_harness.py
@@ -1,0 +1,86 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Drives one request through the real ``openAIModelServerClient`` against a
+fake server and hands back the ``RequestLifecycleMetric`` it recorded.
+
+Shared by the integration tests that fake a misbehaving server (#531, #713):
+they differ in what the server sends, not in how the client is driven.
+"""
+
+import time
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+from inference_perf.apis import InferenceAPIData, RequestLifecycleMetric
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
+from inference_perf.config import APIConfig, APIType
+from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+
+
+class ConcreteOpenAIClient(openAIModelServerClient):
+    """openAIModelServerClient is abstract only in the two methods below, and
+    neither participates in the request path under test."""
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion]
+
+    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
+        raise NotImplementedError("no server metrics are scraped in the integration tier")
+
+
+# A tokenizer stand-in that counts whitespace-separated words, so no Hub download.
+def make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+# Sends one request (a 16-token completion by default) through the real client to
+# `base_url` with the given API config, and returns the single metric the client
+# recorded for it. Fails if the client recorded zero or several metrics.
+async def run_request_against(
+    base_url: str,
+    api_config: Optional[APIConfig] = None,
+    data: Optional[InferenceAPIData] = None,
+) -> RequestLifecycleMetric:
+    """One request through the real client, returning the metric it recorded."""
+    collector = LocalRequestMetricCollector()
+    # The client builds a CustomTokenizer, which would otherwise fetch from the
+    # Hub; token counts are irrelevant to these tests, only the response body is.
+    with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
+        client = ConcreteOpenAIClient(
+            metrics_collector=collector,
+            api_config=api_config or APIConfig(type=APIType.Completion, streaming=True),
+            uri=base_url,
+            model_name="fake-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+
+    session = client.new_session()
+    try:
+        await session.process_request(
+            data or CompletionAPIData(prompt="the quick brown fox", max_tokens=16),
+            stage_id=0,
+            scheduled_time=time.perf_counter(),
+        )
+    finally:
+        await session.close()
+
+    metrics = collector.get_metrics()
+    assert len(metrics) == 1, "the client must record exactly one metric for one request"
+    return metrics[0]

--- a/tests/required/integration/openai_client_harness.py
+++ b/tests/required/integration/openai_client_harness.py
@@ -14,20 +14,23 @@
 """Drives one request through the real ``openAIModelServerClient`` against a
 fake server and hands back the ``RequestLifecycleMetric`` it recorded.
 
-Shared by the integration tests that fake a misbehaving server (#531, #713):
-they differ in what the server sends, not in how the client is driven.
+Shared by the integration tests that fake a misbehaving server (#531, #655,
+#713): they differ in what the server sends, not in how the client is driven.
 """
 
 import time
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import MagicMock, patch
 
 from inference_perf.apis import InferenceAPIData, RequestLifecycleMetric
 from inference_perf.apis.completion import CompletionAPIData
 from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.metrics import BaseMetrics
 from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
-from inference_perf.config import APIConfig, APIType
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
+from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
 from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+from inference_perf.reportgen.base import ReportGenerator
 
 
 class ConcreteOpenAIClient(openAIModelServerClient):
@@ -49,12 +52,14 @@ def make_tokenizer() -> MagicMock:
 
 
 # Sends one request (a 16-token completion by default) through the real client to
-# `base_url` with the given API config, and returns the single metric the client
-# recorded for it. Fails if the client recorded zero or several metrics.
+# `base_url` with the given API config and ignore_eos setting (on by default, as
+# in the config), and returns the single metric the client recorded for it.
+# Fails if the client recorded zero or several metrics.
 async def run_request_against(
     base_url: str,
     api_config: Optional[APIConfig] = None,
     data: Optional[InferenceAPIData] = None,
+    ignore_eos: bool = True,
 ) -> RequestLifecycleMetric:
     """One request through the real client, returning the metric it recorded."""
     collector = LocalRequestMetricCollector()
@@ -69,6 +74,7 @@ async def run_request_against(
             tokenizer_config=None,
             max_tcp_connections=1,
             additional_filters=[],
+            ignore_eos=ignore_eos,
         )
 
     session = client.new_session()
@@ -84,3 +90,31 @@ async def run_request_against(
     metrics = collector.get_metrics()
     assert len(metrics) == 1, "the client must record exactly one metric for one request"
     return metrics[0]
+
+
+# Runs the real report generator over the given recorded metrics (one stage,
+# summary + per-request enabled) and returns (summary contents, per-request
+# entries). Fails unless exactly one of each report was produced.
+async def generate_reports(metrics: List[RequestLifecycleMetric]) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    config = MagicMock()
+    config.tokenizer = None
+    config.model_dump = MagicMock(return_value={})
+    generator = ReportGenerator(
+        metrics_client=None,
+        metrics_collector=MagicMock(get_metrics=MagicMock(return_value=list(metrics))),
+        config=config,
+    )
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=0.0,
+        duration=1.0,
+        model_server_metrics=BaseMetrics(),
+        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
+    )
+    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(summary=True, per_request=True))
+
+    reports = await generator.generate_reports(report_config, runtime_parameters)
+
+    summary = [r for r in reports if r.name == "summary_lifecycle_metrics"]
+    per_request = [r for r in reports if r.name == "per_request_lifecycle_metrics"]
+    assert len(summary) == 1 and len(per_request) == 1
+    return summary[0].contents, per_request[0].contents

--- a/tests/required/integration/test_in_band_error_200.py
+++ b/tests/required/integration/test_in_band_error_200.py
@@ -26,20 +26,15 @@ body preserved. No model server needed.
 """
 
 import json
-from typing import Any, Dict, List
-from unittest.mock import MagicMock
+from typing import Any, Dict
 
 import pytest
 
 from fake_truncating_server import TruncatingSSEServer
-from openai_client_harness import run_request_against
+from openai_client_harness import generate_reports, run_request_against
 
-from inference_perf.apis import RequestLifecycleMetric
 from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
-from inference_perf.client.modelserver.metrics import BaseMetrics
-from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
-from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
-from inference_perf.reportgen.base import ReportGenerator
+from inference_perf.config import APIConfig, APIType
 
 # The OpenAI error object as vLLM and SGLang emit it mid-stream and as a proxy
 # might return it whole. `code` inside the payload says 503; the transport says 200.
@@ -47,33 +42,6 @@ ERROR_PAYLOAD: Dict[str, Any] = {
     "error": {"message": "The model is overloaded, retry later", "type": "server_error", "code": 503}
 }
 ERROR_FRAME = json.dumps(ERROR_PAYLOAD)
-
-
-# Runs the summary and per-request reports over one metric and returns
-# (summary contents, per-request entries), so each test skips that plumbing.
-async def generate_reports(metric: RequestLifecycleMetric) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
-    config = MagicMock()
-    config.tokenizer = None
-    config.model_dump = MagicMock(return_value={})
-    generator = ReportGenerator(
-        metrics_client=None,
-        metrics_collector=MagicMock(get_metrics=MagicMock(return_value=[metric])),
-        config=config,
-    )
-    runtime_parameters = PerfRuntimeParameters(
-        start_time=0.0,
-        duration=1.0,
-        model_server_metrics=BaseMetrics(),
-        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
-    )
-    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(summary=True, per_request=True))
-
-    reports = await generator.generate_reports(report_config, runtime_parameters)
-
-    summary = [r for r in reports if r.name == "summary_lifecycle_metrics"]
-    per_request = [r for r in reports if r.name == "per_request_lifecycle_metrics"]
-    assert len(summary) == 1 and len(per_request) == 1
-    return summary[0].contents, per_request[0].contents
 
 
 # Streaming completion (default) and streaming chat against a complete 200 whose
@@ -162,7 +130,7 @@ async def test_in_band_error_lands_in_the_failure_bucket_of_the_report() -> None
         metric = await run_request_against(server.base_url)
         sent_body = server.sent_body
 
-    summary, entries = await generate_reports(metric)
+    summary, entries = await generate_reports([metric])
 
     assert summary["successes"]["count"] == 0
     assert summary["failures"]["count"] == 1

--- a/tests/required/integration/test_in_band_error_200.py
+++ b/tests/required/integration/test_in_band_error_200.py
@@ -1,0 +1,176 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for issue #713 (#606 Integration tier, per-change lane).
+
+A 200 is only a success if its body is a completion. Some servers and proxies
+answer ``200 OK`` and put the failure in the body; before #713 such a request
+was recorded as a success with ``output_tokens: 0`` and counted toward
+throughput, with nothing in the report pointing at the cause.
+
+These tests drive the real client against a fake that returns a *complete*,
+well-formed 200 (the ``Content-Length`` is honest, nothing breaks) whose
+payload is either an error object or nothing at all, in both the streaming and
+the unary path, and assert the request lands in the failure bucket with the
+body preserved. No model server needed.
+"""
+
+import json
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from fake_truncating_server import TruncatingSSEServer
+from openai_client_harness import run_request_against
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
+from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
+from inference_perf.reportgen.base import ReportGenerator
+
+# The OpenAI error object as vLLM and SGLang emit it mid-stream and as a proxy
+# might return it whole. `code` inside the payload says 503; the transport says 200.
+ERROR_PAYLOAD: Dict[str, Any] = {
+    "error": {"message": "The model is overloaded, retry later", "type": "server_error", "code": 503}
+}
+ERROR_FRAME = json.dumps(ERROR_PAYLOAD)
+
+
+# Runs the summary and per-request reports over one metric and returns
+# (summary contents, per-request entries), so each test skips that plumbing.
+async def generate_reports(metric: RequestLifecycleMetric) -> tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    config = MagicMock()
+    config.tokenizer = None
+    config.model_dump = MagicMock(return_value={})
+    generator = ReportGenerator(
+        metrics_client=None,
+        metrics_collector=MagicMock(get_metrics=MagicMock(return_value=[metric])),
+        config=config,
+    )
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=0.0,
+        duration=1.0,
+        model_server_metrics=BaseMetrics(),
+        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
+    )
+    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(summary=True, per_request=True))
+
+    reports = await generator.generate_reports(report_config, runtime_parameters)
+
+    summary = [r for r in reports if r.name == "summary_lifecycle_metrics"]
+    per_request = [r for r in reports if r.name == "per_request_lifecycle_metrics"]
+    assert len(summary) == 1 and len(per_request) == 1
+    return summary[0].contents, per_request[0].contents
+
+
+# Streaming completion (default) and streaming chat against a complete 200 whose
+# only data frame is the error object, followed by [DONE]. Both must record a
+# failure of type InBandError whose error_msg is that object, with the whole
+# body (frame and [DONE]) as response_data.
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("api_config", "data"),
+    [
+        pytest.param(APIConfig(type=APIType.Completion, streaming=True), None, id="completion"),
+        pytest.param(
+            APIConfig(type=APIType.Chat, streaming=True),
+            ChatCompletionAPIData(messages=[ChatMessage(role="user", content="hi")], max_tokens=16),
+            id="chat",
+        ),
+    ],
+)
+async def test_streaming_in_band_error_frame_is_a_failure(api_config: APIConfig, data: Any) -> None:
+    """The #713 streaming shape. The stream is complete and well-formed, so no
+    transport error fires; the payload alone has to make this a failure."""
+    async with TruncatingSSEServer([ERROR_FRAME, "[DONE]"], missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url, api_config, data)
+        sent_body = server.sent_body
+
+    assert metric.error is not None, "a 200 carrying an error payload must be recorded as a failure"
+    assert metric.error.error_type == "InBandError"
+    assert json.loads(metric.error.error_msg) == ERROR_PAYLOAD, "error_msg must be the server's error object"
+    assert metric.response_data == sent_body, "the whole body must be preserved, framing included"
+    assert "[DONE]" in (metric.response_data or "")
+
+
+# Streaming completion against a complete 200 whose only frame is [DONE]: no
+# content, no usage. Must record an EmptyResponseError failure with the body kept.
+@pytest.mark.asyncio
+async def test_streaming_empty_stream_is_a_failure() -> None:
+    """A stream that says nothing is not a zero-token completion. Before #713 this
+    was a success with output_tokens 0 and an empty response."""
+    async with TruncatingSSEServer(["[DONE]"], missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url)
+        sent_body = server.sent_body
+
+    assert metric.error is not None
+    assert metric.error.error_type == "EmptyResponseError"
+    assert metric.response_data == sent_body == "data: [DONE]\n\n"
+
+
+# Unary completion against a complete 200 whose JSON body is the error object.
+# Must record an InBandError failure whose error_msg is that object and whose
+# response_data is the body as sent.
+@pytest.mark.asyncio
+async def test_unary_in_band_error_body_is_a_failure() -> None:
+    """The #713 unary shape: a proxy that answers 200 with an OpenAI error object.
+    The client reads the body before process_response, so it is the client's own
+    copy that must survive as response_data."""
+    async with TruncatingSSEServer([], missing_bytes=0, body=ERROR_FRAME, content_type="application/json") as server:
+        metric = await run_request_against(server.base_url, APIConfig(type=APIType.Completion, streaming=False))
+
+    assert metric.error is not None
+    assert metric.error.error_type == "InBandError"
+    assert json.loads(metric.error.error_msg) == ERROR_PAYLOAD
+    assert metric.response_data == ERROR_FRAME
+
+
+# Unary completion against a complete 200 whose body is `{}`. Must record an
+# EmptyResponseError failure with response_data == "{}".
+@pytest.mark.asyncio
+async def test_unary_empty_body_is_a_failure() -> None:
+    async with TruncatingSSEServer([], missing_bytes=0, body="{}", content_type="application/json") as server:
+        metric = await run_request_against(server.base_url, APIConfig(type=APIType.Completion, streaming=False))
+
+    assert metric.error is not None
+    assert metric.error.error_type == "EmptyResponseError"
+    assert metric.response_data == "{}"
+
+
+# End of the chain: the in-band error request must show up in the summary as
+# failures.count == 1 under the "inbanderror" label carrying the server's
+# message, successes.count == 0, and the per-request entry must carry both the
+# error and the raw body.
+@pytest.mark.asyncio
+async def test_in_band_error_lands_in_the_failure_bucket_of_the_report() -> None:
+    """What #713 is about: the request must not count toward throughput, and the
+    report has to say why it failed."""
+    async with TruncatingSSEServer([ERROR_FRAME, "[DONE]"], missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url)
+        sent_body = server.sent_body
+
+    summary, entries = await generate_reports(metric)
+
+    assert summary["successes"]["count"] == 0
+    assert summary["failures"]["count"] == 1
+    by_label = summary["failures"]["by_label"]
+    assert list(by_label) == ["inbanderror"], by_label
+    assert by_label["inbanderror"]["count"] == 1
+    assert by_label["inbanderror"]["messages"][0]["message"] == ERROR_PAYLOAD["error"]["message"]
+
+    assert len(entries) == 1
+    assert entries[0]["error"]["error_type"] == "InBandError"
+    assert entries[0]["response"] == sent_body

--- a/tests/required/integration/test_streaming_failure_body.py
+++ b/tests/required/integration/test_streaming_failure_body.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration test for issue #531 (#606 Integration tier, per-change lane).
+
+#530 fixed the bug: ``parse_sse_stream`` now wraps a mid-stream failure in
+``StreamInterruptedError`` carrying the bytes read so far, and
+``process_request`` recovers them into ``response_data`` so the per-request
+report still shows what the server sent. Nothing gates that recovery, and an
+ungated fix is how #410 reached the #564 postmortem.
+
+These tests drive the real client against a fake that returns 200, writes
+valid SSE frames, then ends the connection short of its declared
+``Content-Length``. That is the reproduction described in #531, and it raises a
+genuine ``aiohttp.ClientPayloadError`` inside the client, so the recovery
+branch is exercised through the real exception path rather than a patched-in
+one.
+"""
+
+import time
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fake_truncating_server import TruncatingSSEServer
+
+from inference_perf.apis import RequestLifecycleMetric
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.client.modelserver import openai_client as openai_client_module
+from inference_perf.client.modelserver.metrics import BaseMetrics
+from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
+from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
+from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
+from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+from inference_perf.reportgen.base import ReportGenerator
+
+# Two well-formed frames, so a break after them leaves a body that is both
+# non-empty and recognizably SSE.
+EVENTS = [
+    '{"choices":[{"text":"Hello "}]}',
+    '{"choices":[{"text":"world "}]}',
+]
+
+
+class _ConcreteOpenAIClient(openAIModelServerClient):
+    """openAIModelServerClient is abstract only in the two methods below, and
+    neither participates in the streaming path under test."""
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat, APIType.Completion]
+
+    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
+        raise NotImplementedError("no server metrics are scraped in the integration tier")
+
+
+def make_tokenizer() -> MagicMock:
+    tokenizer = MagicMock()
+    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
+    return tokenizer
+
+
+async def run_request_against(server: TruncatingSSEServer) -> RequestLifecycleMetric:
+    """One streaming completion through the real client, returning the metric
+    the client recorded for it."""
+    collector = LocalRequestMetricCollector()
+    # The client builds a CustomTokenizer, which would otherwise fetch from the
+    # Hub; token counts are irrelevant to this test, only the response body is.
+    with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
+        client = _ConcreteOpenAIClient(
+            metrics_collector=collector,
+            api_config=APIConfig(type=APIType.Completion, streaming=True),
+            uri=server.base_url,
+            model_name="fake-model",
+            tokenizer_config=None,
+            max_tcp_connections=1,
+            additional_filters=[],
+        )
+
+    session = client.new_session()
+    try:
+        await session.process_request(
+            CompletionAPIData(prompt="the quick brown fox", max_tokens=16),
+            stage_id=0,
+            scheduled_time=time.perf_counter(),
+        )
+    finally:
+        await session.close()
+
+    metrics = collector.get_metrics()
+    assert len(metrics) == 1, "the client must record exactly one metric for one request"
+    return metrics[0]
+
+
+@pytest.mark.asyncio
+async def test_partial_body_is_preserved_when_the_stream_breaks() -> None:
+    """The #531 regression: bytes received before the break must reach
+    response_data, byte for byte."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+
+    assert metric.response_data == server.sent_body, "the partial body must be preserved exactly as sent"
+    # Guards against a future "fix" that stores the parsed text instead: the
+    # value has to be the raw wire bytes, framing included, or it is useless
+    # for diagnosing a malformed stream.
+    assert "data: " in (metric.response_data or ""), "response_data must hold raw SSE framing, not reassembled output"
+    assert "Hello " in (metric.response_data or "")
+
+
+@pytest.mark.asyncio
+async def test_underlying_exception_is_reported_not_the_wrapper() -> None:
+    """StreamInterruptedError is plumbing. The report must name the error the
+    client actually hit, or the bucket in build_error_counts is useless."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+
+    assert metric.error is not None, "a broken stream must be recorded as a failure"
+    assert metric.error.error_type == "ClientPayloadError"
+    assert metric.error.error_type != "StreamInterruptedError"
+
+
+@pytest.mark.asyncio
+async def test_break_before_any_body_byte_leaves_the_response_empty() -> None:
+    """The empty-raw_content branch: with nothing received there is nothing to
+    preserve, and the 200 path must not fall through to the placeholder text
+    the non-200 path writes."""
+    async with TruncatingSSEServer([]) as server:
+        metric = await run_request_against(server)
+
+    assert metric.response_data == ""
+    assert metric.error is not None
+    assert metric.error.error_type == "ClientPayloadError"
+    assert "Failed to read response text" not in (metric.response_data or "")
+
+
+@pytest.mark.asyncio
+async def test_per_request_report_carries_the_partial_body() -> None:
+    """End of the chain: the preserved bytes have to survive into
+    per_request_lifecycle_metrics, which is the escape hatch #531 is about."""
+    async with TruncatingSSEServer(EVENTS) as server:
+        metric = await run_request_against(server)
+        sent_body = server.sent_body
+
+    config = MagicMock()
+    config.tokenizer = None
+    config.model_dump = MagicMock(return_value={})
+    generator = ReportGenerator(
+        metrics_client=None,
+        metrics_collector=MagicMock(get_metrics=MagicMock(return_value=[metric])),
+        config=config,
+    )
+    runtime_parameters = PerfRuntimeParameters(
+        start_time=0.0,
+        duration=1.0,
+        model_server_metrics=BaseMetrics(),
+        stages={0: StageRuntimeInfo(stage_id=0, rate=1.0, start_time=0.0, end_time=1.0, status=StageStatus.COMPLETED)},
+    )
+    report_config = ReportConfig(request_lifecycle=RequestLifecycleMetricsReportConfig(per_request=True))
+
+    reports = await generator.generate_reports(report_config, runtime_parameters)
+
+    per_request = [report for report in reports if report.name == "per_request_lifecycle_metrics"]
+    assert len(per_request) == 1, "per_request: true must emit the per-request report"
+    entries: List[Dict[str, Any]] = per_request[0].contents
+    assert len(entries) == 1
+    assert entries[0]["response"] == sent_body, "the per-request entry must carry the partial body, not an empty string"
+    assert entries[0]["error"]["error_type"] == "ClientPayloadError"

--- a/tests/required/integration/test_streaming_failure_body.py
+++ b/tests/required/integration/test_streaming_failure_body.py
@@ -27,22 +27,17 @@ branch is exercised through the real exception path rather than a patched-in
 one.
 """
 
-import time
 from typing import Any, Dict, List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from fake_truncating_server import TruncatingSSEServer
+from openai_client_harness import run_request_against
 
-from inference_perf.apis import RequestLifecycleMetric
-from inference_perf.apis.completion import CompletionAPIData
-from inference_perf.client.modelserver import openai_client as openai_client_module
 from inference_perf.client.modelserver.metrics import BaseMetrics
-from inference_perf.client.modelserver.openai_client import OpenAIMetrics, openAIModelServerClient
 from inference_perf.client.server_metrics.base import PerfRuntimeParameters, StageRuntimeInfo, StageStatus
-from inference_perf.config import APIConfig, APIType, ReportConfig, RequestLifecycleMetricsReportConfig
-from inference_perf.metrics.request_collector.local import LocalRequestMetricCollector
+from inference_perf.config import ReportConfig, RequestLifecycleMetricsReportConfig
 from inference_perf.reportgen.base import ReportGenerator
 
 # Two well-formed frames, so a break after them leaves a body that is both
@@ -53,61 +48,12 @@ EVENTS = [
 ]
 
 
-class _ConcreteOpenAIClient(openAIModelServerClient):
-    """openAIModelServerClient is abstract only in the two methods below, and
-    neither participates in the streaming path under test."""
-
-    def get_supported_apis(self) -> List[APIType]:
-        return [APIType.Chat, APIType.Completion]
-
-    def get_prometheus_metric_metadata(self) -> OpenAIMetrics:
-        raise NotImplementedError("no server metrics are scraped in the integration tier")
-
-
-def make_tokenizer() -> MagicMock:
-    tokenizer = MagicMock()
-    tokenizer.count_tokens = MagicMock(side_effect=lambda text, **kwargs: len(text.split()))
-    return tokenizer
-
-
-async def run_request_against(server: TruncatingSSEServer) -> RequestLifecycleMetric:
-    """One streaming completion through the real client, returning the metric
-    the client recorded for it."""
-    collector = LocalRequestMetricCollector()
-    # The client builds a CustomTokenizer, which would otherwise fetch from the
-    # Hub; token counts are irrelevant to this test, only the response body is.
-    with patch.object(openai_client_module, "CustomTokenizer", return_value=make_tokenizer()):
-        client = _ConcreteOpenAIClient(
-            metrics_collector=collector,
-            api_config=APIConfig(type=APIType.Completion, streaming=True),
-            uri=server.base_url,
-            model_name="fake-model",
-            tokenizer_config=None,
-            max_tcp_connections=1,
-            additional_filters=[],
-        )
-
-    session = client.new_session()
-    try:
-        await session.process_request(
-            CompletionAPIData(prompt="the quick brown fox", max_tokens=16),
-            stage_id=0,
-            scheduled_time=time.perf_counter(),
-        )
-    finally:
-        await session.close()
-
-    metrics = collector.get_metrics()
-    assert len(metrics) == 1, "the client must record exactly one metric for one request"
-    return metrics[0]
-
-
 @pytest.mark.asyncio
 async def test_partial_body_is_preserved_when_the_stream_breaks() -> None:
     """The #531 regression: bytes received before the break must reach
     response_data, byte for byte."""
     async with TruncatingSSEServer(EVENTS) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
 
     assert metric.response_data == server.sent_body, "the partial body must be preserved exactly as sent"
     # Guards against a future "fix" that stores the parsed text instead: the
@@ -122,7 +68,7 @@ async def test_underlying_exception_is_reported_not_the_wrapper() -> None:
     """StreamInterruptedError is plumbing. The report must name the error the
     client actually hit, or the bucket in build_error_counts is useless."""
     async with TruncatingSSEServer(EVENTS) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
 
     assert metric.error is not None, "a broken stream must be recorded as a failure"
     assert metric.error.error_type == "ClientPayloadError"
@@ -135,7 +81,7 @@ async def test_break_before_any_body_byte_leaves_the_response_empty() -> None:
     preserve, and the 200 path must not fall through to the placeholder text
     the non-200 path writes."""
     async with TruncatingSSEServer([]) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
 
     assert metric.response_data == ""
     assert metric.error is not None
@@ -148,7 +94,7 @@ async def test_per_request_report_carries_the_partial_body() -> None:
     """End of the chain: the preserved bytes have to survive into
     per_request_lifecycle_metrics, which is the escape hatch #531 is about."""
     async with TruncatingSSEServer(EVENTS) as server:
-        metric = await run_request_against(server)
+        metric = await run_request_against(server.base_url)
         sent_body = server.sent_body
 
     config = MagicMock()

--- a/tests/required/integration/test_truncated_response.py
+++ b/tests/required/integration/test_truncated_response.py
@@ -1,0 +1,241 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for issue #655 (#606 Integration tier, per-change lane).
+
+A stream the server closes cleanly after a handful of tokens is a well-formed
+200 and, before #655, indistinguishable from a legitimately short completion:
+no stream break, no token-count mismatch, no error, so it landed in the success
+bucket and quietly depressed the output-length distribution.
+
+These tests drive the real client against a fake that returns a complete,
+well-formed 200 carrying fewer tokens than the request's ``max_tokens``, with an
+honest ``finish_reason`` and ``usage``, and assert:
+
+- with ``ignore_eos`` on (the config default) the request is recorded as a
+  ``TruncatedResponseError`` failure with the parsed metrics and body kept;
+- with ``ignore_eos`` off it stays a success and the report shows it as a
+  ``finish_reasons`` bucket plus one ``output_shortfalls``;
+- a response that delivers the full budget is a success either way.
+
+No model server needed.
+"""
+
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from fake_truncating_server import TruncatingSSEServer
+from openai_client_harness import generate_reports, run_request_against
+
+from inference_perf.apis.chat import ChatCompletionAPIData, ChatMessage
+from inference_perf.apis.completion import CompletionAPIData
+from inference_perf.config import APIConfig, APIType
+
+MAX_TOKENS = 16
+
+
+# The SSE frames of a completion stream that stops after `words` content words
+# with the given finish_reason, followed by a usage frame that reports exactly
+# that many completion_tokens (the harness tokenizer also counts words, so the
+# client and server counts agree unless a test breaks that on purpose).
+def short_completion_stream(words: List[str], finish_reason: str, completion_tokens: int | None = None) -> List[str]:
+    frames = [json.dumps({"choices": [{"index": 0, "text": f"{w} ", "finish_reason": None}]}) for w in words[:-1]] + [
+        json.dumps({"choices": [{"index": 0, "text": words[-1], "finish_reason": finish_reason}]})
+    ]
+    usage = {"prompt_tokens": 4, "completion_tokens": completion_tokens if completion_tokens is not None else len(words)}
+    frames.append(json.dumps({"choices": [], "usage": usage}))
+    frames.append("[DONE]")
+    return frames
+
+
+# A unary chat body whose single choice carries `content`, `finish_reason` and
+# a usage block reporting `completion_tokens`.
+def unary_chat_body(content: str, finish_reason: str, completion_tokens: int) -> str:
+    return json.dumps(
+        {
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": finish_reason}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": completion_tokens, "total_tokens": 4 + completion_tokens},
+        }
+    )
+
+
+# Streaming completion, ignore_eos on, max_tokens 16: the fake sends 3 words then
+# finish_reason "stop" and usage completion_tokens 3. Must be recorded as a
+# failure of type TruncatedResponseError whose message names 3 of 16 and "stop",
+# with the parsed metrics (finish_reason "stop", 3 delivered tokens), max_tokens
+# 16 and the whole SSE body still on the record.
+@pytest.mark.asyncio
+async def test_streaming_short_stop_under_ignore_eos_is_a_truncation_failure() -> None:
+    async with TruncatingSSEServer(short_completion_stream(["one", "two", "three"], "stop"), missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url, ignore_eos=True)
+
+    assert metric.error is not None
+    assert metric.error.error_type == "TruncatedResponseError"
+    assert "delivered 3 of 16" in metric.error.error_msg
+    assert "finish_reason=stop" in metric.error.error_msg
+    assert metric.max_tokens == MAX_TOKENS
+    assert metric.info.response_metrics is not None
+    assert metric.info.response_metrics.finish_reason == "stop"
+    assert metric.info.response_metrics.delivered_output_tokens() == 3
+    assert metric.response_data == server.sent_body
+
+
+# Same short stream, ignore_eos off: a model emitting EOS early is legitimate, so
+# the request must stay a success (error None) with finish_reason "stop" recorded,
+# and the report must show finish_reasons {"stop": 1} and output_shortfalls 1.
+@pytest.mark.asyncio
+async def test_streaming_short_stop_without_ignore_eos_is_a_success_with_a_shortfall() -> None:
+    async with TruncatingSSEServer(short_completion_stream(["one", "two", "three"], "stop"), missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url, ignore_eos=False)
+
+    assert metric.error is None
+    assert metric.info.response_metrics is not None
+    assert metric.info.response_metrics.finish_reason == "stop"
+
+    summary, entries = await generate_reports([metric])
+    assert summary["successes"]["count"] == 1
+    assert summary["successes"]["finish_reasons"] == {"stop": 1}
+    assert summary["successes"]["output_shortfalls"] == 1
+    assert summary["failures"]["count"] == 0
+    assert entries[0]["max_tokens"] == MAX_TOKENS
+
+
+# Streaming completion that delivers exactly max_tokens (16 words, finish_reason
+# "length", usage 16), ignore_eos on: the budget was met, so it must be a success
+# with no shortfall and finish_reasons {"length": 1}.
+@pytest.mark.asyncio
+async def test_streaming_full_budget_under_ignore_eos_is_a_success() -> None:
+    words = [f"w{i}" for i in range(MAX_TOKENS)]
+    async with TruncatingSSEServer(short_completion_stream(words, "length"), missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url, ignore_eos=True)
+
+    assert metric.error is None
+    assert metric.info.response_metrics is not None
+    assert metric.info.response_metrics.finish_reason == "length"
+
+    summary, _ = await generate_reports([metric])
+    assert summary["successes"]["finish_reasons"] == {"length": 1}
+    assert summary["successes"]["output_shortfalls"] == 0
+
+
+# The server says finish_reason "length" but its usage reports only 10 of the 16
+# requested tokens (the shape of a max_model_len cap): under ignore_eos the
+# requested budget was still not delivered, so it is a TruncatedResponseError
+# whose message says "finish_reason=length".
+@pytest.mark.asyncio
+async def test_streaming_capped_length_under_ignore_eos_is_still_a_truncation() -> None:
+    words = [f"w{i}" for i in range(10)]
+    async with TruncatingSSEServer(short_completion_stream(words, "length"), missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url, ignore_eos=True)
+
+    assert metric.error is not None
+    assert metric.error.error_type == "TruncatedResponseError"
+    assert "delivered 10 of 16" in metric.error.error_msg
+    assert "finish_reason=length" in metric.error.error_msg
+
+
+# The server's usage is what counts: the fake streams 16 words (client count 16)
+# but reports completion_tokens 5. Under ignore_eos the server's own count wins,
+# so this is a truncation of 5 of 16.
+@pytest.mark.asyncio
+async def test_server_completion_tokens_take_precedence_over_the_client_count() -> None:
+    words = [f"w{i}" for i in range(MAX_TOKENS)]
+    async with TruncatingSSEServer(short_completion_stream(words, "stop", completion_tokens=5), missing_bytes=0) as server:
+        metric = await run_request_against(server.base_url, ignore_eos=True)
+
+    assert metric.error is not None
+    assert metric.error.error_type == "TruncatedResponseError"
+    assert "delivered 5 of 16" in metric.error.error_msg
+
+
+# Unary chat, ignore_eos on: a 200 body with a 2-word answer, finish_reason
+# "stop" and usage completion_tokens 2 against max_tokens 16 is a
+# TruncatedResponseError; the same body with ignore_eos off is a success whose
+# report shows finish_reasons {"stop": 1} and output_shortfalls 1.
+@pytest.mark.asyncio
+async def test_unary_chat_short_stop_follows_ignore_eos() -> None:
+    api_config = APIConfig(type=APIType.Chat, streaming=False)
+    body = unary_chat_body("Paris.", "stop", 2)
+
+    def chat_request() -> ChatCompletionAPIData:
+        return ChatCompletionAPIData(messages=[ChatMessage(role="user", content="capital of France?")], max_tokens=16)
+
+    async with TruncatingSSEServer([], missing_bytes=0, body=body, content_type="application/json") as server:
+        truncated = await run_request_against(server.base_url, api_config, chat_request(), ignore_eos=True)
+    async with TruncatingSSEServer([], missing_bytes=0, body=body, content_type="application/json") as server:
+        accepted = await run_request_against(server.base_url, api_config, chat_request(), ignore_eos=False)
+
+    assert truncated.error is not None
+    assert truncated.error.error_type == "TruncatedResponseError"
+    assert "delivered 2 of 16" in truncated.error.error_msg
+    assert truncated.response_data == body
+
+    assert accepted.error is None
+    summary, _ = await generate_reports([accepted])
+    assert summary["successes"]["finish_reasons"] == {"stop": 1}
+    assert summary["successes"]["output_shortfalls"] == 1
+
+
+# One truncated request and one full-budget request through the report, ignore_eos
+# on: the failure bucket shows by_label {"truncatedresponseerror": {count 1, the
+# delivered-3-of-16 message}} and the success bucket shows finish_reasons
+# {"length": 1} with output_shortfalls 0; the per-request entry for the failure
+# still carries its response and its max_tokens.
+@pytest.mark.asyncio
+async def test_truncation_lands_in_the_failure_bucket_of_the_report() -> None:
+    async with TruncatingSSEServer(short_completion_stream(["one", "two", "three"], "stop"), missing_bytes=0) as server:
+        truncated = await run_request_against(server.base_url, ignore_eos=True)
+    full = [f"w{i}" for i in range(MAX_TOKENS)]
+    async with TruncatingSSEServer(short_completion_stream(full, "length"), missing_bytes=0) as server:
+        complete = await run_request_against(server.base_url, ignore_eos=True)
+
+    summary, entries = await generate_reports([truncated, complete])
+
+    assert summary["successes"]["count"] == 1
+    assert summary["successes"]["finish_reasons"] == {"length": 1}
+    assert summary["successes"]["output_shortfalls"] == 0
+    assert summary["failures"]["count"] == 1
+    by_label: Dict[str, Any] = summary["failures"]["by_label"]
+    assert list(by_label) == ["truncatedresponseerror"]
+    assert by_label["truncatedresponseerror"]["count"] == 1
+    assert "delivered 3 of 16" in by_label["truncatedresponseerror"]["messages"][0]["message"]
+
+    failed_entry = next(e for e in entries if e["error"] is not None)
+    assert failed_entry["max_tokens"] == MAX_TOKENS
+    assert failed_entry["response"]
+    assert failed_entry["info"]["response_metrics"]["finish_reason"] == "stop"
+
+
+# A request the API layer produced no response_metrics for (a 200 with usage but
+# an empty choices list keeps its early return from #713) has nothing to compare
+# against max_tokens, so under ignore_eos it is neither a truncation nor a
+# shortfall: error None and output_shortfalls 0.
+@pytest.mark.asyncio
+async def test_no_response_metrics_is_not_judged() -> None:
+    body = json.dumps({"choices": [], "usage": {"prompt_tokens": 4, "completion_tokens": 0}})
+    async with TruncatingSSEServer([], missing_bytes=0, body=body, content_type="application/json") as server:
+        metric = await run_request_against(
+            server.base_url,
+            APIConfig(type=APIType.Completion, streaming=False),
+            CompletionAPIData(prompt="hi", max_tokens=16),
+            ignore_eos=True,
+        )
+
+    assert metric.error is None
+    assert metric.info.response_metrics is None
+    summary, _ = await generate_reports([metric])
+    assert summary["successes"]["output_shortfalls"] == 0
+    assert summary["successes"]["finish_reasons"] == {}

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -5,6 +5,7 @@ import pytest
 from inference_perf.reportgen.base import summarize_requests, summarize_prompt_token_usage, ReportGenerator
 from inference_perf.apis.base import (
     RequestLifecycleMetric,
+    ErrorResponseInfo,
     InferenceInfo,
     StreamedResponseMetrics,
     UnaryResponseMetrics,
@@ -703,3 +704,75 @@ def test_summarize_requests_handles_null_prompt_tokens_details() -> None:
     assert prompt_tokens["total"] == pytest.approx(10.0)
     assert prompt_tokens["cached"] == pytest.approx(0.0)
     assert prompt_tokens["uncached"] == pytest.approx(10.0)
+
+
+# Builds one successful request that asked for `max_tokens`, whose server usage
+# says `completion_tokens` were delivered (client count deliberately different,
+# 999, so a wrong source shows), with the given finish_reason.
+def _finished_request(
+    max_tokens: int | None, completion_tokens: int | None, finish_reason: str | None
+) -> RequestLifecycleMetric:
+    server_usage = {"completion_tokens": completion_tokens} if completion_tokens is not None else None
+    info = InferenceInfo(
+        request_metrics=RequestMetrics(text=Text(input_tokens=5)),
+        response_metrics=UnaryResponseMetrics(output_tokens=999, server_usage=server_usage, finish_reason=finish_reason),
+    )
+    return RequestLifecycleMetric(
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="r",
+        info=info,
+        error=None,
+        max_tokens=max_tokens,
+    )
+
+
+# Four successes: two stopped at "length" delivering the full 16, one stopped at
+# "stop" with 4 of 16, one whose server reported no reason and 16 of 16. Pins
+# finish_reasons == {"length": 2, "stop": 1} (unreported ones are not a bucket)
+# and output_shortfalls == 1 (only the 4-of-16 request), sorted by count.
+def test_summarize_requests_reports_finish_reasons_and_output_shortfalls() -> None:
+    metrics = [
+        _finished_request(16, 16, "length"),
+        _finished_request(16, 4, "stop"),
+        _finished_request(16, 16, "length"),
+        _finished_request(16, 16, None),
+    ]
+
+    successes = summarize_requests(metrics, [50]).successes
+
+    assert successes["finish_reasons"] == {"length": 2, "stop": 1}
+    assert list(successes["finish_reasons"]) == ["length", "stop"]
+    assert successes["output_shortfalls"] == 1
+
+
+# A request with no max_tokens recorded (None) and one whose server sent no usage
+# so the client count (3 here) stands in: the first cannot be judged and is not a
+# shortfall, the second is (3 < 8). output_shortfalls == 1.
+def test_output_shortfalls_needs_max_tokens_and_falls_back_to_client_count() -> None:
+    no_budget = _finished_request(None, 2, "stop")
+    no_usage = _finished_request(8, None, "stop")
+    assert no_usage.info.response_metrics is not None
+    no_usage.info.response_metrics.output_tokens = 3
+
+    successes = summarize_requests([no_budget, no_usage], [50]).successes
+
+    assert successes["output_shortfalls"] == 1
+    assert successes["finish_reasons"] == {"stop": 2}
+
+
+# A request that was already moved to the failure bucket (error set) does not
+# feed either field: one truncated failure plus one full-length success gives
+# finish_reasons == {"length": 1} and output_shortfalls == 0.
+def test_finish_reasons_and_shortfalls_only_count_successes() -> None:
+    truncated = _finished_request(16, 4, "stop")
+    truncated.error = ErrorResponseInfo(error_type="TruncatedResponseError", error_msg="delivered 4 of 16")
+
+    result = summarize_requests([truncated, _finished_request(16, 16, "length")], [50])
+
+    assert result.successes["finish_reasons"] == {"length": 1}
+    assert result.successes["output_shortfalls"] == 0
+    assert result.failures["by_label"] == {
+        "truncatedresponseerror": {"count": 1, "messages": [{"message": "delivered 4 of 16"}]}
+    }


### PR DESCRIPTION
Stacked on #744, which is stacked on #712: the first two commits are theirs, the last one is this change. Will rebase to a single commit once they merge.

Closes #655. Part of #606, Success classification.

### What

A stream the server closes cleanly after a handful of tokens is a well-formed 200: no stream break (#530), no token-count mismatch (#565), no error. It landed in the success bucket and dragged the output-length distribution down silently.

- `ResponseMetrics.finish_reason`: the server's reason verbatim (OpenAI `finish_reason`, Anthropic `stop_reason`), captured on every streaming and unary path (completion, chat, Anthropic, trace replay). `ResponseMetrics.delivered_output_tokens()`: server `usage.completion_tokens` when reported, else the client count.
- `RequestLifecycleMetric.max_tokens`: what the request body asked for, also on each per-request report entry.
- Under `ignore_eos`, a completion that delivered fewer tokens than `max_tokens` is recorded as a `TruncatedResponseError` failure (label `truncatedresponseerror`; the message names delivered-of-requested and the finish_reason). Its metrics and body stay on the record. The rule reads `ignore_eos` from the request body, not the client setting: Anthropic bodies never carry it, and the trace replay turns it off per request for tool calls.
- Without `ignore_eos`, a short response stays a success and the summary reports `successes.finish_reasons` (reason to count) and `successes.output_shortfalls`.
- The OTel `finish_reason` attribute read a never-populated `extra_info` key; it now reads the persisted field.

### Two calls to check

1. `length` with fewer tokens is still a truncation. A server that caps below `max_tokens` (a `max_model_len` cap) reports `length` and fewer tokens; under `ignore_eos` the requested budget was not delivered, so it fails, with the finish_reason in the message for diagnosis.
2. The rule is on by default, since `ignore_eos` defaults to true. A server that ignores the `ignore_eos` field will now report every natural stop as truncated. That is the config misdescribing the run, and the fix is `ignore_eos: false`; the field description and `docs/reports.md` say so. Fallback if wanted: a report-config toggle.

### Tests

- `tests/required/integration/test_truncated_response.py` against the #712 fake: short-with-`stop` under `ignore_eos` on (failure) and off (success plus shortfall), full budget, `length`-capped, server count over client count, unary chat, the report bucket, and a no-`choices` body that is not judged.
- Parser (`finish_reason` on the last content frame, on a content-free frame, Anthropic `message_delta`), API layer, and reportgen fields.
- `e2e/tests/test_output_length_sim.py`: sim v0.6.1 honours `ignore_eos`; on gives `finish_reasons {"length": 10}` and 0 shortfalls; off gives shortfalls equal to the per-request entries whose `completion_tokens` is below `max_tokens`. The fidelity test asserts the same on its ground truth.
- The golden fixture serves fixed `n_tokens` regardless of `max_tokens`, so it now runs with `ignore_eos: false` (comment explains); the backend suite's 5-token canned replies likewise.

`pdm run validate` clean, 935 unit tests pass, sim e2e run locally.
