### PR TITLE
docs: rewrite RELEASE.md as the runbook for the tag-driven release process

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -24,7 +24,12 @@ jobs:
 
       - name: Update version for testing
         run: |
-          sed -i 's/version = ".*"/version = "0.0.1-dev0"/' pyproject.toml
+          # TestPyPI rejects a re-upload of an existing file, so give every run its own
+          # dev version derived from the version currently in pyproject.toml.
+          BASE_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml)
+          VERSION="${BASE_VERSION}.dev${{ github.run_number }}"
+          echo "Updating version to: $VERSION"
+          sed -i 's/version = ".*"/version = "'$VERSION'"/' pyproject.toml
 
       - name: Build package
         run: python -m build
@@ -33,4 +38,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: python -m twine upload --repository testpypi dist/*
+        run: python -m twine upload --repository testpypi --skip-existing dist/*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,110 @@
 # Release Process
 
-The Kubernetes Template Project is released on an as-needed basis. The process is as follows:
+Releases are tag-driven. Pushing a `vX.Y.Z` tag runs
+[`publish-on-release.yml`](.github/workflows/publish-on-release.yml), which creates the GitHub
+Release, publishes the Python package to PyPI, pushes the container image to quay.io, and packages
+the Helm chart. Everything below is what a maintainer does around that automation.
 
-1. An issue is proposing a new release with a changelog since the last release
-1. All [OWNERS](OWNERS) must LGTM this release
-1. An OWNER runs `git tag -s $VERSION` and inserts the changelog and pushes the tag with `git push $VERSION`
-1. The release issue is closed
-1. An announcement email is sent to `dev@kubernetes.io` with the subject `[ANNOUNCE] kubernetes-template-project $VERSION is released`
+## Runbook
+
+### 1. Before the cut
+
+- [ ] The release milestone is groomed: every open item is either merged, moved to the next
+      milestone, or closed with a reason. Close the milestone.
+- [ ] `main` is green: `Python Linting and Type Checks`, `Unit Tests`, `Code Coverage`, and
+      `E2E Test on change` all pass on the commit you are about to tag. The e2e job is the
+      release-blocking suite; do not tag a commit it has not passed on.
+- [ ] The commit you tag is a tide-merged commit on `main` (`git merge-base --is-ancestor
+      <commit> upstream/main`). Every such commit already passed the deterministic suites at
+      merge time via the merge gate, which is why the publish workflow runs no tests of its
+      own (#643); tagging anything else forfeits that guarantee.
+- [ ] Every PR that should appear in the changelog carries one of the labels in
+      [`.github/changelog-config.json`](.github/changelog-config.json) (`feature`, `enhancement`,
+      `bug`, `fix`, `documentation`, `docs`, `performance`, `perf`, `dependencies`, `deps`).
+      Unlabelled PRs are dropped from the generated changelog (v0.6.1 shipped with 22 merged PRs
+      and 0 categorized).
+- [ ] Draft the written summary (see step 4). Past releases (v0.5.0, v0.6.0) put a short
+      "Summary" of features, fixes, and improvements above the generated list.
+- [ ] Optional: run [`test-release.yml`](.github/workflows/test-release.yml) (`workflow_dispatch`)
+      to dry-run the package build against TestPyPI.
+
+### 2. Cut
+
+Tags are pushed directly by a maintainer with write access; there is no release PR.
+
+```sh
+git fetch upstream
+git tag vX.Y.Z upstream/main            # the tested commit
+git push upstream vX.Y.Z
+git push upstream upstream/main:refs/heads/release-vX.Y.Z   # convention: one branch per release, at the tag
+```
+
+Creating the release through the GitHub UI (draft, then publish) also creates the tag and
+triggers the same workflow; v0.6.0 and v0.6.1 were cut that way.
+
+The version in `pyproject.toml` and `deploy/inference-perf/Chart.yaml` is not the source of truth:
+the workflow rewrites `pyproject.toml` from the tag at publish time, and the checked-in values lag
+(both read `0.5.0` at v0.6.1). Bumping them in a follow-up PR is tidy but not required to cut.
+
+### 3. What the automation does
+
+| Job | Action | Output |
+|---|---|---|
+| `build-and-publish` | changelog from labelled PRs since the previous tag; creates the GitHub Release | `https://github.com/kubernetes-sigs/inference-perf/releases/tag/vX.Y.Z` |
+| `python-package` | rewrites `version` in `pyproject.toml` from the tag, `python -m build`, `twine upload` | `pip install inference-perf==X.Y.Z` |
+| `docker` | `linux/amd64` image, tags `vX.Y.Z` and `latest` | `quay.io/inference-perf/inference-perf:vX.Y.Z` |
+| `helm-chart` | packages `deploy/inference-perf` and pushes to `oci://quay.io/inference-perf/charts/inference-perf` | see "Known gaps": this job has failed on every release so far |
+
+Watch the run under Actions, "Release Processing". A red `helm-chart` job does not block the
+package or image; a red `python-package` or `docker` job means the release notes advertise
+artifacts that do not exist, so fix and re-run before announcing.
+
+### 4. After the cut
+
+- [ ] Edit the release body: if the generated changelog is empty or thin, use "Generate release
+      notes" in the release editor and put the written summary above it.
+- [ ] Verify each artifact:
+      `pip install inference-perf==X.Y.Z && python -c 'import importlib.metadata as m; print(m.version("inference-perf"))'`;
+      `docker pull quay.io/inference-perf/inference-perf:vX.Y.Z`;
+      `helm show chart oci://quay.io/inference-perf/charts/inference-perf --version X.Y.Z`.
+      Remove any line from the release notes whose artifact did not publish.
+- [ ] Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf) on Kubernetes Slack; link the release page.
+- [ ] Open the next milestone if it does not exist yet.
+
+## Cadence and scope
+
+- Minor releases are milestone-driven, not calendar-driven: a milestone opens with a theme and a
+  target date, and the cut happens when its release-blocking items are done, with the rest
+  explicitly moved out.
+- Release-blocking means: the item is on the milestone and marked blocking in the milestone's
+  tracking issue, or it is a correctness regression in a shipped code path. Everything else moves
+  to the next milestone at cut time with one line of why.
+- Patch releases (`vX.Y.Z+1`) ship fixes only, cut from the tested tip of `main` unless `main`
+  carries unreleased features, in which case cherry-pick onto `release-vX.Y.Z` and tag there.
+- The e2e suite (`E2E Test on change`) is the release gate; a nightly live-server run, when it
+  exists, is release-blocking for the rows it covers.
+
+## Versioning
+
+Semantic versioning, `vX.Y.Z`, `v` prefix on tags and image tags, no prefix on PyPI or chart
+versions.
+
+- **Minor (`Y`)**: new features, new config fields, new report fields, new metrics, dependency
+  bumps that change behaviour. Anything a user must read release notes to adopt.
+- **Patch (`Z`)**: bug fixes, doc fixes, CI changes, dependency bumps with no behaviour change.
+- **Major (`X`)**: reserved for v1.0.0 (#321); pre-1.0, minor releases may change config and
+  report formats, and the release notes must call every such change out.
+
+## Known gaps in the automation
+
+Tracked so a release owner is not surprised; fixes are separate PRs.
+
+1. `helm-chart` in `publish-on-release.yml` fails at `helm package`: `--app-version` reads
+   `env.RELEASE_VERSION`, which is set in a different job, so the flag is empty. Failed on
+   v0.5.0, v0.6.0, v0.6.1.
+2. `helm push` in `publish-on-change.yml` fails with `401` against
+   `quay.io/inference-perf/charts/inference-perf`; the robot account cannot write that repository.
+   No chart has been published, so the "Helm Chart" section in every release body is not true.
+3. The generated changelog only lists labelled PRs (item 1 above).
+4. `pip install inference-perf==vX.Y.Z` in the release template keeps the `v`; pip accepts it, but
+   the canonical form is `X.Y.Z`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,18 +7,18 @@ document is what a maintainer does around that automation.
 
 ## 1. Before the cut
 
-- [ ] Close the milestone. Every open item is merged, moved to the next milestone, or closed
+- Close the milestone. Every open item is merged, moved to the next milestone, or closed
       with a reason.
-- [ ] Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
+- Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
       `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
-- [ ] Label every PR that belongs in the changelog with one of the categories in
+- Label every PR that belongs in the changelog with one of the categories in
       [`.github/changelog-config.json`](.github/changelog-config.json). Unlabelled PRs are
       dropped from the generated changelog.
-- [ ] Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
+- Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
       coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
-- [ ] Draft the summary of features, fixes, and improvements that goes above the generated
+- Draft the summary of features, fixes, and improvements that goes above the generated
       changelog.
-- [ ] Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
+- Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
       `workflow_dispatch` to build the package against TestPyPI.
 
 ## 2. Cut
@@ -49,14 +49,14 @@ fix and re-run any failed job before announcing.
 
 ## 4. After the cut
 
-- [ ] Put the written summary above the generated changelog in the release body.
-- [ ] Verify each artifact:
+- Put the written summary above the generated changelog in the release body.
+- Verify each artifact:
       `pip install inference-perf==X.Y.Z`,
       `docker pull quay.io/inference-perf/inference-perf:vX.Y.Z`,
       `helm show chart oci://quay.io/inference-perf/charts/inference-perf --version X.Y.Z`.
-- [ ] Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
+- Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
       on Kubernetes Slack and link the release page.
-- [ ] Open the next milestone.
+- Open the next milestone.
 
 ## Cadence
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,7 @@
 
 Releases are tag-driven. Pushing a `vX.Y.Z` tag runs
 [`publish-on-release.yml`](.github/workflows/publish-on-release.yml), which creates the GitHub
-Release, publishes to PyPI, pushes the image to quay.io, and packages the Helm chart. This
-pertains to how maintainers cut releases.
+Release, publishes to PyPI, pushes the image to quay.io, and packages the Helm chart.
 
 ## 1. Before the cut
 
@@ -16,8 +15,7 @@ pertains to how maintainers cut releases.
    coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
 1. Run [`test-release.yml`](.github/workflows/test-release.yml) by `workflow_dispatch` on `main`.
    It builds the package and uploads it to TestPyPI under a dev version. Fix any failure before
-   tagging: the release is created before the package is published, so a build failure after the
-   tag leaves a release with missing artifacts and needs a new version to correct.
+   tagging.
 1. Optional: Draft the summary of features, fixes, and improvements that goes above the generated
    changelog.
 
@@ -51,20 +49,8 @@ fix and re-run any failed job before announcing.
 
 - Put the written summary above the generated changelog in the release body.
 - Verify each artifact:
-      `pip install inference-perf==X.Y.Z`,
-      `docker pull quay.io/inference-perf/inference-perf:vX.Y.Z`,
-      `helm show chart oci://quay.io/inference-perf/charts/inference-perf --version X.Y.Z`.
+  `pip install inference-perf==X.Y.Z`,
+  `docker pull quay.io/inference-perf/inference-perf:vX.Y.Z`,
+  `helm show chart oci://quay.io/inference-perf/charts/inference-perf --version X.Y.Z`.
 - Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
-      on Kubernetes Slack and link the release page.
-
-## Cadence
-
-Minor releases are milestone-driven. The cut happens when the milestone's release-blocking items
-are done, and everything else moves to the next milestone with one line of why. Patch releases
-ship fixes only, cut from the tip of `main`, or cherry-picked onto `release-vX.Y.Z` when `main` 
-carries unreleased features.
-
-## Versioning
-
-Semantic versioning, `vX.Y.Z`, with the `v` prefix on tags and image tags and no prefix on PyPI
-and chart versions. Suffixes are heavily discouraged.
+  on Kubernetes Slack and link the release page.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,10 +14,12 @@ pertains to how maintainers cut releases.
    [`.github/changelog-config.json`](.github/changelog-config.json).
 1. Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
    coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
+1. Run [`test-release.yml`](.github/workflows/test-release.yml) by `workflow_dispatch` on `main`.
+   It builds the package and uploads it to TestPyPI under a dev version. Fix any failure before
+   tagging: the release is created before the package is published, so a build failure after the
+   tag leaves a release with missing artifacts and needs a new version to correct.
 1. Optional: Draft the summary of features, fixes, and improvements that goes above the generated
    changelog.
-1. Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
-   `workflow_dispatch` to build the package against TestPyPI.
 
 ## 2. Cut
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,16 +7,16 @@ pertains to how maintainers cut releases.
 
 ## 1. Before the cut
 
-a) Close the milestone. Every open item is either merged, deferred, or closed with reason.
-b) Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
+a. Close the milestone. Every open item is either merged, deferred, or closed with reason.
+b. Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
       `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
-c) Label every PR that belongs in the changelog with one of the categories in
+c. Label every PR that belongs in the changelog with one of the categories in
       [`.github/changelog-config.json`](.github/changelog-config.json).
-d) Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
+d. Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
       coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
-e) Optional: Draft the summary of features, fixes, and improvements that goes above the generated
+e. Optional: Draft the summary of features, fixes, and improvements that goes above the generated
       changelog.
-f) Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
+f. Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
       `workflow_dispatch` to build the package against TestPyPI.
 
 ## 2. Cut

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,17 +7,17 @@ pertains to how maintainers cut releases.
 
 ## 1. Before the cut
 
-a. Close the milestone. Every open item is either merged, deferred, or closed with reason.
-b. Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
-      `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
-c. Label every PR that belongs in the changelog with one of the categories in
-      [`.github/changelog-config.json`](.github/changelog-config.json).
-d. Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
-      coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
-e. Optional: Draft the summary of features, fixes, and improvements that goes above the generated
-      changelog.
-f. Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
-      `workflow_dispatch` to build the package against TestPyPI.
+1. Close the milestone. Every open item is either merged, deferred, or closed with reason.
+1. Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
+   `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
+1. Label every PR that belongs in the changelog with one of the categories in
+   [`.github/changelog-config.json`](.github/changelog-config.json).
+1. Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
+   coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
+1. Optional: Draft the summary of features, fixes, and improvements that goes above the generated
+   changelog.
+1. Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
+   `workflow_dispatch` to build the package against TestPyPI.
 
 ## 2. Cut
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,13 +7,11 @@ document is what a maintainer does around that automation.
 
 ## 1. Before the cut
 
-- Close the milestone. Every open item is merged, moved to the next milestone, or closed
-      with a reason.
+- Close the milestone. Every open item is merged, deferred, or closed with reason.
 - Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
       `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
 - Label every PR that belongs in the changelog with one of the categories in
-      [`.github/changelog-config.json`](.github/changelog-config.json). Unlabelled PRs are
-      dropped from the generated changelog.
+      [`.github/changelog-config.json`](.github/changelog-config.json).
 - Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
       coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
 - Draft the summary of features, fixes, and improvements that goes above the generated
@@ -56,7 +54,7 @@ fix and re-run any failed job before announcing.
       `helm show chart oci://quay.io/inference-perf/charts/inference-perf --version X.Y.Z`.
 - Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
       on Kubernetes Slack and link the release page.
-- Open the next milestone.
+- (optional) Open the next milestone.
 
 ## Cadence
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,109 +2,77 @@
 
 Releases are tag-driven. Pushing a `vX.Y.Z` tag runs
 [`publish-on-release.yml`](.github/workflows/publish-on-release.yml), which creates the GitHub
-Release, publishes the Python package to PyPI, pushes the container image to quay.io, and packages
-the Helm chart. Everything below is what a maintainer does around that automation.
+Release, publishes to PyPI, pushes the image to quay.io, and packages the Helm chart. This
+document is what a maintainer does around that automation.
 
-## Runbook
+## 1. Before the cut
 
-### 1. Before the cut
+- [ ] Close the milestone. Every open item is merged, moved to the next milestone, or closed
+      with a reason.
+- [ ] Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
+      `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
+- [ ] Label every PR that belongs in the changelog with one of the categories in
+      [`.github/changelog-config.json`](.github/changelog-config.json). Unlabelled PRs are
+      dropped from the generated changelog.
+- [ ] Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
+      coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
+- [ ] Draft the summary of features, fixes, and improvements that goes above the generated
+      changelog.
+- [ ] Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
+      `workflow_dispatch` to build the package against TestPyPI.
 
-- [ ] The release milestone is groomed: every open item is either merged, moved to the next
-      milestone, or closed with a reason. Close the milestone.
-- [ ] `main` is green: `Python Linting and Type Checks`, `Unit Tests`, `Code Coverage`, and
-      `E2E Test on change` all pass on the commit you are about to tag. The e2e job is the
-      release-blocking suite; do not tag a commit it has not passed on.
-- [ ] The commit you tag is a tide-merged commit on `main` (`git merge-base --is-ancestor
-      <commit> upstream/main`). Every such commit already passed the deterministic suites at
-      merge time via the merge gate, which is why the publish workflow runs no tests of its
-      own (#643); tagging anything else forfeits that guarantee.
-- [ ] Every PR that should appear in the changelog carries one of the labels in
-      [`.github/changelog-config.json`](.github/changelog-config.json) (`feature`, `enhancement`,
-      `bug`, `fix`, `documentation`, `docs`, `performance`, `perf`, `dependencies`, `deps`).
-      Unlabelled PRs are dropped from the generated changelog (v0.6.1 shipped with 22 merged PRs
-      and 0 categorized).
-- [ ] Draft the written summary (see step 4). Past releases (v0.5.0, v0.6.0) put a short
-      "Summary" of features, fixes, and improvements above the generated list.
-- [ ] Optional: run [`test-release.yml`](.github/workflows/test-release.yml) (`workflow_dispatch`)
-      to dry-run the package build against TestPyPI.
+## 2. Cut
 
-### 2. Cut
-
-Tags are pushed directly by a maintainer with write access; there is no release PR.
+A maintainer with write access pushes the tag. There is no release PR.
 
 ```sh
 git fetch upstream
-git tag vX.Y.Z upstream/main            # the tested commit
+git tag vX.Y.Z upstream/main
 git push upstream vX.Y.Z
-git push upstream upstream/main:refs/heads/release-vX.Y.Z   # convention: one branch per release, at the tag
+git push upstream upstream/main:refs/heads/release-vX.Y.Z   # one branch per release, at the tag
 ```
 
-Creating the release through the GitHub UI (draft, then publish) also creates the tag and
-triggers the same workflow; v0.6.0 and v0.6.1 were cut that way.
+Drafting and publishing a release in the GitHub UI creates the same tag and triggers the same
+workflow.
 
-The version in `pyproject.toml` and `deploy/inference-perf/Chart.yaml` is not the source of truth:
-the workflow rewrites `pyproject.toml` from the tag at publish time, and the checked-in values lag
-(both read `0.5.0` at v0.6.1). Bumping them in a follow-up PR is tidy but not required to cut.
+## 3. What the automation does
 
-### 3. What the automation does
+- `build-and-publish` builds the changelog from labelled PRs since the previous tag and creates
+  the GitHub Release.
+- `python-package` sets `version` from the tag, builds the package, and uploads it to PyPI.
+- `docker` builds `linux/amd64` and tags it `vX.Y.Z` and `latest`.
+- `helm-chart` packages `deploy/inference-perf` and pushes it to
+  `oci://quay.io/inference-perf/charts/inference-perf`.
 
-| Job | Action | Output |
-|---|---|---|
-| `build-and-publish` | changelog from labelled PRs since the previous tag; creates the GitHub Release | `https://github.com/kubernetes-sigs/inference-perf/releases/tag/vX.Y.Z` |
-| `python-package` | rewrites `version` in `pyproject.toml` from the tag, `python -m build`, `twine upload` | `pip install inference-perf==X.Y.Z` |
-| `docker` | `linux/amd64` image, tags `vX.Y.Z` and `latest` | `quay.io/inference-perf/inference-perf:vX.Y.Z` |
-| `helm-chart` | packages `deploy/inference-perf` and pushes to `oci://quay.io/inference-perf/charts/inference-perf` | see "Known gaps": this job has failed on every release so far |
+Watch the run under Actions, "Release Processing". The release notes advertise every artifact, so
+fix and re-run any failed job before announcing.
 
-Watch the run under Actions, "Release Processing". A red `helm-chart` job does not block the
-package or image; a red `python-package` or `docker` job means the release notes advertise
-artifacts that do not exist, so fix and re-run before announcing.
+## 4. After the cut
 
-### 4. After the cut
-
-- [ ] Edit the release body: if the generated changelog is empty or thin, use "Generate release
-      notes" in the release editor and put the written summary above it.
+- [ ] Put the written summary above the generated changelog in the release body.
 - [ ] Verify each artifact:
-      `pip install inference-perf==X.Y.Z && python -c 'import importlib.metadata as m; print(m.version("inference-perf"))'`;
-      `docker pull quay.io/inference-perf/inference-perf:vX.Y.Z`;
+      `pip install inference-perf==X.Y.Z`,
+      `docker pull quay.io/inference-perf/inference-perf:vX.Y.Z`,
       `helm show chart oci://quay.io/inference-perf/charts/inference-perf --version X.Y.Z`.
-      Remove any line from the release notes whose artifact did not publish.
-- [ ] Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf) on Kubernetes Slack; link the release page.
-- [ ] Open the next milestone if it does not exist yet.
+- [ ] Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
+      on Kubernetes Slack and link the release page.
+- [ ] Open the next milestone.
 
-## Cadence and scope
+## Cadence
 
-- Minor releases are milestone-driven, not calendar-driven: a milestone opens with a theme and a
-  target date, and the cut happens when its release-blocking items are done, with the rest
-  explicitly moved out.
-- Release-blocking means: the item is on the milestone and marked blocking in the milestone's
-  tracking issue, or it is a correctness regression in a shipped code path. Everything else moves
-  to the next milestone at cut time with one line of why.
-- Patch releases (`vX.Y.Z+1`) ship fixes only, cut from the tested tip of `main` unless `main`
-  carries unreleased features, in which case cherry-pick onto `release-vX.Y.Z` and tag there.
-- The e2e suite (`E2E Test on change`) is the release gate; a nightly live-server run, when it
-  exists, is release-blocking for the rows it covers.
+Minor releases are milestone-driven. The cut happens when the milestone's release-blocking items
+are done, and everything else moves to the next milestone with one line of why. Release-blocking
+means the item is marked blocking in the milestone's tracking issue, or it is a correctness
+regression in a shipped code path. Patch releases ship fixes only, cut from the tip of `main`, or
+cherry-picked onto `release-vX.Y.Z` when `main` carries unreleased features.
 
 ## Versioning
 
-Semantic versioning, `vX.Y.Z`, `v` prefix on tags and image tags, no prefix on PyPI or chart
-versions.
+Semantic versioning, `vX.Y.Z`, with the `v` prefix on tags and image tags and no prefix on PyPI
+and chart versions.
 
-- **Minor (`Y`)**: new features, new config fields, new report fields, new metrics, dependency
-  bumps that change behaviour. Anything a user must read release notes to adopt.
-- **Patch (`Z`)**: bug fixes, doc fixes, CI changes, dependency bumps with no behaviour change.
-- **Major (`X`)**: reserved for v1.0.0 (#321); pre-1.0, minor releases may change config and
-  report formats, and the release notes must call every such change out.
-
-## Known gaps in the automation
-
-Tracked so a release owner is not surprised; fixes are separate PRs.
-
-1. `helm-chart` in `publish-on-release.yml` fails at `helm package`: `--app-version` reads
-   `env.RELEASE_VERSION`, which is set in a different job, so the flag is empty. Failed on
-   v0.5.0, v0.6.0, v0.6.1.
-2. `helm push` in `publish-on-change.yml` fails with `401` against
-   `quay.io/inference-perf/charts/inference-perf`; the robot account cannot write that repository.
-   No chart has been published, so the "Helm Chart" section in every release body is not true.
-3. The generated changelog only lists labelled PRs (item 1 above).
-4. `pip install inference-perf==vX.Y.Z` in the release template keeps the `v`; pip accepts it, but
-   the canonical form is `X.Y.Z`.
+- Minor: new features, config fields, report fields, or metrics, and dependency bumps that change
+  behaviour. Anything a user must read the release notes to adopt.
+- Patch: bug fixes, doc fixes, CI changes, and dependency bumps with no behaviour change.
+- Major: reserved for v1.0.0 (#321). Before then, minor releases may change config and report
+  formats, and the release notes must call out every such change.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,16 +7,16 @@ pertains to how maintainers cut releases.
 
 ## 1. Before the cut
 
-- Close the milestone. Every open item is either merged, deferred, or closed with reason.
-- Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
+a) Close the milestone. Every open item is either merged, deferred, or closed with reason.
+b) Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
       `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
-- Label every PR that belongs in the changelog with one of the categories in
+c) Label every PR that belongs in the changelog with one of the categories in
       [`.github/changelog-config.json`](.github/changelog-config.json).
-- Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
+d) Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
       coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
-- Optional: Draft the summary of features, fixes, and improvements that goes above the generated
+e) Optional: Draft the summary of features, fixes, and improvements that goes above the generated
       changelog.
-- Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
+f) Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
       `workflow_dispatch` to build the package against TestPyPI.
 
 ## 2. Cut

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ Release, publishes to PyPI, pushes the image to quay.io, and packages the Helm c
 1. Close the milestone. Every open item is either merged, deferred, or closed with reason.
 1. Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
    `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
-1. Label every PR that belongs in the changelog with one of the categories in
+1. Optional: Label every PR that belongs in the changelog with one of the categories in
    [`.github/changelog-config.json`](.github/changelog-config.json).
 1. Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
    coverage, and `E2E Test on change`. Tag only a merged commit on `main`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,18 +3,18 @@
 Releases are tag-driven. Pushing a `vX.Y.Z` tag runs
 [`publish-on-release.yml`](.github/workflows/publish-on-release.yml), which creates the GitHub
 Release, publishes to PyPI, pushes the image to quay.io, and packages the Helm chart. This
-document is what a maintainer does around that automation.
+pertains to how maintainers cut releases.
 
 ## 1. Before the cut
 
-- Close the milestone. Every open item is merged, deferred, or closed with reason.
+- Close the milestone. Every open item is either merged, deferred, or closed with reason.
 - Merge a PR bumping `version` in `pyproject.toml` and `version` and `appVersion` in
       `deploy/inference-perf/Chart.yaml` to `X.Y.Z`.
 - Label every PR that belongs in the changelog with one of the categories in
       [`.github/changelog-config.json`](.github/changelog-config.json).
 - Confirm the commit you will tag is green on `main`: linting and type checks, unit tests,
       coverage, and `E2E Test on change`. Tag only a merged commit on `main`.
-- Draft the summary of features, fixes, and improvements that goes above the generated
+- Optional: Draft the summary of features, fixes, and improvements that goes above the generated
       changelog.
 - Optional: run [`test-release.yml`](.github/workflows/test-release.yml) by
       `workflow_dispatch` to build the package against TestPyPI.
@@ -54,17 +54,15 @@ fix and re-run any failed job before announcing.
       `helm show chart oci://quay.io/inference-perf/charts/inference-perf --version X.Y.Z`.
 - Announce in [#inference-perf](https://kubernetes.slack.com/?redir=%2Fmessages%2Finference-perf)
       on Kubernetes Slack and link the release page.
-- (optional) Open the next milestone.
 
 ## Cadence
 
 Minor releases are milestone-driven. The cut happens when the milestone's release-blocking items
-are done, and everything else moves to the next milestone with one line of why. Release-blocking
-means the item is marked blocking in the milestone's tracking issue, or it is a correctness
-regression in a shipped code path. Patch releases ship fixes only, cut from the tip of `main`, or
-cherry-picked onto `release-vX.Y.Z` when `main` carries unreleased features.
+are done, and everything else moves to the next milestone with one line of why. Patch releases
+ship fixes only, cut from the tip of `main`, or cherry-picked onto `release-vX.Y.Z` when `main` 
+carries unreleased features.
 
 ## Versioning
 
 Semantic versioning, `vX.Y.Z`, with the `v` prefix on tags and image tags and no prefix on PyPI
-and chart versions.
+and chart versions. Suffixes are heavily discouraged.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,9 +70,3 @@ cherry-picked onto `release-vX.Y.Z` when `main` carries unreleased features.
 
 Semantic versioning, `vX.Y.Z`, with the `v` prefix on tags and image tags and no prefix on PyPI
 and chart versions.
-
-- Minor: new features, config fields, report fields, or metrics, and dependency bumps that change
-  behaviour. Anything a user must read the release notes to adopt.
-- Patch: bug fixes, doc fixes, CI changes, and dependency bumps with no behaviour change.
-- Major: reserved for v1.0.0 (#321). Before then, minor releases may change config and report
-  formats, and the release notes must call out every such change.


### PR DESCRIPTION
Fixes #640. Part of the release-process section of #606.

RELEASE.md was untouched kubernetes-template boilerplate. The actual process is tag-driven:
pushing `vX.Y.Z` runs `publish-on-release.yml`, which builds the changelog and publishes the
GitHub Release, PyPI package, quay image, and Helm chart.

This replaces it with a runbook for what a maintainer does before, during, and after the tag,
plus short cadence and versioning sections.

The runbook requires the TestPyPI dry run, so this also fixes it. 