### PR TITLE
feat(loadgen): bound a session-replay stage by duration

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -537,9 +537,10 @@ load:
   type: trace_session_replay                      # Required for otel_trace_replay
   stages:
     - concurrent_sessions: 4                      # Max sessions active simultaneously
-      num_sessions: 20                            # Run 20 sessions in this stage
+      num_sessions: 20                            # Run 20 sessions in this stage (omit when using duration)
       session_rate: 2.0                           # Optional: start max 2 sessions/sec
-      timeout: 300                                # Optional: stage timeout in seconds
+      duration: 1800                              # Optional: planned stop after 30 min; stage reports COMPLETED
+      timeout: 2100                               # Optional: safety limit; reports FAILED. Must exceed duration
   num_workers: 4                                  # Worker processes
   worker_max_concurrency: 10                      # Max concurrent requests per worker
 ```
@@ -558,8 +559,15 @@ load:
 - Omit for no rate limiting
 - Useful for controlled ramp-up scenarios
 
+**`duration`** (optional): Planned stage length in seconds — bound the stage by time rather than by session count
+- At the deadline the stage stops dispatching and exits as COMPLETED
+- Sessions still running are recorded as truncated: counted under `num_sessions_truncated`, and left out of the session success/failure counts and duration percentiles. The requests they completed still count
+- The corpus must be large enough to fill the window (each session is drawn once); a stage that runs out early ends short and logs a warning. Raise `duplicate_sessions_target` to cover it
+- Wall-clock time is `duration` plus teardown, since in-flight requests are given a chance to finish
+
 **`timeout`** (optional): Wall-clock safety limit
 - If exceeded, in-flight sessions are cancelled and stage exits as FAILED
+- Distinct from `duration`: this is the fault signal, `duration` is the planned stop. Must be longer than `duration` when both are set
 
 #### Trace File Format
 

--- a/docs/otel_trace_replay.md
+++ b/docs/otel_trace_replay.md
@@ -261,6 +261,33 @@ The `load.trace_session_replay` section controls how sessions are executed. Unli
 | `concurrent_sessions` | integer | Yes | Max sessions running simultaneously. Set to `0` for unlimited (stress mode) |
 | `num_sessions` | integer | No | Total sessions to run in this stage. Omit to run all remaining sessions (entire corpus if single stage) |
 | `session_rate` | float | No | Optional rate limit for starting new sessions (sessions/sec) |
+| `duration` | float | No | Planned stage length in seconds. The stage stops dispatching once reached and reports `COMPLETED`. See [Bounding a stage by time](#bounding-a-stage-by-time) |
+| `timeout` | float | No | Safety limit in seconds. If exceeded, in-flight sessions are cancelled and the stage reports `FAILED`. Must be longer than `duration` when both are set |
+
+#### Bounding a stage by time
+
+Set `duration` to hold a fixed level of load for a fixed window rather than replaying a set number of sessions — the usual shape for a sustained-load measurement ("hold 16 conversations open for half an hour").
+
+```yaml
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 16
+      duration: 1800          # stop after 30 minutes
+      timeout: 2100           # safety net, must be longer than duration
+```
+
+What happens at the deadline:
+
+- No further sessions or turns are dispatched.
+- The stage reports `COMPLETED`, not `FAILED`. This is the difference from using `timeout` alone: a timeout is a fault signal, so a stop you asked for would be recorded as a failure.
+- Requests already in flight finish during stage teardown and keep their metrics.
+- Sessions that had not finished are recorded as **truncated**. They appear in the report with `truncated: true` and are counted under `num_sessions_truncated`, but are left out of the session success/failure counts and the `session_duration_sec` percentiles — a truncated session's duration reflects where the deadline fell, not how long that session takes. The requests those sessions did complete still count in the request-level metrics.
+- The stage's `stage_metadata` carries `duration_configured` alongside `actual_duration`, so a report read on its own shows whether the full window was run.
+
+**The corpus must be large enough to cover the window.** A stage draws each session once, so if the corpus runs out before the deadline the stage ends early and logs a warning saying how much short it fell. Raise `duplicate_sessions_target` until the corpus covers the window; duplicates are KV-cache-isolated automatically, so they do not inflate the cache hit rate.
+
+Note that a stage's wall-clock time is `duration` plus however long teardown takes, since in-flight requests are given a chance to finish. `duration` bounds load generation, not total stage time.
 
 **Example:**
 
@@ -346,7 +373,8 @@ After a run, three session report files are generated:
 
 - **`summary_session_lifecycle_metrics.json`** — Aggregate statistics across all sessions:
   - `num_sessions`, `num_sessions_succeeded`, `num_sessions_failed`
-  - `total_events`, `total_events_completed`, `total_events_cancelled`
+  - `num_sessions_truncated` — sessions cut short at the stage boundary (see [Bounding a stage by time](#bounding-a-stage-by-time)). Counted here but excluded from the succeeded/failed counts and from `session_duration_sec`, since a truncated session's duration reflects where the boundary fell rather than how long the session takes
+  - `total_events`, `total_events_completed`, `total_events_cancelled` — inclusive of truncated sessions: those events really did complete
   - Distributions: `session_duration_sec`, `num_events`, `total_input_tokens`, `total_output_tokens`
   
 - **`stage_N_session_lifecycle_metrics.json`** — Same statistics grouped by stage

--- a/docs/weka_trace_replay.md
+++ b/docs/weka_trace_replay.md
@@ -51,6 +51,23 @@ data:
                           # Defaults to available CPU cores; set to 1 for serial.
 ```
 
