### PR TITLE
fix: explain worker process crashes instead of one context-free log line

### DIFF
--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -56,6 +56,7 @@ else:
 from typing import List, Tuple, Optional, NamedTuple, Union, Set, Dict
 from types import FrameType
 import time
+import traceback
 import multiprocessing as mp
 from queue import Empty
 from multiprocessing.synchronize import Barrier as SyncBarrier, Event as SyncEvent
@@ -88,6 +89,74 @@ class RequestQueueData(NamedTuple):
     lora_adapter: Optional[str]
 
 
+class WorkerCrash(NamedTuple):
+    """What a worker managed to record about its own unhandled exception before dying."""
+
+    worker_id: int
+    stage_id: Optional[int]
+    exc_type: str
+    message: str
+    traceback_text: str
+    in_flight: int
+
+
+class WorkerFailure(NamedTuple):
+    """A worker that is no longer alive, with whatever the parent can say about why."""
+
+    worker_id: int
+    exitcode: Optional[int]
+    crash: Optional[WorkerCrash]
+
+    def describe(self) -> str:
+        if self.exitcode is not None and self.exitcode < 0:
+            try:
+                signame = signal.Signals(-self.exitcode).name
+            except ValueError:
+                signame = f"signal {-self.exitcode}"
+            cause = f"was killed by {signame}"
+        elif self.exitcode == 0:
+            cause = "exited cleanly before the stage finished"
+        else:
+            cause = f"exited with code {self.exitcode}"
+        if self.crash is not None:
+            return (
+                f"Worker {self.worker_id} {cause} after an unhandled "
+                f"{self.crash.exc_type} during stage {self.crash.stage_id} "
+                f"with {self.crash.in_flight} request(s) in flight: {self.crash.message}\n"
+                f"{self.crash.traceback_text.rstrip()}"
+            )
+        return (
+            f"Worker {self.worker_id} {cause} without reporting a Python traceback (segfault, OOM kill, or forced termination)"
+        )
+
+
+def collect_worker_failures(
+    workers: List["Worker"],
+    crash_queue: Optional["mp.SimpleQueue[WorkerCrash]"],
+) -> List[WorkerFailure]:
+    """Pair every dead worker with its crash record, if the worker lived long enough to send one.
+
+    A worker killed by a signal never reports, so exitcode is the only evidence
+    available for that case and the record is None.
+    """
+    crashes: Dict[int, WorkerCrash] = {}
+    if crash_queue is not None:
+        while True:
+            try:
+                if crash_queue.empty():
+                    break
+                record = crash_queue.get()
+            except (OSError, EOFError, ValueError):
+                break
+            crashes[record.worker_id] = record
+    failures = []
+    for worker in workers:
+        if worker.is_alive() or worker.exitcode is None:
+            continue
+        failures.append(WorkerFailure(worker_id=worker.id, exitcode=worker.exitcode, crash=crashes.get(worker.id)))
+    return failures
+
+
 class Worker(mp.Process):
     def __init__(
         self,
@@ -104,6 +173,7 @@ class Worker(mp.Process):
         shared_max_concurrency: Optional["Synchronized[int]"],
         base_seed: int,
         stage_barrier: Optional[SyncBarrier] = None,
+        crash_queue: Optional["mp.SimpleQueue[WorkerCrash]"] = None,
     ):
         super().__init__(daemon=True)  # kill worker process if main process exit unexpected
         self.id = id
@@ -120,6 +190,10 @@ class Worker(mp.Process):
         self.skip = False
         self.base_seed = base_seed
         self.stage_barrier = stage_barrier
+        self.crash_queue = crash_queue
+        # Stage this worker is currently serving, reported alongside a crash so the
+        # failure can be attributed to a stage rather than to the run as a whole.
+        self._current_stage_id: Optional[int] = None
         # Snapshot the parent's effective root log level so the worker
         # interpreter (which under forkserver/spawn does not inherit the
         # parent's basicConfig) can configure its own handler to surface
@@ -163,6 +237,8 @@ class Worker(mp.Process):
                     # Use partial to pass named arg
                     get = partial(self.request_queue.get, timeout=timeout)
                     item = await event_loop.run_in_executor(None, get)
+                    if item is not None:
+                        self._current_stage_id = item.stage_id
                     if item is None:
                         self.request_queue.task_done()
                         semaphore.release()
@@ -266,6 +342,17 @@ class Worker(mp.Process):
         logger.debug(f"[Worker {self.id}] stopped")
 
     def run(self) -> None:
+        """Entry point in the worker process. Nothing below may escape unexplained."""
+        try:
+            self._run()
+        except BaseException as exc:
+            # Without this the process dies with the traceback on its own stderr,
+            # which races the parent's terminate() and is attributed to no worker.
+            # Record it first, then re-raise so the exit code still reflects the failure.
+            self._report_crash(exc)
+            raise
+
+    def _run(self) -> None:
         # forkserver/spawn workers start from a fresh interpreter without the
         # parent's logging.basicConfig, so logger.info() calls are silently
         # dropped by the lastResort handler (WARNING+). Install a minimal
