### PR TITLE
Fix issue 732: circuit breaker edge cases and tests

### DIFF
--- a/inference_perf/circuit_breaker/simple_breaker.py
+++ b/inference_perf/circuit_breaker/simple_breaker.py
@@ -44,20 +44,20 @@ class SimpleCircuitBreaker(CircuitBreaker):
         data = metric.model_dump(mode="json", exclude_unset=True, exclude_none=True)
         if self._search(self._matches, data):
             hit = 1 if not self._rules or self._search(self._rules, data) else 0
-            
+
             # Use metric.end_time if available to get request time
-            if hasattr(metric, 'end_time') and metric.end_time is not None:
+            if hasattr(metric, "end_time") and metric.end_time is not None:
                 ts = datetime.fromtimestamp(metric.end_time)
-            elif hasattr(metric, 'end_timestamp_ns') and metric.end_timestamp_ns is not None:
+            elif hasattr(metric, "end_timestamp_ns") and metric.end_timestamp_ns is not None:
                 ts = datetime.fromtimestamp(metric.end_timestamp_ns / 1e9)
-            elif hasattr(metric, 'timestamp') and metric.timestamp is not None:
+            elif hasattr(metric, "timestamp") and metric.timestamp is not None:
                 if isinstance(metric.timestamp, datetime):
                     ts = metric.timestamp
                 else:
                     ts = datetime.fromtimestamp(metric.timestamp)
             else:
                 ts = datetime.now()
-                
+
             hit_sample = HitSample(ts, hit)
             for t in self._triggers:
                 t.update(hit_sample)

--- a/inference_perf/circuit_breaker/simple_breaker.py
+++ b/inference_perf/circuit_breaker/simple_breaker.py
@@ -36,18 +36,29 @@ class SimpleCircuitBreaker(CircuitBreaker):
 
     def _search(self, exprs: List[jmespath.parser.ParsedResult], data: Dict[str, Any]) -> bool:
         for expr in exprs:
-            try:
-                if bool(expr.search(data)):
-                    return True
-            except Exception:
-                pass
+            if bool(expr.search(data)):
+                return True
         return False
 
     def feed(self, metric: BaseModel) -> None:
         data = metric.model_dump(mode="json", exclude_unset=True, exclude_none=True)
         if self._search(self._matches, data):
             hit = 1 if not self._rules or self._search(self._rules, data) else 0
-            hit_sample = HitSample(datetime.now(), hit)
+            
+            # Use metric.end_time if available to get request time
+            if hasattr(metric, 'end_time') and metric.end_time is not None:
+                ts = datetime.fromtimestamp(metric.end_time)
+            elif hasattr(metric, 'end_timestamp_ns') and metric.end_timestamp_ns is not None:
+                ts = datetime.fromtimestamp(metric.end_timestamp_ns / 1e9)
+            elif hasattr(metric, 'timestamp') and metric.timestamp is not None:
+                if isinstance(metric.timestamp, datetime):
+                    ts = metric.timestamp
+                else:
+                    ts = datetime.fromtimestamp(metric.timestamp)
+            else:
+                ts = datetime.now()
+                
+            hit_sample = HitSample(ts, hit)
             for t in self._triggers:
                 t.update(hit_sample)
                 if t.fired():
@@ -58,3 +69,5 @@ class SimpleCircuitBreaker(CircuitBreaker):
 
     def reset(self) -> None:
         self._open = False
+        for t in self._triggers:
+            t.reset()

--- a/inference_perf/circuit_breaker/triggers/consecutive.py
+++ b/inference_perf/circuit_breaker/triggers/consecutive.py
@@ -26,8 +26,7 @@ class Consecutive(Trigger, spec_cls=TriggerConsecutive):
 
     def update(self, s: HitSample) -> None:
         self.c = self.c + 1 if s.hit else 0
-        if self.c >= self.n:
-            self._fired = True
+        self._fired = self.c >= self.n
 
     def fired(self) -> bool:
         return self._fired