+### Bounding a stage by time instead of session count
+
+These corpora are large and usually are not replayed in full — the useful measurement is sustained load over a fixed window. Set `duration` on the stage instead of `num_sessions`:
+
+```yaml
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 16
+      duration: 1800     # hold 16 conversations open for 30 minutes
+      timeout: 2100      # safety net; must be longer than duration
+```
+
+At the deadline the stage stops dispatching and reports `COMPLETED` (not `FAILED`, which is what using `timeout` alone would give you). Sessions still running are recorded as **truncated**: counted under `num_sessions_truncated` and kept out of the session success/failure counts and duration percentiles, while the requests they completed still count.
+
+The corpus has to be large enough to fill the window, since each session is drawn once. If it runs out early the stage ends short and logs a warning; raise `duplicate_sessions_target` until the corpus covers the window. See [OTel Trace Replay](otel_trace_replay.md#bounding-a-stage-by-time) for the full description.
+
 ---
 
 ## 🏃 Running the Benchmark

--- a/inference_perf/apis/base.py
+++ b/inference_perf/apis/base.py
@@ -117,6 +117,14 @@ class SessionLifecycleMetric(BaseModel):
     num_events: int
     num_events_completed: int
     num_events_cancelled: Optional[int] = None
+    # True when the stage boundary (its configured duration, or a timeout or
+    # interrupt) cut this session short before its graph finished. The event and
+    # token counts are real, but the duration is an artifact of where the boundary
+    # fell, so summarize_sessions keeps a truncated session out of the
+    # success/failure counts and the duration percentiles and reports it under
+    # num_sessions_truncated instead. The requests it did complete still count in
+    # the request-level metrics.
+    truncated: bool = False
     # Per-session count of events whose live tool_call response was
     # detected malformed and replaced with the recorded assistant
     # message at substitution time. None when bad_tool_call_handling

--- a/inference_perf/client/server_metrics/base.py
+++ b/inference_perf/client/server_metrics/base.py
@@ -46,6 +46,10 @@ class StageRuntimeInfo(BaseModel):
     # Requests generated for the stage but never dispatched to the model
     # server because the stage ended first; > 0 marks a truncated stage.
     dropped_requests: Optional[int] = None
+    # The `duration` configured for this stage, when it was bounded by time instead of by
+    # session count. Compare against end_time - start_time to see whether the stage ran
+    # the full window or stopped early because the corpus ran out.
+    duration: Optional[float] = None
 
 
 class PerfRuntimeParameters:

--- a/inference_perf/config/loadgen/config.py
+++ b/inference_perf/config/loadgen/config.py
@@ -119,6 +119,18 @@ class TraceSessionReplayLoadStage(LoadStage):
             "cancelled and stage exits as FAILED. Optional."
         ),
     )
+    duration: Optional[float] = Field(
+        None,
+        gt=0,
+        description=(
+            "Planned run length in seconds. When reached, the stage stops dispatching and "
+            "reports COMPLETED rather than FAILED. Sessions still running are cut short and "
+            "recorded as truncated: they are kept out of the session success/failure counts "
+            "and duration percentiles, while the requests they did complete still count. "
+            "In-flight requests finish within load.stage_teardown_grace_seconds and keep "
+            "their metrics. Must be shorter than timeout when both are set. Optional."
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")
 
@@ -132,6 +144,17 @@ class TraceSessionReplayLoadStage(LoadStage):
                     f"concurrent_sessions ({self.concurrent_sessions}). "
                     f"You can't start sessions faster than the concurrency limit allows."
                 )
+
+        # duration is the planned stop; timeout is the failure safety net. If the net fires
+        # first, every duration-bounded run reports FAILED and duration silently does
+        # nothing, so require a real gap rather than only documenting one.
+        if self.duration is not None and self.timeout is not None and self.duration >= self.timeout:
+            raise ValueError(
+                f"duration ({self.duration}) must be shorter than timeout ({self.timeout}). "
+                f"duration is the planned stop and reports success; timeout is a safety limit "
+                f"that reports FAILED. With timeout <= duration the stage always fails before "
+                f"reaching its planned stop."
+            )
 
         return self
 

--- a/inference_perf/loadgen/load_generator.py
+++ b/inference_perf/loadgen/load_generator.py
@@ -552,6 +552,7 @@ class LoadGenerator:
         concurrent_sessions = stage.concurrent_sessions
         session_rate = stage.session_rate
         timeout = stage.timeout
+        duration = stage.duration
 
         # Compute this stage's session slice from the cursor
         available_sessions = total_sessions - self._session_cursor
@@ -563,11 +564,14 @@ class LoadGenerator:
         )
 
         stage_start_cursor = self._session_cursor
-        self._session_cursor += effective_num_sessions
+        # The cursor is advanced at stage end by what this stage actually consumed, not
+        # here by the planned slice: a duration-bounded stage stops well before the slice
+        # is used up, and pre-advancing would silently skip the remainder for the next
+        # stage.
 
         logger.info(
             f"Session pool: concurrent_sessions={concurrent_sessions}, "
-            f"session_rate={session_rate}, timeout={timeout}, "
+            f"session_rate={session_rate}, timeout={timeout}, duration={duration}, "
             f"num_sessions={effective_num_sessions} (corpus offset {stage_start_cursor}), "
             f"total_sessions={total_sessions}"
         )
@@ -597,6 +601,8 @@ class LoadGenerator:
                 stage_info["session_rate"] = session_rate
             if timeout is not None:
                 stage_info["timeout"] = timeout
+            if duration is not None:
+                stage_info["duration"] = duration
 
             stage_span, stage_context_dict = otel_instr.start_stage_span(stage_id, stage_info)
             logger.info(f"Started stage-level OTEL span for stage {stage_id}")
@@ -608,6 +614,13 @@ class LoadGenerator:
 
         def should_start_next_session() -> bool:
             """Check if we should start the next session."""
+            # Past the planned stop: admit nothing new. Checked here as well as at the
+            # loop exit because dispatch runs earlier in the same iteration, so without
+            # this a session could be started microseconds after the deadline only to be
+            # cut short immediately.
+            if duration is not None and time.perf_counter() - start_time >= duration:
+                return False
+
             # Check concurrency limit (0 = unlimited)
             if concurrent_sessions > 0 and len(active_session_indices) >= concurrent_sessions:
                 return False
@@ -821,6 +834,21 @@ class LoadGenerator:
                     logger.warning(f"{skipped} session(s) were skipped (failed to build or had no schedulable events)")
                 break
 