@@ -289,6 +376,38 @@ class Worker(mp.Process):
         set_event_loop_policy(uvloop.EventLoopPolicy())
         run(self.loop())
 
+    def _report_crash(self, exc: BaseException) -> None:
+        """Log the failure locally and hand a structured copy to the parent before exiting."""
+        try:
+            in_flight = int(self.active_requests_counter.value)
+        except (AttributeError, OSError, ValueError):
+            in_flight = -1
+        record = WorkerCrash(
+            worker_id=self.id,
+            stage_id=self._current_stage_id,
+            exc_type=type(exc).__name__,
+            message=str(exc),
+            traceback_text="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            in_flight=in_flight,
+        )
+        logger.error(
+            "[Worker %d] unhandled %s during stage %s with %d request(s) in flight: %s\n%s",
+            record.worker_id,
+            record.exc_type,
+            record.stage_id,
+            record.in_flight,
+            record.message,
+            record.traceback_text.rstrip(),
+        )
+        if self.crash_queue is None:
+            return
+        try:
+            # SimpleQueue writes straight to the pipe, so the record is not lost to an
+            # unflushed feeder thread when the process exits immediately after this.
+            self.crash_queue.put(record)
+        except Exception:
+            logger.error("[Worker %d] could not report its crash to the parent process", self.id)
+
 
 class LoadGenerator:
     def __init__(
@@ -309,6 +428,8 @@ class LoadGenerator:
         self.sweep_config = load_config.sweep
         self.interrupt_sig = False
         self.session_metrics_collector = session_metrics_collector
+        self.worker_crash_queue: Optional["mp.SimpleQueue[WorkerCrash]"] = None
+        self.worker_failures: List[WorkerFailure] = []
         signal.signal(signal.SIGINT, self._sigint_handler)
 
         # Validate that datagen type matches load_type
@@ -813,7 +934,12 @@ class LoadGenerator:
                 timed_out = True
                 break
             if self.workers and len([w for w in self.workers if w.is_alive()]) < self.num_workers:
-                logger.error("A worker process died unexpectedly!")
+                failures = collect_worker_failures(self.workers, self.worker_crash_queue)
+                for failure in failures:
+                    logger.error("%s", failure.describe())
+                self.worker_failures.extend(failures)
+                if not failures:
+                    logger.error("A worker process died unexpectedly and left no exit status behind!")
                 timed_out = True  # Trigger cleanup
                 break
             await sleep(1)
@@ -834,7 +960,14 @@ class LoadGenerator:
         # on all items it pulled before we drain/join (avoids orphaned untasked items).
         request_phase.clear()
         if stage_barrier:
-            stage_barrier.wait()
+            if self.worker_failures:
+                logger.warning(
+                    "Stage %d: skipping the worker rendezvous, %d dead worker(s) can never reach the barrier",
+                    stage_id,
+                    len(self.worker_failures),
+                )
+            else:
+                stage_barrier.wait()
         if stage_status == StageStatus.FAILED and cancel_signal:
             request_queue.drain()
             cancel_signal.clear()
@@ -949,6 +1082,8 @@ class LoadGenerator:
         # Synchronize workers and main at stage boundaries so workers finish
         # in-flight requests and clear session state before the next stage begins.
         stage_barrier: SyncBarrier = mp.Barrier(self.num_workers + 1)
+        # Channel a dying worker uses to hand its traceback to the parent.
+        self.worker_crash_queue = mp.SimpleQueue()
         # start workers in the request phase
         request_phase.set()
 
@@ -975,6 +1110,7 @@ class LoadGenerator:
                     shared_max_concurrency,
                     self.base_seed,
                     stage_barrier,
+                    crash_queue=self.worker_crash_queue,
                 )
             )
             self.workers[-1].start()
@@ -1085,6 +1221,13 @@ class LoadGenerator:
 
                 # If we encountered a SIGINT, we can break out of run stages loop
                 if self.interrupt_sig:
+                    break
+                if self.worker_failures:
+                    logger.error(
+                        "Stopping the run after %d worker failure(s): the load actually offered no longer "
+                        "matches the configuration, so the remaining stages would not be comparable",
+                        len(self.worker_failures),
+                    )
                     break
                 progress.update(overall_task, advance=1)
                 if self.stageInterval:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -60,6 +60,7 @@ from typing import List, Tuple, Optional, NamedTuple, Union, Set, Dict, cast
 from types import FrameType
 import ctypes
 import time
+import traceback
 import multiprocessing as mp
 from queue import Empty
 from multiprocessing.synchronize import Event as SyncEvent
@@ -119,6 +120,74 @@ class RequestQueueData(NamedTuple):
     lora_adapter: Optional[str]
 
 
