### PR TITLE
fix(otel): preserve tool results from the response field

### DIFF
--- a/inference_perf/datagen/replay/otel_trace_to_replay_graph.py
+++ b/inference_perf/datagen/replay/otel_trace_to_replay_graph.py
@@ -235,7 +235,7 @@ def _replay_message_to_dict(x: ReplayMessage) -> Dict[str, Any]:
                 tool_call_id = first.get("id")
                 if tool_call_id:
                     msg["tool_call_id"] = tool_call_id
-                text_parts.append(_coerce_text(first.get("result", "")))
+                text_parts.append(_coerce_text(first.get("result", first.get("response", ""))))
             if tool_calls:
                 msg["tool_calls"] = tool_calls
             # Emit content for text / tool-result messages. For an assistant
@@ -268,7 +268,7 @@ def _replay_message_to_dict(x: ReplayMessage) -> Dict[str, Any]:
                 tool_call_id = first.get("id")
                 if tool_call_id:
                     msg["tool_call_id"] = tool_call_id
-                msg["content"] = _coerce_text(first.get("result", ""))
+                msg["content"] = _coerce_text(first.get("result", first.get("response", "")))
                 return msg
 
         if info.get("tool_calls") is not None:

--- a/inference_perf/datagen/replay/otel_trace_utils.py
+++ b/inference_perf/datagen/replay/otel_trace_utils.py
@@ -240,12 +240,13 @@ def _format_tool_result(tool_result: Dict[str, Any]) -> str:
     Handles tool result formatting consistently across different parts of the code.
     Supports both formats:
     - tool_result: {"tool_use_id": "...", "content": "...", "is_error": ...}
-    - tool_call_response: {"id": "...", "result": "...", "is_error": ...}
+    - tool_call_response: {"id": "...", "response": "...", "is_error": ...}
+      (older traces use "result" instead of "response")
     """
     # Handle both "tool_use_id" and "id" field names
     tool_id = tool_result.get("tool_use_id") or tool_result.get("id", "unknown")
-    # Handle both "content" and "result" field names
-    result_content = tool_result.get("content") or tool_result.get("result", "")
+    # Preserve legacy field precedence, falling back to the OTel "response" field.
+    result_content = tool_result.get("content") or tool_result.get("result", tool_result.get("response", ""))
     is_error = tool_result.get("is_error", False)
     error_marker = " [ERROR]" if is_error else ""
     return f"<tool_result: {tool_id}{error_marker}>\n{result_content}\n</tool_result>"

--- a/tests/test_otel_replay_datagen.py
+++ b/tests/test_otel_replay_datagen.py
@@ -2120,6 +2120,25 @@ def _graph_messages_from_input(input_messages: List[dict[str, Any]]) -> List[dic
 class TestStructuredToolCallPreservation:
     """GraphCall.messages must carry structured tool_calls / tool_call_id."""
 
+    @pytest.mark.parametrize("container", ["parts", "content"])
+    @pytest.mark.parametrize("role", ["tool", "user"])
+    @pytest.mark.parametrize(
+        ("fields", "expected"),
+        [
+            ({"response": "sunny"}, "sunny"),
+            ({"response": [{"type": "text", "text": "sunny"}]}, "sunny"),
+            ({"response": {"temp_c": 18}}, "{'temp_c': 18}"),
+            ({"response": ""}, ""),
+            ({"response": None}, ""),
+            ({"result": "legacy", "response": "standard"}, "legacy"),
+            ({"result": "", "response": "standard"}, ""),
+            ({}, ""),
+        ],
+    )
+    def test_tool_response_fields(self, container: str, role: str, fields: dict[str, Any], expected: str) -> None:
+        msgs = _graph_messages_from_input([{"role": role, container: [{"type": "tool_call_response", "id": "c1", **fields}]}])
+        assert msgs == [{"role": "tool", "tool_call_id": "c1", "content": expected}]
+
     def test_assistant_tool_calls_only_openai_format(self) -> None:
         msgs = _graph_messages_from_input(
             [

--- a/tests/test_otel_trace_utils.py
+++ b/tests/test_otel_trace_utils.py
@@ -16,6 +16,10 @@
 
 """Tests for otel_trace_utils - LLM output/input reconstruction."""
 
+from typing import Any
+
+import pytest
+
 from inference_perf.datagen.replay.otel_trace_utils import (
     reconstruct_llm_output,
     reconstruct_llm_input,
@@ -58,6 +62,23 @@ class TestReconstructLLMOutput:
 
 class TestReconstructLLMInput:
     """Test reconstruct_llm_input."""
+
+    @pytest.mark.parametrize("container", ["parts", "content"])
+    @pytest.mark.parametrize(
+        ("fields", "expected"),
+        [
+            ({"response": "sunny"}, "sunny"),
+            ({"response": ""}, ""),
+            ({"response": 0}, "0"),
+            ({"result": "legacy", "response": "standard"}, "legacy"),
+            ({"result": "", "response": "standard"}, ""),
+            ({"content": "native", "result": "legacy", "response": "standard"}, "native"),
+            ({}, ""),
+        ],
+    )
+    def test_tool_response_fields(self, container: str, fields: dict[str, Any], expected: str) -> None:
+        msg = {"role": "tool", container: [{"type": "tool_call_response", "id": "c1", **fields}]}
+        assert reconstruct_llm_input(msg) == f"<tool_result: c1>\n{expected}\n</tool_result>"
 
     def test_basic_formats(self) -> None:
         """Test basic input formats."""


### PR DESCRIPTION
OTel traces using the standard `tool_call_response.response` field currently replay with empty tool content. Read `response` when the legacy `result` field is absent, both when building OpenAI-compatible graph messages and when reconstructing input text. Existing field precedence, including explicitly empty legacy results, is preserved.

Fixes #665.

Regression tests cover `parts` and `content` containers, tool/user role normalization, structured response values, empty/missing values, and legacy field precedence. Before the fix, 16 new cases fail because the tool content is discarded.

Validation:

- Full unit suite with coverage: 1266 passed, 7 skipped.
- OTel replay, trace graph, and reconstruction tests: 156 passed.
- `pdm run validate`: passed (formatting, lint, strict types, CLI documentation sync).
- Mock-client benchmark: passed and generated reports.
- `pdm run check:cov`: passed; current coverage 77.96%, above the 77% floor.

The standalone license-header checker rejects the touched files' existing 2025 headers (and leading shebangs); those headers are unchanged from main.