+            # Planned stop. stage_status is deliberately left RUNNING so the fall-through
+            # below marks it COMPLETED: this is a stop we asked for, not a failure. Any
+            # session still active is recorded as truncated after teardown rather than
+            # here, so that a session whose last request lands while the stage winds down
+            # is recorded as complete instead of truncated. Checked before the
+            # pending/active exit so a corpus that runs dry exactly at the deadline
+            # reports the planned stop rather than the short-corpus warning.
+            if duration is not None and time.perf_counter() - start_time >= duration:
+                logger.info(
+                    f"Stage {stage_id}: duration {duration:.1f}s reached; "
+                    f"{len(completed_session_ids)} session(s) completed, "
+                    f"{len(active_session_indices)} still running"
+                )
+                break
+
             # Check if we should stop (no more sessions to start or wait for)
             if not pending_session_indices and not active_session_indices:
                 logger.info("No more sessions to dispatch or wait for")
@@ -836,6 +864,29 @@ class LoadGenerator:
         # Clean up progress task
         if progress_ctx and stage_task:
             progress_ctx.remove_task(stage_task)
+
+        # A duration-bounded stage that exited before its deadline ran out of corpus, so
+        # it measured a shorter window than was asked for. Checked here rather than at
+        # each break so every early-exit path is covered, and only while the status is
+        # still RUNNING — on a failure the shortfall is not the story.
+        #
+        # TODO: draw from the corpus again instead of ending short, so a requested
+        # duration is met without the operator having to size the corpus by hand. Each
+        # replay needs a distinct session id (the existing `_dup{N}` convention already
+        # triggers the per-session KV-cache marker) and, because workers resolve session
+        # indices against their own fork-time snapshot of the datagen, the mapping has to
+        # be derivable from the index rather than appended at runtime.
+        if duration is not None and stage_status == StageStatus.RUNNING:
+            elapsed = time.perf_counter() - start_time
+            if elapsed < duration:
+                # Kept generic: trace replay grows a corpus with duplicate_sessions_target,
+                # synthetic_agentic pins that to None and wants num_sessions raised instead.
+                logger.warning(
+                    f"Stage {stage_id}: corpus exhausted after {elapsed:.1f}s but duration="
+                    f"{duration:.1f}s was requested - the stage ran {duration - elapsed:.1f}s short "
+                    f"of the requested window. Grow the session corpus in the data config until "
+                    f"it covers the window."
+                )
 
         # Mark stage as completed if we finished normally
         if stage_status == StageStatus.RUNNING:
@@ -854,6 +905,63 @@ class LoadGenerator:
         if not teardown.clean:
             stage_status = StageStatus.FAILED
 
+        # Sessions still active when the loop exited never reached the completion path
+        # above, so they produced no lifecycle metric and their OTEL span was never
+        # ended. Both are handled here — deliberately after teardown, because a session
+        # whose last request lands while in-flight work is winding down completes, and
+        # recording earlier would label it truncated when it is not. check_session_
+        # completed() drains the worker completion queue, so those late completions are
+        # picked up.
+        #
+        # This runs on every exit path, not just the duration one: a timeout, an
+        # interrupt or an open circuit breaker drops sessions the same way, and marking
+        # them truncated keeps them out of the success/failure counts either way. The
+        # requests they did complete are already in the request-level metrics.
+        sessions_truncated = 0
+        for session_idx in list(active_session_indices):
+            session_id = self.datagen.get_session_info(session_idx)["session_id"]
+            if session_id in completed_session_ids:
+                continue
+            session_completed = self.datagen.check_session_completed(session_id)
+            # Stamped with the boundary captured above, not the current time: the teardown
+            # tail is excluded from the metrics window, and reading the clock here would
+            # pull up to the whole grace into session_duration_sec (via a wind-down
+            # completion, which is not truncated) and into the span sessions_per_second
+            # divides by.
+            session_metric = self.datagen.build_session_metric(
+                session_id=session_id,
+                stage_id=stage_id,
+                start_time=session_dispatch_times.get(session_id, start_time_epoch),
+                end_time=end_time_epoch,
+            )
+            session_metric.dispatch_perf_counter = session_dispatch_perf_counters.get(session_id)
+            if not session_completed:
+                session_metric.truncated = True
+                sessions_truncated += 1
+            if self.session_metrics_collector:
+                self.session_metrics_collector.record_metric(session_metric)
+            if session_id in session_spans:
+                otel_instr.end_session_span(
+                    session_spans[session_id],
+                    None if session_completed else "Session cut short at stage boundary",
+                )
+                del session_spans[session_id]
+            self.datagen.cleanup_session(session_id)
+
+        if sessions_truncated:
+            logger.warning(
+                f"Stage {stage_id}: {sessions_truncated} session(s) cut short at the stage boundary; "
+                f"recorded as truncated and excluded from the session success/failure counts and "
+                f"duration percentiles"
+            )
+
+        # Advance the cursor by what this stage actually consumed from its slice, so a
+        # duration-bounded stage does not burn the sessions it never started. Derived
+        # from the pending list rather than sessions_dispatched, which does not count
+        # slots whose graph failed to build (see dispatch_session) — those were consumed
+        # and must not be retried by the next stage.
+        self._session_cursor = stage_start_cursor + (effective_num_sessions - len(pending_session_indices))
+
         # End stage-level span if trace_per_stage is enabled
         if stage_span is not None:
             error_msg = None if stage_status == StageStatus.COMPLETED else "Stage failed or timed out"
@@ -868,6 +976,7 @@ class LoadGenerator:
             status=stage_status,
             concurrency_level=concurrent_sessions,
             timeout=timeout,
+            duration=duration,
             teardown_duration=teardown_duration,
             dropped_requests=teardown.dropped_requests,
         )

--- a/inference_perf/metrics/session_collector.py
+++ b/inference_perf/metrics/session_collector.py
@@ -89,4 +89,8 @@ class SessionMetricsCollector:
             request_error = error_by_session.get(sm.session_id)
             if request_error is not None:
                 sm.error = request_error
-            sm.success = (sm.num_events_completed == sm.num_events) and (sm.error is None)
+            # Mirrors ReportGenerator._enrich_sessions: a session cut short at the stage
+            # boundary is not a failure, so it is left None rather than False. This copy
+            # has no callers today (report generation uses _enrich_sessions), but the two
+            # must not disagree if it is ever wired up.
+            sm.success = None if sm.truncated else ((sm.num_events_completed == sm.num_events) and (sm.error is None))

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -1122,6 +1122,13 @@ class ReportGenerator:
         num_sessions = len(metrics)
         num_succeeded = sum(1 for m in metrics if m.success is True)
         num_failed = sum(1 for m in metrics if m.success is False)