+class WorkerCrash(NamedTuple):
+    """What a worker managed to record about its own unhandled exception before dying."""
+
+    worker_id: int
+    stage_id: Optional[int]
+    exc_type: str
+    message: str
+    traceback_text: str
+    in_flight: int
+
+
+class WorkerFailure(NamedTuple):
+    """A worker that is no longer alive, with whatever the parent can say about why."""
+
+    worker_id: int
+    exitcode: Optional[int]
+    crash: Optional[WorkerCrash]
+
+    def describe(self) -> str:
+        if self.exitcode is not None and self.exitcode < 0:
+            try:
+                signame = signal.Signals(-self.exitcode).name
+            except ValueError:
+                signame = f"signal {-self.exitcode}"
+            cause = f"was killed by {signame}"
+        elif self.exitcode == 0:
+            cause = "exited cleanly before the stage finished"
+        else:
+            cause = f"exited with code {self.exitcode}"
+        if self.crash is not None:
+            return (
+                f"Worker {self.worker_id} {cause} after an unhandled "
+                f"{self.crash.exc_type} during stage {self.crash.stage_id} "
+                f"with {self.crash.in_flight} request(s) in flight: {self.crash.message}\n"
+                f"{self.crash.traceback_text.rstrip()}"
+            )
+        return (
+            f"Worker {self.worker_id} {cause} without reporting a Python traceback (segfault, OOM kill, or forced termination)"
+        )
+
+
+def collect_worker_failures(
+    workers: List["Worker"],
+    crash_queue: Optional["mp.SimpleQueue[WorkerCrash]"],
+) -> List[WorkerFailure]:
+    """Pair every dead worker with its crash record, if the worker lived long enough to send one.
+
+    A worker killed by a signal never reports, so exitcode is the only evidence
+    available for that case and the record is None.
+    """
+    crashes: Dict[int, WorkerCrash] = {}
+    if crash_queue is not None:
+        while True:
+            try:
+                if crash_queue.empty():
+                    break
+                record = crash_queue.get()
+            except (OSError, EOFError, ValueError):
+                break
+            crashes[record.worker_id] = record
+    failures = []
+    for worker in workers:
+        if worker.is_alive() or worker.exitcode is None:
+            continue
+        failures.append(WorkerFailure(worker_id=worker.id, exitcode=worker.exitcode, crash=crashes.get(worker.id)))
+    return failures
+
+
 class Worker(mp.Process):
     def __init__(
         self,
@@ -138,6 +207,7 @@ class Worker(mp.Process):
         stage_done_counter: Optional["Synchronized[int]"] = None,
         stage_boundary_seq: Optional["Synchronized[int]"] = None,
         teardown_grace_seconds: float = 120.0,
+        crash_queue: Optional["mp.SimpleQueue[WorkerCrash]"] = None,
     ):
         super().__init__(daemon=True)  # kill worker process if main process exit unexpected
         self.id = id
@@ -160,6 +230,10 @@ class Worker(mp.Process):
         # True while the stage is winding down: in-flight requests may finish,
         # but no new requests are dispatched to the model server.
         self.draining = False
+        self.crash_queue = crash_queue
+        # Stage this worker is currently serving, reported alongside a crash so the
+        # failure can be attributed to a stage rather than to the run as a whole.
+        self._current_stage_id: Optional[int] = None
         # Snapshot the parent's effective root log level so the worker
         # interpreter (which under forkserver/spawn does not inherit the
         # parent's basicConfig) can configure its own handler to surface
@@ -219,6 +293,8 @@ class Worker(mp.Process):
                     # including its own respawned replacement. get_nowait
                     # holds the lock only while actually transferring an item.
                     item = await event_loop.run_in_executor(None, self.request_queue.get_nowait)
+                    if item is not None:
+                        self._current_stage_id = item.stage_id
                     if item is None:
                         semaphore.release()
                         continue
@@ -386,6 +462,17 @@ class Worker(mp.Process):
             self.draining = False
 
     def run(self) -> None:
+        """Entry point in the worker process. Nothing below may escape unexplained."""
+        try:
+            self._run()
+        except BaseException as exc:
+            # Without this the process dies with the traceback on its own stderr,
+            # which races the parent's terminate() and is attributed to no worker.
+            # Record it first, then re-raise so the exit code still reflects the failure.
+            self._report_crash(exc)
+            raise
+
+    def _run(self) -> None:
         # forkserver/spawn workers start from a fresh interpreter without the
         # parent's logging.basicConfig, so logger.info() calls are silently
         # dropped by the lastResort handler (WARNING+). Install a minimal
@@ -408,6 +495,38 @@ class Worker(mp.Process):
         signal.signal(signal.SIGINT, signal.SIG_IGN)
         set_event_loop_policy(uvloop.EventLoopPolicy())
         run(self.loop())
