### PR TITLE
feat(datagen): support the filter config key in weka replay

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -169,6 +169,11 @@ Security: Filter expressions use eval() and should only contain trusted input. |
   - String: 'username/dataset-name'
   - Dict: {'path': 'username/dataset-name', 'revision': 'main', 'split': 'train'}
 Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
+| `--data.weka_trace_replay.filter` | str | Lambda expression to filter traces. Applied uniformly to all data sources.
+Receives the trace dict plus derived aggregates: max_tokens (largest
+single-request input+output), total_tokens, num_turns.
+Example: "lambda x: x['max_tokens'] < 262144"
+Security: Filter expressions use eval() and should only contain trusted input. |
 | `--data.weka_trace_replay.trace_idle_gap_cap_seconds` | float | Cap idle timing gaps between turns in seconds |
 | `--data.weka_trace_replay.ignore_trace_delays` | boolean | Ignore delays/delays from original trace and run back-to-back |
 | `--data.weka_trace_replay.use_think_time_only` | boolean | Only use think_time attribute instead of timestamps |

--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -171,7 +171,8 @@ Security: Filter expressions use eval() and should only contain trusted input. |
 Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--data.weka_trace_replay.filter` | str | Lambda expression to filter traces. Applied uniformly to all data sources.
 Receives the trace dict plus derived aggregates: max_tokens (largest
-single-request input+output), total_tokens, num_turns.
+single-request input+output), total_tokens, and num_turns, which counts
+flattened requests, so a subagent making three calls contributes three.
 Example: "lambda x: x['max_tokens'] < 262144"
 Security: Filter expressions use eval() and should only contain trusted input. |
 | `--data.weka_trace_replay.trace_idle_gap_cap_seconds` | float | Cap idle timing gaps between turns in seconds |

--- a/docs/weka_trace_replay.md
+++ b/docs/weka_trace_replay.md
@@ -41,7 +41,13 @@ data:
   type: weka_trace_replay
   weka_trace_replay:
     hf_dataset_path: "semianalysisai/cc-traces-weka-with-subagents-060826-256k"
-    num_dataset_entries: 500
+    num_dataset_entries: 500 # Caps accepted traces, not lines scanned
+    # filter: "lambda x: x['max_tokens'] < 262144" # Keep traces that fit a context window.
+                          # Derived per trace: max_tokens (largest single-request
+                          # input+output), total_tokens, num_turns (flattened
+                          # request count, so a subagent's three calls count as
+                          # three). Uses eval(), so treat the expression as
+                          # trusted input.
     use_static_model: true
     static_model_name: "mock-model"
     default_block_size: 64

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -269,6 +269,17 @@ class WekaTraceReplayConfig(SessionReplayConfig):
             "Any extra keys in the dict are passed as kwargs to datasets.load_dataset()."
         ),
     )
+    filter: Optional[str] = Field(
+        None,
+        description=(
+            "Lambda expression to filter traces. Applied uniformly to all data sources.\n"
+            "Receives the trace dict plus derived aggregates: max_tokens (largest\n"
+            "single-request input+output), total_tokens, and num_turns, which counts\n"
+            "flattened requests, so a subagent making three calls contributes three.\n"
+            "Example: \"lambda x: x['max_tokens'] < 262144\"\n"
+            "Security: Filter expressions use eval() and should only contain trusted input."
+        ),
+    )
     trace_idle_gap_cap_seconds: float = Field(60.0, description="Cap idle timing gaps between turns in seconds")
     ignore_trace_delays: bool = Field(False, description="Ignore delays/delays from original trace and run back-to-back")
     use_think_time_only: bool = Field(False, description="Only use think_time attribute instead of timestamps")

--- a/inference_perf/datagen/replay/otel_trace_replay_datagen.py
+++ b/inference_perf/datagen/replay/otel_trace_replay_datagen.py
@@ -62,13 +62,14 @@ import logging
 import random
 from multiprocessing.managers import SyncManager
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 from datasets import load_dataset, Dataset
 from inference_perf.config import APIConfig, DataConfig
 from inference_perf.datagen.replay.replay_graph_session_datagen import (
     ReplaySession,
     ReplayGraphSessionGeneratorBase,
 )
+from inference_perf.datagen.replay.otel_trace_utils import _compile_filter
 from inference_perf.datagen.replay.otel_trace_to_replay_graph import (
     build_raw_calls,
     build_graph,
@@ -204,37 +205,6 @@ def _normalize_file_trace(data: Dict[str, Any], source_name: str, source_path: s
             normalized["total_tokens"] = total_tokens
 
     return normalized
-
-
-def _compile_filter(filter_expr: Optional[str]) -> Optional[Callable[..., Any]]:
-    """Compile a filter expression once for reuse.
-
-    Args:
-        filter_expr: Lambda expression string to evaluate (e.g., "lambda x: x['benchmark'] == 'gsm8k'"),
-                    or None for no filtering
-
-    Returns:
-        Compiled filter function, or None if no filter expression provided
-
-    Raises:
-        ValueError: If filter expression is malformed or not callable
-
-    Security Note:
-        This uses eval() on user-provided input. This is acceptable for a local benchmarking tool
-        where the operator controls the configuration, but the filter expression should be treated
-        as trusted input only. Do not expose this to untrusted users.
-    """
-    if not filter_expr:
-        return None
-    try:
-        filter_func = eval(filter_expr, {"__builtins__": {}}, {})
-        if not callable(filter_func):
-            raise ValueError(f"Filter expression must be a callable (lambda), got: {type(filter_func).__name__}")
-        return cast(Callable[..., Any], filter_func)
-    except SyntaxError as e:
-        raise ValueError(f"Invalid filter expression syntax '{filter_expr}': {e}") from e
-    except Exception as e:
-        raise ValueError(f"Failed to compile filter expression '{filter_expr}': {e}") from e
 
 
 def _load_trace_file(

--- a/inference_perf/datagen/replay/otel_trace_utils.py
+++ b/inference_perf/datagen/replay/otel_trace_utils.py
@@ -26,7 +26,7 @@ Supports:
 """
 
 import json
-from typing import Dict, List, Any, Union, Optional
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 
 def reconstruct_llm_output(response_data: Union[str, Dict[str, Any], List[Any]]) -> str:
@@ -444,6 +444,39 @@ def reconstruct_input_with_token_estimate(
 
 
 # Example usage and testing
+
+
+def _compile_filter(filter_expr: Optional[str]) -> Optional[Callable[..., Any]]:
+    """Compile a filter expression once for reuse.
+
+    Args:
+        filter_expr: Lambda expression string to evaluate (e.g., "lambda x: x['benchmark'] == 'gsm8k'"),
+                    or None for no filtering
+
+    Returns:
+        Compiled filter function, or None if no filter expression provided
+
+    Raises:
+        ValueError: If filter expression is malformed or not callable
+
+    Security Note:
+        This uses eval() on user-provided input. This is acceptable for a local benchmarking tool
+        where the operator controls the configuration, but the filter expression should be treated
+        as trusted input only. Do not expose this to untrusted users.
+    """
+    if not filter_expr:
+        return None
+    try:
+        filter_func = eval(filter_expr, {"__builtins__": {}}, {})
+        if not callable(filter_func):
+            raise ValueError(f"Filter expression must be a callable (lambda), got: {type(filter_func).__name__}")
+        return cast(Callable[..., Any], filter_func)
+    except SyntaxError as e:
+        raise ValueError(f"Invalid filter expression syntax '{filter_expr}': {e}") from e
+    except Exception as e:
+        raise ValueError(f"Failed to compile filter expression '{filter_expr}': {e}") from e
+
+
 if __name__ == "__main__":
     print("=" * 80)
     print("LLM Output Reconstruction Examples")

--- a/inference_perf/datagen/replay/weka_trace_replay_datagen.py
+++ b/inference_perf/datagen/replay/weka_trace_replay_datagen.py
@@ -78,6 +78,7 @@ from inference_perf.datagen.replay.replay_graph_session_datagen import (
     ReplaySession,
     ReplayGraphSessionGeneratorBase,
 )
+from inference_perf.datagen.replay.otel_trace_utils import _compile_filter
 from inference_perf.datagen.replay.otel_trace_to_replay_graph import (
     DEPENDENCY_TYPE,
     RawCall,
@@ -89,6 +90,10 @@ from inference_perf.datagen.replay.replay_graph_types import ComplexReplayMessag
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 logger = logging.getLogger(__name__)
+
+
+class FilterExpressionError(ValueError):
+    """A filter expression that fails to evaluate; never skippable as bad input data."""
 
 
 # =============================================================================
@@ -872,9 +877,48 @@ class WekaTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
         sessions = self._build_sessions_from_traces(traces)
         self.initialize_sessions(sessions)
 
+    @staticmethod
+    def _augment_for_filter(blob: Dict[str, Any]) -> Dict[str, Any]:
+        requests = blob.get("requests") or []
+        flat: List[Dict[str, Any]] = []
+        for entry in requests:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("type") == "subagent":
+                flat.extend(r for r in (entry.get("requests") or []) if isinstance(r, dict))
+            else:
+                flat.append(entry)
+
+        # both halves occupy the context window, as in the OTel datagen
+        request_tokens = [(r.get("in") or 0) + (r.get("out") or 0) for r in flat]
+        derived = {
+            "max_tokens": max(request_tokens, default=0),
+            "total_tokens": sum(request_tokens),
+            "num_turns": len(flat),
+        }
+        return {**blob, **derived}
+
+    def _keep_trace(self, augmented: Dict[str, Any], filter_func: Optional[Any]) -> bool:
+        """Evaluate the filter against an already-augmented trace.
+
+        Augmentation happens in the caller so malformed trace data fails as
+        invalid input rather than being blamed on the filter expression.
+        """
+        if filter_func is None:
+            return True
+        try:
+            return bool(filter_func(augmented))
+        except Exception as e:
+            # a bad expression is a config error, so it must outrank skip_invalid_files
+            raise FilterExpressionError(f"Filter expression failed on trace {augmented.get('id')!r}: {e!r}") from e
+
     def _load_weka_traces(self) -> List[WekaTrace]:
         """Loads traces from directories, files, or Hugging Face dataset."""
         raw_traces: List[WekaTrace] = []
+        filter_func = _compile_filter(self.weka_config.filter)
+        if filter_func:
+            logger.info(f"Using filter expression: {self.weka_config.filter}")
+        n_filtered = 0
 
         if self.weka_config.trace_directory:
             trace_dir = Path(self.weka_config.trace_directory)
@@ -887,7 +931,13 @@ class WekaTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
             for f in files:
                 try:
                     blob = json.loads(f.read_text(encoding="utf-8"))
+                    augmented = self._augment_for_filter(blob) if filter_func else blob
+                    if not self._keep_trace(augmented, filter_func):
+                        n_filtered += 1
+                        continue
                     raw_traces.append(WekaTrace.model_validate(blob))
+                except FilterExpressionError:
+                    raise
                 except Exception as e:
                     logger.error(f"Failed to load trace {f.name}: {e}")
                     if not self.weka_config.skip_invalid_files:
@@ -900,7 +950,13 @@ class WekaTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
                     raise ValueError(f"Trace file does not exist: {path}")
                 try:
                     blob = json.loads(f.read_text(encoding="utf-8"))
+                    augmented = self._augment_for_filter(blob) if filter_func else blob
+                    if not self._keep_trace(augmented, filter_func):
+                        n_filtered += 1
+                        continue
                     raw_traces.append(WekaTrace.model_validate(blob))
+                except FilterExpressionError:
+                    raise
                 except Exception as e:
                     logger.error(f"Failed to load trace {f.name}: {e}")
                     if not self.weka_config.skip_invalid_files:
@@ -918,18 +974,32 @@ class WekaTraceReplayDataGenerator(ReplayGraphSessionGeneratorBase):
 
                 with open(local_path, "r", encoding="utf-8") as file_stream:
                     for line_idx, line in enumerate(file_stream):
-                        if line_idx >= self.weka_config.num_dataset_entries:
+                        if len(raw_traces) >= self.weka_config.num_dataset_entries:
                             break
                         if line.strip():
                             try:
                                 blob = json.loads(line)
+                                augmented = self._augment_for_filter(blob) if filter_func else blob
+                                if not self._keep_trace(augmented, filter_func):
+                                    n_filtered += 1
+                                    continue
                                 raw_traces.append(WekaTrace.model_validate(blob))
+                            except FilterExpressionError:
+                                raise
                             except Exception as e:
                                 logger.error(f"Failed to validate row {line_idx}: {e}")
                                 if not self.weka_config.skip_invalid_files:
                                     raise
+            except FilterExpressionError:
+                raise
             except Exception as e:
                 raise ValueError(f"Failed to load Hugging Face dataset {repo_id}: {e}") from e
+
+        if filter_func:
+            # scanned, not corpus size: the quota caps accepted traces, so scanning can stop early
+            logger.info(
+                f"Filter applied: {len(raw_traces)} traces kept, {n_filtered} rejected of {n_filtered + len(raw_traces)} scanned"
+            )
 
         # Ensure unique trace IDs
         unique_traces: Dict[str, WekaTrace] = {}

--- a/tests/test_weka_replay_datagen.py
+++ b/tests/test_weka_replay_datagen.py
@@ -14,14 +14,18 @@
 
 import json
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock
 
 import pytest
 
 from inference_perf.config import APIConfig, APIType, DataConfig, DataGenType
+from inference_perf.config.datagen.replay import WekaTraceReplayConfig
 from inference_perf.datagen.replay.weka_trace_replay_datagen import (
+    FilterExpressionError,
     HashIdRandomGenerator,
     WekaTraceReplayDataGenerator,
+    WekaTrace,
     RoleSegment,
     ConversationReconstructor,
     longest_common_prefix,
@@ -685,3 +689,171 @@ def test_cgroup_cpu_limit(tmp_path: Path) -> None:
     # cgroup v1, unlimited (quota -1).
     (v1 / "cpu" / "cpu.cfs_quota_us").write_text("-1\n")
     assert _cgroup_cpu_limit(v1) is None
+
+
+def _filter_trace(trace_id: str, peak_in: int, out: int = 2, subagent_in: int = 0) -> Dict[str, Any]:
+    requests: List[Dict[str, Any]] = [{"t": 0.1, "type": "n", "model": "m", "in": peak_in, "out": out, "hash_ids": [1]}]
+    if subagent_in:
+        requests.append(
+            {
+                "t": 0.2,
+                "type": "subagent",
+                "agent_id": "a1",
+                "subagent_type": "Subagent",
+                "requests": [{"t": 0.3, "type": "n", "model": "m", "in": subagent_in, "out": out, "hash_ids": [2]}],
+            }
+        )
+    return {"id": trace_id, "models": ["m"], "block_size": 2, "requests": requests}
+
+
+def _load_filtered(cfg: WekaTraceReplayConfig) -> List[WekaTrace]:
+    # trace loading reads only weka_config, so skip the tokenizer/corpus setup __init__ does
+    gen = WekaTraceReplayDataGenerator.__new__(WekaTraceReplayDataGenerator)
+    gen.weka_config = cfg
+    return WekaTraceReplayDataGenerator._load_weka_traces(gen)
+
+
+def _load_dir(
+    tmp_path: Path, traces: List[Dict[str, Any]], filter_expr: Optional[str], source: str = "trace_directory"
+) -> List[WekaTrace]:
+    paths = []
+    for i, trace in enumerate(traces):
+        p = tmp_path / f"trace_{i:03d}.json"
+        p.write_text(json.dumps(trace))
+        paths.append(str(p))
+    src: Dict[str, Any] = {"trace_directory": str(tmp_path)} if source == "trace_directory" else {"trace_files": paths}
+    return _load_filtered(WekaTraceReplayConfig(default_block_size=2, filter=filter_expr, **src))
+
+
+def test_augment_for_filter_derives_aggregates() -> None:
+    blob = _filter_trace("t1", peak_in=100, out=5, subagent_in=300)
+    blob["total_tokens"] = 999
+    augmented = WekaTraceReplayDataGenerator._augment_for_filter(blob)
+
+    assert augmented["max_tokens"] == 300 + 5
+    assert augmented["num_turns"] == 2
+    # derived values outrank a recorded key of the same name
+    assert augmented["total_tokens"] == 100 + 300 + 5 + 5
+
+
+def test_num_turns_counts_flattened_requests() -> None:
+    # a subagent's calls each count, so this must not collapse to top-level entries
+    blob = {
+        "id": "t1",
+        "models": ["m"],
+        "block_size": 2,
+        "requests": [
+            {"t": 0.1, "type": "n", "model": "m", "in": 10, "out": 1, "hash_ids": [1]},
+            {
+                "type": "subagent",
+                "agent_id": "a1",
+                "subagent_type": "Subagent",
+                "requests": [
+                    {"t": 0.2, "type": "n", "model": "m", "in": 20, "out": 2, "hash_ids": [2]},
+                    {"t": 0.3, "type": "n", "model": "m", "in": 30, "out": 3, "hash_ids": [3]},
+                    {"t": 0.4, "type": "n", "model": "m", "in": 40, "out": 4, "hash_ids": [4]},
+                ],
+            },
+        ],
+    }
+    assert WekaTraceReplayDataGenerator._augment_for_filter(blob)["num_turns"] == 4
+
+
+@pytest.mark.parametrize(
+    "filter_expr, expected",
+    [
+        (None, ["small", "big"]),
+        ("lambda x: x['max_tokens'] < 262144", ["small", "big"]),
+        ("lambda x: x['max_tokens'] < 200", ["small"]),
+        ("lambda x: x['max_tokens'] < 1", []),
+    ],
+)
+@pytest.mark.parametrize("source", ["trace_directory", "trace_files"])
+def test_filter_selects_traces(tmp_path: Path, filter_expr: Optional[str], expected: List[str], source: str) -> None:
+    traces = [_filter_trace("small", peak_in=100), _filter_trace("big", peak_in=500)]
+    assert [t.id for t in _load_dir(tmp_path, traces, filter_expr, source)] == expected
+
+
+def test_malformed_filter_expression_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Invalid filter expression syntax"):
+        _load_dir(tmp_path, [_filter_trace("a", peak_in=100)], "lambda x: (")
+
+
+@pytest.mark.parametrize("skip_invalid", [False, True])
+@pytest.mark.parametrize("source", ["trace_directory", "trace_files"])
+def test_filter_error_outranks_skip_invalid_files(tmp_path: Path, skip_invalid: bool, source: str) -> None:
+    path = tmp_path / "t.json"
+    path.write_text(json.dumps(_filter_trace("a", peak_in=100)))
+    src: Dict[str, Any] = {"trace_directory": str(tmp_path)} if source == "trace_directory" else {"trace_files": [str(path)]}
+    cfg = WekaTraceReplayConfig(
+        default_block_size=2,
+        skip_invalid_files=skip_invalid,
+        filter="lambda x: x['benchmark'] == 'swebench'",
+        **src,
+    )
+    with pytest.raises(FilterExpressionError, match="benchmark"):
+        _load_filtered(cfg)
+
+
+@pytest.mark.parametrize("skip_invalid", [False, True])
+@pytest.mark.parametrize("source", ["trace_directory", "trace_files"])
+def test_malformed_trace_data_respects_skip_invalid_files(tmp_path: Path, skip_invalid: bool, source: str) -> None:
+    # schema-valid but not filter-arithmetic-safe: a data problem, not a filter one
+    trace = _filter_trace("a", peak_in=100)
+    trace["requests"][0]["in"] = "100"
+    path = tmp_path / "t.json"
+    path.write_text(json.dumps(trace))
+    src: Dict[str, Any] = {"trace_directory": str(tmp_path)} if source == "trace_directory" else {"trace_files": [str(path)]}
+    cfg = WekaTraceReplayConfig(
+        default_block_size=2,
+        skip_invalid_files=skip_invalid,
+        filter="lambda x: x['max_tokens'] < 262144",
+        **src,
+    )
+    if skip_invalid:
+        assert _load_filtered(cfg) == []
+    else:
+        with pytest.raises(TypeError):
+            _load_filtered(cfg)
+
+
+@pytest.mark.parametrize("skip_invalid", [False, True])
+def test_filter_error_not_reported_as_dataset_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, skip_invalid: bool
+) -> None:
+    from inference_perf.datagen.replay import weka_trace_replay_datagen as mod
+
+    jsonl = tmp_path / "traces.jsonl"
+    jsonl.write_text(json.dumps(_filter_trace("a", peak_in=100)))
+    monkeypatch.setattr(mod, "hf_hub_download", lambda **kwargs: str(jsonl))
+
+    cfg = WekaTraceReplayConfig(
+        hf_dataset_path="org/dataset",
+        default_block_size=2,
+        skip_invalid_files=skip_invalid,
+        filter="lambda x: x['benchmark'] == 'swebench'",
+    )
+    with pytest.raises(FilterExpressionError, match="benchmark"):
+        _load_filtered(cfg)
+
+
+def test_num_dataset_entries_counts_kept_traces(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from inference_perf.datagen.replay import weka_trace_replay_datagen as mod
+
+    jsonl = tmp_path / "traces.jsonl"
+    jsonl.write_text("\n".join(json.dumps(_filter_trace(f"t{i}", peak_in=100 if i % 2 == 0 else 500)) for i in range(10)))
+    monkeypatch.setattr(mod, "hf_hub_download", lambda **kwargs: str(jsonl))
+
+    def load(num_entries: int, filter_expr: Optional[str]) -> List[str]:
+        cfg = WekaTraceReplayConfig(
+            hf_dataset_path="org/dataset",
+            default_block_size=2,
+            num_dataset_entries=num_entries,
+            filter=filter_expr,
+        )
+        return [t.id for t in _load_filtered(cfg)]
+
+    assert load(3, None) == ["t0", "t1", "t2"]
+    # scans deeper to fill the quota from accepted traces
+    assert load(3, "lambda x: x['max_tokens'] < 200") == ["t0", "t2", "t4"]
+    assert len(load(99, "lambda x: x['max_tokens'] < 200")) == 5


### PR DESCRIPTION
WekaTraceReplayConfig had no `filter` field, so configs are strict and a `filter:` key under weka_trace_replay failed validation outright.

Add it and apply it to all three trace sources, reusing the OTel datagen's _compile_filter. Weka traces record only per-request lengths, so derive the aggregates a filter needs: max_tokens, total_tokens and num_turns. A failing expression raises rather than being skipped as bad input data, so a typo'd key cannot quietly empty the corpus. num_dataset_entries now caps accepted traces rather than lines scanned, so a filter narrows which traces are picked instead of how many.