+        # Sessions cut short at the stage boundary. Their success is left None by
+        # _enrich_sessions so they fall out of both counts above, and their duration is
+        # censored (we know the session ran at least that long, not how long it takes)
+        # so it is excluded from the percentiles below. Event and token aggregates stay
+        # inclusive: those events really did complete.
+        num_truncated = sum(1 for m in metrics if m.truncated)
+        completed_metrics = [m for m in metrics if not m.truncated]
         total_events = sum(m.num_events for m in metrics)
         total_events_completed = sum(m.num_events_completed for m in metrics)
         total_events_cancelled = sum(m.num_events_cancelled for m in metrics if m.num_events_cancelled is not None)
@@ -1199,6 +1206,7 @@ class ReportGenerator:
             "num_sessions": num_sessions,
             "num_sessions_succeeded": num_succeeded,
             "num_sessions_failed": num_failed,
+            "num_sessions_truncated": num_truncated,
             "total_events": total_events,
             "total_events_completed": total_events_completed,
             "total_events_cancelled": total_events_cancelled,
@@ -1206,7 +1214,7 @@ class ReportGenerator:
             "total_recorded_substitutions": total_recorded_substitutions,
             **retry_summary,
             "sessions_per_second": sessions_per_second,
-            "session_duration_sec": summarize([m.duration_sec for m in metrics], percentiles),
+            "session_duration_sec": summarize([m.duration_sec for m in completed_metrics], percentiles),
             "num_events": summarize([float(m.num_events) for m in metrics], percentiles),
             "num_events_cancelled": summarize(
                 [float(m.num_events_cancelled) for m in metrics if m.num_events_cancelled is not None], percentiles
@@ -1302,7 +1310,12 @@ class ReportGenerator:
             request_error = error_by_session.get(sm.session_id)
             if request_error is not None:
                 sm.error = request_error
-            sm.success = (sm.num_events_completed == sm.num_events) and (sm.error is None)
+            # A session cut short at the stage boundary has incomplete events by
+            # construction, so the rule below would mark it failed for something the
+            # server did not do. None keeps it out of both num_sessions_succeeded and
+            # num_sessions_failed, which test `is True` / `is False`; it is reported
+            # under num_sessions_truncated instead.
+            sm.success = None if sm.truncated else ((sm.num_events_completed == sm.num_events) and (sm.error is None))
 
             # Compute TFUT
             ReportGenerator._compute_tfut(sm, requests_by_session_event.get(sm.session_id, {}))
@@ -1405,6 +1418,7 @@ class ReportGenerator:
                         "stage_id": stage_id,
                         "status": status_str,
                         "timeout_configured": stage_info.timeout,
+                        "duration_configured": stage_info.duration,
                         "actual_duration": stage_info.end_time - stage_info.start_time,
                         "teardown_duration": stage_info.teardown_duration,
                         "dropped_requests": stage_info.dropped_requests,

--- a/tests/required/config/loadgen/test_load_config.py
+++ b/tests/required/config/loadgen/test_load_config.py
@@ -103,6 +103,42 @@ def test_trace_session_replay_stage_forbids_extra_fields() -> None:
         TraceSessionReplayLoadStage(concurrent_sessions=2, bogus_field=1)  # type: ignore[call-arg]
 
 
+def test_trace_session_replay_stage_duration_defaults_to_none() -> None:
+    assert TraceSessionReplayLoadStage(concurrent_sessions=2).duration is None
+
+
+def test_trace_session_replay_stage_duration_alone_is_valid() -> None:
+    # timeout is optional: duration on its own bounds load generation, and the
+    # teardown grace bounds the wind-down that follows.
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=1800)
+    assert stage.duration == 1800
+    assert stage.timeout is None
+
+
+def test_trace_session_replay_stage_duration_shorter_than_timeout_is_valid() -> None:
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=1800, timeout=2100)
+    assert stage.duration == 1800
+    assert stage.timeout == 2100
+
+
+def test_trace_session_replay_stage_duration_cannot_exceed_timeout() -> None:
+    # timeout would fire before the planned stop, reporting FAILED for a run that
+    # asked to end.
+    with pytest.raises(ValueError, match="must be shorter than timeout"):
+        TraceSessionReplayLoadStage(concurrent_sessions=4, duration=2100, timeout=1800)
+
+
+def test_trace_session_replay_stage_duration_cannot_equal_timeout() -> None:
+    # Equal is not shorter: the two deadlines coincide and the failure path wins.
+    with pytest.raises(ValueError, match="must be shorter than timeout"):
+        TraceSessionReplayLoadStage(concurrent_sessions=4, duration=1800, timeout=1800)
+
+
+def test_trace_session_replay_stage_duration_must_be_positive() -> None:
+    with pytest.raises(ValidationError):
+        TraceSessionReplayLoadStage(concurrent_sessions=4, duration=0)
+
+
 # --- LoadConfig cross-stage validation -----------------------------------
 
 

