### PR TITLE
feat: add per-session Time to First User Token (TFUT) metric

### DIFF
--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -111,6 +111,14 @@ class SessionLifecycleMetric(BaseModel):
     # server (chat template and tool-schema overhead the client does not model)
     # and can push it above 1.0. None whenever total_cached_tokens is None.
     total_cacheable_input_tokens: Optional[int] = None
+    # TFUT (Time to First User Token) — per-session user-perceived latency.
+    # Anchored on session dispatch time (includes client-side queue delay),
+    # not the moment the first request reached the server.
+    user_facing_event_ids: Optional[List[str]] = None
+    num_structured_output_excluded: Optional[int] = None
+    tfut_sec: Optional[float] = None
+    tfut_none_reason: Optional[str] = None
+    dispatch_perf_counter: Optional[float] = None
 
 
 class InferenceAPIData(BaseModel):

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -15,7 +15,7 @@
 from abc import abstractmethod
 from typing import Any, List, Optional
 from aiohttp import ClientResponse
-from pydantic import BaseModel, SerializeAsAny, computed_field
+from pydantic import BaseModel, Field, SerializeAsAny, computed_field
 from inference_perf.payloads import RequestBody, RequestMetrics
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.config import APIConfig, APIType
@@ -43,6 +43,7 @@ class InferenceInfo(BaseModel):
     response_metrics: Optional[SerializeAsAny[ResponseMetrics]] = None
     extra_info: dict[str, Any] = {}
     lora_adapter: Optional[str] = None
+    graph_event_id: Optional[str] = None
     labels: dict[str, str] = {}
 
     # DEPRECATED: mirror of request_metrics.text.input_tokens kept at the top
@@ -118,13 +119,14 @@ class SessionLifecycleMetric(BaseModel):
     num_structured_output_excluded: Optional[int] = None
     tfut_sec: Optional[float] = None
     tfut_none_reason: Optional[str] = None
-    dispatch_perf_counter: Optional[float] = None
+    dispatch_perf_counter: Optional[float] = Field(default=None, exclude=True)
 
 
 class InferenceAPIData(BaseModel):
     # loadgen should assign this request to preferred worker if possible
     preferred_worker_id: int = -1  # no preferred worker by default
     session_id: Optional[str] = None  # set by loadgen for session-based workloads
+    graph_event_id: Optional[str] = None
     otel_context: Optional[dict[str, str]] = None  # OTEL trace context for distributed tracing
     stage_id: int = 0  # stage id
     headers: Optional[dict[str, str]] = None

--- a/inference_perf/client/modelserver/openai_client.py
+++ b/inference_perf/client/modelserver/openai_client.py
@@ -561,6 +561,8 @@ class openAIModelServerClientSession(ModelServerClientSession):
             info = InferenceInfo(request_metrics=RequestMetrics(text=Text(input_tokens=0)))
         if data.labels:
             info.labels = data.labels
