### PR TITLE
feat(datagen): enable synthetic_agentic data generator

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -234,8 +234,8 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--data.synthetic_agentic.duplicate_sessions_target` | int | Not applicable to synthetic generation (pinned None): raise num_sessions to generate more sessions instead of duplicating existing ones. |
 | `--data.synthetic_agentic.max_wait_ms` | int | Maximum inter-event wait time in milliseconds. Caps the delay between predecessor completion and event dispatch to avoid reproducing unusually long tool/agent execution times from the original trace. |
 | `--data.synthetic_agentic.predecessor_wait_timeout_sec` | float | Seconds to wait for predecessor events to complete before failing. 0 waits indefinitely; use with care because a genuinely stuck predecessor will then never time out and successors will wait forever. |
-| `--data.synthetic_agentic.include_errors` | boolean | Include spans with error status |
-| `--data.synthetic_agentic.skip_invalid_files` | boolean | Skip invalid trace files instead of failing |
+| `--data.synthetic_agentic.include_errors` | boolean | Not applicable to synthetic generation (pinned True): this filters recorded spans by error status when building a replay graph from a trace file; synthetic sessions have no recorded spans to filter. |
+| `--data.synthetic_agentic.skip_invalid_files` | boolean | Not applicable to synthetic generation (pinned False): sessions are generated in-memory, not loaded from trace files, so there are no invalid files to skip. |
 | `--data.synthetic_agentic.bad_tool_call_handling` | Enum (none, use_recorded) | How to handle tool_calls whose function.arguments is not valid JSON. none (default): no mitigation, bytes propagate and vLLM may return HTTP 400 on the next turn. use_recorded: discard the live response and substitute the recorded assistant message at the affected slot; the recorded tool_call_id flows into the recorded role:tool successor unchanged. |
 | `--data.synthetic_agentic.num_sessions` | int | Number of sessions (load volume) |
 | `--data.synthetic_agentic.input_tokens_per_turn.min` | int | Smallest value the distribution can produce; samples below are clamped. |

--- a/docs/synthetic_agentic.md
+++ b/docs/synthetic_agentic.md
@@ -1,9 +1,5 @@
 # Synthetic Agentic Session Replay
 
-> **Not yet available.** `data.type: synthetic_agentic` is still being finalized and is not
-> enabled in any released version. Attempting to use it will produce a validation error at startup.
-> This document describes the intended interface for when the feature ships.
-
 Generate agentic LLM workloads procedurally, without a recorded trace. `synthetic_agentic` builds
 replay-graph sessions — multi-turn conversations, tool-calling loops, and recursive sub-agent
 fan-out — from a handful of config knobs, then drives them against the target inference server

--- a/docs/synthetic_agentic.md
+++ b/docs/synthetic_agentic.md
@@ -46,7 +46,7 @@ python -m inference_perf.main \
 # Inspect a generated session graph without a server
 # (this offline tool sizes turns with a real tokenizer, so the config needs a
 #  top-level `tokenizer: {pretrained_model_name_or_path: "<model>"}` block)
-python -m inference_perf.datagen.synthetic_agentic_to_replay_graph \
+python -m inference_perf.datagen.synthetic_agentic.synthetic_agentic_to_replay_graph \
   --config <your-config>.yml \
   --session-index 0 \
   --output /tmp/graph.json \

--- a/examples/synthetic_agentic/demo/01_bare_no_tools.yml
+++ b/examples/synthetic_agentic/demo/01_bare_no_tools.yml
@@ -1,0 +1,36 @@
+# DEMO 01 — Bare non-agentic baseline (the simplest shape).
+# One agent, one turn, NO tools advertised at all: [system head, user question] -> [assistant answer].
+# (Every agent call carries the fixed shared system head; shared_system_prompt_len defaults to 1000.
+#  Set it to 0 for a truly head-less [user] -> [assistant] baseline.)
+# WHAT TO LOOK FOR: 1 event/session (the answer is the call's OUTPUT, not a separate event);
+# requests carry NO tools; plain chat completion.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 5
+    seed: 1
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}     # single autonomous turn
+    fanout_probability: 0.0                          # no sub-agents
+    tool_loop_depth: {type: fixed, mean: 0}      # answer directly
+    tool_catalog_size_per_agent: {type: fixed, mean: 0}  # NO tools advertised (bare baseline)
+    input_tokens_per_turn:  {type: fixed, mean: 200}
+    output_tokens_per_turn: {type: fixed, mean: 80}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-01-bare"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/02_multiturn_no_tools.yml
+++ b/examples/synthetic_agentic/demo/02_multiturn_no_tools.yml
@@ -1,0 +1,38 @@
+# DEMO 02 — Multi-turn conversation, NO tools (the simplest GROWING shape).
+# 3 human turns, no tools at all: the classic chat back-and-forth. Each round the "user"
+# follows up and the conversation transcript GROWS (round K carries rounds 0..K-1 as context).
+# This isolates conversation growth with nothing else going on.
+# WHAT TO LOOK FOR: 3 events/session; input message count grows 1 -> 3 -> 5 across the rounds
+# (each round adds the prior [assistant answer, new user turn]); prompt tokens INCREASE per round;
+# NO tools advertised.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 5
+    seed: 2
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 3}     # 3 human turns -> growing context
+    fanout_probability: 0.0                          # no sub-agents
+    tool_loop_depth: {type: fixed, mean: 0}      # answer directly each round
+    tool_catalog_size_per_agent: {type: fixed, mean: 0}  # NO tools advertised
+    input_tokens_per_turn:  {type: fixed, mean: 200}
+    output_tokens_per_turn: {type: fixed, mean: 60}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+    user_think_time_sec:    {type: fixed, mean: 1}   # gap before each follow-up
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-02-multiturn-notools"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/03_single_agent_tool_loop.yml
+++ b/examples/synthetic_agentic/demo/03_single_agent_tool_loop.yml
@@ -1,0 +1,35 @@
+# DEMO 03 — Single-agent tool-loop (introduces tools + tool-loop growth).
+# One turn that makes 2 sequential tool calls, then answers: the classic agent loop.
+# WHAT TO LOOK FOR: 3 events/session (principal + 2 tool turns; the last turn's OUTPUT is the
+# answer); input message count grows 1 -> 3 -> 5; each tool turn = 1 forced tool_call + 1 tool
+# result; the ~8-tool catalog is advertised on every request.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 5
+    seed: 2
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 0.0
+    tool_loop_depth: {type: fixed, mean: 2}      # 2 tool calls, then answer
+    tool_catalog_size_per_agent: {type: fixed, mean: 8}
+    input_tokens_per_turn:  {type: fixed, mean: 300}
+    output_tokens_per_turn: {type: fixed, mean: 80}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-02-toolloop"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/04_long_tool_loop.yml
+++ b/examples/synthetic_agentic/demo/04_long_tool_loop.yml
@@ -1,0 +1,36 @@
+# DEMO 04 — Long single-agent tool-loop (tool_loop_depth > 3): watch the loop GROW.
+# One turn that makes 5 sequential tool calls, then answers. Same shape as 03 but longer, so
+# the accumulating tool-loop transcript is unmistakable: each turn re-injects the prior
+# [assistant tool_call, tool result] pair on top of everything before it.
+# WHAT TO LOOK FOR: 6 events/session (principal + 5 tool turns; the last turn's OUTPUT is the
+# answer); input message count grows 1 -> 3 -> 5 -> 7 -> 9 -> 11; prompt tokens climb every turn.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 5
+    seed: 4
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 0.0
+    tool_loop_depth: {type: fixed, mean: 5}      # 5 tool calls, then answer (> 3)
+    tool_catalog_size_per_agent: {type: fixed, mean: 8}
+    input_tokens_per_turn:  {type: fixed, mean: 300}
+    output_tokens_per_turn: {type: fixed, mean: 80}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-04-long-toolloop"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/05_multiturn_with_tools.yml
+++ b/examples/synthetic_agentic/demo/05_multiturn_with_tools.yml
@@ -1,0 +1,39 @@
+# DEMO 05 — Multi-turn conversation WITH tools (rounds AND tool-loops both grow, combined).
+# 3 rounds; each round the "user" follows up (conversation GROWS, round K carries rounds
+# 0..K-1) AND each round runs a 1-turn tool-loop. This is the two growth mechanisms stacked:
+# per-round growth carries the prior rounds, per-loop growth carries the tool call+result.
+# user_think_time_sec spaces the human turns.
+# WHAT TO LOOK FOR: 6 events/session; input message count grows 1 -> 3 -> 3 -> 5 -> 5 -> 7
+# (each round: principal grows over the last round, then its tool turn adds the call+result);
+# per-round prompt tokens INCREASE across rounds.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 4
+    seed: 4
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 3}     # 3 human turns
+    fanout_probability: 0.0
+    tool_loop_depth: {type: fixed, mean: 1}
+    tool_catalog_size_per_agent: {type: fixed, mean: 6}
+    input_tokens_per_turn:  {type: fixed, mean: 250}
+    output_tokens_per_turn: {type: fixed, mean: 60}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+    user_think_time_sec:    {type: fixed, mean: 2}   # gap before each follow-up
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-05-multiturn-tools"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/06_parallel_tool_calls.yml
+++ b/examples/synthetic_agentic/demo/06_parallel_tool_calls.yml
@@ -1,0 +1,36 @@
+# DEMO 06 — Parallel tool calls within a turn (K>1 calls per tool turn).
+# Each tool turn emits 3 tool_calls at once (+ 3 matching results). BEST-EFFORT: against a
+# strict model that emits fewer than 3, that turn may 400 (real models rarely do this — ~97%
+# of real turns are single-call). Use to stress parallel-tool handling.
+# WHAT TO LOOK FOR: assistant turns with 3 tool_calls each, 3 role:tool results with matching ids.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 5
+    seed: 3
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 0.0
+    tool_loop_depth: {type: fixed, mean: 2}
+    parallel_tool_calls_per_step: {type: fixed, mean: 3}   # 3 calls per tool turn
+    tool_catalog_size_per_agent: {type: fixed, mean: 8}
+    input_tokens_per_turn:  {type: fixed, mean: 300}
+    output_tokens_per_turn: {type: fixed, mean: 80}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-06-parallel"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/07_chat_with_tools_varying.yml
+++ b/examples/synthetic_agentic/demo/07_chat_with_tools_varying.yml
@@ -1,0 +1,35 @@
+# DEMO 07 — Chat-with-tools: per-round tool usage VARIES (the general interactive shape).
+# 4 rounds; each round independently draws 0..3 tool turns — so some rounds answer directly,
+# some run a tool-loop. This is the most realistic single-agent conversational shape.
+# WHAT TO LOOK FOR: heterogeneous event counts per round; a mix of answer-only and tool-using rounds.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 4
+    seed: 5
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 4}
+    fanout_probability: 0.0
+    tool_loop_depth: {type: uniform, min: 0, max: 3}   # VARIES per round
+    tool_catalog_size_per_agent: {type: fixed, mean: 8}
+    input_tokens_per_turn:  {type: fixed, mean: 250}
+    output_tokens_per_turn: {type: fixed, mean: 60}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+    user_think_time_sec:    {type: fixed, mean: 2}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-07-chatwithtools"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/08_orchestrator_fanout.yml
+++ b/examples/synthetic_agentic/demo/08_orchestrator_fanout.yml
@@ -1,0 +1,39 @@
+# DEMO 08 — Orchestrator fan-out: spawn 2 sub-agents in PARALLEL, wait for both, then continue.
+# The headline multi-agent capability. depth=1 (children are leaves). Each child runs its OWN
+# 3-turn tool loop before answering, so you can see each sub-agent actually WORK (not just answer).
+# WHAT TO LOOK FOR: within a session the 2 sub-agents run concurrently (their tool-loop calls
+# overlap in time / peak-2+ in-flight); each child = 3 tool turns then an answer; a merge waits
+# for both children, folds their answers in, then the orchestrator's final answer.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 4
+    seed: 6
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 1.0                            # always spawn
+    sub_agents_per_spawn: {type: fixed, mean: 2}       # exactly 2 children
+    max_depth: 1                                        # children don't recurse
+    tool_loop_depth: {type: fixed, mean: 3}        # each child runs a 3-turn tool loop, then answers
+    tool_catalog_size_per_agent: {type: fixed, mean: 6}
+    max_events_per_session: 512
+    input_tokens_per_turn:  {type: fixed, mean: 250}
+    output_tokens_per_turn: {type: fixed, mean: 60}
+    tool_call_latency_sec:  {type: fixed, mean: 0}     # no gap -> children truly overlap
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 3
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-08-orchestrator"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/09_recursive_fanout.yml
+++ b/examples/synthetic_agentic/demo/09_recursive_fanout.yml
@@ -1,0 +1,37 @@
+# DEMO 09 — Recursive fan-out (depth 2): sub-agents spawn their OWN sub-agents.
+# A tree: root -> children -> grandchildren, each merging back up. max_depth=2 bounds recursion.
+# WHAT TO LOOK FOR: larger sessions (~30 events); nested parallelism; every dispatch_agent call
+# is advertised in that turn's tools; no dangling tool_call ids; still deterministic per seed.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 4
+    seed: 7
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 1.0
+    sub_agents_per_spawn: {type: fixed, mean: 2}
+    max_depth: 2                                       # children can spawn grandchildren
+    tool_loop_depth: {type: fixed, mean: 1}
+    tool_catalog_size_per_agent: {type: fixed, mean: 6}
+    max_events_per_session: 512
+    input_tokens_per_turn:  {type: fixed, mean: 200}
+    output_tokens_per_turn: {type: fixed, mean: 50}
+    tool_call_latency_sec:  {type: fixed, mean: 0}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 4
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-09-recursive"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/10_big_catalog.yml
+++ b/examples/synthetic_agentic/demo/10_big_catalog.yml
@@ -1,0 +1,35 @@
+  # DEMO 10 — Big tool-catalog inflation (prefill stress).
+# 200 tools advertised on every request (real agents carry huge catalogs;
+# real Exgentic ~487). Stresses prompt prefill with forced tool-call selection.
+# WHAT TO LOOK FOR: 1 event/session but large-ish input tokens from the advertised catalog;
+# tools present in the request, one called.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 4
+    seed: 8
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 0.0
+    tool_loop_depth: {type: fixed, mean: 1}
+    tool_catalog_size_per_agent: {type: fixed, mean: 200}   # 200-tool catalog
+    input_tokens_per_turn:  {type: fixed, mean: 300}
+    output_tokens_per_turn: {type: fixed, mean: 40}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-10-bigcatalog"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/11_mixed_everything.yml
+++ b/examples/synthetic_agentic/demo/11_mixed_everything.yml
@@ -1,0 +1,38 @@
+# DEMO 11 — Everything combined: 2 themes, probabilistic fan-out, varying rounds + tool-loops.
+# Heterogeneous sessions in one run: some single-agent, some fan-out; both domains; varied sizes.
+# The most "realistic mixed workload" shape (still SmolLM2-safe on sizes).
+# WHAT TO LOOK FOR: wide spread of session sizes; both themes appear across sessions; 0 errors.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 10
+    seed: 9
+    theme_mix: {generic: {weight: 0.5}, db2_latency_incident: {weight: 0.5}}
+    turns_per_session: {type: uniform, min: 1, max: 3}
+    fanout_probability: 0.4
+    sub_agents_per_spawn: {type: uniform, min: 2, max: 3}
+    max_depth: 2
+    tool_loop_depth: {type: uniform, min: 0, max: 2}
+    tool_catalog_size_per_agent: {type: fixed, mean: 10}
+    max_events_per_session: 512
+    input_tokens_per_turn:  {type: lognormal, min: 100, mean: 400, max: 4000, std_dev: 300}
+    output_tokens_per_turn: {type: lognormal, min: 10, mean: 500, max: 3000, std_dev: 800}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+    user_think_time_sec:    {type: fixed, mean: 2}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 4
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-11-mixed"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/12_realistic_scale.yml
+++ b/examples/synthetic_agentic/demo/12_realistic_scale.yml
@@ -1,0 +1,39 @@
+# DEMO 12 — REALISTIC SCALE, matched to real Exgentic (~114K-token prompts, ~487-tool catalog).
+# *** REQUIRES A LARGE-CONTEXT MODEL (>=128K ctx). On SmolLM2 (8K ctx) this WILL exceed context
+# and 400 — that's expected. Swap model_name/base_url below to your big model before running. ***
+# WHAT TO LOOK FOR (on a big model): per-session input tokens ~87K-136K (real agentic scale);
+# fast graph build; 0 errors; mirrors the real Exgentic load profile.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 20
+    seed: 42
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: uniform, min: 1, max: 3}
+    fanout_probability: 0.3
+    sub_agents_per_spawn: {type: uniform, min: 2, max: 3}
+    max_depth: 2
+    tool_loop_depth: {type: uniform, min: 1, max: 4}
+    tool_catalog_size_per_agent: {type: fixed, mean: 487}   # real Exgentic catalog size
+    parallel_tool_calls_per_step: {type: fixed, mean: 1}    # real: ~97% single-call
+    input_tokens_per_turn:  {type: lognormal, min: 300, mean: 110000, max: 160000, std_dev: 30000}
+    output_tokens_per_turn: {type: lognormal, min: 5, mean: 210, max: 3600, std_dev: 300}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+    max_events_per_session: 512
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 4
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-12-realistic"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/13_high_turn_count.yml
+++ b/examples/synthetic_agentic/demo/13_high_turn_count.yml
@@ -1,0 +1,43 @@
+# DEMO 13 — High turn count (turns_per_session fixed at 32, > 30).
+# Motivated by real-world usage data: Baumann et al., "SWE-chat: Coding Agent Interactions From
+# Real Users in the Wild" (arXiv:2604.20779), Figure 4(a) shows turns-per-session is heavily
+# right-skewed with a distinct 30+ bucket that alone accounts for ~5-6% of sessions. This demo
+# pins every session AT that tail value (fixed, not sampled) so the long-conversation shape is
+# reproducible and unmissable: context accumulates across 32 human turns, each with its own
+# tool-loop, growing the transcript every round. keep num_sessions small -- this is 32 rounds of
+# growing context, so wall-clock and prompt-token cost per session are both real.
+# WHAT TO LOOK FOR: 64 events/session (32 rounds x 2 calls/round: principal + 1 tool turn);
+# input message count grows by 2 every round; prompt tokens climb steadily across all 32 rounds
+# (no compaction here, so growth is unbounded within the run -- pair with context_compaction to
+# cap it, see demo 05's discussion in docs/synthetic_agentic.md).
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 2
+    seed: 13
+    theme_mix: {code_change_task: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 32}     # > 30: the paper's long-conversation tail
+    fanout_probability: 0.0
+    tool_loop_depth: {type: fixed, mean: 1}
+    tool_catalog_size_per_agent: {type: fixed, mean: 8}
+    max_events_per_session: 128                    # 32 turns x 2 calls/turn, plus headroom
+    input_tokens_per_turn:  {type: fixed, mean: 200}
+    output_tokens_per_turn: {type: fixed, mean: 60}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-13-highturns"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/14_high_tool_loop_depth.yml
+++ b/examples/synthetic_agentic/demo/14_high_tool_loop_depth.yml
@@ -1,0 +1,44 @@
+# DEMO 14 — High tool-calls-per-turn (tool_loop_depth fixed at 32, > 30).
+# Motivated by real-world usage data: Baumann et al., "SWE-chat: Coding Agent Interactions From
+# Real Users in the Wild" (arXiv:2604.20779), Figure 4(b) shows tool-calls-per-agent-response is
+# dominated by 0 (~43% of turns, plain Q&A) but ALSO has a distinct 30+ bucket (~4-5% of turns) --
+# a single turn where the agent grinds through a long tool loop before answering.
+# This demo pins tool_loop_depth AT that tail value (fixed, not sampled) on a single turn, so the
+# in-turn loop growth is unmissable and reproducible. Same growth mechanism as demo 04, just past
+# the paper's 30+ threshold instead of 5.
+# WHAT TO LOOK FOR: 33 events/session (1 principal + 32 tool turns; the last turn's OUTPUT is the
+# answer); input message count grows by 2 every tool-loop iteration; prompt tokens climb every
+# turn (unbounded within the run -- this is the single-turn analogue of demo 13's growth).
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 2
+    seed: 14
+    theme_mix: {code_change_task: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 0.0
+    tool_loop_depth: {type: fixed, mean: 32}       # > 30: the paper's long-tool-loop tail
+    tool_catalog_size_per_agent: {type: fixed, mean: 8}
+    max_events_per_session: 64                     # 1 turn x 33 calls, plus headroom
+    input_tokens_per_turn:  {type: fixed, mean: 200}
+    output_tokens_per_turn: {type: fixed, mean: 60}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+    user_think_time_sec:    {type: fixed, mean: 2}
+    bad_tool_call_handling: use_recorded
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 2
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-14-hightoolloop"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/15_high_turns_and_tool_loop_distribution.yml
+++ b/examples/synthetic_agentic/demo/15_high_turns_and_tool_loop_distribution.yml
@@ -1,0 +1,41 @@
+# DEMO 15 — Realistic DISTRIBUTION for both tails (most sessions/turns small, ~5% reach 30+).
+# Demos 13-14 pin turns_per_session / tool_loop_depth AT a fixed tail value on every session.
+# This demo samples both knobs from a clipped lognormal tuned so ~5% of draws land at 30+ while the bulk stays
+# small, so ACROSS num_sessions you get the paper's mixed shape (many short sessions, a few very
+# long ones) instead of a uniform worst case.
+# WHAT TO LOOK FOR: wide spread of events/session across the num_sessions run; most sessions
+# finish in a handful of events, a handful run long (30+ turns and/or 30+-call loops); 0 errors.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 30
+    seed: 16
+    theme_mix: {code_change_task: {weight: 1.0}}
+    # mean=8, std_dev=55, clipped to [1, 60]: median 1 turn, ~5% of sessions land at 30+ turns.
+    turns_per_session: {type: lognormal, min: 1, max: 60, mean: 8, std_dev: 55}
+    fanout_probability: 0.0
+    # mean=9, std_dev=60, clipped to [0, 60]: median 1 tool call, ~5-6% of turns loop 30+ times.
+    tool_loop_depth: {type: lognormal, min: 0, max: 60, mean: 9, std_dev: 60}
+    tool_catalog_size_per_agent: {type: fixed, mean: 8}
+    max_events_per_session: 2400                  # generous: worst case ~60 turns x 61 calls/turn
+    input_tokens_per_turn:  {type: fixed, mean: 150}
+    output_tokens_per_turn: {type: fixed, mean: 50}
+    tool_call_latency_sec:  {type: fixed, mean: 1}
+    user_think_time_sec:    {type: fixed, mean: 2}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 4
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-15-turnstoolloop-dist"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/16_budget_cap.yml
+++ b/examples/synthetic_agentic/demo/16_budget_cap.yml
@@ -1,0 +1,40 @@
+# DEMO 16 — Budget cap / session truncation (max_events_per_session).
+# A fully recursive fan-out (fanout_probability=1.0, max_depth=3, 3 sub-agents per spawn) would
+# produce up to 146 events, but max_events_per_session=50
+# cuts each session short once the 50th event is reached.  Sessions are therefore "leaf-truncated":
+# the generator stops adding new events and emits the remaining work as leaf answer calls.
+# WHAT TO LOOK FOR: every session has exactly 47 events; the deep sub-agent branches never
+# appear; no errors — budget exhaustion is a clean, expected stop condition, not a failure.
+api: {type: chat, streaming: false}
+data:
+  type: synthetic_agentic
+  synthetic_agentic:
+    num_sessions: 4
+    seed: 17
+    theme_mix: {generic: {weight: 1.0}}
+    turns_per_session: {type: fixed, mean: 1}
+    fanout_probability: 1.0
+    sub_agents_per_spawn: {type: fixed, mean: 3}
+    max_depth: 3
+    tool_loop_depth: {type: fixed, mean: 2}
+    tool_catalog_size_per_agent: {type: fixed, mean: 5}
+    max_events_per_session: 50          # forces truncation-to-leaf
+    input_tokens_per_turn:  {type: fixed, mean: 80}
+    output_tokens_per_turn: {type: fixed, mean: 30}
+    tool_call_latency_sec:  {type: fixed, mean: 0}
+load:
+  type: trace_session_replay
+  stages:
+    - concurrent_sessions: 4
+  worker_max_concurrency: 20
+  base_seed: 42
+
+server:
+  type: vllm
+  base_url: "http://localhost:8000"        # <-- point at your vLLM
+  model_name: "HuggingFaceTB/SmolLM2-135M-Instruct"  # <-- swap for your model later
+
+storage:
+  local_storage: {path: "reports-demo-16-budget-cap"}
+report:
+  request_lifecycle: {summary: true, per_stage: true}

--- a/examples/synthetic_agentic/demo/16_budget_cap.yml
+++ b/examples/synthetic_agentic/demo/16_budget_cap.yml
@@ -1,9 +1,9 @@
 # DEMO 16 — Budget cap / session truncation (max_events_per_session).
 # A fully recursive fan-out (fanout_probability=1.0, max_depth=3, 3 sub-agents per spawn) would
-# produce up to 146 events, but max_events_per_session=50
-# cuts each session short once the 50th event is reached.  Sessions are therefore "leaf-truncated":
+# produce up to 146 events, but max_events_per_session=10
+# cuts each session short once the 10th event is reached.  Sessions are therefore "leaf-truncated":
 # the generator stops adding new events and emits the remaining work as leaf answer calls.
-# WHAT TO LOOK FOR: every session has exactly 47 events; the deep sub-agent branches never
+# WHAT TO LOOK FOR: every session has exactly 10 events; the deep sub-agent branches never
 # appear; no errors — budget exhaustion is a clean, expected stop condition, not a failure.
 api: {type: chat, streaming: false}
 data:
@@ -18,7 +18,7 @@ data:
     max_depth: 3
     tool_loop_depth: {type: fixed, mean: 2}
     tool_catalog_size_per_agent: {type: fixed, mean: 5}
-    max_events_per_session: 50          # forces truncation-to-leaf
+    max_events_per_session: 10          # forces truncation-to-leaf
     input_tokens_per_turn:  {type: fixed, mean: 80}
     output_tokens_per_turn: {type: fixed, mean: 30}
     tool_call_latency_sec:  {type: fixed, mean: 0}

--- a/examples/synthetic_agentic/demo/README.md
+++ b/examples/synthetic_agentic/demo/README.md
@@ -1,0 +1,63 @@
+# Synthetic Agent Sessions — Demo Progression
+
+A guided tour of the `synthetic_agentic` data generator, from the simplest shape to a
+realistic mixed workload. Each config isolates one new concept, then later ones combine them.
+
+Run any demo (with a vLLM server on `localhost:8000`):
+
+```bash
+python -m inference_perf.main --config examples/synthetic_agentic/demo/01_bare_no_tools.yml
+# or with Jaeger tracing to inspect the per-session event graph, start Jaeger and a target server (see `examples/otel/run_with_jaeger.sh` for the Jaeger prerequisites), then:
+./examples/otel/run_with_jaeger.sh examples/synthetic_agentic/demo/01_bare_no_tools.yml
+```
+
+**Model note:** every config is set to `HuggingFaceTB/SmolLM2-135M-Instruct` (~8K context) so demos
+01–11 run on a small server today. Swap `server.model_name` / `base_url` for your real model when
+ready. **Demo 12 needs a large-context model (≥128K)** — it will exceed SmolLM2's context and 400.
+
+Demos 01–05 build up the **event model** one growth mechanism at a time (start here): a session is a
+DAG of LLM calls where each call's INPUT is the cumulative transcript so far and the assistant reply
+is that call's OUTPUT (not a separate event). Watch how the per-call input message count grows.
+
+Demos 13–15 push `turns_per_session` / `tool_loop_depth` into the long tail reported by real-world
+usage data (Baumann et al., "SWE-chat: Coding Agent Interactions From Real Users in the Wild",
+arXiv:2604.20779, Figure 4): both distributions are heavily right-skewed with a distinct 30+ bucket
+that alone accounts for ~5% of sessions/turns. 13 and 14 pin one dimension at a fixed tail value (32);
+15 samples both from a clipped lognormal tuned to put ~5% of draws at 30+ while most stay small.
+
+Demo 16 exercises `max_events_per_session` as a hard budget cap: a fully recursive fan-out that
+would produce 146 events is truncated to 47 per session. Remaining work is emitted as leaf answer
+calls — budget exhaustion is a clean stop, not a failure.
+
+| # | Config | Demonstrates | What to look for |
+|---|--------|--------------|------------------|
+| 01 | `01_bare_no_tools` | Bare non-agentic baseline (no tools) | 1 event/session (the answer is the call's OUTPUT, not a separate event); no tools in requests |
+| 02 | `02_multiturn_no_tools` | Multi-turn conversation, NO tools — pure conversation growth | 3 events; input msg count grows 1→3→5 across rounds; prompt tokens increase per round; no tools |
+| 03 | `03_single_agent_tool_loop` | A tool-loop (introduces tools) — tool-loop growth | 3 events (principal + 2 tool turns; last turn's OUTPUT is the answer); input grows 1→3→5; catalog advertised |
+| 04 | `04_long_tool_loop` | Long tool-loop (`tool_loop_depth`=5) — growth made obvious | 6 events; input msg count grows 1→3→5→7→9→11; prompt tokens climb every turn |
+| 05 | `05_multiturn_with_tools` | Multi-turn AND tool-loops (both growth mechanisms combined) | 6 events; input msg count grows 1→3→3→5→5→7; prompt tokens INCREASE across rounds |
+| 06 | `06_parallel_tool_calls` | K>1 tool calls per turn (best-effort) | 3 tool_calls + 3 matching results per turn |
+| 07 | `07_chat_with_tools_varying` | Per-round tool usage varies | mix of answer-only and tool-using rounds |
+| 08 | `08_orchestrator_fanout` | Spawn 2 sub-agents in parallel, wait, continue | 2 sub-agent calls overlap in time; merge is terminal (its OUTPUT is the answer) |
+| 09 | `09_recursive_fanout` | Recursive fan-out (depth 2) | nested parallel sub-agents; no dangling ids |
+| 10 | `10_big_catalog` | Tool-catalog inflation (prefill stress) | 1 event but large prompt; 30 tools advertised, none called |
+| 11 | `11_mixed_everything` | Mixed themes + probabilistic fan-out + varying rounds | wide session-size spread; both themes; 0 errors |
+| 12 | `12_realistic_scale` | Real Exgentic scale (~114K-token prompts, 487 tools) | **needs big-context model**; input tokens ~87K–136K |
+| 13 | `13_high_turn_count` | High turn count (`turns_per_session` fixed 32, > 30) | 64 events/session (32 rounds x 2 calls/round); input msg count grows by 2 every round |
+| 14 | `14_high_tool_loop_depth` | High tool-calls-per-turn (`tool_loop_depth` fixed 32, > 30) | 33 events/session (1 principal + 32 tool turns); input msg count grows by 2 every loop iteration |
+| 15 | `15_high_turns_and_tool_loop_distribution` | Realistic distribution for both tails (lognormal, ~5% of draws land at 30+) | wide spread of events/session; most sessions short, a handful run long; 0 errors |
+| 16 | `16_budget_cap` | `max_events_per_session` cap on a deep recursive fan-out (would produce 146 events uncapped) | every session has exactly 47 events; deep sub-agent branches absent; 0 errors — budget exhaustion is a clean stop, not a failure |
+
+**Verify a run** (reconstructs sessions from Jaeger spans and checks they match intent):
+
+```bash
+python tools/verify_synthetic_via_jaeger.py --expect-sessions 5 --expect-events 1   # 01 (bare, 1 event)
+python tools/verify_synthetic_via_jaeger.py --expect-sessions 5 --expect-events 3   # 02/03 (grow 1→3→5)
+python tools/verify_synthetic_via_jaeger.py --expect-sessions 5 --expect-events 6   # 04 (long tool-loop)
+python tools/verify_synthetic_via_jaeger.py --expect-sessions 4 --min-peak-concurrency 2   # 08 (parallel sub-agents)
+```
+
+Use `--expect-events N` for configs with a deterministic per-session event count (e.g., `big_catalog`); use `--min-events` for configs with
+fan-out or variable rounds, where the exact count depends on random draws.
+
+All demos are deterministic: the same config + `seed` produces byte-identical session graphs.

--- a/examples/synthetic_agentic/demo/README.md
+++ b/examples/synthetic_agentic/demo/README.md
@@ -46,7 +46,7 @@ calls — budget exhaustion is a clean stop, not a failure.
 | 13 | `13_high_turn_count` | High turn count (`turns_per_session` fixed 32, > 30) | 64 events/session (32 rounds x 2 calls/round); input msg count grows by 2 every round |
 | 14 | `14_high_tool_loop_depth` | High tool-calls-per-turn (`tool_loop_depth` fixed 32, > 30) | 33 events/session (1 principal + 32 tool turns); input msg count grows by 2 every loop iteration |
 | 15 | `15_high_turns_and_tool_loop_distribution` | Realistic distribution for both tails (lognormal, ~5% of draws land at 30+) | wide spread of events/session; most sessions short, a handful run long; 0 errors |
-| 16 | `16_budget_cap` | `max_events_per_session` cap on a deep recursive fan-out (would produce 146 events uncapped) | every session has exactly 47 events; deep sub-agent branches absent; 0 errors — budget exhaustion is a clean stop, not a failure |
+| 16 | `16_budget_cap` | `max_events_per_session` cap on a deep recursive fan-out (would produce 146 events uncapped) | every session has exactly 10 events; deep sub-agent branches absent; 0 errors — budget exhaustion is a clean stop, not a failure |
 
 **Verify a run** (reconstructs sessions from Jaeger spans and checks they match intent):
 

--- a/inference_perf/config/config.py
+++ b/inference_perf/config/config.py
@@ -59,11 +59,6 @@ class Config(StrictBaseModel):
         default=None, description="Circuit breakers that stop the run when observed metrics cross configured thresholds."
     )
 
-    @model_validator(mode="after")
-    def synthetic_agentic_not_yet_available(self) -> "Config":
-        if self.data.type == DataGenType.SyntheticAgentic:
-            raise ValueError("synthetic_agentic is not yet available and will be enabled in a future release.")
-        return self
 
     @model_validator(mode="after")
     def validate_trace_replay_load_type(self) -> "Config":

--- a/inference_perf/config/config.py
+++ b/inference_perf/config/config.py
@@ -59,7 +59,6 @@ class Config(StrictBaseModel):
         default=None, description="Circuit breakers that stop the run when observed metrics cross configured thresholds."
     )
 
-
     @model_validator(mode="after")
     def validate_trace_replay_load_type(self) -> "Config":
         """Validate that trace replay data types use trace_session_replay load type."""

--- a/inference_perf/config/datagen/config.py
+++ b/inference_perf/config/datagen/config.py
@@ -173,3 +173,9 @@ class DataConfig(StrictBaseModel):
                 f" ignored by type '{self.type.value}'. Unset it or set data.type to 'random'."
             )
         return self
+
+    @model_validator(mode="after")
+    def validate_synthetic_agentic_scope(self) -> "DataConfig":
+        if self.type == DataGenType.SyntheticAgentic and self.synthetic_agentic is None:
+            raise ValueError(f"data.type '{self.type.value}' requires 'data.synthetic_agentic' to be configured.")
+        return self

--- a/inference_perf/config/datagen/replay.py
+++ b/inference_perf/config/datagen/replay.py
@@ -487,6 +487,53 @@ class SyntheticAgenticConfig(SessionReplayConfig):
             "tool call itself, so the generated length is already correct for this model."
         ),
     )
+    skip_invalid_files: bool = Field(
+        False,
+        frozen=True,
+        description=(
+            "Not applicable to synthetic generation (pinned False): sessions are generated "
+            "in-memory, not loaded from trace files, so there are no invalid files to skip."
+        ),
+    )
+    include_errors: bool = Field(
+        True,
+        frozen=True,
+        description=(
+            "Not applicable to synthetic generation (pinned True): this filters recorded spans "
+            "by error status when building a replay graph from a trace file; synthetic sessions "
+            "have no recorded spans to filter."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_pinned_replay_fields(self) -> "SyntheticAgenticConfig":
+        # frozen=True only blocks assignment AFTER construction; Pydantic still
+        # accepts a non-default value passed to the constructor (e.g. loaded
+        # from YAML). Reject that explicitly so these fields stay pinned to the
+        # values documented above for synthetic generation.
+        if self.inject_random_session_id is not False:
+            raise ValueError(
+                "inject_random_session_id is pinned to False for synthetic_agentic: sessions are "
+                "already generated with distinct content per session index, so there is no recorded "
+                "session ID to randomize."
+            )
+        if self.duplicate_sessions_target is not None:
+            raise ValueError(
+                "duplicate_sessions_target is pinned to None for synthetic_agentic: raise num_sessions "
+                "to generate more sessions instead of duplicating existing ones."
+            )
+        if self.skip_invalid_files is not False:
+            raise ValueError(
+                "skip_invalid_files is pinned to False for synthetic_agentic: sessions are generated "
+                "in-memory, not loaded from trace files, so there are no invalid files to skip."
+            )
+        if self.include_errors is not True:
+            raise ValueError(
+                "include_errors is pinned to True for synthetic_agentic: this filters recorded spans "
+                "by error status when building a replay graph from a trace file; synthetic sessions "
+                "have no recorded spans to filter."
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_theme_mix(self) -> "SyntheticAgenticConfig":

--- a/inference_perf/datagen/synthetic_agentic.py
+++ b/inference_perf/datagen/synthetic_agentic.py
@@ -1860,9 +1860,7 @@ def build_graph_for_session(
                 # to be built. Children -- and, because `reserved` is threaded through
                 # `_build_agent`, their descendants -- test the budget against that total,
                 # so a greedy grandchild can no longer consume the events this agent
-                # still owes, and an early child cannot starve a later sibling. Both were
-                # ways to end the loop with `child_terminals != K`, which trips the atomic
-                # rollback below and collapses the whole session to its pre-spawn terminal.
+                # still owes, and an early child cannot starve a later sibling.
                 for c in range(K):
                     child_reserved = reserved + (K + 1) + (K - c - 1) * _MIN_AGENT_COST
                     if not _fits(_MIN_AGENT_COST, child_reserved):
@@ -2029,7 +2027,7 @@ def build_graph_for_session(
                     # pre-spawn snapshot" covers however many events were added, so it
                     # needs no adjustment for the notification chain. prev_id stays at
                     # the pre-spawn terminal; the final normalization re-emits that as a
-                    # plain answer.
+                    # plain answer. Should not be reachable, exists as a safety net.
                     for eid in list(events.keys()):
                         if eid not in events_before_spawn:
                             del events[eid]

--- a/inference_perf/datagen/synthetic_agentic.py
+++ b/inference_perf/datagen/synthetic_agentic.py
@@ -26,7 +26,7 @@ import json
 import logging
 import string
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -260,9 +260,47 @@ def _untruncated_len(tokenizer: CustomTokenizer, text: str) -> int:
     """
     try:
         hf = tokenizer.get_tokenizer()
-        return len(hf(text, truncation=False, add_special_tokens=False)["input_ids"])
+        return len(hf.encode(text, truncation=False, add_special_tokens=False))
     except Exception:
         return tokenizer.count_tokens(text)
+
+
+def _fit_padded_text(
+    tokenizer: CustomTokenizer,
+    filler_budget: int,
+    fixed_cost: int,
+    words: List[str],
+    emit: Callable[[int], str],
+) -> str:
+    """Shared sizing core for filler-padding: pick a word count so `emit(n_words)`
+    lands close to `fixed_cost + filler_budget` tokens total, then emit once more.
+
+    Analytic, not an iterative re-tokenizing loop (see fit_filler's docstring for
+    why that matters at 100K+ token targets). Tokenizes a small fixed-size word
+    SAMPLE once to get an average tokens-per-word ratio, computes
+    n_words = ceil(filler_budget / ratio), emits, then runs ONE bounded correction
+    pass: re-measure the emitted text (untruncated) and re-derive n_words from the
+    OBSERVED ratio if that would change it. Never loops, so it stays fast.
+
+    Callers own the filler_budget<=0 and empty-corpus guards, since their
+    fallback (what to return instead) differs.
+    """
+    sample = _cycled_words(words, min(_RATIO_SAMPLE_WORDS, len(words)))
+    sample_tokens = _untruncated_len(tokenizer, " ".join(sample))
+    tokens_per_word = (sample_tokens / len(sample)) if sample and sample_tokens > 0 else 1.0
+
+    n_words = max(1, int(np.ceil(filler_budget / tokens_per_word)))
+    buf = emit(n_words)
+
+    target_tokens = fixed_cost + filler_budget
+    actual = _untruncated_len(tokenizer, buf)
+    filler_actual = actual - fixed_cost
+    if actual != target_tokens and filler_actual > 0:
+        observed_ratio = filler_actual / n_words
+        corrected = max(1, int(np.ceil(filler_budget / observed_ratio)))
+        if corrected != n_words:
+            buf = emit(corrected)
+    return buf
 
 
 def fit_filler(
@@ -326,34 +364,12 @@ def fit_filler(
         # <context></context> block would signal nothing and just waste tokens).
         return fixed_content
 
-    # Average tokens-per-word from a small, un-truncated sample (measured once).
-    sample = _cycled_words(words, min(_RATIO_SAMPLE_WORDS, len(words)))
-    sample_text = " ".join(sample)
-    sample_tokens = _untruncated_len(tokenizer, sample_text)
-    tokens_per_word = (sample_tokens / len(sample)) if sample and sample_tokens > 0 else 1.0
-
     def _emit(n_words: int) -> str:
         # Wrapped filler FIRST, real content LAST.
         chunk = " ".join(_cycled_words(words, max(1, n_words)))
         return f"{FILLER_OPEN}{chunk}{FILLER_CLOSE} {fixed_content}"
 
-    # Analytic estimate: how many words to cover the remaining budget.
-    n_words = max(1, int(np.ceil(filler_budget / tokens_per_word)))
-    buf = _emit(n_words)
-
-    # One bounded correction pass: measure the real (untruncated) length of the
-    # emitted text and re-derive the word count from the OBSERVED filler ratio,
-    # correcting any systematic bias between the sample and the emitted filler.
-    # This runs at most once -- it never loops, so it stays fast.
-    actual = _untruncated_len(tokenizer, buf)
-    filler_actual = actual - fixed_cost
-    if actual != target_tokens and filler_actual > 0:
-        observed_ratio = filler_actual / n_words
-        corrected = max(1, int(np.ceil(filler_budget / observed_ratio)))
-        if corrected != n_words:
-            n_words = corrected
-            buf = _emit(n_words)
-    return buf
+    return _fit_padded_text(tokenizer, filler_budget, fixed_cost, words, _emit)
 
 
 # Header that introduces the filler padding appended AFTER a real system prompt,
@@ -406,24 +422,11 @@ def _render_system_head(
     if filler_budget <= 0 or not words:
         return prompt
 
-    sample = _cycled_words(words, min(_RATIO_SAMPLE_WORDS, len(words)))
-    sample_tokens = _untruncated_len(tokenizer, " ".join(sample))
-    tokens_per_word = (sample_tokens / len(sample)) if sample and sample_tokens > 0 else 1.0
-
     def _emit(n_words: int) -> str:
         chunk = " ".join(_cycled_words(words, max(1, n_words)))
         return f"{prompt}{_SYSTEM_HEAD_FILLER_HEADER}{chunk}"
 
-    n_words = max(1, int(np.ceil(filler_budget / tokens_per_word)))
-    buf = _emit(n_words)
-    actual = _untruncated_len(tokenizer, buf)
-    filler_actual = actual - header_cost
-    if actual != target_tokens and filler_actual > 0:
-        observed_ratio = filler_actual / n_words
-        corrected = max(1, int(np.ceil(filler_budget / observed_ratio)))
-        if corrected != n_words:
-            buf = _emit(corrected)
-    return buf
+    return _fit_padded_text(tokenizer, filler_budget, header_cost, words, _emit)
 
 
 # --- The seeded single-agent walk -----------------------------------------
@@ -1561,8 +1564,9 @@ def build_graph_for_session(
         # principal still outputs plain text and the merge follows.
         principal_is_terminal = (k == 0) and not will_spawn
         first_calls: List[Dict[str, Any]] = []  # populated only when k >= 1 (silences strict unbound check)
+        first_results: List[Dict[str, Any]] = []
         if k >= 1:
-            first_calls, _, first_names = _turn_calls_and_results(0)
+            first_calls, first_results, first_names = _turn_calls_and_results(0)
             _emit(
                 principal_id,
                 principal_msgs,
@@ -1636,10 +1640,15 @@ def build_graph_for_session(
         #                  placeholder assistant carrying those same ids (so each
         #                  tool_call is matched by exactly one role:tool result).
         #                  Empty when the prior output was plain text.
+        #   out_results -- the results for `out_calls`, already rendered by the
+        #                  `_turn_calls_and_results` call that produced `out_calls`
+        #                  (either the principal's turn-0 call above, or the prior
+        #                  loop iteration's turn-(t+1) lookahead call below).
         prev_id = principal_id
         prev_input_len = len(principal_msgs)
         prev_msgs: List[Dict[str, Any]] = list(principal_msgs)
         prev_out_calls: List[Dict[str, Any]] = first_calls if k >= 1 else []
+        prev_out_results: List[Dict[str, Any]] = first_results if k >= 1 else []
 
         # --- k tool-turn events (accumulating chain) ---
         # Event ':tN' (N = 0..k-1) re-injects the prior event's tool-call reply
@@ -1662,7 +1671,7 @@ def build_graph_for_session(
             # materializes in THIS event which we skip).
             if not _fits(1, reserved):
                 break
-            _, results, _ = _turn_calls_and_results(t)
+            results = prev_out_results
             # The output-slot placeholder assistant carries the prior event's
             # emitted calls (same ids as `results`), so exactly these calls are
             # matched by exactly these results.
@@ -1719,9 +1728,13 @@ def build_graph_for_session(
                     expected_output_tokens=ans_tokens,
                 )
                 next_out_calls: List[Dict[str, Any]] = []
+                next_out_results: List[Dict[str, Any]] = []
             else:
                 # OUTPUT is the NEXT tool call (turn t+1); force it via tool_names.
-                next_calls, _, next_names = _turn_calls_and_results(t + 1)
+                # Render turn t+1's calls+results together now so the NEXT iteration
+                # (or the spawn block below) can reuse `next_out_results` instead of
+                # calling `_turn_calls_and_results` again for the same turn.
+                next_calls, next_out_results, next_names = _turn_calls_and_results(t + 1)
                 _emit(
                     turn_id,
                     turn_msgs,
@@ -1738,6 +1751,7 @@ def build_graph_for_session(
             prev_input_len = len(turn_msgs)
             prev_msgs = turn_msgs
             prev_out_calls = next_out_calls
+            prev_out_results = next_out_results
 
         # --- optional fan-out: ONE spawn event (parallel dispatch_agent calls) +
         # the spawned children + post-dispatch ack + K sequential notification events (the LAST is this
@@ -1815,7 +1829,7 @@ def build_graph_for_session(
                 # the parent's last input with a shared-only prepend, which introduces
                 # no unmatched prior tool_call, so nothing dangles either way.
                 if prev_out_calls:
-                    _, spawn_results, _ = _turn_calls_and_results(n_turn_events)
+                    spawn_results = prev_out_results
                     spawn_output_placeholder = {"role": "assistant", "tool_calls": [dict(c) for c in prev_out_calls]}
                     spawn_msgs = [*prev_msgs, spawn_output_placeholder, *spawn_results, spawn_ctx]
                     spawn_segs = [

--- a/inference_perf/datagen/synthetic_agentic/__init__.py
+++ b/inference_perf/datagen/synthetic_agentic/__init__.py
@@ -1,0 +1,25 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Procedural synthetic multi-agent session generator: builds replay graphs
+from config + theme without any recorded traffic."""
+
+from .synthetic_agentic_datagen import SyntheticAgenticDataGenerator
+from .synthetic_themes import GENERIC_THEME, Theme, load_theme
+
+__all__ = [
+    "SyntheticAgenticDataGenerator",
+    "GENERIC_THEME",
+    "Theme",
+    "load_theme",
+]

--- a/inference_perf/datagen/synthetic_agentic/synthetic_agentic_datagen.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_agentic_datagen.py
@@ -36,7 +36,7 @@ from inference_perf.config.common import Distribution
 from inference_perf.datagen.replay.replay_graph_session_datagen import ReplayGraphSessionGeneratorBase, ReplaySession
 from inference_perf.datagen.replay.otel_trace_to_replay_graph import tag_user_facing_events
 from inference_perf.datagen.replay.replay_graph_types import GraphCall, GraphEvent, InputSegment, ReplayGraph
-from inference_perf.datagen.synthetic_themes import (
+from inference_perf.datagen.synthetic_agentic.synthetic_themes import (
     GENERIC_THEME,
     ROOT_SYSTEM_PROMPTS,
     SUBAGENT_SYSTEM_PROMPTS,
@@ -154,7 +154,7 @@ def _accumulated_wire_tokens(
 # Shakespeare corpus shipped with the repo; same file/location convention
 # used by synthetic_datagen.py and weka_trace_replay_datagen.py for prompt
 # corpora. Loaded lazily (not at import time) and cached in-process.
-_SHAKESPEARE_PATH = Path(__file__).resolve().parents[1] / "assets" / "shakespeare.txt"
+_SHAKESPEARE_PATH = Path(__file__).resolve().parents[2] / "assets" / "shakespeare.txt"
 _corpus_words_cache: Optional[List[str]] = None
 
 

--- a/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
@@ -33,8 +33,8 @@ from pathlib import Path
 from inference_perf.config.config import read_config
 from inference_perf.config.datagen.config import DataGenType
 from inference_perf.datagen.replay.otel_trace_to_replay_graph import graph_to_dict, print_graph, visualize_graph
-from inference_perf.datagen.synthetic_agentic import build_graph_for_session
-from inference_perf.datagen.synthetic_themes import GENERIC_THEME, load_theme
+from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import build_graph_for_session
+from inference_perf.datagen.synthetic_agentic.synthetic_themes import GENERIC_THEME, load_theme
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 

--- a/inference_perf/datagen/synthetic_agentic/synthetic_themes.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_themes.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Optional
 from pydantic import BaseModel
 
-_ASSETS = Path(__file__).parent.parent / "assets" / "synthetic_themes"
+_ASSETS = Path(__file__).parent.parent.parent / "assets" / "synthetic_themes"
 
 DEFAULT_SYSTEM_PROMPT = (
     "You are an autonomous agent. Use the available tools to complete the given task, "

--- a/tests/required/datagen/test_synthetic_agentic.py
+++ b/tests/required/datagen/test_synthetic_agentic.py
@@ -132,9 +132,9 @@ def test_config_still_frozen_against_post_construction_assignment() -> None:
 
     cfg = SyntheticAgenticConfig(**_minimal_synthetic_agentic_kwargs())
     with pytest.raises(ValueError):
-        cfg.inject_random_session_id = True
+        cfg.inject_random_session_id = True  # type: ignore[misc]
     with pytest.raises(ValueError):
-        cfg.duplicate_sessions_target = 5
+        cfg.duplicate_sessions_target = 5  # type: ignore[misc]
 
 
 def test_session_seed_stable_across_calls_and_processes() -> None:

--- a/tests/required/datagen/test_synthetic_agentic.py
+++ b/tests/required/datagen/test_synthetic_agentic.py
@@ -88,6 +88,55 @@ def test_config_valid_minimal() -> None:
     assert cfg.bad_tool_call_handling == BadToolCallHandling.NONE
 
 
+def _minimal_synthetic_agentic_kwargs() -> Dict[str, Any]:
+    return dict(
+        num_sessions=10,
+        turns_per_session=Distribution(type="fixed", mean=1),
+        fanout_probability=0.0,
+        theme_mix={"db2_latency_incident": 1.0},
+        input_tokens_per_turn=Distribution(type="fixed", mean=500),
+        output_tokens_per_turn=Distribution(type="fixed", mean=100),
+    )
+
+
+def test_config_rejects_inject_random_session_id_true() -> None:
+    from pydantic import ValidationError
+    from inference_perf.config.datagen.replay import SyntheticAgenticConfig
+
+    with pytest.raises(ValidationError, match="inject_random_session_id is pinned to False"):
+        SyntheticAgenticConfig(**_minimal_synthetic_agentic_kwargs(), inject_random_session_id=True)
+
+
+def test_config_rejects_duplicate_sessions_target_set() -> None:
+    from pydantic import ValidationError
+    from inference_perf.config.datagen.replay import SyntheticAgenticConfig
+
+    with pytest.raises(ValidationError, match="duplicate_sessions_target is pinned to None"):
+        SyntheticAgenticConfig(**_minimal_synthetic_agentic_kwargs(), duplicate_sessions_target=10)
+
+
+def test_config_rejects_both_pinned_fields_set_together() -> None:
+    from pydantic import ValidationError
+    from inference_perf.config.datagen.replay import SyntheticAgenticConfig
+
+    with pytest.raises(ValidationError):
+        SyntheticAgenticConfig(
+            **_minimal_synthetic_agentic_kwargs(),
+            inject_random_session_id=True,
+            duplicate_sessions_target=5,
+        )
+
+
+def test_config_still_frozen_against_post_construction_assignment() -> None:
+    from inference_perf.config.datagen.replay import SyntheticAgenticConfig
+
+    cfg = SyntheticAgenticConfig(**_minimal_synthetic_agentic_kwargs())
+    with pytest.raises(ValueError):
+        cfg.inject_random_session_id = True
+    with pytest.raises(ValueError):
+        cfg.duplicate_sessions_target = 5
+
+
 def test_session_seed_stable_across_calls_and_processes() -> None:
     # Must NOT depend on PYTHONHASHSEED or process -- pure function of inputs.
     a = session_seed(42, 17)

--- a/tests/required/datagen/test_synthetic_agentic.py
+++ b/tests/required/datagen/test_synthetic_agentic.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, cast
 
 import pytest
 from inference_perf.datagen.replay.replay_graph_types import GraphEvent, ReplayGraph, InputSegment
-from inference_perf.datagen.synthetic_themes import load_theme, Theme, GENERIC_THEME, DEFAULT_SYSTEM_PROMPT  # noqa: F401
-from inference_perf.datagen.synthetic_agentic import (
+from inference_perf.datagen.synthetic_agentic.synthetic_themes import load_theme, Theme, GENERIC_THEME, DEFAULT_SYSTEM_PROMPT  # noqa: F401
+from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import (
     session_seed,
     child_rng,
     fit_filler,
@@ -346,7 +346,7 @@ def test_agent_first_call_carries_role_appropriate_system_head() -> None:
     # spawned sub-agent from SUBAGENT_SYSTEM_PROMPTS -- so the root and its
     # sub-agents carry DIFFERENT heads (like a real harness), not one identical
     # head. Each head is a distinct dict (no aliasing).
-    from inference_perf.datagen.synthetic_themes import ROOT_SYSTEM_PROMPTS, SUBAGENT_SYSTEM_PROMPTS
+    from inference_perf.datagen.synthetic_agentic.synthetic_themes import ROOT_SYSTEM_PROMPTS, SUBAGENT_SYSTEM_PROMPTS
 
     cfg = _cfg(
         fanout_probability=1.0,
@@ -506,7 +506,7 @@ def _min_api() -> "APIConfig":
 
 def test_generator_builds_session_lazily() -> None:
     from inference_perf.config.datagen.config import DataConfig, DataGenType
-    from inference_perf.datagen.synthetic_agentic import SyntheticAgenticDataGenerator
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import SyntheticAgenticDataGenerator
 
     data = DataConfig(type=DataGenType.SyntheticAgentic, synthetic_agentic=_cfg(num_sessions=4))
     gen = SyntheticAgenticDataGenerator(api_config=_min_api(), config=data, tokenizer=_word_tok(), num_workers=1)
@@ -1127,7 +1127,7 @@ def test_theme_mix_accepts_both_shapes_equivalently() -> None:
     )
     # identical weighted draws across sessions (same seed -> same theme choices)
     from inference_perf.config.datagen.config import DataConfig, DataGenType
-    from inference_perf.datagen.synthetic_agentic import SyntheticAgenticDataGenerator
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import SyntheticAgenticDataGenerator
 
     gb = SyntheticAgenticDataGenerator(
         api_config=_min_api(),
@@ -1389,8 +1389,8 @@ def test_render_system_head_fits_truncates_and_is_deterministic() -> None:
     # (no filler header) when the prompt alone exceeds the target, and is
     # deterministic given the rng.
     import numpy as np
-    from inference_perf.datagen.synthetic_agentic import _render_system_head
-    from inference_perf.datagen.synthetic_themes import ROOT_SYSTEM_PROMPTS, SUBAGENT_SYSTEM_PROMPTS
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import _render_system_head
+    from inference_perf.datagen.synthetic_agentic.synthetic_themes import ROOT_SYSTEM_PROMPTS, SUBAGENT_SYSTEM_PROMPTS
 
     tok = _word_tok()
     # _WordTok counts words; the real prompts are ~430-540 words, so a target
@@ -2592,7 +2592,7 @@ def test_notifications_reconstruct_single_assistant_with_matched_stub_results() 
     # (inv #3). Those results are now STATIC launch acks -- the child reports arrive
     # separately as user-role notifications -- so each ack carries ASYNC_DISPATCH_STUB
     # rather than a child's report.
-    from inference_perf.datagen.synthetic_agentic import ASYNC_DISPATCH_STUB
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import ASYNC_DISPATCH_STUB
 
     K = 3
     cfg = _cfg(
@@ -2650,7 +2650,10 @@ def test_subagent_terminal_ends_with_report_directive() -> None:
     # message; cursor math stays exact. Non-terminal child tool-turns and non-terminal
     # notifications must NOT end with it. (The ROOT's last notification ends with the
     # ANSWER directive, not this one -- covered separately.)
-    from inference_perf.datagen.synthetic_agentic import SUBAGENT_REPORT_DIRECTIVE, ROOT_ANSWER_DIRECTIVE
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import (
+        SUBAGENT_REPORT_DIRECTIVE,
+        ROOT_ANSWER_DIRECTIVE,
+    )
 
     # depth 2 so there are BOTH leaf-child terminals AND sub-agent (non-root) merges.
     cfg = _cfg(
@@ -2725,7 +2728,7 @@ def test_root_terminal_ends_with_answer_directive() -> None:
     # Applies to both a k>=1 tool loop's terminal and a k=0 answer-directly turn --
     # as long as the agent has a tool catalog (a no-tools agent can't emit tool-call
     # text, so it gets NO nudge). Non-terminal (tool-call) turns must NOT end with it.
-    from inference_perf.datagen.synthetic_agentic import ROOT_ANSWER_DIRECTIVE
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import ROOT_ANSWER_DIRECTIVE
 
     frag = ROOT_ANSWER_DIRECTIVE
 
@@ -2781,7 +2784,7 @@ def test_nonroot_last_notification_ends_with_report_directive() -> None:
     # non-leaf level); the ROOT's last notification must NOT (its output is the
     # orchestrator's final answer). Earlier links in either chain are ack turns and
     # carry NO directive. Cursor math must stay exact after the appended message.
-    from inference_perf.datagen.synthetic_agentic import SUBAGENT_REPORT_DIRECTIVE
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import SUBAGENT_REPORT_DIRECTIVE
 
     cfg = _cfg(
         theme_mix={"generic": 1.0},
@@ -3087,7 +3090,7 @@ def test_percentile_and_heap_render_no_placeholder_leak() -> None:
 
 
 def test_connective_lowercases_common_first_word() -> None:
-    from inference_perf.datagen.synthetic_agentic import _join_connective_case
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import _join_connective_case
 
     out = _join_connective_case("Following up, ", "Are other services in us-east-1 showing the same 5xx?", GENERIC_THEME)
     assert out.startswith("are other services"), f"common-word seam not fixed: {out!r}"
@@ -3097,7 +3100,7 @@ def test_connective_lowercases_common_first_word() -> None:
 
 
 def test_connective_preserves_entity_and_acronym_first_word() -> None:
-    from inference_perf.datagen.synthetic_agentic import _join_connective_case
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import _join_connective_case
 
     # An entity value (service name) as the first word is a proper noun -> preserved.
     entity = GENERIC_THEME.entities["service"][2]  # "cart-service"
@@ -3180,7 +3183,7 @@ def test_region_is_pinned_across_a_multi_round_session() -> None:
 def test_region_in_primary_categories_and_pinned() -> None:
     # region is now a pinned primary-subject category, and _pinned_primary_entities
     # only pins categories the theme declares (a theme without `region` is unaffected).
-    from inference_perf.datagen.synthetic_agentic import (
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import (
         _PRIMARY_ENTITY_CATEGORIES,
         _pinned_primary_entities,
     )
@@ -3313,7 +3316,7 @@ def test_code_change_task_result_shapes_render_realistically() -> None:
     # run_tests -> traceback marker + pass/fail summary; git_diff -> unified diff
     # markers; read_file -> line-number formatting. Rendered directly so the test
     # does not depend on which tools a given session happens to schedule.
-    from inference_perf.datagen.synthetic_agentic import _render_tool_result
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import _render_tool_result
 
     t = load_theme("code_change_task")
     seed = 4242
@@ -3475,7 +3478,7 @@ def test_code_change_focus_and_payload_deterministic() -> None:
 def test_payload_arg_size_from_schema_hint() -> None:
     # A payload arg's word count = its `x-payload-tokens` schema hint; a payload arg
     # without the hint falls back to _DEFAULT_PAYLOAD_WORDS. (_WordTok: 1 word == 1 token.)
-    from inference_perf.datagen.synthetic_agentic import (
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import (
         _render_tool_arguments,
         theme_payload_words,
         _DEFAULT_PAYLOAD_WORDS,
@@ -3495,7 +3498,7 @@ def test_payload_arg_size_from_schema_hint() -> None:
 def test_payload_pool_falls_back_to_filler_when_no_payload_templates() -> None:
     # theme_payload_words returns the payload_templates pool when present, else the
     # filler_templates pool (so themes without payload_templates behave as before).
-    from inference_perf.datagen.synthetic_agentic import theme_payload_words, theme_filler_words
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import theme_payload_words, theme_filler_words
 
     # a theme WITH payload_templates -> its payload pool differs from its filler pool
     coding = load_theme("code_change_task")
@@ -3520,7 +3523,7 @@ def test_all_themes_payloads_render_domain_shaped_no_leak() -> None:
     # Every theme with a payload tool renders that payload from its payload pool with
     # NO unresolved {placeholder} leak, and long enough to be a real payload.
     import re
-    from inference_perf.datagen.synthetic_agentic import _render_tool_arguments, theme_payload_words
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import _render_tool_arguments, theme_payload_words
 
     cases = [
         (load_theme("code_change_task"), "write_file", "content"),
@@ -3541,7 +3544,7 @@ def test_all_themes_payloads_render_domain_shaped_no_leak() -> None:
 
 
 def test_payload_render_deterministic() -> None:
-    from inference_perf.datagen.synthetic_agentic import _render_tool_arguments, theme_payload_words
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import _render_tool_arguments, theme_payload_words
 
     t = load_theme("db2_latency_incident")
     pool = theme_payload_words(t, 9, (68,))
@@ -3847,7 +3850,7 @@ def test_only_last_notification_is_the_terminal() -> None:
     # (b) Only the LAST notification produces the answer/report; the earlier ones are
     # short ack turns. The last link is also the event the agent chain hands upward,
     # so for a root spawn it must be a graph terminal (nothing depends on it).
-    from inference_perf.datagen.synthetic_agentic import ROOT_ANSWER_DIRECTIVE
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import ROOT_ANSWER_DIRECTIVE
 
     K = 3
     # Pin output_tokens_per_turn well above _FB_ACK_TOKENS so "the terminal answer is
@@ -4012,7 +4015,7 @@ def test_ack_text_is_short_form_and_distinct_from_the_terminal_answer() -> None:
     # this module behaves (including _answer_text) -- so the meaningful invariant is
     # that an ack is short-form and clearly distinct from the terminal ANSWER, not
     # that the acks differ from each other.
-    from inference_perf.datagen.synthetic_agentic import _FB_ACK_TOKENS
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import _FB_ACK_TOKENS
 
     ack_target = _FB_ACK_TOKENS.mean
     g = build_graph_for_session(
@@ -4051,7 +4054,7 @@ def test_orchestrator_flow_is_dispatch_ack_then_k_reports() -> None:
     BEFORE any child report -- the property that distinguishes a genuinely async
     dispatch from one that only appears async.
     """
-    from inference_perf.datagen.synthetic_agentic import ASYNC_DISPATCH_STUB
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import ASYNC_DISPATCH_STUB
 
     K = 3
     g = build_graph_for_session(_async_fanout_cfg(K), GENERIC_THEME, _word_tok(), session_index=0)
@@ -4102,7 +4105,7 @@ def test_dispatch_ack_turn_is_the_short_prefill_shape() -> None:
 def test_k1_spawn_degenerates_to_ack_then_single_terminal() -> None:
     """With K=1 there is no non-terminal report turn: the flow is spawn ->
     dispatch_ack -> notify0(TERMINAL). Guards the degenerate case."""
-    from inference_perf.datagen.synthetic_agentic import ROOT_ANSWER_DIRECTIVE
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import ROOT_ANSWER_DIRECTIVE
 
     g = build_graph_for_session(_async_fanout_cfg(1), GENERIC_THEME, _word_tok(), session_index=0)
     chains = _notify_chains(g)
@@ -4509,7 +4512,7 @@ def test_notification_envelope_survives_multiline_and_markup_reports() -> None:
 
 def test_dispatch_description_documents_the_envelope_and_ordering() -> None:
     """The dispatch tool definition must document the envelope shape and completion-order delivery."""
-    from inference_perf.datagen.synthetic_agentic import (
+    from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import (
         DISPATCH_AGENT_DESCRIPTION,
         DISPATCH_AGENT_TOOL_DEF,
     )

--- a/tests/required/datagen/test_tfut_synthetic_graph.py
+++ b/tests/required/datagen/test_tfut_synthetic_graph.py
@@ -17,8 +17,8 @@
 from typing import cast
 
 from inference_perf.datagen.replay.replay_graph_types import ReplayGraph
-from inference_perf.datagen.synthetic_agentic import build_graph_for_session
-from inference_perf.datagen.synthetic_themes import GENERIC_THEME
+from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import build_graph_for_session
+from inference_perf.datagen.synthetic_agentic.synthetic_themes import GENERIC_THEME
 from inference_perf.datagen.replay.otel_trace_to_replay_graph import tag_user_facing_events
 from inference_perf.config.common import Distribution
 from inference_perf.config.datagen.replay import SyntheticAgenticConfig

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@
 from inference_perf.config import (
     APIType,
     Config,
+    DataConfig,
     DataGenType,
     Distribution,
     DistributionType,
@@ -364,6 +365,26 @@ def test_use_chat_template_accepted_for_random_type() -> None:
         }
     )
     assert config.data.use_chat_template is True
+
+
+def test_synthetic_agentic_type_requires_synthetic_agentic_config() -> None:
+    with pytest.raises(Exception, match="requires 'data.synthetic_agentic' to be configured"):
+        DataConfig.model_validate({"type": DataGenType.SyntheticAgentic})
+
+
+def test_synthetic_agentic_type_accepted_with_synthetic_agentic_config() -> None:
+    data = DataConfig.model_validate(
+        {
+            "type": DataGenType.SyntheticAgentic,
+            "synthetic_agentic": {
+                "num_sessions": 10,
+                "input_tokens_per_turn": {"type": "fixed", "mean": 500},
+                "output_tokens_per_turn": {"type": "fixed", "mean": 100},
+            },
+        }
+    )
+    assert data.synthetic_agentic is not None
+    assert data.synthetic_agentic.num_sessions == 10
 
 
 def test_distribution_variance_conversion() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pydantic import ValidationError
 from inference_perf.config import (
     APIType,
     Config,
@@ -368,7 +369,7 @@ def test_use_chat_template_accepted_for_random_type() -> None:
 
 
 def test_synthetic_agentic_type_requires_synthetic_agentic_config() -> None:
-    with pytest.raises(Exception, match="requires 'data.synthetic_agentic' to be configured"):
+    with pytest.raises(ValidationError, match="requires 'data.synthetic_agentic' to be configured"):
         DataConfig.model_validate({"type": DataGenType.SyntheticAgentic})
 
 


### PR DESCRIPTION
Follow-up to #716.

## What this PR does

#716 added the `synthetic_agentic` data generator but shipped it behind a
`model_validator` guard that unconditionally rejected `data.type: synthetic_agentic`
with "not yet available and will be enabled in a future release." This PR removes
that guard, turning the generator on.

- Removes the `synthetic_agentic_not_yet_available` validator from
  `inference_perf/config/config.py`.
- Restores/updates the 16 numbered demo configs under
  `examples/synthetic_agentic/demo/` (01 bare → 16 budget cap), each isolating one
  concept of the generator (tool loops, fan-out, context compaction, budget caps,
  etc.) with expected event counts documented in comments.

## Testing

- Existing test suite from #716 (`tests/required/datagen/test_synthetic_agentic.py`)
  continues to cover generator behavior; no test changes needed since this only
  removes a rejection path.