### PR TITLE
docs: say which token counts come from the server and which from the client

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -36,6 +36,48 @@ This document outlines the key metrics used for evaluating performance, their de
 
 ---
 
+## Token Accounting and Provenance
+
+Every token count in a report comes from one of two places. The **server** reports `usage` on
+the response; the **client** tokenizes the prompt it sent and the text it received. The two
+disagree in practice, because of tokenizer revision differences, chat-template and tool-schema
+overhead the client does not model, and streamed text re-encoded in fragments. The report
+therefore keeps both and records which is which.
+
+| Field | Source | Notes |
+| :--- | :--- | :---
+| `prompt_tokens` | server `usage.prompt_tokens`, client tokenization when the server reports none | Resolved per request while the response is processed. Supersedes `prompt_len`. |
+| `prompt_tokens.cached` / `.uncached` | server `usage.prompt_tokens_details` | Absent when the server does not report the detail |
+| `output_len` | client | The response text re-tokenized as one whole message |
+| `output_tokens` | server `usage.completion_tokens`, client `output_len` when the server reports none | Server-side this is an exact count of decode steps |
+| `client_fallback_counts` | n/a | Per side (`prompt_tokens`, `output_tokens`), how many successful requests carry a client count because the server reported none. Nonzero means that distribution mixes sources |
+| `token_count_mismatches` | n/a | Streamed requests where the sum of the per-chunk client tokenization differs from the server count |
+
+Usage keys differ by API: OpenAI-compatible servers report `prompt_tokens` and
+`completion_tokens`, the Anthropic Messages API reports `input_tokens` and `output_tokens`.
+Both are read.
+
+### Which count normalizes per-token latency
+
+TPOT, normalized TPOT, output token throughput and token goodput divide by the client-side
+`output_len` by default. Setting `report.request_lifecycle.use_server_output_tokens: true`
+switches them to the server count for every request where the server reported one. The flag
+does not change `output_len` or `output_tokens` themselves, only which of the two the
+per-token metrics divide by.
+
+### Reading a mismatch
+
+A nonzero `token_count_mismatches` means client and server disagree on how many tokens the
+response contained, so any metric normalized by the client count is off by that much. A
+nonzero `client_fallback_counts` entry means the opposite problem: for those requests there is no
+server number to compare against, and `output_tokens` is carrying the client count. Both are
+worth checking before comparing runs, and before comparing against another tool.
+
+The CLI summary's Token Length Aggregates table labels each column with its source and reports
+any fallbacks in the table caption.
+
+---
+
 ## Session-Based KV Cache Hit Rate
 
 | Metric | Formula | Unit | Used For

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -49,7 +49,7 @@ therefore keeps both and records which is which.
 | `prompt_tokens` | server `usage.prompt_tokens`, client tokenization when the server reports none | Resolved per request while the response is processed. Supersedes `prompt_len`. |
 | `prompt_tokens.cached` / `.uncached` | server `usage.prompt_tokens_details` | Absent when the server does not report the detail |
 | `output_len` | client | The response text re-tokenized as one whole message |
-| `output_tokens` | server `usage.completion_tokens`, client `output_len` when the server reports none | Server-side this is an exact count of decode steps |
+| `output_tokens` | server `usage.completion_tokens` / `usage.output_tokens`, client `output_len` when the server reports none | Server-side this is an exact count of decode steps |
 | `client_fallback_requests` | n/a | Per side (`prompt`, `output`), how many successful requests carry a client count because the server reported none. Counts requests, not tokens. Nonzero means that distribution mixes sources |
 | `token_count_mismatches` | n/a | Streamed requests where the sum of the per-chunk client tokenization differs from the server count |
 
@@ -61,8 +61,9 @@ Both are read.
 
 TPOT, normalized TPOT, output token throughput and token goodput divide by the client-side
 `output_len` by default. Setting `report.request_lifecycle.use_server_output_tokens: true`
-switches them to the server count for every request where the server reported one. The flag
-does not change `output_len` or `output_tokens` themselves, only which of the two the
+switches them to the server count for every request where the server reported one. It resolves
+that count from the same usage keys the report does, so either spelling switches the metrics.
+The flag does not change `output_len` or `output_tokens` themselves, only which of the two the
 per-token metrics divide by.
 
 ### Reading a mismatch

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -50,7 +50,7 @@ therefore keeps both and records which is which.
 | `prompt_tokens.cached` / `.uncached` | server `usage.prompt_tokens_details` | Absent when the server does not report the detail |
 | `output_len` | client | The response text re-tokenized as one whole message |
 | `output_tokens` | server `usage.completion_tokens`, client `output_len` when the server reports none | Server-side this is an exact count of decode steps |
-| `client_fallback_counts` | n/a | Per side (`prompt_tokens`, `output_tokens`), how many successful requests carry a client count because the server reported none. Nonzero means that distribution mixes sources |
+| `client_fallback_requests` | n/a | Per side (`prompt`, `output`), how many successful requests carry a client count because the server reported none. Counts requests, not tokens. Nonzero means that distribution mixes sources |
 | `token_count_mismatches` | n/a | Streamed requests where the sum of the per-chunk client tokenization differs from the server count |
 
 Usage keys differ by API: OpenAI-compatible servers report `prompt_tokens` and