+        if data.graph_event_id:
+            info.graph_event_id = data.graph_event_id
 
         metric = RequestLifecycleMetric(
             stage_id=stage_id,

--- a/inference_perf/datagen/replay/otel_trace_replay_datagen.py
+++ b/inference_perf/datagen/replay/otel_trace_replay_datagen.py
@@ -72,6 +72,7 @@ from inference_perf.datagen.replay.replay_graph_session_datagen import (
 from inference_perf.datagen.replay.otel_trace_to_replay_graph import (
     build_raw_calls,
     build_graph,
+    tag_user_facing_events,
 )
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 from inference_perf.apis import InferenceAPIData, LazyLoadInferenceAPIData
@@ -503,6 +504,8 @@ class OTelTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
                 logger.warning(f"No LLM calls found in {session_id}")
                 return None
             graph = build_graph(raw_calls, source_file=source_id)
+            # Re-tag leaves with full span list for structural tool-internal detection
+            tag_user_facing_events(graph, all_spans=spans)
         except Exception as e:
             logger.error(f"Error building graph from {session_id}: {e}", exc_info=True)
             return None

--- a/inference_perf/datagen/replay/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/replay/otel_trace_to_replay_graph.py
@@ -1290,7 +1290,102 @@ def build_graph(
 
     root_event_ids = [event_ids[i] for i in range(n) if not predecessor_indices[i]]
 
-    return ReplayGraph(events=events, root_event_ids=root_event_ids, source_file=source_file)
+    graph = ReplayGraph(events=events, root_event_ids=root_event_ids, source_file=source_file)
+    tag_user_facing_events(graph)
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# User-facing event tagging (TFUT)
+# ---------------------------------------------------------------------------
+
+
+def tag_user_facing_events(graph: ReplayGraph, all_spans: Optional[List[Dict[str, Any]]] = None) -> None:
+    """Tag each event with is_user_facing, is_structured_output_call, is_tool_internal.
+
+    A user-facing event is one whose output reaches the end user — used as
+    the anchor for Time to First User Token (TFUT). Three conditions must all hold:
+      1. Not a tool call (expected_output_is_tool_call == False AND
+         finish_reason not in {tool_use, tool_calls}; either signal excludes)
+      2. Not a structured-output call (no output_schema, output.type != "json")
+      3. Not tool-internal — detected via two strategies:
+         - Structural (primary): event's span is nested under a tool.execution span.
+         - Fallback (no span data): event outputs a tool call AND has a causal
+           successor. Prose events with successors (multi-turn) are NOT tool-internal.
+    """
+    # Build successor map
+    successors: Dict[str, List[Tuple[str, str]]] = {eid: [] for eid in graph.events}
+    for eid, event in graph.events.items():
+        for pred_id, dep_type in event.predecessor_dependency_types.items():
+            if pred_id in successors:
+                successors[pred_id].append((eid, dep_type))
+
+    # Build set of span_ids nested under tool-execution spans (structural tool-internal detection)
+    tool_internal_span_ids: Set[str] = set()
+    tool_exec_span_ids: Set[str] = set()
+    if all_spans:
+        span_by_id: Dict[str, Dict[str, Any]] = {}
+        for span in all_spans:
+            sid = span.get("span_id", "")
+            span_by_id[sid] = span
+            name = span.get("name", "") or ""
+            if "tool.execution" in name or "tool_execution" in name:
+                tool_exec_span_ids.add(sid)
+
+        if tool_exec_span_ids:
+            for span in all_spans:
+                parent = span.get("parent_span_id")
+                if parent and parent in tool_exec_span_ids:
+                    tool_internal_span_ids.add(span.get("span_id", ""))
+                # Walk up the parent chain for deeper nesting
+                visited: Set[str] = set()
+                current_parent = parent
+                while current_parent and current_parent not in visited:
+                    visited.add(current_parent)
+                    if current_parent in tool_exec_span_ids:
+                        tool_internal_span_ids.add(span.get("span_id", ""))
+                        break
+                    parent_span = span_by_id.get(current_parent)
+                    current_parent = parent_span.get("parent_span_id") if parent_span else None
+
+    has_structural_tool_info = bool(tool_exec_span_ids)
+
+    _TOOL_CALL_FINISH_REASONS = {"tool_use", "tool_calls"}
+
+    for eid, event in graph.events.items():
+        gc = event.call
+        attrs = gc.attributes or {}
+
+        # Condition 2: structured-output call detection
+        # A call with an output schema answers a programmatic consumer, not the user.
+        has_output_schema = "gen_ai.request.output_schema" in attrs
+        output_type = attrs.get("gen_ai.output.type", "")
+        is_structured_output = has_output_schema or (isinstance(output_type, str) and output_type.lower() == "json")
+        event.is_structured_output_call = is_structured_output
+
+        # Condition 3: tool-internal detection
+        # Primary: structural (span nested under tool execution)
+        span_id = gc.call_id
+        is_tool_internal_structural = span_id in tool_internal_span_ids
+        # Fallback (no span info): an event is tool-internal when its output is a
+        # tool call consumed by a successor. A prose-output event with successors is
+        # just multi-turn context sharing, not tool-internal.
+        is_tool_internal_fallback = gc.expected_output_is_tool_call and any(
+            dep_type != "temporal" for _, dep_type in successors[eid]
+        )
+        is_tool_internal = is_tool_internal_structural or (not has_structural_tool_info and is_tool_internal_fallback)
+        event.is_tool_internal = is_tool_internal
+
+        # Condition 1: not a tool call (two independent signals, either excludes)
+        finish_reasons_raw = attrs.get("gen_ai.response.finish_reasons", [])
+        if isinstance(finish_reasons_raw, str):
+            finish_reasons_raw = [finish_reasons_raw]
+        has_tool_call_finish_reason = bool(finish_reasons_raw) and any(
+            (fr.lower() if isinstance(fr, str) else "") in _TOOL_CALL_FINISH_REASONS for fr in finish_reasons_raw
+        )
+        not_tool_call = not gc.expected_output_is_tool_call and not has_tool_call_finish_reason
+
+        event.is_user_facing = not_tool_call and not is_structured_output and not is_tool_internal
 
 
 # ---------------------------------------------------------------------------
@@ -1333,7 +1428,7 @@ def graph_call_to_dict(gc: GraphCall) -> Dict[str, Any]:
 
 
 def graph_event_to_dict(event: GraphEvent) -> Dict[str, Any]:
-    return {
+    d: Dict[str, Any] = {
         "event_id": event.event_id,
         "t_start_ms": event.t_start_ms,
         "t_end_ms": event.t_end_ms,
@@ -1342,6 +1437,13 @@ def graph_event_to_dict(event: GraphEvent) -> Dict[str, Any]:
         "wait_ms": event.wait_ms,
         "call": graph_call_to_dict(event.call),
     }
+    if event.is_user_facing:
+        d["is_user_facing"] = True
+    if event.is_structured_output_call:
+        d["is_structured_output_call"] = True
+    if event.is_tool_internal:
+        d["is_tool_internal"] = True
+    return d
 
 
 def graph_to_dict(graph: ReplayGraph) -> Dict[str, Any]:
@@ -1555,6 +1657,8 @@ def main() -> None:
         raise SystemExit("No LLM spans found in trace file")
 
     graph = build_graph(calls, source_file=args.input)
+    # Re-tag with full span list for structural tool-internal detection
+    tag_user_facing_events(graph, all_spans=spans)
 
     out_path = Path(args.output)
     out_path.write_text(

--- a/inference_perf/datagen/replay/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay/replay_graph_session_datagen.py
@@ -1659,8 +1659,8 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             error=error,
             n_recorded_substitutions=state.n_recorded_substitutions,
             recorded_substitution_event_ids=state.recorded_substitution_event_ids,
-            user_facing_event_ids=user_facing_event_ids or None,
-            num_structured_output_excluded=num_structured_output_excluded or None,
+            user_facing_event_ids=user_facing_event_ids,
+            num_structured_output_excluded=num_structured_output_excluded,
         )
 
     def activate_session(self, session_id: str) -> None:
@@ -1871,7 +1871,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             # Back-reference so the event can evict this session from the worker once drained.
             generator=self,
         )
-        api_data.labels["event_id"] = raw_event_id
+        api_data.graph_event_id = raw_event_id
         return api_data
 
     def cleanup_session(self, session_id: str) -> None:

--- a/inference_perf/datagen/replay/replay_graph_session_datagen.py
+++ b/inference_perf/datagen/replay/replay_graph_session_datagen.py
@@ -1642,6 +1642,10 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
         if state.failure_reason:
             error = ErrorResponseInfo(error_type="SessionReplayError", error_msg=state.failure_reason)
 
+        # Extract user-facing leaf event IDs and confidence from the graph
+        user_facing_event_ids = [eid for eid, event in state.graph.events.items() if event.is_user_facing]
+        num_structured_output_excluded = sum(1 for event in state.graph.events.values() if event.is_structured_output_call)
+
         return SessionLifecycleMetric(
             session_id=session_id,
             stage_id=stage_id,
@@ -1655,6 +1659,8 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             error=error,
             n_recorded_substitutions=state.n_recorded_substitutions,
             recorded_substitution_event_ids=state.recorded_substitution_event_ids,
+            user_facing_event_ids=user_facing_event_ids or None,
+            num_structured_output_excluded=num_structured_output_excluded or None,
         )
 
     def activate_session(self, session_id: str) -> None:
@@ -1830,7 +1836,7 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
         if api_config is not None and api_config.type == APIType.AnthropicMessages:
             api_data_class = SessionAnthropicMessagesAPIData
 
-        return api_data_class(
+        api_data = api_data_class(
             messages=chat_messages,
             max_tokens=max_tokens,
             tool_definitions=event.tool_definitions,
@@ -1865,6 +1871,8 @@ class ReplayGraphSessionGeneratorBase(SessionGenerator, LazyLoadDataMixin):
             # Back-reference so the event can evict this session from the worker once drained.
             generator=self,
         )
+        api_data.labels["event_id"] = raw_event_id
+        return api_data
 
     def cleanup_session(self, session_id: str) -> None:
         state = self.session_graph_state.get(session_id)

--- a/inference_perf/datagen/replay/replay_graph_types.py
+++ b/inference_perf/datagen/replay/replay_graph_types.py
@@ -109,6 +109,7 @@ class GraphEvent:
     wait_ms: int
     t_start_ms: int
     t_end_ms: int
+    # Set by tag_user_facing_events; persisted mostly for graph JSON export.
     is_user_facing: bool = False
     is_structured_output_call: bool = False
     is_tool_internal: bool = False

--- a/inference_perf/datagen/replay/replay_graph_types.py
+++ b/inference_perf/datagen/replay/replay_graph_types.py
@@ -109,6 +109,9 @@ class GraphEvent:
     wait_ms: int
     t_start_ms: int
     t_end_ms: int
+    is_user_facing: bool = False
+    is_structured_output_call: bool = False
+    is_tool_internal: bool = False
 
 
 @dataclass

--- a/inference_perf/datagen/synthetic_agentic.py
+++ b/inference_perf/datagen/synthetic_agentic.py
@@ -34,6 +34,7 @@ from inference_perf.config import APIConfig, DataConfig
 from inference_perf.config.datagen.replay import SyntheticAgenticConfig
 from inference_perf.config.common import Distribution
 from inference_perf.datagen.replay.replay_graph_session_datagen import ReplayGraphSessionGeneratorBase, ReplaySession
+from inference_perf.datagen.replay.otel_trace_to_replay_graph import tag_user_facing_events
 from inference_perf.datagen.replay.replay_graph_types import GraphCall, GraphEvent, InputSegment, ReplayGraph
 from inference_perf.datagen.synthetic_themes import (
     GENERIC_THEME,
@@ -2316,5 +2317,6 @@ class SyntheticAgenticDataGenerator(ReplayGraphSessionGeneratorBase):
         graph = build_graph_for_session(self.synthetic_config, theme, self.tokenizer, session_index)
         if not graph.events:
             return None
+        tag_user_facing_events(graph)
         sid = f"synthN{session_index}"
         return ReplaySession(session_id=sid, source_id=sid, session_index=session_index, graph=graph)

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -461,6 +461,7 @@ class LoadGenerator:
         )  # Sessions waiting to start
         completed_session_ids: Set[str] = set()  # Session IDs that have completed
         session_dispatch_times: Dict[str, float] = {}  # session_id → wall-clock dispatch time
+        session_dispatch_perf_counters: Dict[str, float] = {}  # session_id → perf_counter dispatch time
 
         # Cache OTEL instrumentation to avoid redundant calls
         otel_instr = get_otel_instrumentation()
@@ -542,6 +543,7 @@ class LoadGenerator:
 
             # Record dispatch time for session duration tracking
             session_dispatch_times[session_id] = time.time()
+            session_dispatch_perf_counters[session_id] = time.perf_counter()
 
             # Get all events for this session
             events = self.datagen.get_session_events(session_idx)
@@ -654,12 +656,19 @@ class LoadGenerator:
                 # Build and record session-level metric before cleanup
                 session_info = self.datagen.get_session_info(session_idx)
                 session_id = session_info["session_id"]
+                dispatch_time = session_dispatch_times.get(session_id)
+                if dispatch_time is None:
+                    logger.warning(
+                        f"Session {session_id} has no recorded dispatch time; "
+                        f"falling back to stage start for session start_time."
+                    )
                 session_metric = self.datagen.build_session_metric(
                     session_id=session_id,
                     stage_id=stage_id,
-                    start_time=session_dispatch_times.get(session_id, start_time_epoch),
+                    start_time=dispatch_time if dispatch_time is not None else start_time_epoch,
                     end_time=time.time(),
                 )
+                session_metric.dispatch_perf_counter = session_dispatch_perf_counters.get(session_id)
 
                 # Record in collector instead of datagen
                 if self.session_metrics_collector:

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -1046,7 +1046,7 @@ class ReportGenerator:
                 )
                 if m.session_id not in error_by_session and m.error is not None:
                     error_by_session[m.session_id] = m.error
-                event_id = m.info.labels.get("event_id")
+                event_id = m.info.graph_event_id
                 if event_id:
                     requests_by_session_event[m.session_id][event_id] = m
 

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -960,6 +960,18 @@ class ReportGenerator:
         prompt_total = sum(m.total_cacheable_input_tokens for m in metrics if m.total_cacheable_input_tokens is not None)
         kv_cache_hit_percent = (100.0 * cached_total / prompt_total) if prompt_total else None
 
+        # TFUT summary
+        tfut_values = [m.tfut_sec for m in metrics if m.tfut_sec is not None]
+        sessions_with_tfut = len(tfut_values)
+        tfut_none_reasons: dict[str, int] = defaultdict(int)
+        for m in metrics:
+            if m.tfut_none_reason:
+                tfut_none_reasons[m.tfut_none_reason] += 1
+        num_uf_events_values = [float(len(m.user_facing_event_ids)) for m in metrics if m.user_facing_event_ids is not None]
+        structured_output_excluded_values = [
+            float(m.num_structured_output_excluded) for m in metrics if m.num_structured_output_excluded is not None
+        ]
+
         return {
             "num_sessions": num_sessions,
             "num_sessions_succeeded": num_succeeded,
@@ -993,6 +1005,11 @@ class ReportGenerator:
             ),
             "kv_cache_hit_percent": kv_cache_hit_percent,
             "kv_cache_hit_per_session_percent": summarize(kv_cache_hit_per_session_percent, percentiles),
+            "tfut_sec": summarize(tfut_values, percentiles),
+            "sessions_with_tfut": sessions_with_tfut,
+            "tfut_none_reasons": dict(tfut_none_reasons) if tfut_none_reasons else None,
+            "num_user_facing_events": summarize(num_uf_events_values, percentiles),
+            "num_structured_output_excluded": summarize(structured_output_excluded_values, percentiles),
         }
 
     def _enrich_sessions(
@@ -1001,11 +1018,11 @@ class ReportGenerator:
         request_metrics: List[RequestLifecycleMetric],
         use_server_output_tokens: bool = False,
     ) -> None:
-        """Aggregate per-request token totals and error status onto each session.
+        """Aggregate per-request token totals, error status, and TFUT onto each session.
 
         Mutates each ``SessionLifecycleMetric`` in ``session_metrics`` in place,
         setting ``total_input_tokens``, ``total_output_tokens``,
-        ``total_cached_tokens``, ``error``, and ``success`` from the matching
+        ``total_cached_tokens``, ``error``, ``success``, and TFUT fields from the matching
         request-level metrics.
         """
         token_by_session: dict[str, tuple[int, int]] = defaultdict(lambda: (0, 0))
@@ -1017,6 +1034,8 @@ class ReportGenerator:
         # tokens. Numerator and denominator accumulate over exactly the same
         # requests so the ratio never mixes sources.
         cache_by_session: dict[str, tuple[int, int]] = {}
+        # Index requests by (session_id, event_id) for TFUT lookup
+        requests_by_session_event: dict[str, dict[str, RequestLifecycleMetric]] = defaultdict(dict)
 
         for m in request_metrics:
             if m.session_id:
@@ -1027,6 +1046,9 @@ class ReportGenerator:
                 )
                 if m.session_id not in error_by_session and m.error is not None:
                     error_by_session[m.session_id] = m.error
+                event_id = m.info.labels.get("event_id")
+                if event_id:
+                    requests_by_session_event[m.session_id][event_id] = m
 
                 if m.error is None:
                     response_metrics = m.info.response_metrics
@@ -1048,6 +1070,57 @@ class ReportGenerator:
             if request_error is not None:
                 sm.error = request_error
             sm.success = (sm.num_events_completed == sm.num_events) and (sm.error is None)
+
+            # Compute TFUT
+            ReportGenerator._compute_tfut(sm, requests_by_session_event.get(sm.session_id, {}))
+
+    @staticmethod
+    def _compute_tfut(
+        sm: SessionLifecycleMetric,
+        event_requests: dict[str, "RequestLifecycleMetric"],
+    ) -> None:
+        """Compute Time to First User Token for a single session.
+        TFUT = time from session dispatch to the first output token on the
+        earliest user-facing event (measured on the same monotonic clock).
+        """
+        uf_event_ids = sm.user_facing_event_ids
+        if not uf_event_ids:
+            sm.tfut_none_reason = "no_user_facing"
+            return
+
+        # dispatch_perf_counter is the monotonic anchor for all TFUT math
+        if sm.dispatch_perf_counter is None:
+            sm.tfut_none_reason = "no_dispatch_anchor"
+            return
+
+        candidates: List[float] = []
+        has_non_streaming = False
+        has_no_output_tokens = False
+
+        # Collect TFUT from each user-facing event that has token timestamps
+        for eid in uf_event_ids:
+            req = event_requests.get(eid)
+            if req is None:
+                continue
+            response_metrics = req.info.response_metrics
+            if not isinstance(response_metrics, StreamedResponseMetrics):
+                has_non_streaming = True
+                continue
+            if len(response_metrics.output_token_times) < 1:
+                has_no_output_tokens = True
+                continue
+            tfut = response_metrics.output_token_times[0] - sm.dispatch_perf_counter
+            candidates.append(tfut)
+
+        # TFUT is the minimum across user-facing events (earliest user-visible output)
+        if candidates:
+            sm.tfut_sec = min(candidates)
+        elif has_non_streaming:
+            sm.tfut_none_reason = "non_streaming"
+        elif has_no_output_tokens:
+            sm.tfut_none_reason = "no_output_tokens"
+        else:
+            sm.tfut_none_reason = "no_user_facing"
 
     def generate_session_reports(
         self,

--- a/inference_perf/utils/cli_summary.py
+++ b/inference_perf/utils/cli_summary.py
@@ -345,6 +345,20 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
     session_tokens_table.add_column("Out Tok/Sess Med", justify="right")
     session_tokens_table.add_column("Out Tok/Sess P90", justify="right")
 
+    # Table 4: TFUT (Time to First User Token)
+    tfut_table = Table(
+        title="[bold magenta]Session TFUT (Time to First User Token)[/bold magenta]",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    tfut_table.add_column("Stage", justify="right")
+    tfut_table.add_column("TFUT Mean (s)", justify="right")
+    tfut_table.add_column("TFUT Med (s)", justify="right")
+    tfut_table.add_column("TFUT P90 (s)", justify="right")
+    tfut_table.add_column("Sessions w/ TFUT", justify="right")
+    tfut_table.add_column("TFUT None Reasons", justify="right")
+    has_any_tfut = False
+
     for stage_id in sorted_stages:
         contents = session_reports[stage_id]
 
@@ -439,6 +453,33 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
             f"{output_p90:.1f}",
         )
 
+        # Extract TFUT metrics
+        sessions_with_tfut = contents.get("sessions_with_tfut", 0)
+        tfut_sec = contents.get("tfut_sec", {})
+        tfut_none_reasons = contents.get("tfut_none_reasons")
+
+        if sessions_with_tfut > 0:
+            has_any_tfut = True
+            tfut_mean = f"{tfut_sec.get('mean', 0.0):.3f}"
+            tfut_median = f"{tfut_sec.get('median', 0.0):.3f}"
+            tfut_p90 = f"{tfut_sec.get('p90', 0.0):.3f}"
+        else:
+            tfut_mean = tfut_median = tfut_p90 = "-"
+
+        reasons_str = "-"
+        if tfut_none_reasons:
+            reasons_str = ", ".join(f"{k}: {v}" for k, v in tfut_none_reasons.items())
+
+        # Populate Table 4
+        tfut_table.add_row(
+            str(stage_id),
+            tfut_mean,
+            tfut_median,
+            tfut_p90,
+            str(sessions_with_tfut),
+            reasons_str,
+        )
+
     # Table 4: KV Cache Hit Rate (only when at least one stage reports it)
     has_cache_info = any(session_reports[stage_id].get("kv_cache_hit_percent") is not None for stage_id in sorted_stages)
     cache_table: Optional[Table] = None
@@ -474,6 +515,8 @@ def print_session_summary_tables(reports: List[ReportFile]) -> None:
     console.print(session_tokens_table)
     if cache_table is not None:
         console.print(cache_table)
+    if has_any_tfut:
+        console.print(tfut_table)
 
 
 def _collect_error_labels(failures_by_stage: Dict[int, Dict[str, Any]]) -> list[str]:

--- a/tests/required/datagen/test_tag_user_facing_events.py
+++ b/tests/required/datagen/test_tag_user_facing_events.py
@@ -1,0 +1,305 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tag_user_facing_events (TFUT user-facing event tagging)."""
+
+from inference_perf.datagen.replay.replay_graph_types import GraphCall, GraphEvent, ReplayGraph
+from inference_perf.datagen.replay.otel_trace_to_replay_graph import tag_user_facing_events
+
+
+def _make_call(
+    call_id: str = "span1",
+    expected_output_is_tool_call: bool = False,
+    attributes: dict[str, object] | None = None,
+) -> GraphCall:
+    from inference_perf.datagen.replay.replay_graph_types import InputSegment
+
+    return GraphCall(
+        call_id=call_id,
+        model="test-model",
+        messages=[{"role": "user", "content": "hello"}],
+        expected_output="response",
+        input_segments=[InputSegment(type="unique", message_count=1, token_count=5)],
+        total_input_tokens=5,
+        expected_output_tokens=10,
+        temperature=0.0,
+        max_tokens_recorded=100,
+        expected_output_is_tool_call=expected_output_is_tool_call,
+        attributes=attributes,
+    )
+
+
+def _make_event(
+    event_id: str,
+    call: GraphCall | None = None,
+    predecessor_event_ids: list[str] | None = None,
+    predecessor_dependency_types: dict[str, str] | None = None,
+) -> GraphEvent:
+    return GraphEvent(
+        event_id=event_id,
+        call=call or _make_call(call_id=event_id),
+        predecessor_event_ids=predecessor_event_ids or [],
+        predecessor_dependency_types=predecessor_dependency_types or {},
+        wait_ms=0,
+        t_start_ms=0,
+        t_end_ms=100,
+    )
+
+
+def _make_graph(events: list[GraphEvent]) -> ReplayGraph:
+    event_map = {e.event_id: e for e in events}
+    root_ids = [e.event_id for e in events if not e.predecessor_event_ids]
+    return ReplayGraph(events=event_map, root_event_ids=root_ids, source_file="test")
+
+
+# ---------------------------------------------------------------------------
+# Graph position: successors do NOT exclude (only tool-internal does)
+# ---------------------------------------------------------------------------
+
+
+class TestGraphPosition:
+    def test_single_event_is_user_facing(self) -> None:
+        """A single event with no successors is user-facing."""
+        e = _make_event("e1")
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is True
+
+    def test_non_leaf_with_temporal_successor_is_user_facing(self) -> None:
+        """In a multi-turn conversation, all events are user-facing (temporal deps)."""
+        e1 = _make_event("e1")
+        e2 = _make_event("e2", predecessor_event_ids=["e1"], predecessor_dependency_types={"e1": "temporal"})
+        graph = _make_graph([e1, e2])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is True
+        assert graph.events["e2"].is_user_facing is True
+
+    def test_tool_call_with_causal_successor_is_not_user_facing(self) -> None:
+        """A tool-call event whose output is consumed by a successor is not user-facing."""
+        e1 = _make_event("e1", call=_make_call(expected_output_is_tool_call=True))
+        e2 = _make_event("e2", predecessor_event_ids=["e1"], predecessor_dependency_types={"e1": "causal"})
+        graph = _make_graph([e1, e2])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is False
+        assert graph.events["e2"].is_user_facing is True
+
+    def test_prose_with_causal_successor_is_user_facing(self) -> None:
+        """A prose event with a causal successor is still user-facing (multi-turn)."""
+        e1 = _make_event("e1", call=_make_call(expected_output_is_tool_call=False))
+        e2 = _make_event("e2", predecessor_event_ids=["e1"], predecessor_dependency_types={"e1": "causal"})
+        graph = _make_graph([e1, e2])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is True
+        assert graph.events["e2"].is_user_facing is True
+
+
+# ---------------------------------------------------------------------------
+# Condition 2: not a tool call
+# ---------------------------------------------------------------------------
+
+
+class TestConditionNotToolCall:
+    def test_expected_tool_call_excludes(self) -> None:
+        """expected_output_is_tool_call=True excludes from leaf."""
+        e = _make_event("e1", call=_make_call(expected_output_is_tool_call=True))
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is False
+
+    def test_tool_call_finish_reason_excludes(self) -> None:
+        """finish_reason='tool_calls' excludes even when expected_output_is_tool_call=False."""
+        e = _make_event(
+            "e1",
+            call=_make_call(
+                expected_output_is_tool_call=False,
+                attributes={"gen_ai.response.finish_reasons": ["tool_calls"]},
+            ),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is False
+
+    def test_tool_use_finish_reason_excludes(self) -> None:
+        """finish_reason='tool_use' (Anthropic style) also excludes."""
+        e = _make_event(
+            "e1",
+            call=_make_call(
+                expected_output_is_tool_call=False,
+                attributes={"gen_ai.response.finish_reasons": ["tool_use"]},
+            ),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is False
+
+    def test_stop_finish_reason_does_not_exclude(self) -> None:
+        """finish_reason='stop' does not trigger the tool-call exclusion."""
+        e = _make_event(
+            "e1",
+            call=_make_call(
+                expected_output_is_tool_call=False,
+                attributes={"gen_ai.response.finish_reasons": ["stop"]},
+            ),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is True
+
+
+# ---------------------------------------------------------------------------
+# Condition 3: not a structured-output call
+# ---------------------------------------------------------------------------
+
+
+class TestConditionNotStructuredOutput:
+    def test_output_schema_excludes(self) -> None:
+        e = _make_event(
+            "e1",
+            call=_make_call(attributes={"gen_ai.request.output_schema": '{"type": "object"}'}),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is False
+        assert graph.events["e1"].is_structured_output_call is True
+
+    def test_json_output_type_excludes(self) -> None:
+        e = _make_event(
+            "e1",
+            call=_make_call(attributes={"gen_ai.output.type": "json"}),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is False
+        assert graph.events["e1"].is_structured_output_call is True
+
+    def test_text_output_type_does_not_exclude(self) -> None:
+        e = _make_event(
+            "e1",
+            call=_make_call(attributes={"gen_ai.output.type": "text"}),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is True
+        assert graph.events["e1"].is_structured_output_call is False
+
+
+# ---------------------------------------------------------------------------
+# Condition 4: not tool-internal
+# ---------------------------------------------------------------------------
+
+
+class TestConditionNotToolInternal:
+    def test_structural_tool_internal_via_spans(self) -> None:
+        """Event nested under a tool.execution span is marked tool-internal."""
+        e = _make_event("e1", call=_make_call(call_id="child_span"))
+        graph = _make_graph([e])
+        spans = [
+            {"span_id": "tool_exec_1", "name": "tool.execution", "parent_span_id": "root"},
+            {"span_id": "child_span", "name": "llm.call", "parent_span_id": "tool_exec_1"},
+        ]
+        tag_user_facing_events(graph, all_spans=spans)
+        assert graph.events["e1"].is_tool_internal is True
+        assert graph.events["e1"].is_user_facing is False
+
+    def test_deeply_nested_tool_internal(self) -> None:
+        """Event nested two levels deep under tool.execution is still tool-internal."""
+        e = _make_event("e1", call=_make_call(call_id="deep_span"))
+        graph = _make_graph([e])
+        spans = [
+            {"span_id": "tool_exec_1", "name": "tool.execution", "parent_span_id": "root"},
+            {"span_id": "mid_span", "name": "processing", "parent_span_id": "tool_exec_1"},
+            {"span_id": "deep_span", "name": "llm.call", "parent_span_id": "mid_span"},
+        ]
+        tag_user_facing_events(graph, all_spans=spans)
+        assert graph.events["e1"].is_tool_internal is True
+
+    def test_fallback_tool_call_with_causal_successor(self) -> None:
+        """Without span info, a tool-call event with a causal successor is tool-internal."""
+        e1 = _make_event("e1", call=_make_call(expected_output_is_tool_call=True))
+        e2 = _make_event("e2", predecessor_event_ids=["e1"], predecessor_dependency_types={"e1": "causal"})
+        graph = _make_graph([e1, e2])
+        tag_user_facing_events(graph, all_spans=None)
+        assert graph.events["e1"].is_tool_internal is True
+        assert graph.events["e1"].is_user_facing is False
+
+    def test_fallback_prose_with_causal_successor_not_tool_internal(self) -> None:
+        """Without span info, a prose event with a causal successor is NOT tool-internal (multi-turn)."""
+        e1 = _make_event("e1", call=_make_call(expected_output_is_tool_call=False))
+        e2 = _make_event("e2", predecessor_event_ids=["e1"], predecessor_dependency_types={"e1": "causal"})
+        graph = _make_graph([e1, e2])
+        tag_user_facing_events(graph, all_spans=None)
+        assert graph.events["e1"].is_tool_internal is False
+        assert graph.events["e1"].is_user_facing is True
+
+    def test_temporal_successor_not_tool_internal(self) -> None:
+        """A temporal-only successor does NOT trigger tool-internal fallback."""
+        e1 = _make_event("e1")
+        e2 = _make_event("e2", predecessor_event_ids=["e1"], predecessor_dependency_types={"e1": "temporal"})
+        graph = _make_graph([e1, e2])
+        tag_user_facing_events(graph, all_spans=None)
+        assert graph.events["e1"].is_tool_internal is False
+
+    def test_structural_info_disables_fallback(self) -> None:
+        """When span info is available, causal-successor fallback is disabled."""
+        e1 = _make_event("e1", call=_make_call(call_id="span_a"))
+        e2 = _make_event(
+            "e2",
+            call=_make_call(call_id="span_b"),
+            predecessor_event_ids=["e1"],
+            predecessor_dependency_types={"e1": "causal"},
+        )
+        graph = _make_graph([e1, e2])
+        # Provide spans but e1's span is NOT under a tool.execution
+        spans = [
+            {"span_id": "tool_exec_1", "name": "tool.execution", "parent_span_id": "root"},
+            {"span_id": "span_a", "name": "llm.call", "parent_span_id": "root"},
+            {"span_id": "span_b", "name": "llm.call", "parent_span_id": "root"},
+        ]
+        tag_user_facing_events(graph, all_spans=spans)
+        # e1 has a causal successor but structural info says it's NOT under tool.execution
+        assert graph.events["e1"].is_tool_internal is False
+
+
+# ---------------------------------------------------------------------------
+# Combined conditions
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedConditions:
+    def test_all_conditions_met(self) -> None:
+        """Not tool call + not structured output + not tool-internal = user-facing."""
+        e = _make_event(
+            "e1",
+            call=_make_call(
+                expected_output_is_tool_call=False,
+                attributes={"gen_ai.response.finish_reasons": ["stop"]},
+            ),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is True
+
+    def test_multiple_exclusion_reasons(self) -> None:
+        """An event that fails multiple conditions is still not user-facing."""
+        e = _make_event(
+            "e1",
+            call=_make_call(
+                expected_output_is_tool_call=True,
+                attributes={"gen_ai.request.output_schema": "{}"},
+            ),
+        )
+        graph = _make_graph([e])
+        tag_user_facing_events(graph)
+        assert graph.events["e1"].is_user_facing is False
+        assert graph.events["e1"].is_structured_output_call is True

--- a/tests/required/datagen/test_tfut_synthetic_graph.py
+++ b/tests/required/datagen/test_tfut_synthetic_graph.py
@@ -1,0 +1,159 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test: synthetic agentic graph has correct TFUT user-facing tagging."""
+
+from typing import cast
+
+from inference_perf.datagen.replay.replay_graph_types import ReplayGraph
+from inference_perf.datagen.synthetic_agentic import build_graph_for_session
+from inference_perf.datagen.synthetic_themes import GENERIC_THEME
+from inference_perf.datagen.replay.otel_trace_to_replay_graph import tag_user_facing_events
+from inference_perf.config.common import Distribution
+from inference_perf.config.datagen.replay import SyntheticAgenticConfig
+from inference_perf.utils.custom_tokenizer import CustomTokenizer
+
+
+class _WordTok:
+    """Simple word-counting tokenizer for tests (no HF dependency)."""
+
+    def count_tokens(self, text: str, add_special_tokens: bool = True) -> int:
+        return max(1, len(str(text).split()))
+
+    def get_tokenizer(self) -> None:
+        raise NotImplementedError
+
+
+def _build_graph(turns: int = 2, tool_loop_depth: int = 2, fanout: float = 0.0, seed: int = 42) -> ReplayGraph:
+    cfg = SyntheticAgenticConfig(
+        num_sessions=1,
+        input_tokens_per_turn=Distribution(type="fixed", mean=20),
+        output_tokens_per_turn=Distribution(type="fixed", mean=10),
+        turns_per_session=Distribution(type="fixed", mean=turns),
+        tool_loop_depth=Distribution(type="fixed", mean=tool_loop_depth),
+        tool_call_latency_sec=Distribution(type="fixed", mean=1),
+        fanout_probability=fanout,
+        seed=seed,
+    )
+    graph = build_graph_for_session(cfg, GENERIC_THEME, cast(CustomTokenizer, _WordTok()), session_index=0)
+    tag_user_facing_events(graph)
+    return graph
+
+
+class TestSyntheticGraphUserFacingTagging:
+    """Verify user-facing tagging on synthetic agentic graphs (no span info, fallback logic)."""
+
+    def test_at_least_one_user_facing_event(self) -> None:
+        """Every synthetic session must produce at least one user-facing event."""
+        graph = _build_graph()
+        uf = [eid for eid, ev in graph.events.items() if ev.is_user_facing]
+        assert len(uf) >= 1
+
+    def test_user_facing_is_not_a_tool_call(self) -> None:
+        """User-facing events must not be tool-call events."""
+        graph = _build_graph()
+        for eid, ev in graph.events.items():
+            if ev.is_user_facing:
+                assert ev.call.expected_output_is_tool_call is False, f"{eid} is user-facing but also a tool call"
+
+    def test_user_facing_is_not_tool_internal(self) -> None:
+        """User-facing events must not be tool-internal."""
+        graph = _build_graph()
+        for eid, ev in graph.events.items():
+            if ev.is_user_facing:
+                assert ev.is_tool_internal is False, f"{eid} is user-facing but also tool-internal"
+
+    def test_tool_call_events_are_not_user_facing(self) -> None:
+        """Events with expected_output_is_tool_call=True must never be user-facing."""
+        graph = _build_graph()
+        for eid, ev in graph.events.items():
+            if ev.call.expected_output_is_tool_call:
+                assert ev.is_user_facing is False, f"{eid} is a tool call but tagged as user-facing"
+
+    def test_tool_calls_are_majority(self) -> None:
+        """In a session with tool loops, most events should be tool calls (not user-facing)."""
+        graph = _build_graph(turns=2, tool_loop_depth=4)
+        tool_calls = [ev for ev in graph.events.values() if ev.call.expected_output_is_tool_call]
+        user_facing = [ev for ev in graph.events.values() if ev.is_user_facing]
+        assert len(tool_calls) > len(user_facing)
+
+    def test_fanout_graph_has_user_facing(self) -> None:
+        """A graph with fan-out still produces user-facing events."""
+        graph = _build_graph(turns=1, tool_loop_depth=1, fanout=1.0, seed=7)
+        user_facing = [eid for eid, ev in graph.events.items() if ev.is_user_facing]
+        assert len(user_facing) >= 1
+
+    def test_fanout_graph_user_facing_count_bounded(self) -> None:
+        """Fan-out produces user-facing events — but not more than total events."""
+        graph = _build_graph(turns=1, tool_loop_depth=1, fanout=1.0, seed=7)
+        user_facing = [eid for eid, ev in graph.events.items() if ev.is_user_facing]
+        assert len(user_facing) <= len(graph.events)
+
+    def test_multi_turn_has_user_facing_per_round(self) -> None:
+        """Multi-turn: each round's terminal answer is user-facing."""
+        graph = _build_graph(turns=3, tool_loop_depth=2, fanout=0.0)
+        user_facing = [eid for eid, ev in graph.events.items() if ev.is_user_facing]
+        # Each round produces one user-facing answer event (the terminal prose response).
+        # With 3 turns, we expect at least 3 user-facing events.
+        assert len(user_facing) >= 3
+
+    def test_deep_tool_loop_single_user_facing(self) -> None:
+        """A single-turn session with a deep tool loop has exactly one user-facing event."""
+        graph = _build_graph(turns=1, tool_loop_depth=8, fanout=0.0)
+        user_facing = [eid for eid, ev in graph.events.items() if ev.is_user_facing]
+        assert len(user_facing) == 1
+
+    def test_no_structured_output_in_synthetic(self) -> None:
+        """Synthetic graphs don't use structured output — none should be excluded."""
+        graph = _build_graph()
+        structured = [ev for ev in graph.events.values() if ev.is_structured_output_call]
+        assert len(structured) == 0
+
+    def test_tool_internal_via_causal_fallback(self) -> None:
+        """Without span info, tool-call events with causal successors are marked tool-internal."""
+        graph = _build_graph(turns=1, tool_loop_depth=3)
+        # Tool-call events that have a causal successor should be tool_internal
+        # (fallback logic, since no spans). Prose events with causal successors are NOT.
+        successors: dict[str, list[str]] = {eid: [] for eid in graph.events}
+        for _eid, ev in graph.events.items():
+            for pred_id, dep_type in ev.predecessor_dependency_types.items():
+                if pred_id in successors:
+                    successors[pred_id].append(dep_type)
+        for eid, ev in graph.events.items():
+            has_causal_succ = any(dt != "temporal" for dt in successors[eid])
+            if has_causal_succ and ev.call.expected_output_is_tool_call:
+                assert ev.is_tool_internal is True, f"{eid} is tool-call with causal successor but not tool_internal"
+
+    def test_user_facing_and_tool_internal_are_disjoint(self) -> None:
+        """No event can be both user-facing and tool-internal."""
+        graph = _build_graph(turns=2, tool_loop_depth=3, fanout=0.0)
+        for eid, ev in graph.events.items():
+            if ev.is_user_facing:
+                assert ev.is_tool_internal is False, f"{eid} is both user-facing and tool_internal"
+
+    def test_deterministic_across_rebuilds(self) -> None:
+        """Same seed produces identical user-facing tagging."""
+        g1 = _build_graph(seed=99)
+        g2 = _build_graph(seed=99)
+        for eid in g1.events:
+            assert g1.events[eid].is_user_facing == g2.events[eid].is_user_facing
+            assert g1.events[eid].is_tool_internal == g2.events[eid].is_tool_internal
+            assert g1.events[eid].is_structured_output_call == g2.events[eid].is_structured_output_call
+
+    def test_multiple_seeds_all_have_user_facing(self) -> None:
+        """Various seeds all produce at least one user-facing event."""
+        for seed in range(10):
+            graph = _build_graph(seed=seed)
+            uf = [ev for ev in graph.events.values() if ev.is_user_facing]
+            assert len(uf) >= 1, f"seed={seed} produced no user-facing events"

--- a/tests/required/reportgen/test_tfut.py
+++ b/tests/required/reportgen/test_tfut.py
@@ -1,0 +1,210 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Time to First User Token (TFUT) computation and reporting."""
+
+import pytest
+
+from inference_perf.apis.base import (
+    InferenceInfo,
+    RequestLifecycleMetric,
+    ResponseMetrics,
+    SessionLifecycleMetric,
+    StreamedResponseMetrics,
+)
+from inference_perf.payloads import RequestMetrics, Text
+from inference_perf.reportgen.base import ReportGenerator
+
+
+def _make_session(
+    session_id: str = "s1",
+    start_time: float = 100.0,
+    dispatch_perf_counter: float | None = 100.0,
+    user_facing_event_ids: list[str] | None = None,
+    num_structured_output_excluded: int | None = None,
+) -> SessionLifecycleMetric:
+    return SessionLifecycleMetric(
+        session_id=session_id,
+        stage_id=0,
+        file_path="test.json",
+        start_time=start_time,
+        end_time=start_time + 10.0,
+        duration_sec=10.0,
+        num_events=3,
+        num_events_completed=3,
+        user_facing_event_ids=user_facing_event_ids,
+        num_structured_output_excluded=num_structured_output_excluded,
+        dispatch_perf_counter=dispatch_perf_counter,
+    )
+
+
+def _make_request(
+    session_id: str = "s1",
+    event_id: str = "e1",
+    streaming: bool = True,
+    output_token_times: list[float] | None = None,
+) -> RequestLifecycleMetric:
+    response_metrics: StreamedResponseMetrics | ResponseMetrics
+    if streaming:
+        response_metrics = StreamedResponseMetrics(
+            output_tokens=5,
+            output_token_times=output_token_times or [],
+        )
+    else:
+        response_metrics = ResponseMetrics(output_tokens=5)
+    return RequestLifecycleMetric(
+        scheduled_time=0.0,
+        start_time=100.0,
+        end_time=110.0,
+        request_data="r",
+        info=InferenceInfo(
+            request_metrics=RequestMetrics(text=Text(input_tokens=10)),
+            response_metrics=response_metrics,
+            labels={"event_id": event_id},
+        ),
+        error=None,
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _compute_tfut unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeTfut:
+    def test_happy_path_single_user_facing(self) -> None:
+        sm = _make_session(start_time=100.0, user_facing_event_ids=["e1"])
+        reqs = {"e1": _make_request(output_token_times=[100.5, 101.0, 101.5])}
+        ReportGenerator._compute_tfut(sm, reqs)
+        assert sm.tfut_sec == pytest.approx(0.5)
+        assert sm.tfut_none_reason is None
+
+    def test_min_across_multiple_user_facing(self) -> None:
+        sm = _make_session(start_time=100.0, user_facing_event_ids=["e1", "e2"])
+        reqs = {
+            "e1": _make_request(event_id="e1", output_token_times=[101.0]),
+            "e2": _make_request(event_id="e2", output_token_times=[100.3]),
+        }
+        ReportGenerator._compute_tfut(sm, reqs)
+        assert sm.tfut_sec == pytest.approx(0.3)
+
+    def test_no_user_facing_ids_none(self) -> None:
+        sm = _make_session(user_facing_event_ids=None)
+        ReportGenerator._compute_tfut(sm, {})
+        assert sm.tfut_sec is None
+        assert sm.tfut_none_reason == "no_user_facing"
+
+    def test_empty_user_facing_ids(self) -> None:
+        sm = _make_session(user_facing_event_ids=[])
+        ReportGenerator._compute_tfut(sm, {})
+        assert sm.tfut_sec is None
+        assert sm.tfut_none_reason == "no_user_facing"
+
+    def test_non_streaming_sets_reason(self) -> None:
+        sm = _make_session(start_time=100.0, user_facing_event_ids=["e1"])
+        reqs = {"e1": _make_request(event_id="e1", streaming=False)}
+        ReportGenerator._compute_tfut(sm, reqs)
+        assert sm.tfut_sec is None
+        assert sm.tfut_none_reason == "non_streaming"
+
+    def test_streaming_no_output_tokens(self) -> None:
+        sm = _make_session(start_time=100.0, user_facing_event_ids=["e1"])
+        reqs = {"e1": _make_request(event_id="e1", output_token_times=[])}
+        ReportGenerator._compute_tfut(sm, reqs)
+        assert sm.tfut_sec is None
+        assert sm.tfut_none_reason == "no_output_tokens"
+
+    def test_mixed_user_facing_valid_wins(self) -> None:
+        """One non-streaming + one valid streaming user-facing event → TFUT from the valid one."""
+        sm = _make_session(start_time=100.0, user_facing_event_ids=["e1", "e2"])
+        reqs = {
+            "e1": _make_request(event_id="e1", streaming=False),
+            "e2": _make_request(event_id="e2", output_token_times=[100.8]),
+        }
+        ReportGenerator._compute_tfut(sm, reqs)
+        assert sm.tfut_sec == pytest.approx(0.8)
+        assert sm.tfut_none_reason is None
+
+    def test_user_facing_id_not_in_requests(self) -> None:
+        sm = _make_session(start_time=100.0, user_facing_event_ids=["e_missing"])
+        ReportGenerator._compute_tfut(sm, {})
+        assert sm.tfut_sec is None
+        assert sm.tfut_none_reason == "no_user_facing"
+
+    def test_no_dispatch_perf_counter(self) -> None:
+        sm = _make_session(dispatch_perf_counter=None, user_facing_event_ids=["e1"])
+        reqs = {"e1": _make_request(output_token_times=[100.5])}
+        ReportGenerator._compute_tfut(sm, reqs)
+        assert sm.tfut_sec is None
+        assert sm.tfut_none_reason == "no_dispatch_anchor"
+
+
+# ---------------------------------------------------------------------------
+# _enrich_sessions integration (TFUT wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichSessionsTfut:
+    def test_enrich_populates_tfut(self) -> None:
+        sm = _make_session(start_time=100.0, user_facing_event_ids=["e1"])
+        req = _make_request(session_id="s1", event_id="e1", output_token_times=[100.2])
+        ReportGenerator._enrich_sessions(None, [sm], [req])  # type: ignore[arg-type]
+        assert sm.tfut_sec == pytest.approx(0.2)
+
+    def test_enrich_no_user_facing_yields_none_reason(self) -> None:
+        sm = _make_session(start_time=100.0, user_facing_event_ids=None)
+        req = _make_request(session_id="s1", event_id="e1", output_token_times=[100.5])
+        ReportGenerator._enrich_sessions(None, [sm], [req])  # type: ignore[arg-type]
+        assert sm.tfut_sec is None
+        assert sm.tfut_none_reason == "no_user_facing"
+
+
+# ---------------------------------------------------------------------------
+# summarize_sessions includes TFUT fields
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeSessionsTfut:
+    def test_summary_includes_tfut_percentiles(self) -> None:
+        sessions = [
+            _make_session(session_id="s1", start_time=100.0, user_facing_event_ids=["e1"]),
+            _make_session(session_id="s2", start_time=200.0, user_facing_event_ids=["e2"]),
+        ]
+        sessions[0].tfut_sec = 0.5
+        sessions[1].tfut_sec = 1.0
+        summary = ReportGenerator.summarize_sessions(None, sessions, [50, 99], max_error_messages=5)  # type: ignore[arg-type]
+        assert summary["sessions_with_tfut"] == 2
+        assert summary["tfut_sec"]["mean"] == pytest.approx(0.75)
+        assert summary["tfut_none_reasons"] is None
+
+    def test_summary_reports_none_reasons(self) -> None:
+        sessions = [
+            _make_session(session_id="s1", user_facing_event_ids=None),
+            _make_session(session_id="s2", user_facing_event_ids=["e1"]),
+        ]
+        sessions[0].tfut_none_reason = "no_user_facing"
+        sessions[1].tfut_none_reason = "non_streaming"
+        summary = ReportGenerator.summarize_sessions(None, sessions, [50], max_error_messages=5)  # type: ignore[arg-type]
+        assert summary["sessions_with_tfut"] == 0
+        assert summary["tfut_none_reasons"] == {"no_user_facing": 1, "non_streaming": 1}
+
+    def test_summary_includes_user_facing_and_exclusion_counts(self) -> None:
+        sessions = [
+            _make_session(session_id="s1", user_facing_event_ids=["e1", "e2"], num_structured_output_excluded=1),
+            _make_session(session_id="s2", user_facing_event_ids=["e3"], num_structured_output_excluded=0),
+        ]
+        summary = ReportGenerator.summarize_sessions(None, sessions, [50], max_error_messages=5)  # type: ignore[arg-type]
+        assert summary["num_user_facing_events"]["mean"] == pytest.approx(1.5)
+        assert summary["num_structured_output_excluded"]["mean"] == pytest.approx(0.5)

--- a/tests/required/reportgen/test_tfut.py
+++ b/tests/required/reportgen/test_tfut.py
@@ -71,7 +71,7 @@ def _make_request(
         info=InferenceInfo(
             request_metrics=RequestMetrics(text=Text(input_tokens=10)),
             response_metrics=response_metrics,
-            labels={"event_id": event_id},
+            graph_event_id=event_id,
         ),
         error=None,
         session_id=session_id,

--- a/tests/required/utils/test_cli_summary.py
+++ b/tests/required/utils/test_cli_summary.py
@@ -77,8 +77,31 @@ class TestCliSummary(unittest.TestCase):
         }
         report = ReportFile(name="stage_0_session_lifecycle_metrics", contents=contents)
         print_session_summary_tables([report])
-        # 3 session tables printed
+        # 3 session tables printed (no TFUT data → TFUT table skipped)
         self.assertEqual(mock_console_print.call_count, 3)
+
+    @patch("inference_perf.utils.cli_summary.Console.print")
+    def test_print_session_summary_tables_with_tfut(self, mock_console_print: MagicMock) -> None:
+        contents = {
+            "num_sessions": 5,
+            "num_sessions_succeeded": 5,
+            "num_sessions_failed": 0,
+            "total_events": 30,
+            "total_events_completed": 30,
+            "total_events_cancelled": 0,
+            "sessions_per_second": 0.12,
+            "session_duration_sec": {"mean": 13.8, "median": 12.7, "p90": 15.7},
+            "num_events": {"mean": 6.0, "median": 6.0, "p90": 6.0},
+            "total_input_tokens": {"mean": 9068.0, "median": 9065.0, "p90": 9093.0},
+            "total_output_tokens": {"mean": 239.0, "median": 239.0, "p90": 243.0},
+            "tfut_sec": {"mean": 11.84, "median": 10.69, "p90": 13.71},
+            "sessions_with_tfut": 5,
+            "tfut_none_reasons": None,
+        }
+        report = ReportFile(name="stage_0_session_lifecycle_metrics", contents=contents)
+        print_session_summary_tables([report])
+        # 3 session tables + 1 TFUT table = 4
+        self.assertEqual(mock_console_print.call_count, 4)
 
     @patch("inference_perf.utils.cli_summary.Console.print")
     def test_print_summary_table_includes_session_tables(self, mock_console_print: MagicMock) -> None:


### PR DESCRIPTION
Summary

- Adds TFUT (Time to First User Token) as a per-session metric: the time from session dispatch to the first output token on the earliest user-facing event
- Tags events as user-facing via tag_user_facing_events using three conditions: not a tool call, not structured output, and not tool-internal
- Tool-internal detection uses structural span nesting (primary) with a fallback heuristic for graphs without OTel span data
- Reports TFUT in the CLI summary table and JSON session reports, with diagnostic tfut_none_reason when TFUT cannot be computed

Changes

- otel_trace_to_replay_graph.py: tag_user_facing_events function with structural + fallback tool-internal detection
- replay_graph_types.py: is_user_facing, is_tool_internal, is_structured_output_call fields on GraphEvent
- replay_graph_session_datagen.py: populate user_facing_event_ids on SessionLifecycleMetric
- load_generator.py: record dispatch_perf_counter at session dispatch
- reportgen/base.py: _compute_tfut computes TFUT from perf_counter timestamps; summarize_sessions includes TFUT percentiles and none-reason breakdown
- cli_summary.py: new TFUT table in CLI output
- synthetic_agentic.py, otel_trace_replay_datagen.py: call tag_user_facing_events after graph construction

Test plan

- [x] tests/required/datagen/test_tag_user_facing_events.py — unit tests for all tagging conditions (tool call, structured output, tool-internal structural + fallback)
- [x] tests/required/datagen/test_tfut_synthetic_graph.py — integration tests on synthetic agentic graphs
- [x] tests/required/reportgen/test_tfut.py — unit tests for _compute_tfut, _enrich_sessions, and summarize_sessions TFUT fields
- [x] Validated on real OTel traces (simple_chain, fan-out) — TFUT correctly reports first-turn latency