--- a/tests/required/loadgen/test_run_session_stage_duration.py
+++ b/tests/required/loadgen/test_run_session_stage_duration.py
@@ -1,0 +1,346 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`duration` on a trace_session_replay stage: stopping on time, and accounting for it.
+
+A stage could only be bounded by session count before this; the nearest time-based
+option was ``timeout``, which is a failure mechanism, so an intended stop was recorded
+as FAILED and the sessions in flight at the cutoff produced no lifecycle metric at all.
+These tests pin the two halves of the fix: the stage stops on its own deadline and still
+reports COMPLETED, and the sessions it cut short are recorded as truncated rather than
+dropped.
+
+``run_session_stage`` is driven directly with a scripted SessionGenerator and mock IPC —
+no worker processes and no server. ``sleep`` is patched out so the dispatch loop spins
+freely, which is how the existing timeout coverage keeps a wall-clock deadline fast; the
+assertions are about ordering and status, never about exact timings, so a slow machine
+makes these slower rather than flaky.
+"""
+
+import multiprocessing as mp
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from inference_perf.apis import LazyLoadInferenceAPIData, SessionLifecycleMetric
+from inference_perf.client.server_metrics.base import StageStatus
+from inference_perf.config import APIConfig, APIType, DataConfig, LoadConfig, LoadType, TraceSessionReplayLoadStage
+from inference_perf.datagen import SessionGenerator
+from inference_perf.loadgen.load_generator import LoadGenerator
+from inference_perf.metrics import SessionMetricsCollector
+
+
+class ScriptedSessionGenerator(SessionGenerator):
+    """A corpus of trivial sessions whose completion the test controls.
+
+    Each session holds one event and completes after ``polls_to_complete`` checks, so a
+    stage makes steady progress without any real request being sent. ``activated`` records
+    dispatch order, which is what the admission assertions read.
+    """
+
+    def __init__(self, num_sessions: int, polls_to_complete: Optional[int] = 2) -> None:
+        """``polls_to_complete=None`` means no session ever finishes on its own.
+
+        That is how a stage is held open until its deadline without depending on how fast
+        the loop happens to spin: the pool fills to ``concurrent_sessions`` and stays full,
+        so admission is capped by the pool rather than by throughput.
+        """
+        super().__init__(APIConfig(type=APIType.Chat), DataConfig(), None)
+        self._num_sessions = num_sessions
+        self._polls_to_complete = polls_to_complete
+        self.activated: List[str] = []
+        self.cleaned_up: List[str] = []
+        self._polls: Dict[str, int] = {}
+        self._never_completes: set[str] = set()
+
+    def never_complete(self, session_id: str) -> None:
+        """Keep one session active for the whole stage, so it is still running at the cutoff."""
+        self._never_completes.add(session_id)
+
+    # --- SessionGenerator surface ---------------------------------------
+
+    def get_supported_apis(self) -> List[APIType]:
+        return [APIType.Chat]
+
+    def get_session_count(self) -> int:
+        return self._num_sessions
+
+    def get_session_info(self, session_index: int) -> Dict[str, Any]:
+        return {
+            "session_id": f"s{session_index}",
+            "file_path": f"s{session_index}.json",
+            "source_id": f"s{session_index}.json",
+            "session_index": session_index,
+            "num_events": 1,
+        }
+
+    def get_session_event_indices(self, session_index: int) -> List[int]:
+        return [0]
+
+    def get_session_events(self, session_index: int) -> List[LazyLoadInferenceAPIData]:
+        return [LazyLoadInferenceAPIData(data_index=session_index, preferred_worker_id=-1)]
+
+    def activate_session(self, session_id: str) -> None:
+        self.activated.append(session_id)
+        self._polls[session_id] = 0
+
+    def check_session_completed(self, session_id: str) -> bool:
+        if self._polls_to_complete is None or session_id in self._never_completes:
+            return False
+        self._polls[session_id] = self._polls.get(session_id, 0) + 1
+        return self._polls[session_id] >= self._polls_to_complete
+
+    def get_session_state(self, session_id: str) -> Any:
+        return None
+
+    def build_session_metric(
+        self, session_id: str, stage_id: int, start_time: float, end_time: float
+    ) -> SessionLifecycleMetric:
+        completed = session_id not in self._never_completes
+        return SessionLifecycleMetric(
+            session_id=session_id,
+            stage_id=stage_id,
+            file_path=f"{session_id}.json",
+            start_time=start_time,
+            end_time=end_time,
+            duration_sec=end_time - start_time,
+            num_events=1,
+            num_events_completed=1 if completed else 0,
+        )
+
+    def cleanup_session(self, session_id: str) -> None:
+        self.cleaned_up.append(session_id)
+
+
+def _load_generator(datagen: SessionGenerator) -> tuple[LoadGenerator, SessionMetricsCollector]:
+    collector = SessionMetricsCollector()
+    config = LoadConfig(type=LoadType.TRACE_SESSION_REPLAY, stages=[], num_workers=1)
+    return LoadGenerator(datagen, config, collector), collector
+
+
+async def _run_stage(
+    loadgen: LoadGenerator,
+    stage: TraceSessionReplayLoadStage,
+    stage_id: int = 0,
+) -> MagicMock:
+    """Drive one session stage with mock IPC. Returns the request queue for inspection."""
+    request_queue = MagicMock()
+    # Real shared counters: run_session_stage takes their locks.
+    finished = mp.Value("i", 0)
+    active = mp.Value("i", 0)
+    request_phase = mp.Event()
+
+    # `sleep` patched so the dispatch loop spins instead of yielding for real time; the
+    # stage's own deadline still comes from the wall clock.
+    with patch("inference_perf.loadgen.load_generator.sleep", new_callable=AsyncMock):
+        await loadgen.run_session_stage(
+            stage_id,
+            stage,
+            request_queue,
+            active,
+            finished,
+            request_phase,
+            cancel_signal=None,
+            progress_ctx=None,
+        )
+    return request_queue
+
+
+@pytest.mark.asyncio
+async def test_duration_bounded_stage_completes_rather_than_fails(caplog: pytest.LogCaptureFixture) -> None:
+    """A stage that stops on its own deadline is COMPLETED, not FAILED.
+
+    This is the whole point of the field: `timeout` already stopped a stage on time, but
+    recorded it as a failure, so an intended stop was indistinguishable from a fault.
+    """
+    datagen = ScriptedSessionGenerator(num_sessions=5000, polls_to_complete=None)
+    loadgen, _ = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=0.2)
+
+    with caplog.at_level("INFO"):
+        await _run_stage(loadgen, stage)
+
+    # Assert which exit fired, so the test cannot pass by the stage merely running out of
+    # sessions before the deadline.
+    assert "duration 0.2s reached" in caplog.text
+    info = loadgen.stage_runtime_info[0]
+    assert info.status == StageStatus.COMPLETED
+    assert info.duration == 0.2
+
+
+@pytest.mark.asyncio
+async def test_no_session_is_admitted_after_the_deadline() -> None:
+    """Nothing new starts once the deadline passes, so the stage stops offering load.
+
+    Dispatch runs earlier in the loop than the exit check, so without the admission guard
+    a session could be started just after the deadline only to be cut short at once.
+    """
+    # No session finishes on its own, so the pool fills to 4 and stays full: admission is
+    # capped by the pool, and the stage can only end on its deadline.
+    datagen = ScriptedSessionGenerator(num_sessions=5000, polls_to_complete=None)
+    loadgen, _ = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=0.2)
+
+    await _run_stage(loadgen, stage)
+
+    assert datagen.activated == ["s0", "s1", "s2", "s3"]
+    assert loadgen.stage_runtime_info[0].status == StageStatus.COMPLETED
+    # Every session that started was accounted for and released.
+    assert len(datagen.cleaned_up) == len(datagen.activated)
+
+
+@pytest.mark.asyncio
+async def test_sessions_running_at_the_deadline_are_recorded_as_truncated() -> None:
+    """A session still running at the cutoff produces a metric marked truncated.
+
+    Before this, session metrics were only built on completion, so the sessions in flight
+    at the boundary produced nothing at all — and because a long session is likelier to be
+    mid-flight at any instant, the ones lost were disproportionately the long ones.
+    """
+    datagen = ScriptedSessionGenerator(num_sessions=8)
+    datagen.never_complete("s0")  # still running when the deadline lands
+    loadgen, collector = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=0.2)
+
+    await _run_stage(loadgen, stage)
+
+    metrics = {m.session_id: m for m in collector.get_metrics()}
+    assert "s0" in metrics, "a session cut short must still be reported"
+    assert metrics["s0"].truncated is True
+    # Sessions that finished normally are untouched.
+    assert all(not m.truncated for sid, m in metrics.items() if sid != "s0")
+
+
+@pytest.mark.asyncio
+async def test_boundary_rows_carry_the_tfut_dispatch_anchor() -> None:
+    """Rows recorded at the boundary get the same TFUT anchor as the in-loop path.
+
+    `_compute_tfut` needs `dispatch_perf_counter`; without it the session reports
+    `no_dispatch_anchor` and drops out of `tfut_sec`. That loses a valid observation,
+    since a session's first user-facing event usually completes long before the deadline
+    falls, and first-token latency is much of what a duration-bounded run measures.
+    """
+    datagen = ScriptedSessionGenerator(num_sessions=5000, polls_to_complete=None)
+    loadgen, collector = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=0.2)
+
+    await _run_stage(loadgen, stage)
+
+    metrics = collector.get_metrics()
+    assert metrics, "the boundary rows must be recorded at all"
+    assert all(m.dispatch_perf_counter is not None for m in metrics)
+
+
+@pytest.mark.asyncio
+async def test_boundary_rows_end_at_the_stage_boundary_not_after_teardown() -> None:
+    """Boundary rows are stamped with the end of the load window, not the current time.
+
+    Teardown is excluded from the metrics window, so reading the clock while recording
+    these rows would pull up to the whole teardown grace into two published numbers: the
+    `session_duration_sec` percentiles (via a wind-down completion, which is not marked
+    truncated) and the span `summarize_sessions` divides by for `sessions_per_second`.
+    """
+    datagen = ScriptedSessionGenerator(num_sessions=5000, polls_to_complete=None)
+    loadgen, collector = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=0.2)
+
+    await _run_stage(loadgen, stage)
+
+    stage_end = loadgen.stage_runtime_info[0].end_time
+    metrics = collector.get_metrics()
+    assert metrics
+    # Exactly the stage boundary, not merely close to it: both come from the same stamp.
+    assert all(m.end_time == stage_end for m in metrics)
+
+
+@pytest.mark.asyncio
+async def test_completed_sessions_are_not_marked_truncated() -> None:
+    """A stage that runs its corpus out before the deadline truncates nothing."""
+    datagen = ScriptedSessionGenerator(num_sessions=4)
+    loadgen, collector = _load_generator(datagen)
+    # Generous window: all four sessions finish well inside it.
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=30)
+
+    await _run_stage(loadgen, stage)
+
+    metrics = collector.get_metrics()
+    assert len(metrics) == 4
+    assert all(not m.truncated for m in metrics)
+    assert loadgen.stage_runtime_info[0].status == StageStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_cursor_advances_only_by_sessions_actually_consumed() -> None:
+    """The session cursor must not skip sessions the stage never started.
+
+    The cursor used to advance by the planned slice up front, which was right when a stage
+    always ran its whole slice. A duration-bounded stage stops early, so pre-advancing
+    would silently burn the remainder and the next stage would start too far in.
+    """
+    datagen = ScriptedSessionGenerator(num_sessions=5000, polls_to_complete=None)
+    loadgen, _ = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=4, duration=0.2)
+
+    await _run_stage(loadgen, stage)
+
+    # Only the 4 sessions the pool admitted are consumed; the other 4996 remain for the
+    # next stage. Pre-advancing would have left the cursor at 5000.
+    assert loadgen._session_cursor == 4
+    assert loadgen._session_cursor == len(datagen.activated)
+
+
+@pytest.mark.asyncio
+async def test_cursor_still_covers_the_whole_slice_when_the_stage_runs_out() -> None:
+    """Without duration, the cursor lands exactly where it did before this change."""
+    datagen = ScriptedSessionGenerator(num_sessions=5)
+    loadgen, _ = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=2, num_sessions=5)
+
+    await _run_stage(loadgen, stage)
+
+    assert loadgen._session_cursor == 5
+
+
+@pytest.mark.asyncio
+async def test_short_corpus_warns_that_the_window_was_not_met(caplog: pytest.LogCaptureFixture) -> None:
+    """Running out of corpus before the deadline is reported, not silently accepted.
+
+    The stage still succeeded — nothing failed — but it measured a shorter window than was
+    asked for, which would otherwise be invisible.
+    """
+    datagen = ScriptedSessionGenerator(num_sessions=3)
+    loadgen, _ = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=2, duration=60)
+
+    with caplog.at_level("WARNING"):
+        await _run_stage(loadgen, stage)
+
+    assert "corpus exhausted" in caplog.text
+    assert loadgen.stage_runtime_info[0].status == StageStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_stage_without_duration_is_unchanged() -> None:
+    """A count-bounded stage behaves exactly as before: no duration, no truncation."""
+    datagen = ScriptedSessionGenerator(num_sessions=6)
+    loadgen, collector = _load_generator(datagen)
+    stage = TraceSessionReplayLoadStage(concurrent_sessions=3, num_sessions=6)
+
+    await _run_stage(loadgen, stage)
+
+    info = loadgen.stage_runtime_info[0]
+    assert info.status == StageStatus.COMPLETED
+    assert info.duration is None
+    assert len(collector.get_metrics()) == 6
+    assert all(not m.truncated for m in collector.get_metrics())

--- a/tests/required/reportgen/test_session_and_prometheus_reports.py
+++ b/tests/required/reportgen/test_session_and_prometheus_reports.py
@@ -114,6 +114,7 @@ def _stage_info(
     end_time: float = 10.0,
     rate: float = 2.0,
     timeout: Optional[float] = None,
+    duration: Optional[float] = None,
     concurrency_level: Optional[int] = None,
 ) -> StageRuntimeInfo:
     return StageRuntimeInfo(
@@ -123,6 +124,7 @@ def _stage_info(
         end_time=end_time,
         status=status,
         timeout=timeout,
+        duration=duration,
         concurrency_level=concurrency_level,
     )
 
@@ -297,12 +299,38 @@ class TestGenerateSessionReports:
             "stage_id": 0,
             "status": "COMPLETED",
             "timeout_configured": 30.0,
+            # None for a count-bounded stage; set when the stage was bounded by time.
+            "duration_configured": None,
             "actual_duration": 6.0,
             "teardown_duration": None,
             "dropped_requests": None,
             "concurrent_sessions": 4,
             "session_rate": 2.0,
         }
+
+    def test_duration_bounded_stage_reports_the_window_it_asked_for(self) -> None:
+        """A time-bounded stage reports COMPLETED plus the duration it was given.
+
+        duration_configured next to actual_duration is what tells a reader of the report
+        whether the stage ran its full window or ended early because the corpus ran out —
+        both of which report COMPLETED.
+        """
+        gen = _make_generator()
+        runtime = _runtime({0: _stage_info(0, start_time=1.0, end_time=7.0, timeout=30.0, duration=20.0, concurrency_level=4)})
+
+        reports = gen.generate_session_reports(
+            [_sess(stage_id=0)],
+            SessionLifecycleReportConfig(summary=False, per_stage=True, per_session=False),
+            PERCENTILES,
+            runtime,
+            100,
+        )
+
+        metadata = reports[0].contents["stage_metadata"]
+        assert metadata["status"] == "COMPLETED"
+        assert metadata["duration_configured"] == 20.0
+        # Ran 6s of a 20s window: the corpus ran out before the deadline.
+        assert metadata["actual_duration"] == 6.0
 
     def test_a_stage_with_no_runtime_info_reports_measurements_without_metadata(self) -> None:
         gen = _make_generator()

--- a/tests/required/reportgen/test_summarize_requests.py
+++ b/tests/required/reportgen/test_summarize_requests.py
@@ -732,3 +732,96 @@ def test_summarize_requests_handles_null_prompt_tokens_details() -> None:
     assert prompt_tokens["total"] == pytest.approx(10.0)
     assert prompt_tokens["cached"] == pytest.approx(0.0)
     assert prompt_tokens["uncached"] == pytest.approx(10.0)
+
+
+# --- truncated sessions (stage duration boundary) ------------------------
+
+
+def _truncated_session(session_id: str = "cut", num_events: int = 5, num_events_completed: int = 2) -> SessionLifecycleMetric:
+    """A session cut short at the stage boundary: fewer events done than the graph holds."""
+    return SessionLifecycleMetric(
+        session_id=session_id,
+        stage_id=0,
+        file_path=f"{session_id}.json",
+        start_time=0.0,
+        end_time=7.0,
+        duration_sec=7.0,
+        num_events=num_events,
+        num_events_completed=num_events_completed,
+        truncated=True,
+    )
+
+
+def test_enrich_sessions_truncated_is_neither_success_nor_failure() -> None:
+    """A truncated session gets success=None so it is not counted as a server failure.
+
+    Its events are incomplete by construction (the stage boundary stopped it), so the
+    normal `num_events_completed == num_events` rule would report it as FAILED.
+    """
+    truncated = _truncated_session()
+    ReportGenerator._enrich_sessions(None, [truncated], [])  # type: ignore[arg-type]
+
+    assert truncated.success is None
+
+    summary = ReportGenerator.summarize_sessions(None, [truncated], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+    assert summary["num_sessions"] == 1
+    assert summary["num_sessions_succeeded"] == 0
+    assert summary["num_sessions_failed"] == 0
+    assert summary["num_sessions_truncated"] == 1
+
+
+def test_enrich_sessions_untruncated_still_fails_on_incomplete_events() -> None:
+    """The truncated guard must not mask a genuinely incomplete session."""
+    incomplete = _truncated_session(session_id="broken")
+    incomplete.truncated = False
+    ReportGenerator._enrich_sessions(None, [incomplete], [])  # type: ignore[arg-type]
+
+    assert incomplete.success is False
+
+
+def test_summarize_sessions_excludes_truncated_from_duration_percentiles() -> None:
+    """Truncated durations are censored, so they must not enter session_duration_sec.
+
+    A session stopped at the boundary ran *at least* that long; counting it as if it
+    finished drags every percentile down.
+    """
+    complete = _cache_session("done")
+    complete.duration_sec = 100.0
+    cut = _truncated_session("cut")
+    cut.duration_sec = 7.0
+
+    ReportGenerator._enrich_sessions(None, [complete, cut], [])  # type: ignore[arg-type]
+    summary = ReportGenerator.summarize_sessions(None, [complete, cut], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+
+    # Only the completed session's 100s contributes.
+    assert summary["session_duration_sec"]["mean"] == pytest.approx(100.0)
+    assert summary["session_duration_sec"]["max"] == pytest.approx(100.0)
+    assert summary["num_sessions_truncated"] == 1
+
+
+def test_summarize_sessions_all_truncated_gives_null_duration_not_crash() -> None:
+    """A stage where every session was cut short reports None, not an exception."""
+    sessions = [_truncated_session("a"), _truncated_session("b")]
+    ReportGenerator._enrich_sessions(None, sessions, [])  # type: ignore[arg-type]
+
+    summary = ReportGenerator.summarize_sessions(None, sessions, DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+
+    assert summary["session_duration_sec"] is None
+    assert summary["num_sessions_truncated"] == 2
+
+
+def test_summarize_sessions_truncated_events_still_counted() -> None:
+    """Event aggregates stay inclusive: a truncated session's completed events are real."""
+    cut = _truncated_session("cut", num_events=5, num_events_completed=2)
+    ReportGenerator._enrich_sessions(None, [cut], [])  # type: ignore[arg-type]
+
+    summary = ReportGenerator.summarize_sessions(None, [cut], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+
+    assert summary["total_events"] == 5
+    assert summary["total_events_completed"] == 2
+
+
+def test_summarize_sessions_truncated_defaults_to_zero() -> None:
+    """Runs with no truncation report 0, so the key is always present in the report."""
+    summary = ReportGenerator.summarize_sessions(None, [_cache_session("s1")], DEFAULT_PERCENTILES)  # type: ignore[arg-type]
+    assert summary["num_sessions_truncated"] == 0


### PR DESCRIPTION
Implements #763.

## Problem

A `trace_session_replay` stage can only be bounded by session count. The closest time-based option is the stage `timeout`, but that is a failure mechanism, so using it to express an intended stop means:

- **The run is reported as a failure.** A stage that reaches its timeout is recorded as `FAILED`, so a stop we asked for is indistinguishable from something having gone wrong.
- **The sessions in flight at the cutoff drop out of the report.** Session metrics are only built when a session completes, so those sessions produce nothing at all. Longer sessions are the likeliest to be running at any given moment, so the ones lost are disproportionately the long ones.

## What this adds

- `duration` on `TraceSessionReplayLoadStage`, with a validator requiring it to be shorter than `timeout` when both are set. If the safety net could fire first, every duration-bounded run would report `FAILED` and the field would silently do nothing.
- An admission check so no new session starts past the deadline, and a loop exit that leaves the stage status `COMPLETED`.
- Sessions still running at the boundary are recorded instead of dropped, marked `truncated: true` and counted under a new `num_sessions_truncated`. They are deliberately kept out of the session success/failure counts and the `session_duration_sec` percentiles — a truncated session's events are incomplete by construction, so the normal rule would report it as a server failure, and its duration is censored. The requests those sessions did complete still count in the request-level metrics.
- This accounting runs on **every** exit path, not just the duration one: a timeout, an interrupt or an open circuit breaker drops sessions the same way. `truncated` keeps them out of the success/failure counts either way, so no existing metric changes meaning, though `num_sessions` and the event totals grow for stages that previously dropped sessions silently.
- `duration_configured` in `stage_metadata`, so a report read without its config shows whether the full window ran.
- A fix to the session cursor: it now advances by the sessions a stage actually consumed rather than its planned slice. Pre-advancing was correct while a stage always ran its whole slice; a duration-bounded stage stops early, and pre-advancing would silently skip the remainder for the next stage.

## Semantics, and how they compare to aiperf

AIPerf's `--benchmark-duration` stops issuing new requests, lets in-flight work finish within a grace, and does not treat a truncated conversation as an error. This matches that: the cutoff is at the request level, sessions are not run to completion, and truncation is not a failure.

The one place we go further is recording the truncated sessions, because inference-perf publishes a session lifecycle report that AIPerf does not have in the same shape — so for us "not recorded" means invisible, which is the second half of the problem above.

## Relationship to #662

Independent of #662, and better with it. Nothing is in flight when the loop exits on the happy path, so this works standalone. #662's `stage_teardown_grace_seconds` lets in-flight requests finish and keep their metrics, which means more of the cut-short sessions record as complete rather than truncated — the truncated-session accounting here is placed **after** teardown for exactly that reason.

Two notes for the rebase, since #662 touches the same files:
- It replaces the post-loop teardown block; this PR's accounting belongs after its `_teardown_stage(...)` call and before its `StageRuntimeInfo`, which is where it already sits relative to the current teardown.
- The `duration` field description deliberately does not mention `stage_teardown_grace_seconds`, since that field does not exist yet. Worth adding once #662 lands.
- `test_stage_metadata_leads_the_report_and_carries_the_run_shape` pins the exact `stage_metadata` dict, so #662 will hit the same test this PR updates.

## Known limitation

`session_duration_sec` still covers only sessions that finished inside the window, so the long tail is understated. A drain window that lets active sessions finish their remaining turns would address it; worth doing if a real run shows it matters.

## Out of scope

- **Corpus reuse.** A stage draws each session once, so a duration-bounded run needs a corpus large enough to cover the window; `duplicate_sessions_target` does that today, and a stage that runs out early logs how far short it fell. Drawing from the corpus again is the follow-up, with a `TODO` in the code covering why the mapping has to be derivable from the session index rather than appended at runtime (workers resolve indices against their own fork-time snapshot of the datagen).
- `constant`, `poisson` and `concurrent` are unchanged. If `duration` is extended to them later, note that they pre-generate a prompt pool sized from `rate x duration` and consume it by position, so a time-based run could ask for more prompts than the pool holds.

## Testing

21 new tests. `run_session_stage` is driven directly with a scripted `SessionGenerator` and mock IPC — no worker processes, no server — following the pattern the existing timeout coverage uses. Assertions are on ordering and status rather than exact timings, so a slow machine makes them slower rather than flaky.

- `tests/required/loadgen/test_run_session_stage_duration.py` (8): the stage completes rather than fails and proves *which* exit fired; nothing is admitted after the deadline; a session running at the cutoff is recorded as truncated; a stage that finishes its corpus truncates nothing; the cursor advances by sessions consumed; a count-bounded stage is unchanged; the short-corpus warning fires.
- `tests/required/config/loadgen/test_load_config.py` (6): the `duration`/`timeout` ordering rules.
- `tests/required/reportgen/` (7): truncated is neither success nor failure, a genuinely incomplete session still fails, truncated durations are excluded, an all-truncated stage reports null rather than crashing, event totals stay inclusive, and `duration_configured` is surfaced.

`pytest tests/required/` (925 passed), `ruff check`, `ruff format --check`, `mypy --strict`, and `pdm run check:cli-flags` all pass locally.

Note that `docs/cli_flags.md` needs no change: `--load.stages` is a single JSON blob, so individual stage fields never appear there.