@@ -69,7 +69,7 @@ per-token metrics divide by.
 
 A nonzero `token_count_mismatches` means client and server disagree on how many tokens the
 response contained, so any metric normalized by the client count is off by that much. A
-nonzero `client_fallback_counts` entry means the opposite problem: for those requests there is no
+nonzero `client_fallback_requests` entry means the opposite problem: for those requests there is no
 server number to compare against, and `output_tokens` is carrying the client count. Both are
 worth checking before comparing runs, and before comparing against another tool.
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -88,3 +88,14 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
 - **`successes`**: Metrics for successful requests.
 - **`failures`**: Metrics for failed requests, including the per-label error breakdown.
 - **`goodput_metrics`**: (Optional) Goodput statistics if constraints were configured.
+
+### Token Counts
+
+`successes` carries both a client-side and a server-side token count, and they are not
+interchangeable: `output_len` is the client's re-tokenization of the response text,
+`output_tokens` is the server's own count, `prompt_tokens` is the server's count of the prompt
+with client tokenization as the fallback, and `token_count_mismatches` counts the requests
+where the two output counts disagree. Alongside it, `client_fallback_counts` says how many
+requests had no server number at all, per side. See
+[Token Accounting and Provenance](./metrics.md#token-accounting-and-provenance) for what each
+field is derived from and which one normalizes per-token latency.

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -95,7 +95,7 @@ Here is an example snippet from a `summary_lifecycle_metrics.json` report:
 interchangeable: `output_len` is the client's re-tokenization of the response text,
 `output_tokens` is the server's own count, `prompt_tokens` is the server's count of the prompt
 with client tokenization as the fallback, and `token_count_mismatches` counts the requests
-where the two output counts disagree. Alongside it, `client_fallback_counts` says how many
+where the two output counts disagree. Alongside it, `client_fallback_requests` says how many
 requests had no server number at all, per side. See
 [Token Accounting and Provenance](./metrics.md#token-accounting-and-provenance) for what each
 field is derived from and which one normalizes per-token latency.

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -213,6 +213,43 @@ def extract_cached_prompt_tokens(server_usage: Optional[dict[str, Any]]) -> Opti
     return min(max(cached, 0), prompt), prompt
 
 
+# Which usage keys carry token counts depends on the API: OpenAI-compatible servers report
+# prompt_tokens / completion_tokens, the Anthropic Messages API reports input_tokens /
+# output_tokens.
+SERVER_PROMPT_TOKEN_KEYS = ("prompt_tokens", "input_tokens")
+SERVER_OUTPUT_TOKEN_KEYS = ("completion_tokens", "output_tokens")
+
+
+def server_reported_tokens(server_usage: Optional[dict[str, Any]], keys: tuple[str, ...]) -> Optional[float]:
+    """Token count the server reported under any of ``keys``, or None if it reported none.
+
+    None is the provenance signal: the number the report carries for that request
+    came from client-side tokenization rather than from the server.
+    """
+    if not server_usage:
+        return None
+    for key in keys:
+        value = server_usage.get(key)
+        if value is not None:
+            return safe_float(value)
+    return None
+
+
+def count_client_fallbacks(metrics: List[RequestLifecycleMetric], keys: tuple[str, ...]) -> int:
+    """How many of these requests carry a client-side token count rather than the server's.
+
+    Reported next to token_count_mismatches rather than inside the token summaries,
+    which stay a total plus a pure distribution. A nonzero count means that
+    distribution mixes sources.
+    """
+    return sum(
+        1
+        for metric in metrics
+        if server_reported_tokens(metric.info.response_metrics.server_usage if metric.info.response_metrics else None, keys)
+        is None
+    )
+
+
 def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric], percentiles: List[float]) -> dict[str, float]:
     """Input tokens already resolved at request time (request_metrics.text.input_tokens).
 
@@ -220,6 +257,8 @@ def summarize_prompt_token_usage(metrics: List[RequestLifecycleMetric], percenti
     provided it, otherwise the client-side tokenization — resolved once by
     _resolve_prompt_tokens at response-processing time and stored in request_metrics.
     Also reports the cached/uncached split from usage.prompt_tokens_details when present.
+    How many of these requests fell back to the client-side count is counted separately,
+    by count_client_fallbacks.
     """
     prompt_tokens_total = 0.0
     prompt_tokens_cached = 0.0