+
+    def _report_crash(self, exc: BaseException) -> None:
+        """Log the failure locally and hand a structured copy to the parent before exiting."""
+        try:
+            in_flight = int(self.active_requests_counter.value)
+        except (AttributeError, OSError, ValueError):
+            in_flight = -1
+        record = WorkerCrash(
+            worker_id=self.id,
+            stage_id=self._current_stage_id,
+            exc_type=type(exc).__name__,
+            message=str(exc),
+            traceback_text="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+            in_flight=in_flight,
+        )
+        logger.error(
+            "[Worker %d] unhandled %s during stage %s with %d request(s) in flight: %s\n%s",
+            record.worker_id,
+            record.exc_type,
+            record.stage_id,
+            record.in_flight,
+            record.message,
+            record.traceback_text.rstrip(),
+        )
+        if self.crash_queue is None:
+            return
+        try:
+            # SimpleQueue writes straight to the pipe, so the record is not lost to an
+            # unflushed feeder thread when the process exits immediately after this.
+            self.crash_queue.put(record)
+        except Exception:
+            logger.error("[Worker %d] could not report its crash to the parent process", self.id)
 
 
 class LoadGenerator:
@@ -439,6 +558,8 @@ class LoadGenerator:
         # (not increment) their counter at the boundary.
         self._expected_stage_done = 0
         self._stage_boundary_seq: Optional["Synchronized[int]"] = None
+        self.worker_crash_queue: Optional["mp.SimpleQueue[WorkerCrash]"] = None
+        self.worker_failures: List[WorkerFailure] = []
         signal.signal(signal.SIGINT, self._sigint_handler)
 
         # Validate that datagen type matches load_type
@@ -747,7 +868,13 @@ class LoadGenerator:
                 if progress_ctx and stage_task:
                     progress_ctx.remove_task(stage_task)
                     stage_task = None
-                logger.error(f"Stage {stage_id}: a worker process died unexpectedly; failing stage")
+                failures = collect_worker_failures(self.workers, self.worker_crash_queue)
+                for failure in failures:
+                    logger.error("%s", failure.describe())
+                self.worker_failures.extend(failures)
+                if not failures:
+                    logger.error(f"Stage {stage_id}: a worker process died unexpectedly and left no exit status behind")
+                logger.error(f"Stage {stage_id}: failing stage after worker death")
                 stage_status = StageStatus.FAILED
                 for sid in list(session_spans.keys()):
                     otel_instr.end_session_span(session_spans[sid], "Worker process died")
@@ -1004,6 +1131,7 @@ class LoadGenerator:
             stage_done_counter=stage_done_counter,
             stage_boundary_seq=dead.stage_boundary_seq,
             teardown_grace_seconds=dead.teardown_grace_seconds,
+            crash_queue=dead.crash_queue,
         )
 
     async def run_stage(
@@ -1083,7 +1211,12 @@ class LoadGenerator:
                 timed_out = True
                 break
             if self.workers and len([w for w in self.workers if w.is_alive()]) < self.num_workers:
-                logger.error("A worker process died unexpectedly!")
+                failures = collect_worker_failures(self.workers, self.worker_crash_queue)
+                for failure in failures:
+                    logger.error("%s", failure.describe())
+                self.worker_failures.extend(failures)
+                if not failures:
+                    logger.error("A worker process died unexpectedly and left no exit status behind!")
                 timed_out = True  # Trigger cleanup
                 break
             await sleep(1)
@@ -1223,6 +1356,8 @@ class LoadGenerator:
         # (see _teardown_stage).
         stage_boundary_seq: "Synchronized[int]" = mp.Value("i", 0)
         self._stage_boundary_seq = stage_boundary_seq
+        # Channel a dying worker uses to hand its traceback to the parent.
+        self.worker_crash_queue = mp.SimpleQueue()
         # start workers in the request phase
         request_phase.set()
 
@@ -1257,6 +1392,7 @@ class LoadGenerator:
                     stage_done_counter=stage_done_counter,
                     stage_boundary_seq=stage_boundary_seq,
                     teardown_grace_seconds=self.teardown_grace_seconds,
+                    crash_queue=self.worker_crash_queue,
                 )
             )
             self.workers[-1].start()
@@ -1366,6 +1502,13 @@ class LoadGenerator:
 
                 # If we encountered a SIGINT, we can break out of run stages loop
                 if self.interrupt_sig:
+                    break
+                if self.worker_failures:
+                    logger.error(
+                        "Stopping the run after %d worker failure(s): the load actually offered no longer "
+                        "matches the configuration, so the remaining stages would not be comparable",
+                        len(self.worker_failures),
+                    )
                     break
                 progress.update(overall_task, advance=1)
                 if self.stageInterval:

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -150,10 +150,15 @@ class WorkerFailure(NamedTuple):
         else:
             cause = f"exited with code {self.exitcode}"
         if self.crash is not None:
+            # stage_id is None when the worker died before it pulled its first request,
+            # which is the usual shape for a failure during startup.
+            where = "before serving any stage" if self.crash.stage_id is None else f"during stage {self.crash.stage_id}"
+            # in_flight is read from a counter shared by every worker, so it is the
+            # run-wide figure at the moment of the crash, not this worker's own share.
             return (
                 f"Worker {self.worker_id} {cause} after an unhandled "
-                f"{self.crash.exc_type} during stage {self.crash.stage_id} "
-                f"with {self.crash.in_flight} request(s) in flight: {self.crash.message}\n"
+                f"{self.crash.exc_type} {where} "
+                f"with {self.crash.in_flight} request(s) in flight run-wide: {self.crash.message}\n"
                 f"{self.crash.traceback_text.rstrip()}"
             )
         return (
@@ -511,10 +516,10 @@ class Worker(mp.Process):
             in_flight=in_flight,
         )
         logger.error(
-            "[Worker %d] unhandled %s during stage %s with %d request(s) in flight: %s\n%s",
+            "[Worker %d] unhandled %s %s with %d request(s) in flight run-wide: %s\n%s",
             record.worker_id,
             record.exc_type,
-            record.stage_id,
+            "before serving any stage" if record.stage_id is None else f"during stage {record.stage_id}",
             record.in_flight,
             record.message,
             record.traceback_text.rstrip(),
@@ -1502,13 +1507,6 @@ class LoadGenerator:
 
                 # If we encountered a SIGINT, we can break out of run stages loop
                 if self.interrupt_sig:
-                    break
-                if self.worker_failures:
-                    logger.error(
-                        "Stopping the run after %d worker failure(s): the load actually offered no longer "
-                        "matches the configuration, so the remaining stages would not be comparable",
-                        len(self.worker_failures),
-                    )
                     break
                 progress.update(overall_task, advance=1)
                 if self.stageInterval:

--- a/tests/required/loadgen/test_worker_crash_diagnostics.py
+++ b/tests/required/loadgen/test_worker_crash_diagnostics.py
@@ -1,0 +1,252 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for #593: a dying worker used to produce one context-free log line.
+
+Before this change the only output was "A worker process died unexpectedly!" with no
+worker id, no exit code and no traceback, and the run then hung on the stage barrier.
+"""
+
+import multiprocessing as mp
+import os
+import signal
+import unittest
+from typing import Any, List, Optional
+
+import numpy as np
+
+from inference_perf.client.modelserver.mock_client import MockModelServerClient
+from inference_perf.config import (
+    APIConfig,
+    APIType,
+    DataConfig,
+    DataGenType,
+    Distribution,
+    LoadConfig,
+    LoadType,
+    StandardLoadStage,
+)
+from inference_perf.datagen.synthetic.random_datagen import RandomDataGenerator
+from inference_perf.loadgen.load_generator import (
+    LoadGenerator,
+    WorkerCrash,
+    WorkerFailure,
+    collect_worker_failures,
+)
+from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+
+class _FakeWorker:
+    # Stands in for a Worker process. is_alive()/exitcode/id are the only attributes
+    # collect_worker_failures() reads, so a stub avoids spawning real processes here.
+    def __init__(self, id: int, alive: bool, exitcode: Optional[int]) -> None:
+        self.id = id
+        self._alive = alive
+        self.exitcode = exitcode
+
+    def is_alive(self) -> bool:
+        return self._alive
+
+
+class _Tokenizer:
+    # Space-delimited integers stand in for tokens, so "10 11 12" is 3 tokens.
+    vocab_size = 1000
+    all_special_ids = [1, 2, 3]
+
+    def decode(self, tokens: List[int], **kwargs: Any) -> str:
+        return " ".join(str(t) for t in tokens)
+
+    def encode(self, text: str) -> List[int]:
+        try:
+            return [int(t) for t in text.split()]
+        except ValueError:
+            return list(range(10, 10010))
+
+
+class _CustomTokenizer(CustomTokenizer):
+    def __init__(self) -> None:
+        pass
+
+    def get_tokenizer(self) -> Any:
+        return _Tokenizer()
+
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
+        return len(text.split()) if text else 0
+
+
+class CrashingDataGenerator(RandomDataGenerator):
+    # Raises RuntimeError("induced worker crash") the first time `rng` is read in a
+    # child process, and behaves normally in the parent. Worker._run() reads `rng`
+    # while seeding, so this crashes the worker exactly once it has started.
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._real_rng = np.random.default_rng(0)
+        self._parent_pid = os.getpid()
+        super().__init__(*args, **kwargs)
+
+    @property
+    def rng(self) -> Any:
+        if os.getpid() != self._parent_pid:
+            raise RuntimeError("induced worker crash")
+        return self._real_rng
+
+    @rng.setter
+    def rng(self, value: Any) -> None:
+        self._real_rng = value
+
+
+class TestWorkerFailureDescription(unittest.TestCase):
+    """The text a user sees for each way a worker can die."""
+
+    def test_crash_with_traceback_names_worker_stage_and_exception(self) -> None:
+        # A worker that raised TypeError during stage 2 with 3 requests in flight
+        # must report all four facts plus the traceback body.
+        failure = WorkerFailure(
+            worker_id=1,
+            exitcode=1,
+            crash=WorkerCrash(
+                worker_id=1,
+                stage_id=2,
+                exc_type="TypeError",
+                message="cannot pickle 'generator' object",
+                traceback_text="Traceback (most recent call last):\n  ...\nTypeError: nope\n",
+                in_flight=3,
+            ),
+        )
+        described = failure.describe()
+        self.assertIn("Worker 1", described)
+        self.assertIn("exited with code 1", described)
+        self.assertIn("TypeError", described)
+        self.assertIn("stage 2", described)
+        self.assertIn("3 request(s) in flight", described)
+        self.assertIn("cannot pickle 'generator' object", described)
+        self.assertIn("Traceback (most recent call last):", described)
+
+    def test_signal_death_reports_the_signal_by_name(self) -> None:
+        # A worker killed by SIGKILL has exitcode -9 and can never send a record,
+        # so the description must name SIGKILL and say no traceback exists.
+        failure = WorkerFailure(worker_id=0, exitcode=-int(signal.SIGKILL), crash=None)
+        described = failure.describe()
+        self.assertIn("Worker 0", described)
+        self.assertIn("SIGKILL", described)
+        self.assertIn("without reporting a Python traceback", described)
+
+    def test_clean_early_exit_is_still_reported_as_a_failure(self) -> None:
+        # Exit code 0 mid-stage is abnormal: the worker should have stayed alive
+        # until the stop signal, so it is described rather than silently ignored.
+        described = WorkerFailure(worker_id=4, exitcode=0, crash=None).describe()
+        self.assertIn("Worker 4", described)
+        self.assertIn("exited cleanly before the stage finished", described)
+
+
+class TestCollectWorkerFailures(unittest.TestCase):
+    """Pairing dead workers with the crash records drained from the queue."""
+
+    def test_pairs_each_record_with_its_worker_and_skips_healthy_ones(self) -> None:
+        # Workers 0 (alive), 1 (dead, sent a record), 2 (dead, killed by signal),
+        # 3 (never started) must yield failures for 1 and 2 only, and only
+        # worker 1 carries a crash record.
+        queue: "mp.SimpleQueue[WorkerCrash]" = mp.SimpleQueue()
+        queue.put(
+            WorkerCrash(
+                worker_id=1,
+                stage_id=0,
+                exc_type="ValueError",
+                message="boom",
+                traceback_text="tb",
+                in_flight=1,
+            )
+        )
+        workers = [
+            _FakeWorker(0, alive=True, exitcode=None),
+            _FakeWorker(1, alive=False, exitcode=1),
+            _FakeWorker(2, alive=False, exitcode=-9),
+            _FakeWorker(3, alive=False, exitcode=None),
+        ]
+        failures = collect_worker_failures(workers, queue)  # type: ignore[arg-type]
+
+        self.assertEqual([f.worker_id for f in failures], [1, 2])
+        self.assertIsNotNone(failures[0].crash)
+        assert failures[0].crash is not None
+        self.assertEqual(failures[0].crash.exc_type, "ValueError")
+        self.assertIsNone(failures[1].crash)
+
+    def test_no_queue_still_reports_exit_codes(self) -> None:
+        # With no crash channel at all, a dead worker must still be reported using
+        # its exit code alone rather than disappearing.
+        failures = collect_worker_failures([_FakeWorker(0, alive=False, exitcode=3)], None)  # type: ignore[list-item]
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].exitcode, 3)
+        self.assertIsNone(failures[0].crash)
+
+
+class TestWorkerCrashEndToEnd(unittest.IsolatedAsyncioTestCase):
+    """A real worker process crashes and the parent explains it without hanging."""
+
+    def setUp(self) -> None:
+        # Worker._run() reads the datagen's `rng` in the child; under fork the
+        # object is inherited so the crash lands inside the worker. Python 3.14
+        # defaults to forkserver on Linux, where the same object is pickled and
+        # the failure moves into process startup instead (see #526).
+        self._previous_start_method = mp.get_start_method(allow_none=True)
+        try:
+            mp.set_start_method("fork", force=True)
+        except RuntimeError:
+            self.skipTest("fork start method unavailable on this platform")
+
+    def tearDown(self) -> None:
+        if self._previous_start_method is not None:
+            mp.set_start_method(self._previous_start_method, force=True)
+
+    async def test_crash_is_attributed_and_the_run_terminates(self) -> None:
+        # One worker, two stages, and a datagen that raises as soon as the worker
+        # starts. mp_run must return instead of hanging on the stage barrier, and
+        # must record worker 0 with exit code 1 and the RuntimeError traceback.
+        api_config = APIConfig(type=APIType.Completion, streaming=False)
+        data_config = DataConfig(
+            type=DataGenType.Random,
+            input_distribution=Distribution(min=10, max=10, mean=10.0, std_dev=0.0, total_count=4),
+            output_distribution=Distribution(min=5, max=5, mean=5.0, std_dev=0.0, total_count=4),
+        )
+        datagen = CrashingDataGenerator(api_config, data_config, _CustomTokenizer())
+
+        collector = MultiprocessRequestMetricCollector()
+        client = MockModelServerClient(collector, api_config, mock_latency=0)
+        load_config = LoadConfig(
+            type=LoadType.CONSTANT,
+            num_workers=1,
+            worker_max_concurrency=4,
+            stages=[StandardLoadStage(rate=4, duration=1), StandardLoadStage(rate=4, duration=1)],
+            base_seed=42,
+        )
+        load_gen = LoadGenerator(datagen, load_config)
+
+        async with collector.start():
+            await load_gen.mp_run(client)
+
+        self.assertEqual(len(load_gen.worker_failures), 1, "the dead worker must be recorded exactly once")
+        failure = load_gen.worker_failures[0]
+        self.assertEqual(failure.worker_id, 0)
+        self.assertEqual(failure.exitcode, 1)
+        self.assertIsNotNone(failure.crash, "the worker must report its traceback before dying")
+        assert failure.crash is not None
+        self.assertEqual(failure.crash.exc_type, "RuntimeError")
+        self.assertIn("induced worker crash", failure.crash.traceback_text)
+
+        # The second stage must be skipped: a run that lost a worker never offered
+        # the configured load, so later stages are not comparable.
+        self.assertEqual(len(load_gen.stage_runtime_info), 1, "stages after the failure must not run")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/required/loadgen/test_worker_crash_diagnostics.py
+++ b/tests/required/loadgen/test_worker_crash_diagnostics.py
@@ -43,6 +43,7 @@ from inference_perf.loadgen.load_generator import (
     WorkerFailure,
     collect_worker_failures,
 )
+from inference_perf.client.server_metrics.base import StageStatus
 from inference_perf.metrics.request_collector import MultiprocessRequestMetricCollector
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
@@ -128,9 +129,31 @@ class TestWorkerFailureDescription(unittest.TestCase):
         self.assertIn("exited with code 1", described)
         self.assertIn("TypeError", described)
         self.assertIn("stage 2", described)
-        self.assertIn("3 request(s) in flight", described)
+        # The counter behind in_flight is shared by every worker, so the text has to
+        # say run-wide rather than imply the count belongs to the crashing worker.
+        self.assertIn("3 request(s) in flight run-wide", described)
         self.assertIn("cannot pickle 'generator' object", described)
         self.assertIn("Traceback (most recent call last):", described)
+
+    def test_crash_before_the_first_request_says_so_instead_of_stage_none(self) -> None:
+        # A worker that dies during startup has pulled no request yet, so stage_id is
+        # None. The description must read "before serving any stage" rather than the
+        # bare "during stage None".
+        failure = WorkerFailure(
+            worker_id=0,
+            exitcode=1,
+            crash=WorkerCrash(
+                worker_id=0,
+                stage_id=None,
+                exc_type="RuntimeError",
+                message="induced worker crash",
+                traceback_text="Traceback (most recent call last):\n  ...\n",
+                in_flight=0,
+            ),
+        )
+        described = failure.describe()
+        self.assertIn("before serving any stage", described)
+        self.assertNotIn("stage None", described)
 
     def test_signal_death_reports_the_signal_by_name(self) -> None:
         # A worker killed by SIGKILL has exitcode -9 and can never send a record,
@@ -198,20 +221,21 @@ class TestWorkerCrashEndToEnd(unittest.IsolatedAsyncioTestCase):
         # object is inherited so the crash lands inside the worker. Python 3.14
         # defaults to forkserver on Linux, where the same object is pickled and
         # the failure moves into process startup instead (see #526).
-        self._previous_start_method = mp.get_start_method(allow_none=True)
+        self._previous_start_method = mp.get_start_method()
         try:
             mp.set_start_method("fork", force=True)
         except RuntimeError:
             self.skipTest("fork start method unavailable on this platform")
 
     def tearDown(self) -> None:
-        if self._previous_start_method is not None:
-            mp.set_start_method(self._previous_start_method, force=True)
+        mp.set_start_method(self._previous_start_method, force=True)
 
-    async def test_crash_is_attributed_and_the_run_terminates(self) -> None:
+    async def test_crash_is_attributed_and_the_stage_is_failed(self) -> None:
         # One worker, two stages, and a datagen that raises as soon as the worker
-        # starts. mp_run must return instead of hanging on the stage barrier, and
-        # must record worker 0 with exit code 1 and the RuntimeError traceback.
+        # starts. mp_run must return instead of hanging, must record worker 0 with
+        # exit code 1 and the RuntimeError traceback, and must mark the stage FAILED.
+        # The worker is respawned between stages and the run continues, so the
+        # second stage runs and fails the same way: two failures, two failed stages.
         api_config = APIConfig(type=APIType.Completion, streaming=False)
         data_config = DataConfig(
             type=DataGenType.Random,
@@ -234,18 +258,21 @@ class TestWorkerCrashEndToEnd(unittest.IsolatedAsyncioTestCase):
         async with collector.start():
             await load_gen.mp_run(client)
 
-        self.assertEqual(len(load_gen.worker_failures), 1, "the dead worker must be recorded exactly once")
-        failure = load_gen.worker_failures[0]
-        self.assertEqual(failure.worker_id, 0)
-        self.assertEqual(failure.exitcode, 1)
-        self.assertIsNotNone(failure.crash, "the worker must report its traceback before dying")
-        assert failure.crash is not None
-        self.assertEqual(failure.crash.exc_type, "RuntimeError")
-        self.assertIn("induced worker crash", failure.crash.traceback_text)
+        self.assertEqual(len(load_gen.worker_failures), 2, "each stage must record the worker it lost")
+        for failure in load_gen.worker_failures:
+            self.assertEqual(failure.worker_id, 0)
+            self.assertEqual(failure.exitcode, 1)
+            self.assertIsNotNone(failure.crash, "the worker must report its traceback before dying")
+            assert failure.crash is not None
+            self.assertEqual(failure.crash.exc_type, "RuntimeError")
+            self.assertIn("induced worker crash", failure.crash.traceback_text)
+            self.assertIn("Worker 0", failure.describe())
 
-        # The second stage must be skipped: a run that lost a worker never offered
-        # the configured load, so later stages are not comparable.
-        self.assertEqual(len(load_gen.stage_runtime_info), 1, "stages after the failure must not run")
+        # Losing a worker fails the stage it happened in. The run itself continues,
+        # because main respawns the dead worker at the stage boundary.
+        self.assertEqual(len(load_gen.stage_runtime_info), 2, "both stages must run")
+        for info in load_gen.stage_runtime_info.values():
+            self.assertEqual(info.status, StageStatus.FAILED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #593.

## Problem

A worker dying from an unhandled exception produced exactly one line:

```
ERROR inference_perf.loadgen.load_generator - A worker process died unexpectedly!
```

No worker id, no exit code, no traceback, and no way to separate a segfault from a bug in the data generator. #662 made the run survive a dead worker. It did not make the loss explicable.

## What changed

**The catch-all covers the whole worker body.** `Worker.run()` is now a wrapper around `_run()`. The previous entry point would have left a failure during numpy seeding or uvloop policy installation uncaught, which is the same silent-crash class the issue is about.

**The worker reports before it dies.** It logs the exception locally and hands the parent a `WorkerCrash` (worker id, stage, exception type, message, traceback, in-flight count). The channel is `mp.SimpleQueue`, which writes straight to the pipe, so the record is not lost to an unflushed feeder thread when the process exits immediately after.

**The parent explains what it lost.** `collect_worker_failures()` pairs each dead worker with its record, at both detection sites (`run_stage` and `run_session_stage`). Output now reads:

```
ERROR Worker 0 exited with code 1 after an unhandled RuntimeError during stage 0
      with 3 request(s) in flight run-wide: cannot pickle 'generator' object
      Traceback (most recent call last):
      ...
```

The in-flight counter is shared by every worker, so it is labelled run-wide. A worker that died before pulling its first request reads `before serving any stage`. A worker killed by a signal never reports, so the exit code is the only evidence: `-9` is decoded to `SIGKILL` and the text says plainly that no traceback exists rather than implying one was lost.

**The policy is #662's, not this PR's.** Losing a worker fails the stage it happened in, `_respawn_worker` starts a replacement at the boundary and forwards the crash channel to it, and the run continues. Failures accumulate in `LoadGenerator.worker_failures`.

## Comparability

A stage that lost a worker did not offer the configured load, so it is not comparable with the stages around it or with a clean run. That caveat is carried by #740 as `inference_perf_workers_lost_total{stage,cause}`, incremented at stage end, with the HELP text and the generated doc row stating it. #740 is `[PENDING: #747]`.

## Tests

`tests/required/loadgen/test_worker_crash_diagnostics.py`, 7 cases: the four description shapes (traceback, crash before any stage, signal death, clean early exit), record-to-worker pairing including live and never-started workers, exit codes with no crash channel available, and an end-to-end case that crashes a real worker process across two stages and asserts both stages run, both are marked `FAILED`, and both failures are attributed to worker 0 with its traceback.

## Scope and follow-ups

- **Non-zero `main.py` exit is out of scope here.** `worker_failures` is populated but nothing outside the load generator reads it yet. Wiring it into an exit code, plus report and summary attribution, belongs with the #587/#601 taxonomy and not with this PR.
- **forkserver is a separate failure mode.** On Python 3.14, which defaults to forkserver on Linux, a worker that cannot be constructed fails in the parent during process startup, not in the child, so no child-side handler sees it. The end-to-end test forces `fork` for that reason and restores the previous start method unconditionally. This is the #526 interaction the issue anticipated and it needs its own pass.
- The queue-get path in `Worker.loop()` swallows exceptions at INFO level and continues. Left alone here, but it is adjacent silent-failure surface.
