### PR TITLE
ci: pass the tag to helm package so the release chart job runs

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -157,7 +157,7 @@ jobs:
           mkdir -p helm-releases
           # Remove 'v' prefix from version
           CHART_VERSION=${GITHUB_REF#refs/tags/v}
-          helm package deploy/inference-perf -d helm-releases --version $CHART_VERSION --app-version ${{ env.RELEASE_VERSION }}
+          helm package deploy/inference-perf -d helm-releases --version $CHART_VERSION --app-version ${{ github.ref_name }}
 
       - name: Push Helm chart to OCI registry
         run: |


### PR DESCRIPTION
The `helm-chart` job in `publish-on-release.yml` packages with `--app-version ${{ env.RELEASE_VERSION }}`. `RELEASE_VERSION` is exported by a step in the `build-and-publish` job, and `env` does not cross jobs, so the expression resolves to an empty string and helm sees the flag with no value:

```
helm package deploy/inference-perf -d helm-releases --version $CHART_VERSION --app-version
Error: flag needs an argument: --app-version
```

The job has therefore failed on every tag pushed since it was added in #240, which is why `Release Processing` shows a red run for v0.3.0 through v0.6.1.

This uses `${{ github.ref_name }}` instead. That is the same value, it is already how the `docker` job in this workflow reads the tag, and it keeps the `v` prefix so the packaged `appVersion` continues to match the convention in `deploy/inference-perf/Chart.yaml`.

Verified locally against the chart on `main`: the empty-argument form reproduces the CI error exactly, and the fixed form produces `inference-perf-0.7.0.tgz` with `version: 0.7.0` and `appVersion: v0.7.0`.

This does not make the chart publish. With packaging fixed the job advances to `helm push`, which currently returns `401 Unauthorized` on `quay.io/inference-perf/charts/inference-perf` for the same robot account, as seen on every `Publish Resources on Change` run. That half needs a quay.io org owner and is tracked in the issue below.

Part of #750