@@ -251,8 +290,9 @@ def summarize_output_token_usage(metrics: List[RequestLifecycleMetric], percenti
     The server-side count is exact (a count of decode steps), unlike a
     client-side re-tokenization of the streamed text. Reports the aggregate
     total alongside the per-request distribution (min/mean/max/percentiles).
-    Falls back to the client-side output_tokens when the server does not report
-    usage. Mirrors summarize_prompt_token_usage on the input side.
+    Falls back to the client-side output_tokens for any request whose usage does
+    not report an output count; count_client_fallbacks counts those requests.
+    Mirrors summarize_prompt_token_usage on the input side.
     """
     output_tokens_total = 0.0
     per_request: List[float] = []
@@ -260,14 +300,11 @@ def summarize_output_token_usage(metrics: List[RequestLifecycleMetric], percenti
     for metric in metrics:
         response_metrics = metric.info.response_metrics
         server_usage = response_metrics.server_usage if response_metrics else None
-        completion_tokens = (
-            server_usage.get("completion_tokens")
-            if server_usage
-            else (response_metrics.output_tokens if response_metrics else None)
-        )
-        completion_tokens_value = safe_float(completion_tokens)
-        output_tokens_total += completion_tokens_value
-        per_request.append(completion_tokens_value)
+        completion_tokens = server_reported_tokens(server_usage, SERVER_OUTPUT_TOKEN_KEYS)
+        if completion_tokens is None:
+            completion_tokens = safe_float(response_metrics.output_tokens if response_metrics else None)
+        output_tokens_total += completion_tokens
+        per_request.append(completion_tokens)
 
     result = {"total": output_tokens_total}
     if distribution := summarize(per_request, percentiles):
@@ -700,6 +737,10 @@ def summarize_requests(
         ),
         "output_tokens": summarize_output_token_usage(all_successful, percentiles),
         "token_count_mismatches": mismatched_requests,
+        "client_fallback_counts": {
+            "prompt_tokens": count_client_fallbacks(all_successful, SERVER_PROMPT_TOKEN_KEYS),
+            "output_tokens": count_client_fallbacks(all_successful, SERVER_OUTPUT_TOKEN_KEYS),
+        },
     }
     if goodput_metrics:
         successes_dict["goodput_metrics"] = goodput_metrics

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -737,9 +737,11 @@ def summarize_requests(
         ),
         "output_tokens": summarize_output_token_usage(all_successful, percentiles),
         "token_count_mismatches": mismatched_requests,
-        "client_fallback_counts": {
-            "prompt_tokens": count_client_fallbacks(all_successful, SERVER_PROMPT_TOKEN_KEYS),
-            "output_tokens": count_client_fallbacks(all_successful, SERVER_OUTPUT_TOKEN_KEYS),
+        # Keyed by side, not by the sibling field names: the values count requests,
+        # and a prompt_tokens/output_tokens key here would read as a token count.
+        "client_fallback_requests": {
+            "prompt": count_client_fallbacks(all_successful, SERVER_PROMPT_TOKEN_KEYS),
+            "output": count_client_fallbacks(all_successful, SERVER_OUTPUT_TOKEN_KEYS),
         },
     }
     if goodput_metrics:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -316,15 +316,21 @@ def effective_output_tokens(response_metrics: Optional[ResponseMetrics], use_ser
     """Output token count used to normalize per-token latency metrics (TPOT, NTPOT).
 
     Defaults to the client-side re-tokenized count (`output_tokens`). When
-    `use_server_output_tokens` is set and the server reported an exact
-    `usage.completion_tokens`, that count is used instead.
+    `use_server_output_tokens` is set and the server reported a count under any of
+    SERVER_OUTPUT_TOKEN_KEYS, that count is used instead. Reads the same keys as
+    summarize_output_token_usage so "the server's output count" means one thing:
+    against a server reporting the Anthropic spelling, resolving only
+    `completion_tokens` here left the flag a silent no-op while the report field
+    said the count was server-sourced.
     """
     if response_metrics is None:
         return 0
-    if use_server_output_tokens and response_metrics.server_usage:
-        completion_tokens = response_metrics.server_usage.get("completion_tokens")
-        if completion_tokens:
-            return int(completion_tokens)
+    if use_server_output_tokens:
+        # `is not None`, not truthiness: a server that reports 0 output tokens has
+        # counted the request, and the report's own summary already records that 0.
+        server_tokens = server_reported_tokens(response_metrics.server_usage, SERVER_OUTPUT_TOKEN_KEYS)
+        if server_tokens is not None:
+            return int(server_tokens)
     return response_metrics.output_tokens
 
 

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import re
-from typing import List, Dict, Any, Optional
+from typing import Iterable, List, Dict, Any, Optional
 from rich.console import Console
 from rich.table import Table
 from rich import print as rprint
@@ -34,6 +34,32 @@ def extract_session_stage_id(report_name: str) -> Optional[int]:
     if match:
         return int(match.group(1))
     return None
+
+
+def token_source_caption(stage_contents: Iterable[Dict[str, Any]], has_server_output: bool) -> str:
+    """Caption naming the source of each token column, plus any client fallbacks.
+
+    Prompt and output counts are both dual-sourced: the server's usage when it
+    reports one, client-side tokenization otherwise. A run that silently fell back
+    for some requests reads identically to one that did not, so say how many.
+    """
+    parts = [
+        "Prompt: server-reported usage where available, client tokenization otherwise.",
+        "Out (client): response text re-tokenized by the client (output_len).",
+    ]
+    if has_server_output:
+        parts.append("Out (server): count reported in the server's usage (output_tokens).")
+
+    fallbacks = 0
+    for contents in stage_contents:
+        counts = contents.get("successes", {}).get("client_fallback_counts")
+        if isinstance(counts, dict):
+            fallbacks += sum(int(v or 0) for v in counts.values())
+    if fallbacks:
+        parts.append(f"{fallbacks} counts fell back to client tokenization (no server usage).")
+
+    parts.append("See docs/metrics.md.")
+    return " ".join(parts)
 
 
 def print_summary_table(reports: List[ReportFile]) -> None:
@@ -102,17 +128,31 @@ def print_summary_table(reports: List[ReportFile]) -> None:
     speed_table.add_column("Norm TPOT Med", justify="right")
     speed_table.add_column("Norm TPOT P90", justify="right")
 
-    # Table 4: Token Lengths
+    # Table 4: Token Lengths. Column labels carry the source of each count: prompt tokens
+    # come from the server's usage when it reports them, output has two independent
+    # counts, and a report that mixes sources is otherwise indistinguishable from one
+    # that does not.
+    has_server_output = any(
+        isinstance(r.get("successes", {}).get("output_tokens"), dict) and "mean" in r["successes"]["output_tokens"]
+        for r in stage_reports.values()
+    )
     token_table = Table(
-        title="[bold magenta]Token Length Aggregates[/bold magenta]", show_header=True, header_style="bold cyan"
+        title="[bold magenta]Token Length Aggregates[/bold magenta]",
+        caption=token_source_caption(stage_reports.values(), has_server_output),
+        show_header=True,
+        header_style="bold cyan",
     )
     token_table.add_column("Stage", justify="right")
     token_table.add_column("Prompt Mean", justify="right")
     token_table.add_column("Prompt Med", justify="right")
     token_table.add_column("Prompt P90", justify="right")
-    token_table.add_column("Output Mean", justify="right")
-    token_table.add_column("Output Med", justify="right")
-    token_table.add_column("Output P90", justify="right")
+    token_table.add_column("Out Mean\n(client)", justify="right")
+    token_table.add_column("Out Med\n(client)", justify="right")
+    token_table.add_column("Out P90\n(client)", justify="right")
+    if has_server_output:
+        token_table.add_column("Out Mean\n(server)", justify="right")
+        token_table.add_column("Out Med\n(server)", justify="right")
+        token_table.add_column("Out P90\n(server)", justify="right")
 
     for stage_id in sorted_stages:
         contents = stage_reports[stage_id]
@@ -214,6 +254,15 @@ def print_summary_table(reports: List[ReportFile]) -> None:
             output_med = f"{output_len.get('median', 0.0):0.1f}"
             output_p90 = f"{output_len.get('p90', 0.0):0.1f}"
 
+        # Server-reported output tokens (usage.completion_tokens), the independent count
+        # that output_len is compared against.
+        server_output = successes.get("output_tokens")
+        srv_out_mean = srv_out_med = srv_out_p90 = "-"
+        if isinstance(server_output, dict) and "mean" in server_output:
+            srv_out_mean = f"{server_output.get('mean', 0.0):0.1f}"
+            srv_out_med = f"{server_output.get('median', 0.0):0.1f}"
+            srv_out_p90 = f"{server_output.get('p90', 0.0):0.1f}"
+
         # Populate Table 1
         summary_row = [
             str(stage_id),
@@ -267,7 +316,7 @@ def print_summary_table(reports: List[ReportFile]) -> None:
         )
 
         # Populate Table 4
-        token_table.add_row(
+        token_row = [
             str(stage_id),
             prompt_mean,
             prompt_med,
@@ -275,7 +324,10 @@ def print_summary_table(reports: List[ReportFile]) -> None:
             output_mean,
             output_med,
             output_p90,
-        )
+        ]
+        if has_server_output:
+            token_row.extend([srv_out_mean, srv_out_med, srv_out_p90])
+        token_table.add_row(*token_row)
 
     console.print(summary_table)
     console.print(latency_table)

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -50,7 +50,10 @@ def token_source_caption(stage_contents: Iterable[Dict[str, Any]], has_server_ou
         "Out (client): response text re-tokenized by the client (output_len).",
     ]
     if has_server_output:
-        parts.append("Out (server): count reported in the server's usage (output_tokens).")
+        parts.append(
+            "Out (server): the count reported in the server's usage (output_tokens), "
+            "with the client count substituted for any request the server did not count."
+        )
 
     prompt_fallbacks = 0
     output_fallbacks = 0
@@ -67,6 +70,29 @@ def token_source_caption(stage_contents: Iterable[Dict[str, Any]], has_server_ou
 
     parts.append("See docs/metrics.md.")
     return " ".join(parts)
+
+
+def has_server_reported_output(stage_contents: Iterable[Dict[str, Any]]) -> bool:
+    """Whether any successful request carried an output count the server actually reported.
+
+    Not the same question as "does output_tokens have a distribution". A request whose
+    usage reports no output count contributes the client count to that distribution, so
+    against a server that reports no usage at all the distribution is still there and is
+    identical to the client one: labeling those values "(server)" would show one number
+    twice and read as two independent counts agreeing. What earns the label is a request
+    that did not fall back, which is the success count minus the output-side fallbacks.
+    """
+    for contents in stage_contents:
+        successes = contents.get("successes", {})
+        if not isinstance(successes.get("output_tokens"), dict):
+            continue
+        fallbacks = successes.get("client_fallback_requests")
+        # A report predating client_fallback_requests cannot be classified; treat it as
+        # having server counts, which is what the table did before that field existed.
+        fallback_count = int(fallbacks.get("output") or 0) if isinstance(fallbacks, dict) else 0
+        if int(successes.get("count") or 0) - fallback_count > 0:
+            return True
+    return False
 
 
 def print_summary_table(reports: List[ReportFile]) -> None:
@@ -139,10 +165,7 @@ def print_summary_table(reports: List[ReportFile]) -> None:
     # come from the server's usage when it reports them, output has two independent
     # counts, and a report that mixes sources is otherwise indistinguishable from one
     # that does not.
-    has_server_output = any(
-        isinstance(r.get("successes", {}).get("output_tokens"), dict) and "mean" in r["successes"]["output_tokens"]
-        for r in stage_reports.values()
-    )
+    has_server_output = has_server_reported_output(stage_reports.values())
     token_table = Table(
         title="[bold magenta]Token Length Aggregates[/bold magenta]",
         caption=token_source_caption(stage_reports.values(), has_server_output),

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -42,6 +42,8 @@ def token_source_caption(stage_contents: Iterable[Dict[str, Any]], has_server_ou
     Prompt and output counts are both dual-sourced: the server's usage when it
     reports one, client-side tokenization otherwise. A run that silently fell back
     for some requests reads identically to one that did not, so say how many.
+    Reported per side: a request with no usage at all falls back on both sides,
+    so summing the two would overstate the number of requests.
     """
     parts = [
         "Prompt: server-reported usage where available, client tokenization otherwise.",
@@ -50,13 +52,18 @@ def token_source_caption(stage_contents: Iterable[Dict[str, Any]], has_server_ou
     if has_server_output:
         parts.append("Out (server): count reported in the server's usage (output_tokens).")
 
-    fallbacks = 0
+    prompt_fallbacks = 0
+    output_fallbacks = 0
     for contents in stage_contents:
-        counts = contents.get("successes", {}).get("client_fallback_counts")
+        counts = contents.get("successes", {}).get("client_fallback_requests")
         if isinstance(counts, dict):
-            fallbacks += sum(int(v or 0) for v in counts.values())
-    if fallbacks:
-        parts.append(f"{fallbacks} counts fell back to client tokenization (no server usage).")
+            prompt_fallbacks += int(counts.get("prompt") or 0)
+            output_fallbacks += int(counts.get("output") or 0)
+    if prompt_fallbacks or output_fallbacks:
+        parts.append(
+            "Requests that fell back to client tokenization (no server usage): "
+            f"{prompt_fallbacks} prompt-side, {output_fallbacks} output-side."
+        )
 
     parts.append("See docs/metrics.md.")
     return " ".join(parts)

--- a/tests/required/reportgen/test_token_provenance.py
+++ b/tests/required/reportgen/test_token_provenance.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional
+
+from inference_perf.apis.base import InferenceInfo, RequestLifecycleMetric, StreamedResponseMetrics
+from inference_perf.config.reportgen.config import RequestLifecycleMetricsReportConfig
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.reportgen.base import (
+    SERVER_OUTPUT_TOKEN_KEYS,
+    SERVER_PROMPT_TOKEN_KEYS,
+    count_client_fallbacks,
+    summarize_output_token_usage,
+    summarize_prompt_token_usage,
+    summarize_requests,
+)
+from inference_perf.utils.cli_summary import token_source_caption
+
+DEFAULT_PERCENTILES = RequestLifecycleMetricsReportConfig().percentiles
+
+
+# One finished request. input_tokens is what the report already resolved for the prompt side,
+# client_output_tokens is the client's re-tokenization of the response, and server_usage is the
+# usage dict the server returned (None when it returned none).
+def _request(input_tokens: int, client_output_tokens: int, server_usage: Optional[dict[str, Any]]) -> RequestLifecycleMetric:
+    return RequestLifecycleMetric(
+        scheduled_time=0.0,
+        start_time=0.0,
+        end_time=1.0,
+        request_data="r",
+        info=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=input_tokens)),
+            response_metrics=StreamedResponseMetrics(output_tokens=client_output_tokens, server_usage=server_usage),
+        ),
+        error=None,
+    )
+
+
+# Two requests, both with full OpenAI-style usage. Every count is server-sourced, so neither
+# side counts a fallback and output_tokens totals 100 + 200 = 300.
+def test_no_fallback_when_every_request_has_server_usage() -> None:
+    requests = [
+        _request(10, 99, {"prompt_tokens": 10, "completion_tokens": 100}),
+        _request(20, 201, {"prompt_tokens": 20, "completion_tokens": 200}),
+    ]
+
+    assert count_client_fallbacks(requests, SERVER_PROMPT_TOKEN_KEYS) == 0
+    assert count_client_fallbacks(requests, SERVER_OUTPUT_TOKEN_KEYS) == 0
+    assert summarize_output_token_usage(requests, DEFAULT_PERCENTILES)["total"] == 300.0
+
+
+# Three requests, one of which came back with no usage at all. That request contributes its
+# client count (7) to output_tokens, and each side counts exactly one fallback: totals are
+# 10 + 20 + 30 = 60 prompt and 100 + 200 + 7 = 307 output.
+def test_missing_usage_counts_one_fallback_on_both_sides() -> None:
+    requests = [
+        _request(10, 99, {"prompt_tokens": 10, "completion_tokens": 100}),
+        _request(20, 201, {"prompt_tokens": 20, "completion_tokens": 200}),
+        _request(30, 7, None),
+    ]
+
+    assert count_client_fallbacks(requests, SERVER_PROMPT_TOKEN_KEYS) == 1
+    assert count_client_fallbacks(requests, SERVER_OUTPUT_TOKEN_KEYS) == 1
+    assert summarize_prompt_token_usage(requests, DEFAULT_PERCENTILES)["total"] == 60.0
+    assert summarize_output_token_usage(requests, DEFAULT_PERCENTILES)["total"] == 307.0
+
+
+# One request whose usage uses the Anthropic Messages key names (input_tokens/output_tokens)
+# instead of the OpenAI ones. Those counts are server-reported, so output_tokens must total the
+# server's 500 with no fallback, not the client's 480 and not 0.
+def test_anthropic_usage_keys_count_as_server_reported() -> None:
+    requests = [_request(40, 480, {"input_tokens": 40, "output_tokens": 500})]
+
+    assert count_client_fallbacks(requests, SERVER_PROMPT_TOKEN_KEYS) == 0
+    assert count_client_fallbacks(requests, SERVER_OUTPUT_TOKEN_KEYS) == 0
+    assert summarize_output_token_usage(requests, DEFAULT_PERCENTILES)["total"] == 500.0
+
+
+# A partial usage dict: the server reported the prompt side but no output count. The output side
+# falls back to the client's 480 and is counted as a fallback; the prompt side is not.
+def test_partial_usage_falls_back_only_on_the_missing_side() -> None:
+    requests = [_request(40, 480, {"prompt_tokens": 40})]
+
+    assert count_client_fallbacks(requests, SERVER_PROMPT_TOKEN_KEYS) == 0
+    assert count_client_fallbacks(requests, SERVER_OUTPUT_TOKEN_KEYS) == 1
+    assert summarize_output_token_usage(requests, DEFAULT_PERCENTILES)["total"] == 480.0
+
+
+# Two requests through the full report path, one with usage and one without. The report carries
+# the counts as successes.client_fallback_counts = {prompt_tokens: 1, output_tokens: 1}, and the
+# token summaries stay a total plus a pure distribution, with no count mixed in.
+def test_report_carries_fallback_counts_outside_the_distributions() -> None:
+    requests = [
+        _request(10, 100, {"prompt_tokens": 10, "completion_tokens": 100}),
+        _request(10, 100, None),
+    ]
+
+    successes = summarize_requests(requests, [50]).successes
+
+    assert successes["client_fallback_counts"] == {"prompt_tokens": 1, "output_tokens": 1}
+    assert set(successes["output_tokens"]) == {"total", "mean", "min", "max", "median"}
+    assert set(successes["output_tokens"].values()) - {200.0} == {100.0}
+
+
+# One stage report with 2 prompt-side and 3 output-side fallbacks. The CLI caption names the
+# source of each column and reports the 5 fallbacks in one line.
+def test_caption_reports_sources_and_fallback_total() -> None:
+    stage = {"successes": {"client_fallback_counts": {"prompt_tokens": 2, "output_tokens": 3}}}
+
+    caption = token_source_caption([stage], has_server_output=True)
+
+    assert "Prompt: server-reported usage where available" in caption
+    assert "Out (client)" in caption
+    assert "Out (server)" in caption
+    assert "5 counts fell back to client tokenization" in caption
+
+
+# A run against a server that reported usage for everything: no fallback sentence at all, and no
+# server column described, since the caller found no server-sourced distribution to show.
+def test_caption_omits_fallback_line_when_every_count_is_server_sourced() -> None:
+    stage = {"successes": {"client_fallback_counts": {"prompt_tokens": 0, "output_tokens": 0}}}
+
+    caption = token_source_caption([stage], has_server_output=False)
+
+    assert "fell back" not in caption
+    assert "Out (server)" not in caption