--- a/inference_perf/circuit_breaker/triggers/rate_over_window.py
+++ b/inference_perf/circuit_breaker/triggers/rate_over_window.py
@@ -39,8 +39,9 @@ class RateOverWindow(Trigger, spec_cls=TriggerRateOverWindow):
         if total >= self.min:
             hits = sum(x.hit for x in self.buf)
             rate = hits / total if total else 0.0
-            if rate >= self.th:
-                self._fired = True
+            self._fired = rate >= self.th
+        else:
+            self._fired = False
 
     def fired(self) -> bool:
         return self._fired

--- a/inference_perf/config/circuit_breaker/config.py
+++ b/inference_perf/config/circuit_breaker/config.py
@@ -28,9 +28,14 @@ class TriggerRateOverWindow(BaseModel):
     min_samples: int = Field(0, ge=0, description="Minimum samples in the window before the trigger can trip.")
 
 
-TriggerSpec = Union[
-    TriggerConsecutive,
-    TriggerRateOverWindow,
+from typing import Annotated
+
+TriggerSpec = Annotated[
+    Union[
+        TriggerConsecutive,
+        TriggerRateOverWindow,
+    ],
+    Field(discriminator="type")
 ]
 
 

--- a/inference_perf/config/circuit_breaker/config.py
+++ b/inference_perf/config/circuit_breaker/config.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List, Literal, Union
+from typing import Annotated, List, Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -28,14 +28,12 @@ class TriggerRateOverWindow(BaseModel):
     min_samples: int = Field(0, ge=0, description="Minimum samples in the window before the trigger can trip.")
 
 
-from typing import Annotated
-
 TriggerSpec = Annotated[
     Union[
         TriggerConsecutive,
         TriggerRateOverWindow,
     ],
-    Field(discriminator="type")
+    Field(discriminator="type"),
 ]
 
 

--- a/tests/required/circuit_breaker/test_simple_breaker.py
+++ b/tests/required/circuit_breaker/test_simple_breaker.py
@@ -1,55 +1,55 @@
-import pytest
-import time
+from collections.abc import Generator
 from datetime import datetime
+import time
+import jmespath.exceptions
 from pydantic import BaseModel, ValidationError
+import pytest
 
-from inference_perf.config.circuit_breaker import CircuitBreakerConfig, TriggerConsecutive, TriggerRateOverWindow
-from inference_perf.circuit_breaker import init_circuit_breakers, get_circuit_breaker, feed_breakers
+from inference_perf.circuit_breaker import _initialized_circuit_breakers, get_circuit_breaker, init_circuit_breakers
 from inference_perf.circuit_breaker.simple_breaker import SimpleCircuitBreaker
 from inference_perf.circuit_breaker.triggers import HitSample
 from inference_perf.circuit_breaker.triggers.consecutive import Consecutive
 from inference_perf.circuit_breaker.triggers.rate_over_window import RateOverWindow
-from inference_perf.circuit_breaker import _initialized_circuit_breakers
+from inference_perf.config.circuit_breaker import CircuitBreakerConfig, TriggerConsecutive, TriggerRateOverWindow
+
 
 class DummyMetric(BaseModel):
     foo: str = "bar"
     val: int = 10
     end_time: float = 0.0
 
+
 @pytest.fixture(autouse=True)
-def clear_breakers():
+def clear_breakers() -> Generator[None, None, None]:
     _initialized_circuit_breakers.clear()
     yield
     _initialized_circuit_breakers.clear()
 
-def test_init_circuit_breakers():
+
+def test_init_circuit_breakers() -> None:
     config = CircuitBreakerConfig(
-        name="test",
-        metrics={"matches": ["foo == 'bar'"]},
-        triggers=[TriggerConsecutive(type="consecutive", threshold=3)]
+        name="test", metrics={"matches": ["foo == 'bar'"]}, triggers=[TriggerConsecutive(type="consecutive", threshold=3)]
     )
     init_circuit_breakers([config])
-    
+
     cb = get_circuit_breaker("test")
     assert isinstance(cb, SimpleCircuitBreaker)
-    
+
     with pytest.raises(RuntimeError, match="Circuit breakers already initialized"):
         init_circuit_breakers([config])
-        
+
     with pytest.raises(ValueError, match="Unknown circuit breaker: unknown"):
         get_circuit_breaker("unknown")
 
-def test_simple_breaker_match_rule_semantics():
+
+def test_simple_breaker_match_rule_semantics() -> None:
     config = CircuitBreakerConfig(
         name="test",
-        metrics={
-            "matches": ["foo == 'bar'", "foo == 'baz'"],
-            "rules": ["val > `5`", "val < `0`"]
-        },
-        triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
+        metrics={"matches": ["foo == 'bar'", "foo == 'baz'"], "rules": ["val > `5`", "val < `0`"]},
+        triggers=[TriggerConsecutive(type="consecutive", threshold=1)],
     )
     cb = SimpleCircuitBreaker(config)
-    
+
     # Matches first expr, rule matches first expr
     cb.feed(DummyMetric(foo="bar", val=10, end_time=time.time()))
     assert cb.is_open()
@@ -69,63 +69,54 @@ def test_simple_breaker_match_rule_semantics():
     cb.feed(DummyMetric(foo="bar", val=2, end_time=time.time()))
     assert not cb.is_open()
 
-def test_simple_breaker_invalid_expression():
+
+def test_simple_breaker_invalid_expression() -> None:
     config = CircuitBreakerConfig(
-        name="test",
-        metrics={"matches": ["foo =="]},
-        triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
+        name="test", metrics={"matches": ["foo =="]}, triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
     )
-    with pytest.raises(Exception):
+    with pytest.raises(jmespath.exceptions.JMESPathError):
         SimpleCircuitBreaker(config)
-        
-    config2 = CircuitBreakerConfig(
-        name="test2",
-        metrics={"matches": ["foo == 'bar'"]},
-        triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
-    )
-    cb = SimpleCircuitBreaker(config2)
-    # The search expression shouldn't swallow exception if it somehow raises on valid syntax but runtime failure
-    # Actually, JMESPath compile catches syntax errors. We just want to make sure it doesn't swallow other errors?
-    # No, we removed `except Exception: pass`, so any error during search will raise.
-    
-def test_consecutive_trigger():
+
+
+def test_consecutive_trigger() -> None:
     t = Consecutive(threshold=3)
     ts = datetime.now()
-    
+
     t.update(HitSample(ts, 1))
     assert not t.fired()
-    
+
     t.update(HitSample(ts, 1))
     assert not t.fired()
-    
+
     t.update(HitSample(ts, 1))
-    assert t.fired() # threshold boundary
-    
+    assert t.fired()  # threshold boundary
+
     t.reset()
     assert not t.fired()
-    
+
     # reset to 0 on a miss
     t.update(HitSample(ts, 1))
     t.update(HitSample(ts, 1))
-    t.update(HitSample(ts, 0)) # miss
+    t.update(HitSample(ts, 0))  # miss
     t.update(HitSample(ts, 1))
     t.update(HitSample(ts, 1))
     assert not t.fired()
     t.update(HitSample(ts, 1))
     assert t.fired()
 
-def test_rate_over_window_trigger():
+
+def test_rate_over_window_trigger() -> None:
     # min_samples gating
     t = RateOverWindow(window_sec=10.0, threshold=0.5, min_samples=3)
     ts1 = datetime.fromtimestamp(100)
-    
+
     t.update(HitSample(ts1, 1))
     t.update(HitSample(ts1, 1))
-    assert not t.fired() # only 2 samples
-    
+    assert not t.fired()  # only 2 samples
+
     t.update(HitSample(ts1, 0))
-    assert t.fired() # 3 samples, 2 hits => rate=0.66 > 0.5
-    
+    assert t.fired()  # 3 samples, 2 hits => rate=0.66 > 0.5
+
     t.reset()
     assert not t.fired()
 
@@ -139,7 +130,7 @@ def test_rate_over_window_trigger():
     t_evict.update(HitSample(datetime.fromtimestamp(100), 1))
     t_evict.update(HitSample(datetime.fromtimestamp(101), 1))
     assert t_evict.fired()
-    
+
     t_evict.reset()
     t_evict.update(HitSample(datetime.fromtimestamp(100), 1))
     t_evict.update(HitSample(datetime.fromtimestamp(101), 1))
@@ -147,7 +138,7 @@ def test_rate_over_window_trigger():
     t_evict.update(HitSample(datetime.fromtimestamp(106), 0))
     # window has (101: hit), (106: miss) -> 1/2 = 0.5
     assert t_evict.fired()
-    
+
     t_evict.reset()
     t_evict.update(HitSample(datetime.fromtimestamp(100), 1))
     t_evict.update(HitSample(datetime.fromtimestamp(101), 1))
@@ -155,12 +146,13 @@ def test_rate_over_window_trigger():
     t_evict.update(HitSample(datetime.fromtimestamp(107), 0))
     assert not t_evict.fired()
 
-def test_config_validation():
+
+def test_config_validation() -> None:
     with pytest.raises(ValidationError):
-        TriggerConsecutive(type="consecutive", threshold=0) # ge=1
-        
+        TriggerConsecutive(type="consecutive", threshold=0)  # ge=1
+
     with pytest.raises(ValidationError):
         TriggerRateOverWindow(type="rate_over_window", window_sec=-1.0, threshold=0.5)
-        
+
     with pytest.raises(ValidationError):
         TriggerRateOverWindow(type="rate_over_window", window_sec=1.0, threshold=1.5)

--- a/tests/required/circuit_breaker/test_simple_breaker.py
+++ b/tests/required/circuit_breaker/test_simple_breaker.py
@@ -1,0 +1,166 @@
+import pytest
+import time
+from datetime import datetime
+from pydantic import BaseModel, ValidationError
+
+from inference_perf.config.circuit_breaker import CircuitBreakerConfig, TriggerConsecutive, TriggerRateOverWindow
+from inference_perf.circuit_breaker import init_circuit_breakers, get_circuit_breaker, feed_breakers
+from inference_perf.circuit_breaker.simple_breaker import SimpleCircuitBreaker
+from inference_perf.circuit_breaker.triggers import HitSample
+from inference_perf.circuit_breaker.triggers.consecutive import Consecutive
+from inference_perf.circuit_breaker.triggers.rate_over_window import RateOverWindow
+from inference_perf.circuit_breaker import _initialized_circuit_breakers
+
+class DummyMetric(BaseModel):
+    foo: str = "bar"
+    val: int = 10
+    end_time: float = 0.0
+
+@pytest.fixture(autouse=True)
+def clear_breakers():
+    _initialized_circuit_breakers.clear()
+    yield
+    _initialized_circuit_breakers.clear()
+
+def test_init_circuit_breakers():
+    config = CircuitBreakerConfig(
+        name="test",
+        metrics={"matches": ["foo == 'bar'"]},
+        triggers=[TriggerConsecutive(type="consecutive", threshold=3)]
+    )
+    init_circuit_breakers([config])
+    
+    cb = get_circuit_breaker("test")
+    assert isinstance(cb, SimpleCircuitBreaker)
+    
+    with pytest.raises(RuntimeError, match="Circuit breakers already initialized"):
+        init_circuit_breakers([config])
+        
+    with pytest.raises(ValueError, match="Unknown circuit breaker: unknown"):
+        get_circuit_breaker("unknown")
+
+def test_simple_breaker_match_rule_semantics():
+    config = CircuitBreakerConfig(
+        name="test",
+        metrics={
+            "matches": ["foo == 'bar'", "foo == 'baz'"],
+            "rules": ["val > `5`", "val < `0`"]
+        },
+        triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
+    )
+    cb = SimpleCircuitBreaker(config)
+    
+    # Matches first expr, rule matches first expr
+    cb.feed(DummyMetric(foo="bar", val=10, end_time=time.time()))
+    assert cb.is_open()
+    cb.reset()
+    assert not cb.is_open()
+
+    # Matches second expr, rule matches second expr
+    cb.feed(DummyMetric(foo="baz", val=-5, end_time=time.time()))
+    assert cb.is_open()
+    cb.reset()
+
+    # No match
+    cb.feed(DummyMetric(foo="qux", val=10, end_time=time.time()))
+    assert not cb.is_open()
+
+    # Match, but no rule hit
+    cb.feed(DummyMetric(foo="bar", val=2, end_time=time.time()))
+    assert not cb.is_open()
+
+def test_simple_breaker_invalid_expression():
+    config = CircuitBreakerConfig(
+        name="test",
+        metrics={"matches": ["foo =="]},
+        triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
+    )
+    with pytest.raises(Exception):
+        SimpleCircuitBreaker(config)
+        
+    config2 = CircuitBreakerConfig(
+        name="test2",
+        metrics={"matches": ["foo == 'bar'"]},
+        triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
+    )
+    cb = SimpleCircuitBreaker(config2)
+    # The search expression shouldn't swallow exception if it somehow raises on valid syntax but runtime failure
+    # Actually, JMESPath compile catches syntax errors. We just want to make sure it doesn't swallow other errors?
+    # No, we removed `except Exception: pass`, so any error during search will raise.
+    
+def test_consecutive_trigger():
+    t = Consecutive(threshold=3)
+    ts = datetime.now()
+    
+    t.update(HitSample(ts, 1))
+    assert not t.fired()
+    
+    t.update(HitSample(ts, 1))
+    assert not t.fired()
+    
+    t.update(HitSample(ts, 1))
+    assert t.fired() # threshold boundary
+    
+    t.reset()
+    assert not t.fired()
+    
+    # reset to 0 on a miss
+    t.update(HitSample(ts, 1))
+    t.update(HitSample(ts, 1))
+    t.update(HitSample(ts, 0)) # miss
+    t.update(HitSample(ts, 1))
+    t.update(HitSample(ts, 1))
+    assert not t.fired()
+    t.update(HitSample(ts, 1))
+    assert t.fired()
+
+def test_rate_over_window_trigger():
+    # min_samples gating
+    t = RateOverWindow(window_sec=10.0, threshold=0.5, min_samples=3)
+    ts1 = datetime.fromtimestamp(100)
+    
+    t.update(HitSample(ts1, 1))
+    t.update(HitSample(ts1, 1))
+    assert not t.fired() # only 2 samples
+    
+    t.update(HitSample(ts1, 0))
+    assert t.fired() # 3 samples, 2 hits => rate=0.66 > 0.5
+    
+    t.reset()
+    assert not t.fired()
+
+    # threshold=0.0 edge
+    t_zero = RateOverWindow(window_sec=10.0, threshold=0.0, min_samples=0)
+    t_zero.update(HitSample(ts1, 0))
+    assert t_zero.fired()
+
+    # window eviction
+    t_evict = RateOverWindow(window_sec=5.0, threshold=0.5, min_samples=0)
+    t_evict.update(HitSample(datetime.fromtimestamp(100), 1))
+    t_evict.update(HitSample(datetime.fromtimestamp(101), 1))
+    assert t_evict.fired()
+    
+    t_evict.reset()
+    t_evict.update(HitSample(datetime.fromtimestamp(100), 1))
+    t_evict.update(HitSample(datetime.fromtimestamp(101), 1))
+    # Add a miss at 106, which should evict 100
+    t_evict.update(HitSample(datetime.fromtimestamp(106), 0))
+    # window has (101: hit), (106: miss) -> 1/2 = 0.5
+    assert t_evict.fired()
+    
+    t_evict.reset()
+    t_evict.update(HitSample(datetime.fromtimestamp(100), 1))
+    t_evict.update(HitSample(datetime.fromtimestamp(101), 1))
+    # Add misses at 107, evicting both hits
+    t_evict.update(HitSample(datetime.fromtimestamp(107), 0))
+    assert not t_evict.fired()
+
+def test_config_validation():
+    with pytest.raises(ValidationError):
+        TriggerConsecutive(type="consecutive", threshold=0) # ge=1
+        
+    with pytest.raises(ValidationError):
+        TriggerRateOverWindow(type="rate_over_window", window_sec=-1.0, threshold=0.5)
+        
+    with pytest.raises(ValidationError):
+        TriggerRateOverWindow(type="rate_over_window", window_sec=1.0, threshold=1.5)

--- a/tests/required/loadgen/test_load_generator.py
+++ b/tests/required/loadgen/test_load_generator.py
@@ -60,8 +60,12 @@ class TestLoadGeneratorConcurrency(unittest.TestCase):
         self.mock_datagen = MagicMock(spec=DataGenerator)
         self.load_config = LoadConfig(type=LoadType.CONCURRENT, num_workers=4, worker_max_concurrency=100)
         # Mocking get_circuit_breaker since LoadGenerator init calls it
-        with unittest.mock.patch("inference_perf.loadgen.load_generator.get_circuit_breaker"):
-            self.load_generator = LoadGenerator(self.mock_datagen, self.load_config)
+        self.patcher = unittest.mock.patch("inference_perf.loadgen.load_generator.get_circuit_breaker")
+        self.mock_get_cb = self.patcher.start()
+        self.load_generator = LoadGenerator(self.mock_datagen, self.load_config)
+
+    def tearDown(self) -> None:
+        self.patcher.stop()
 
     def test_set_worker_concurrency_divisible(self) -> None:
         # Setup workers
@@ -262,3 +266,61 @@ class TestLoadGenerator(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestLoadGeneratorRealCircuitBreaker(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        from inference_perf.circuit_breaker import _initialized_circuit_breakers, init_circuit_breakers
+        from inference_perf.config.circuit_breaker import CircuitBreakerConfig, TriggerConsecutive
+        
+        _initialized_circuit_breakers.clear()
+        
+        config = CircuitBreakerConfig(
+            name="real_breaker",
+            metrics={"matches": ["val > `0`"]},
+            triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
+        )
+        init_circuit_breakers([config])
+        
+        self.mock_datagen = MagicMock(spec=DataGenerator)
+        self.load_config = LoadConfig(
+            type=LoadType.CONCURRENT, 
+            num_workers=0, 
+            worker_max_concurrency=10,
+            circuit_breakers=["real_breaker"]
+        )
+        self.load_generator = LoadGenerator(self.mock_datagen, self.load_config)
+
+    def tearDown(self) -> None:
+        from inference_perf.circuit_breaker import _initialized_circuit_breakers
+        _initialized_circuit_breakers.clear()
+
+    async def test_run_local_trips_breaker(self) -> None:
+        self.load_generator.stages = [StandardLoadStage(rate=10, duration=1)]
+        
+        mock_data = MagicMock(spec=InferenceAPIData)
+        mock_data.preferred_worker_id = -1
+        self.mock_datagen.get_data.return_value = [mock_data, mock_data, mock_data]
+        
+        with (
+            patch("inference_perf.loadgen.load_generator.LazyLoadDataMixin.get_request", return_value=mock_data),
+            patch("inference_perf.loadgen.load_generator.time.perf_counter", return_value=0.0)
+        ):
+            # We want to trip the breaker in the middle of the loop
+            from inference_perf.circuit_breaker import get_circuit_breaker
+            cb = get_circuit_breaker("real_breaker")
+            
+            from inference_perf.circuit_breaker.triggers import HitSample
+            from pydantic import BaseModel
+            class MockMetric(BaseModel):
+                val: int = 1
+                end_time: float = 0.0
+                
+            # Feed it once to trip it
+            cb.feed(MockMetric())
+            self.assertTrue(cb.is_open())
+            
+            # Now run a stage, it should exit early
+            await self.load_generator.run_stage(0, None, self.load_generator.stages[0], single_worker=True)
+            
+            # The test passes if it exits cleanly.

--- a/tests/required/loadgen/test_load_generator.py
+++ b/tests/required/loadgen/test_load_generator.py
@@ -272,55 +272,55 @@ class TestLoadGeneratorRealCircuitBreaker(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         from inference_perf.circuit_breaker import _initialized_circuit_breakers, init_circuit_breakers
         from inference_perf.config.circuit_breaker import CircuitBreakerConfig, TriggerConsecutive
-        
+
         _initialized_circuit_breakers.clear()
-        
+
         config = CircuitBreakerConfig(
             name="real_breaker",
             metrics={"matches": ["val > `0`"]},
-            triggers=[TriggerConsecutive(type="consecutive", threshold=1)]
+            triggers=[TriggerConsecutive(type="consecutive", threshold=1)],
         )
         init_circuit_breakers([config])
-        
+
         self.mock_datagen = MagicMock(spec=DataGenerator)
         self.load_config = LoadConfig(
-            type=LoadType.CONCURRENT, 
-            num_workers=0, 
-            worker_max_concurrency=10,
-            circuit_breakers=["real_breaker"]
+            type=LoadType.CONCURRENT, num_workers=0, worker_max_concurrency=10, circuit_breakers=["real_breaker"]
         )
         self.load_generator = LoadGenerator(self.mock_datagen, self.load_config)
 
     def tearDown(self) -> None:
         from inference_perf.circuit_breaker import _initialized_circuit_breakers
+
         _initialized_circuit_breakers.clear()
 
     async def test_run_local_trips_breaker(self) -> None:
         self.load_generator.stages = [StandardLoadStage(rate=10, duration=1)]
-        
+
         mock_data = MagicMock(spec=InferenceAPIData)
         mock_data.preferred_worker_id = -1
         self.mock_datagen.get_data.return_value = [mock_data, mock_data, mock_data]
-        
+
         with (
             patch("inference_perf.loadgen.load_generator.LazyLoadDataMixin.get_request", return_value=mock_data),
-            patch("inference_perf.loadgen.load_generator.time.perf_counter", return_value=0.0)
+            patch("inference_perf.loadgen.load_generator.time.perf_counter", return_value=0.0),
         ):
             # We want to trip the breaker in the middle of the loop
             from inference_perf.circuit_breaker import get_circuit_breaker
+
             cb = get_circuit_breaker("real_breaker")
-            
-            from inference_perf.circuit_breaker.triggers import HitSample
+
             from pydantic import BaseModel
+
             class MockMetric(BaseModel):
                 val: int = 1
                 end_time: float = 0.0
-                
+
             # Feed it once to trip it
-            cb.feed(MockMetric())
+            cb.feed(MockMetric(val=1, end_time=0.0))
             self.assertTrue(cb.is_open())
-            
-            # Now run a stage, it should exit early
-            await self.load_generator.run_stage(0, None, self.load_generator.stages[0], single_worker=True)
-            
-            # The test passes if it exits cleanly.
+            # Now run local, it should exit early
+            mock_client = AsyncMock(spec=ModelServerClient)
+            await self.load_generator.run(mock_client)
+
+            # The test passes if it exits cleanly with FAILED status
+            self.assertEqual(self.load_generator.stage_runtime_info[0].status.name, "FAILED")


### PR DESCRIPTION
Fixes #732.

This PR addresses the missing test coverage and bugs in the circuit breaker logic:
- Fixes `SimpleCircuitBreaker._search` to no longer swallow exceptions, exposing invalid JMESPath expressions.
- Updates `RateOverWindow` and other triggers to use `metric.end_time` or `metric.end_timestamp_ns` instead of `datetime.now()` when `feed()` is called.
- Modifies `SimpleCircuitBreaker.reset()` to properly propagate the reset signal to its underlying triggers.
- Adds comprehensive unit tests for `SimpleCircuitBreaker`, `Consecutive`, and `RateOverWindow` triggers, including boundary and edge cases.
- Includes a loadgen integration test driving a real circuit breaker to ensure `is_open()` triggers correctly.