### PR TITLE
docs: add a review norm that bug fixes ship with their repro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ To contribute to this project, please adhere to the following procedure:
 - **Branch Up-to-Date Requirement**: Your branch must be based on the latest `origin/main` before you can push. A pre-push hook enforces this by running `git fetch origin main` automatically. If it fails, you will need to rebase or merge `origin/main`.
 - **Submit the Pull Request** utilizing the provided template.
 
+### Regression tests for bug fixes
+
+A PR that fixes a behavioral bug should include the bug's reproduction as a test: a unit test where the bug reproduces in process, an e2e test where it only shows up end to end (a wrong metric in a full run, a report that disagrees with what the server actually sent). The test should fail on the code before the fix and pass after it, and reviewers should ask for it when a fix arrives without one. This is a norm rather than a CI gate: documentation, logging, and dependency changes have nothing to pin, and some fixes are already covered by an existing test. Shipping a fix without its repro should be a deliberate call, not an oversight.
+
 ### Resources
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md) - Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests
 - [Kubernetes Contributor Guide](https://k8s.dev/guide) - Main contributor documentation, or you can just jump directly to the [contributing page](https://k8s.dev/docs/guide/contributing/)


### PR DESCRIPTION
Fixes #638. Part of the v0.7.0 release (#606), Documentation pillar.

Adds one short subsection to `CONTRIBUTING.md`: a PR that fixes a behavioral bug should include the bug's reproduction as a test, unit where the bug reproduces in process and e2e where it only shows up end to end, and reviewers should ask for that test when a fix arrives without one. The paragraph also names the exemptions (documentation, logging and dependency changes, and fixes an existing test already covers) so the norm reads as a review habit rather than a checkbox.

Deliberately small: four lines of markdown. No CI gate, no PR-template change, no new file. Judgment stays with reviewers.

**Motivation:** the #564 postmortem. The token-accounting bugs ran silent for roughly two months, and the two places that could have caught them earlier were both fixture-shaped: the in-band mismatch detector added in #410 logged instead of failing, and #602 later fixed an output-token assertion that a repro fixture would have exercised. #630 and #631 covered the e2e half of prevention; this writes the habit down so the next bug class gets its fixture by default instead of by postmortem.

**Placement:** the new subsection sits between the contribution procedure and Resources, so it does not touch the bullet list #708 is rewording. Verified the two branches merge clean.

Marked WIP for wording review; the text is the whole change, so review comments on the paragraph are the review.