--- a/tests/required/reportgen/test_token_provenance.py
+++ b/tests/required/reportgen/test_token_provenance.py
@@ -98,8 +98,9 @@ def test_partial_usage_falls_back_only_on_the_missing_side() -> None:
 
 
 # Two requests through the full report path, one with usage and one without. The report carries
-# the counts as successes.client_fallback_counts = {prompt_tokens: 1, output_tokens: 1}, and the
-# token summaries stay a total plus a pure distribution, with no count mixed in.
+# the request counts as successes.client_fallback_requests = {prompt: 1, output: 1} (keyed by
+# side, since the values count requests, not tokens), and the token summaries stay a total plus
+# a pure distribution, with no count mixed in.
 def test_report_carries_fallback_counts_outside_the_distributions() -> None:
     requests = [
         _request(10, 100, {"prompt_tokens": 10, "completion_tokens": 100}),
@@ -108,28 +109,30 @@ def test_report_carries_fallback_counts_outside_the_distributions() -> None:
 
     successes = summarize_requests(requests, [50]).successes
 
-    assert successes["client_fallback_counts"] == {"prompt_tokens": 1, "output_tokens": 1}
+    assert successes["client_fallback_requests"] == {"prompt": 1, "output": 1}
     assert set(successes["output_tokens"]) == {"total", "mean", "min", "max", "median"}
     assert set(successes["output_tokens"].values()) - {200.0} == {100.0}
 
 
 # One stage report with 2 prompt-side and 3 output-side fallbacks. The CLI caption names the
-# source of each column and reports the 5 fallbacks in one line.
-def test_caption_reports_sources_and_fallback_total() -> None:
-    stage = {"successes": {"client_fallback_counts": {"prompt_tokens": 2, "output_tokens": 3}}}
+# source of each column and reports the fallbacks per side ("2 prompt-side, 3 output-side"),
+# not summed: one request missing usage entirely falls back on both sides, so a sum would
+# overstate the number of requests.
+def test_caption_reports_sources_and_per_side_fallbacks() -> None:
+    stage = {"successes": {"client_fallback_requests": {"prompt": 2, "output": 3}}}
 
     caption = token_source_caption([stage], has_server_output=True)
 
     assert "Prompt: server-reported usage where available" in caption
     assert "Out (client)" in caption
     assert "Out (server)" in caption
-    assert "5 counts fell back to client tokenization" in caption
+    assert "2 prompt-side, 3 output-side" in caption
 
 
 # A run against a server that reported usage for everything: no fallback sentence at all, and no
 # server column described, since the caller found no server-sourced distribution to show.
 def test_caption_omits_fallback_line_when_every_count_is_server_sourced() -> None:
-    stage = {"successes": {"client_fallback_counts": {"prompt_tokens": 0, "output_tokens": 0}}}
+    stage = {"successes": {"client_fallback_requests": {"prompt": 0, "output": 0}}}
 
     caption = token_source_caption([stage], has_server_output=False)
 

--- a/tests/required/reportgen/test_token_provenance.py
+++ b/tests/required/reportgen/test_token_provenance.py
@@ -21,11 +21,12 @@ from inference_perf.reportgen.base import (
     SERVER_OUTPUT_TOKEN_KEYS,
     SERVER_PROMPT_TOKEN_KEYS,
     count_client_fallbacks,
+    effective_output_tokens,
     summarize_output_token_usage,
     summarize_prompt_token_usage,
     summarize_requests,
 )
-from inference_perf.utils.cli_summary import token_source_caption
+from inference_perf.utils.cli_summary import has_server_reported_output, token_source_caption
 
 DEFAULT_PERCENTILES = RequestLifecycleMetricsReportConfig().percentiles
 
@@ -138,3 +139,64 @@ def test_caption_omits_fallback_line_when_every_count_is_server_sourced() -> Non
 
     assert "fell back" not in caption
     assert "Out (server)" not in caption
+
+
+# Two requests through the full report path, neither with any server usage. output_tokens still
+# has a distribution, because both requests contributed their client count to it, but no value
+# in it came from the server, so the table must not grow "(server)" columns: they would repeat
+# the client numbers and read as two independent counts agreeing.
+def test_no_server_columns_when_every_request_fell_back() -> None:
+    successes = summarize_requests([_request(10, 100, None), _request(20, 200, None)], [50]).successes
+
+    assert "mean" in successes["output_tokens"]
+    assert successes["client_fallback_requests"]["output"] == 2
+    assert has_server_reported_output([{"successes": successes}]) is False
+
+
+# Two requests, one with server usage and one without. One request the server did count is
+# enough for the "(server)" columns to mean something, so the check passes while the caption
+# reports the one fallback.
+def test_server_columns_when_any_request_has_a_server_count() -> None:
+    requests = [_request(10, 99, {"prompt_tokens": 10, "completion_tokens": 100}), _request(20, 200, None)]
+
+    successes = summarize_requests(requests, [50]).successes
+
+    assert successes["client_fallback_requests"]["output"] == 1
+    assert has_server_reported_output([{"successes": successes}]) is True
+
+
+# A report written before client_fallback_requests existed carries no such key. It cannot be
+# classified, so it keeps the pre-existing behavior of showing the server columns rather than
+# silently dropping them.
+def test_report_without_fallback_counts_keeps_showing_server_columns() -> None:
+    stage = {"successes": {"count": 2, "output_tokens": {"total": 300.0, "mean": 150.0}}}
+
+    assert has_server_reported_output([stage]) is True
+
+
+# A stage with no successful requests at all: nothing was counted by anyone, so no server column.
+def test_no_server_columns_without_successful_requests() -> None:
+    stage = {"successes": {"count": 0, "output_tokens": {"total": 0.0}, "client_fallback_requests": {"output": 0}}}
+
+    assert has_server_reported_output([stage]) is False
+
+
+# One response carrying the Anthropic usage spelling (output_tokens: 500) next to a client
+# re-tokenization of 480. With use_server_output_tokens on, the per-token metrics must normalize
+# by the server's 500, the same count the report field shows; with it off, by the client's 480.
+def test_use_server_output_tokens_reads_the_anthropic_spelling() -> None:
+    response_metrics = _request(40, 480, {"input_tokens": 40, "output_tokens": 500}).info.response_metrics
+
+    assert effective_output_tokens(response_metrics, use_server_output_tokens=False) == 480
+    assert effective_output_tokens(response_metrics, use_server_output_tokens=True) == 500
+
+
+# A server that reports 0 output tokens has counted the request; that is not the same as
+# reporting no count. With the flag on, normalization takes the server's 0 rather than
+# substituting the client's 7, which is what the report's own output_tokens total does.
+def test_server_reported_zero_is_a_count_not_a_missing_count() -> None:
+    requests = [_request(10, 7, {"prompt_tokens": 10, "completion_tokens": 0})]
+
+    assert count_client_fallbacks(requests, SERVER_OUTPUT_TOKEN_KEYS) == 0
+    assert summarize_output_token_usage(requests, DEFAULT_PERCENTILES)["total"] == 0.0
+    assert effective_output_tokens(requests[0].info.response_metrics, use_server_output_tokens=True) == 0


### PR DESCRIPTION
Fixes #619. Part of the v0.7.0 release (#606), Documentation pillar.

A report carries two token counts on each side and never says which is which: `output_len` is the client's re-tokenization of the response text, `output_tokens` is the server's own count, and `prompt_tokens` is the server's count with client tokenization as a silent fallback. Today the only way to tell them apart is to read docstrings in `reportgen/base.py`, and that is the first question anyone debugging a mismatch (#580) has to answer.

**Docs.** A `Token Accounting and Provenance` section in `docs/metrics.md`: a per-field source table, the usage keys read per API, which count normalizes TPOT / NTPOT / output throughput / token goodput and what `report.request_lifecycle.use_server_output_tokens` actually switches (none of which is documented today), and how to read a mismatch. `docs/reports.md` gains a short Token Counts subsection pointing into it.

**CLI.** The Token Length Aggregates table labels its output columns `(client)` and adds `(server)` columns when the server reported counts. The caption names each source and, when any request fell back, says how many did.

**Report.** One additive field, `successes.client_fallback_requests`, keyed by side (`prompt`, `output`): how many successful requests carry a client-side count because the server reported none. A run against a server without usage reporting is otherwise indistinguishable from one with it. Nothing is renamed or restructured.

It sits next to `token_count_mismatches` rather than inside the token summaries, which was the first attempt. `e2e/tests/test_metrics_fidelity.py` treats `output_tokens` as a total plus a pure distribution and asserts every other value equals the known per-request count, so a request count inside that dict failed it. The contract that test encodes is the right one, so the counter moved out and no existing expectation needed changing.

Annotated report fragment, new field last:

```jsonc
"successes": {
  "prompt_tokens":  { "total": 51200.0, ... },  // server usage ("prompt_tokens" | "input_tokens"); client tokenization substituted per request when absent
  "output_len":     { "mean": 128.0, ... },     // client re-tokenization of the response text, always
  "output_tokens":  { "total": 12800.0, ... },  // server usage ("completion_tokens" | "output_tokens"); client count substituted per request when absent
  "token_count_mismatches": 3,                  // requests where both counts are present and disagree (computed on streamed runs)
  "client_fallback_requests": {                 // NEW: requests where the server reported no count on that side
    "prompt": 0,                                //   a count of requests, not tokens
    "output": 4                                 //   nonzero means that many output_tokens values are client-derived
  }
}
```

The two counters are disjoint per request and answer different questions: a fallback request cannot mismatch, because the substituted value is the client count itself.

**Behavior changes, and the bugs they fix.** Server output tokens now resolve through both key spellings (`completion_tokens` and `output_tokens`) in the report and in `effective_output_tokens`, which `use_server_output_tokens` governs. The Anthropic Messages path (#575) reports the latter spelling, so `output_tokens` read 0 for every request on those runs, and `use_server_output_tokens: true` was a silent no-op: the report said the count came from the server while the per-token metrics kept dividing by the client count. A server-reported 0 is now treated as a count rather than a missing one. Repro tests included, per the #638 norm.

**Tests.** `tests/required/reportgen/test_token_provenance.py` covers all-server, mixed, Anthropic-spelling, partial-usage, the report field itself, and the caption. No existing test expectation changed. Unit suite green; `ruff format`, `ruff check` and `mypy --strict` clean, apart from the two errors that predate this branch (`custom_tokenizer.py:21`, `test_summarize_requests.py:145`).



