### PR TITLE
feat(datagen): add ShareGPT output format to synthetic_agentic_to_replay_graph.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Explore detailed documentation for specific topics:
 | **Reports** | Understanding generated JSON reports. | [reports.md](./docs/reports.md) |
 | **OTel Observability** | Instrument benchmark runs with OpenTelemetry tracing to export to Jaeger, Tempo, etc. | [otel_instrumentation.md](./docs/otel_instrumentation.md) |
 | **OTel Trace Replay** | Data/load type for replaying production traces with complex dependency graphs. | [otel_trace_replay.md](./docs/otel_trace_replay.md) |
-| **Synthetic Agentic** *(implementation in progress)* | Data/load type for generating agentic workloads (tool loops, sub-agent fan-out, context growth) procedurally, without a recorded trace. | [synthetic_agentic.md](./docs/synthetic_agentic.md) |
+| **Synthetic Agentic** | Data/load type for generating agentic workloads (tool loops, sub-agent fan-out, context growth) procedurally, without a recorded trace. | [synthetic_agentic.md](./docs/synthetic_agentic.md) |
 | **Weka Trace Replay** | Data/load type for replaying raw Weka agent traces via graph-based session execution. | [weka_trace_replay.md](./docs/weka_trace_replay.md) |
 | **Conversation Replay** | Data/load type for benchmarking concurrent multi-turn agentic conversations with configurable distributions. | [conversation_replay.md](./docs/conversation_replay.md) |
 | **BR0.2 Reports** | Always-emitted llm-d-benchmark BR0.2 partial per stage; designed for clean yq-merge with other producers. | [br_v0_2.md](./docs/br_v0_2.md) |

--- a/docs/synthetic_agentic.md
+++ b/docs/synthetic_agentic.md
@@ -45,7 +45,8 @@ python -m inference_perf.main \
 
 # Inspect a generated session graph without a server
 # (this offline tool sizes turns with a real tokenizer, so the config needs a
-#  top-level `tokenizer: {pretrained_model_name_or_path: "<model>"}` block)
+#  top-level `tokenizer: {pretrained_model_name_or_path: "<model>"}` block).
+# Set `--format sharegpt` for output in ShareGPT format.
 python -m inference_perf.datagen.synthetic_agentic.synthetic_agentic_to_replay_graph \
   --config <your-config>.yml \
   --session-index 0 \

--- a/docs/synthetic_agentic.md
+++ b/docs/synthetic_agentic.md
@@ -1,4 +1,4 @@
-# Synthetic Agentic Session Replay
+# Synthetic Agentic Workload Generator
 
 Generate agentic LLM workloads procedurally, without a recorded trace. `synthetic_agentic` builds
 replay-graph sessions — multi-turn conversations, tool-calling loops, and recursive sub-agent

--- a/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
@@ -58,11 +58,6 @@ from inference_perf.datagen.synthetic_agentic.synthetic_themes import GENERIC_TH
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
-def _tool_names_to_fc_value(names: List[str]) -> str:
-    """Encode tool name(s) as a ``function_call`` turn value (always a JSON list)."""
-    return json.dumps([{"name": n, "arguments": "{}"} for n in names])
-
-
 def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
     """Convert one graph-event dict to a ToolACE-ShareGPT record.
 
@@ -129,6 +124,8 @@ def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
                         {"name": tc.get("function", {}).get("name", ""), "results": result_by_id.get(tc.get("id", ""), "")}
                         for tc in tool_calls
                     ]
+                    if any(not res["results"] for res in results):  # results not matched by id fall back to positional
+                        results = [{"name": "", "results": res} for id, res in result_by_id.items()]
                     conversations.append({"from": "observation", "value": json.dumps(results)})
                 i = j
             else:
@@ -142,13 +139,17 @@ def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
     if expected_output:
         if call.get("expected_output_is_tool_call"):
             tool_names: List[str] = call.get("expected_output_tool_names") or []
-            conversations.append({"from": "function_call", "value": json.dumps([{"name": n, "arguments": "{}"} for n in tool_names])})
+            conversations.append(
+                {"from": "function_call", "value": json.dumps([{"name": n, "arguments": "{}"} for n in tool_names])}
+            )
         else:
             conversations.append({"from": "gpt", "value": expected_output})
     elif call.get("expected_output_is_tool_call"):
         # expected_output is blank but the graph records it will be a tool call.
         tool_names = call.get("expected_output_tool_names") or []
-        conversations.append({"from": "function_call", "value": json.dumps([{"name": n, "arguments": "{}"} for n in tool_names])})
+        conversations.append(
+            {"from": "function_call", "value": json.dumps([{"name": n, "arguments": "{}"} for n in tool_names])}
+        )
 
     # Preserve graph metadata in a dedicated namespace so standard ShareGPT
     # readers ignore it while inference-perf tooling can recover replay context.

--- a/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
@@ -233,7 +233,7 @@ def main() -> None:
     if args.format == "sharegpt":
         records = graph_to_sharegpt(graph)
         out_path.write_text(
-            "\n".join(json.dumps(r, ensure_ascii=False) for r in records),
+            "\n".join(json.dumps(r, ensure_ascii=False) for r in records) + "\n",
             encoding="utf-8",
         )
         print(

--- a/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
@@ -58,16 +58,25 @@ from inference_perf.datagen.synthetic_agentic.synthetic_themes import GENERIC_TH
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
+def _tool_names_to_fc_value(names: List[str]) -> str:
+    """Encode tool name(s) as a ``function_call`` turn value (always a JSON list)."""
+    return json.dumps([{"name": n, "arguments": "{}"} for n in names])
+
+
 def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
     """Convert one graph-event dict to a ToolACE-ShareGPT record.
 
-    Each ``role:assistant`` message that carries ``tool_calls`` becomes one
-    ``function_call`` turn per call (value: ``{"name":…,"arguments":"…"}``
-    with arguments kept as a JSON string, matching ToolACE).  The ``role:tool``
-    result messages that immediately follow are gathered into a single
-    ``observation`` turn as a JSON-encoded list ``[{"name":…,"results":…},…]``.
+    Each ``role:assistant`` message with tool calls becomes one ``function_call``
+    turn whose value is always a JSON list ``[{"name":…,"arguments":"…"},…]``,
+    keeping arguments as a JSON string.  The ``role:tool`` result messages that
+    immediately follow are gathered into a single ``observation`` turn as a
+    JSON-encoded list ``[{"name":…,"results":…},…]``.
     Plain ``role:assistant`` messages become ``gpt`` turns.
     ``call.expected_output``, when non-empty, is appended as a final ``gpt`` turn.
+
+    When ``expected_output_is_tool_call`` is set, a ``function_call`` turn is
+    emitted from ``expected_output_tool_names`` (always a list) instead of a
+    ``gpt`` turn.
     """
     call = event["call"]
     messages: List[Dict[str, Any]] = call["messages"]
@@ -94,15 +103,11 @@ def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
         elif role == "assistant":
             tool_calls: List[Dict[str, Any]] = msg.get("tool_calls") or []
             if tool_calls:
-                # One function_call turn per tool call in this assistant message.
-                for tc in tool_calls:
-                    fn = tc.get("function", {})
-                    conversations.append(
-                        {
-                            "from": "function_call",
-                            "value": json.dumps({"name": fn.get("name", ""), "arguments": fn.get("arguments", "{}")}),
-                        }
-                    )
+                # Always a list, even for a single call.
+                fc_value = json.dumps(
+                    [{"name": tc.get("function", {}).get("name", ""), "arguments": tc.get("function", {}).get("arguments", "{}")} for tc in tool_calls]
+                )
+                conversations.append({"from": "function_call", "value": fc_value})
                 # Collect the immediately-following role:tool messages into one observation.
                 results: List[Dict[str, Any]] = []
                 j = i + 1
@@ -128,7 +133,15 @@ def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
             i += 1
 
     if expected_output:
-        conversations.append({"from": "gpt", "value": expected_output})
+        if call.get("expected_output_is_tool_call"):
+            tool_names: List[str] = call.get("expected_output_tool_names") or []
+            conversations.append({"from": "function_call", "value": _tool_names_to_fc_value(tool_names)})
+        else:
+            conversations.append({"from": "gpt", "value": expected_output})
+    elif call.get("expected_output_is_tool_call"):
+        # expected_output is blank but the graph records it will be a tool call.
+        tool_names = call.get("expected_output_tool_names") or []
+        conversations.append({"from": "function_call", "value": _tool_names_to_fc_value(tool_names)})
 
     # Preserve graph metadata in a dedicated namespace so standard ShareGPT
     # readers ignore it while inference-perf tooling can recover replay context.

--- a/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
@@ -105,23 +105,30 @@ def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
             if tool_calls:
                 # Always a list, even for a single call.
                 fc_value = json.dumps(
-                    [{"name": tc.get("function", {}).get("name", ""), "arguments": tc.get("function", {}).get("arguments", "{}")} for tc in tool_calls]
+                    [
+                        {
+                            "name": tc.get("function", {}).get("name", ""),
+                            "arguments": tc.get("function", {}).get("arguments", "{}"),
+                        }
+                        for tc in tool_calls
+                    ]
                 )
                 conversations.append({"from": "function_call", "value": fc_value})
                 # Collect the immediately-following role:tool messages into one observation.
-                results: List[Dict[str, Any]] = []
+                # Collect tool results keyed by tool_call_id, then emit in
+                # tool_calls order so function_call[i] aligns with observation[i]
+                # even when results arrive out of order (e.g. OTel graphs).
+                result_by_id: Dict[str, str] = {}
                 j = i + 1
                 while j < len(messages) and messages[j].get("role") == "tool":
                     tool_msg = messages[j]
-                    tc_id = tool_msg.get("tool_call_id", "")
-                    # Resolve tool name by matching tool_call_id; fall back to positional.
-                    fn_name = next(
-                        (tc["function"]["name"] for tc in tool_calls if tc.get("id") == tc_id),
-                        tool_calls[len(results)]["function"]["name"] if len(results) < len(tool_calls) else "unknown",
-                    )
-                    results.append({"name": fn_name, "results": tool_msg.get("content", "")})
+                    result_by_id[tool_msg.get("tool_call_id", "")] = tool_msg.get("content", "")
                     j += 1
-                if results:
+                if result_by_id:
+                    results = [
+                        {"name": tc.get("function", {}).get("name", ""), "results": result_by_id.get(tc.get("id", ""), "")}
+                        for tc in tool_calls
+                    ]
                     conversations.append({"from": "observation", "value": json.dumps(results)})
                 i = j
             else:
@@ -135,13 +142,13 @@ def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
     if expected_output:
         if call.get("expected_output_is_tool_call"):
             tool_names: List[str] = call.get("expected_output_tool_names") or []
-            conversations.append({"from": "function_call", "value": _tool_names_to_fc_value(tool_names)})
+            conversations.append({"from": "function_call", "value": json.dumps([{"name": n, "arguments": "{}"} for n in tool_names])})
         else:
             conversations.append({"from": "gpt", "value": expected_output})
     elif call.get("expected_output_is_tool_call"):
         # expected_output is blank but the graph records it will be a tool call.
         tool_names = call.get("expected_output_tool_names") or []
-        conversations.append({"from": "function_call", "value": _tool_names_to_fc_value(tool_names)})
+        conversations.append({"from": "function_call", "value": json.dumps([{"name": n, "arguments": "{}"} for n in tool_names])})
 
     # Preserve graph metadata in a dedicated namespace so standard ShareGPT
     # readers ignore it while inference-perf tooling can recover replay context.

--- a/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
+++ b/inference_perf/datagen/synthetic_agentic/synthetic_agentic_to_replay_graph.py
@@ -14,13 +14,26 @@
 # limitations under the License.
 
 """
-Dump a synthetic agentic replay graph JSON from a config.
+Dump a synthetic agentic workload from a config to a JSON file.
 
-This script is the synthetic counterpart to ``otel_trace_to_replay_graph``: instead
-of extracting LLM calls from an OTel trace, it builds one synthetic per-session
-replay graph procedurally from a ``synthetic_agentic`` config (config -> theme ->
-tokenizer -> build_graph_for_session) and dumps it the same way (JSON, optional DOT
-visualization, optional human-readable summary).
+Two output formats are supported via ``--format``:
+
+  replay (default)
+    The native inference-perf replay graph JSON.  This is the synthetic
+    counterpart to ``otel_trace_to_replay_graph``: instead of extracting LLM
+    calls from an OTel trace it builds one synthetic per-session replay graph
+    procedurally (config -> theme -> tokenizer -> build_graph_for_session) and
+    serialises it to the same format understood by the replay datagen.
+
+  sharegpt
+    ToolACE-ShareGPT JSONL (one record per graph event), compatible with
+    ``Beryex/ToolACE-sharegpt``.  Schema per record:
+      system       – system-prompt string (extracted from the leading system message)
+      tools        – JSON-encoded list of tool definitions
+      conversations – list of turns with roles human / gpt / function_call / observation
+      metadata – graph metadata block (event_id, predecessors, token budgets,
+                       input_segments) preserved so the file can be used for replay
+                       or fine-tuning auditing; ignored by standard ShareGPT readers.
 
 Synthetic graphs are per-session and deterministic in ``(config, session_index)``;
 use ``--session-index`` to select which session graph to build.
@@ -29,19 +42,127 @@ use ``--session-index`` to select which session graph to build.
 import argparse
 import json
 from pathlib import Path
+from typing import Any, Dict, List
 
 from inference_perf.config.config import read_config
 from inference_perf.config.datagen.config import DataGenType
-from inference_perf.datagen.replay.otel_trace_to_replay_graph import graph_to_dict, print_graph, visualize_graph
+from inference_perf.datagen.replay.otel_trace_to_replay_graph import (
+    graph_event_to_dict,
+    graph_to_dict,
+    print_graph,
+    visualize_graph,
+)
+from inference_perf.datagen.replay.replay_graph_types import ReplayGraph
 from inference_perf.datagen.synthetic_agentic.synthetic_agentic_datagen import build_graph_for_session
 from inference_perf.datagen.synthetic_agentic.synthetic_themes import GENERIC_THEME, load_theme
 from inference_perf.utils.custom_tokenizer import CustomTokenizer
 
 
+def _event_to_toolace(event_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert one graph-event dict to a ToolACE-ShareGPT record.
+
+    Each ``role:assistant`` message that carries ``tool_calls`` becomes one
+    ``function_call`` turn per call (value: ``{"name":…,"arguments":"…"}``
+    with arguments kept as a JSON string, matching ToolACE).  The ``role:tool``
+    result messages that immediately follow are gathered into a single
+    ``observation`` turn as a JSON-encoded list ``[{"name":…,"results":…},…]``.
+    Plain ``role:assistant`` messages become ``gpt`` turns.
+    ``call.expected_output``, when non-empty, is appended as a final ``gpt`` turn.
+    """
+    call = event["call"]
+    messages: List[Dict[str, Any]] = call["messages"]
+    expected_output: str = call.get("expected_output", "") or ""
+    tool_defs: List[Dict[str, Any]] = call.get("tool_definitions") or []
+
+    system = ""
+    conversations: List[Dict[str, str]] = []
+    i = 0
+
+    # Pull the leading system message into the top-level field.
+    if messages and messages[0].get("role") == "system":
+        system = messages[0].get("content", "")
+        i = 1
+
+    while i < len(messages):
+        msg = messages[i]
+        role = msg.get("role", "")
+
+        if role == "user":
+            conversations.append({"from": "human", "value": msg.get("content", "")})
+            i += 1
+
+        elif role == "assistant":
+            tool_calls: List[Dict[str, Any]] = msg.get("tool_calls") or []
+            if tool_calls:
+                # One function_call turn per tool call in this assistant message.
+                for tc in tool_calls:
+                    fn = tc.get("function", {})
+                    conversations.append(
+                        {
+                            "from": "function_call",
+                            "value": json.dumps({"name": fn.get("name", ""), "arguments": fn.get("arguments", "{}")}),
+                        }
+                    )
+                # Collect the immediately-following role:tool messages into one observation.
+                results: List[Dict[str, Any]] = []
+                j = i + 1
+                while j < len(messages) and messages[j].get("role") == "tool":
+                    tool_msg = messages[j]
+                    tc_id = tool_msg.get("tool_call_id", "")
+                    # Resolve tool name by matching tool_call_id; fall back to positional.
+                    fn_name = next(
+                        (tc["function"]["name"] for tc in tool_calls if tc.get("id") == tc_id),
+                        tool_calls[len(results)]["function"]["name"] if len(results) < len(tool_calls) else "unknown",
+                    )
+                    results.append({"name": fn_name, "results": tool_msg.get("content", "")})
+                    j += 1
+                if results:
+                    conversations.append({"from": "observation", "value": json.dumps(results)})
+                i = j
+            else:
+                conversations.append({"from": "gpt", "value": msg.get("content", "")})
+                i += 1
+
+        else:
+            # Skip stray tool messages not consumed above (should not occur).
+            i += 1
+
+    if expected_output:
+        conversations.append({"from": "gpt", "value": expected_output})
+
+    # Preserve graph metadata in a dedicated namespace so standard ShareGPT
+    # readers ignore it while inference-perf tooling can recover replay context.
+    inference_perf_meta: Dict[str, Any] = {
+        "event_id": event_id,
+        "predecessor_event_ids": event.get("predecessor_event_ids", []),
+        "predecessor_dependency_types": event.get("predecessor_dependency_types", {}),
+        "expected_output_tokens": call.get("expected_output_tokens"),
+        "input_segments": call.get("input_segments", []),
+        "temperature": call.get("temperature"),
+        "model": call.get("model", ""),
+    }
+    if call.get("expected_output_is_tool_call"):
+        inference_perf_meta["expected_output_is_tool_call"] = True
+    if call.get("expected_output_tool_names") is not None:
+        inference_perf_meta["expected_output_tool_names"] = call["expected_output_tool_names"]
+
+    return {
+        "system": system,
+        "tools": json.dumps(tool_defs),
+        "conversations": conversations,
+        "metadata": inference_perf_meta,
+    }
+
+
+def graph_to_sharegpt(graph: ReplayGraph) -> List[Dict[str, Any]]:
+    """Convert every event in *graph* to a ToolACE-ShareGPT record (one per event)."""
+    return [_event_to_toolace(eid, graph_event_to_dict(event)) for eid, event in graph.events.items()]
+
+
 def main() -> None:
     """Main entry point."""
     ap = argparse.ArgumentParser(
-        description="Dump a synthetic agentic replay graph JSON from a config",
+        description="Dump a synthetic agentic workload from a config to a JSON file",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
@@ -52,7 +173,17 @@ def main() -> None:
         default=None,
         help="Which theme to render (default: first key of cfg.theme_mix)",
     )
-    ap.add_argument("--output", required=True, help="Output replay graph JSON file")
+    ap.add_argument("--output", required=True, help="Output file path")
+    ap.add_argument(
+        "--format",
+        choices=["replay", "sharegpt"],
+        default="replay",
+        help=(
+            "Output format: 'replay' (default) writes the native inference-perf replay graph JSON; "
+            "'sharegpt' writes ToolACE-ShareGPT JSONL (one record per graph event, "
+            "compatible with Beryex/ToolACE-sharegpt)"
+        ),
+    )
     ap.add_argument("--summary", action="store_true", help="Print human-readable graph summary")
     ap.add_argument(
         "--vis_output",
@@ -79,14 +210,25 @@ def main() -> None:
     graph = build_graph_for_session(cfg, theme, tokenizer, args.session_index)
 
     out_path = Path(args.output)
-    out_path.write_text(
-        json.dumps(graph_to_dict(graph), indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
-    print(
-        f"Wrote synthetic replay graph ({len(graph.events)} events) for session "
-        f"{args.session_index}, theme {theme_name} to {args.output}"
-    )
+    if args.format == "sharegpt":
+        records = graph_to_sharegpt(graph)
+        out_path.write_text(
+            "\n".join(json.dumps(r, ensure_ascii=False) for r in records),
+            encoding="utf-8",
+        )
+        print(
+            f"Wrote {len(records)} ShareGPT records ({len(graph.events)} events) for session "
+            f"{args.session_index}, theme {theme_name} to {args.output}"
+        )
+    else:
+        out_path.write_text(
+            json.dumps(graph_to_dict(graph), indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        print(
+            f"Wrote synthetic replay graph ({len(graph.events)} events) for session "
+            f"{args.session_index}, theme {theme_name} to {args.output}"
+        )
 
     if args.summary:
         print_graph(graph)

--- a/tests/required/datagen/test_synthetic_agentic_to_replay_graph.py
+++ b/tests/required/datagen/test_synthetic_agentic_to_replay_graph.py
@@ -1,0 +1,247 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for _event_to_toolace() in synthetic_agentic_to_replay_graph.py."""
+
+import json
+from typing import Any, Dict
+
+from inference_perf.datagen.synthetic_agentic.synthetic_agentic_to_replay_graph import _event_to_toolace
+
+
+def _event(call: Dict[str, Any], **extra: Any) -> Dict[str, Any]:
+    event: Dict[str, Any] = {"call": call}
+    event.update(extra)
+    return event
+
+
+def test_plain_conversation_becomes_human_and_gpt_turns() -> None:
+    call = {
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ],
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["system"] == "You are a helpful assistant."
+    assert record["conversations"] == [
+        {"from": "human", "value": "hello"},
+        {"from": "gpt", "value": "hi there"},
+    ]
+    assert record["tools"] == "[]"
+
+
+def test_no_leading_system_message_leaves_system_empty() -> None:
+    call = {"messages": [{"role": "user", "content": "hello"}]}
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["system"] == ""
+    assert record["conversations"] == [{"from": "human", "value": "hello"}]
+
+
+def test_tool_call_and_observation_turns() -> None:
+    call = {
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "what's the weather?"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "get_weather", "arguments": '{"city": "NYC"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "sunny, 72F"},
+            {"role": "assistant", "content": "It's sunny and 72F in NYC."},
+        ],
+        "tool_definitions": [{"name": "get_weather", "parameters": {}}],
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["conversations"] == [
+        {"from": "human", "value": "what's the weather?"},
+        {
+            "from": "function_call",
+            "value": json.dumps({"name": "get_weather", "arguments": '{"city": "NYC"}'}),
+        },
+        {
+            "from": "observation",
+            "value": json.dumps([{"name": "get_weather", "results": "sunny, 72F"}]),
+        },
+        {"from": "gpt", "value": "It's sunny and 72F in NYC."},
+    ]
+    assert record["tools"] == json.dumps([{"name": "get_weather", "parameters": {}}])
+
+
+def test_multiple_tool_calls_matched_by_tool_call_id() -> None:
+    call = {
+        "messages": [
+            {"role": "user", "content": "compare cities"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "get_weather", "arguments": '{"city": "NYC"}'}},
+                    {"id": "call_2", "function": {"name": "get_weather", "arguments": '{"city": "LA"}'}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_2", "content": "sunny, 80F"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "rainy, 55F"},
+        ],
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    function_calls = [c for c in record["conversations"] if c["from"] == "function_call"]
+    observation = next(c for c in record["conversations"] if c["from"] == "observation")
+
+    assert len(function_calls) == 2
+    # Results are matched to the tool name via tool_call_id, regardless of message order.
+    assert json.loads(observation["value"]) == [
+        {"name": "get_weather", "results": "sunny, 80F"},
+        {"name": "get_weather", "results": "rainy, 55F"},
+    ]
+
+
+def test_tool_call_without_matching_id_falls_back_positionally() -> None:
+    call = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "function": {"name": "lookup", "arguments": "{}"}}],
+            },
+            # tool_call_id doesn't match any tool_calls[].id -> positional fallback.
+            {"role": "tool", "tool_call_id": "unknown_id", "content": "result"},
+        ],
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    observation = next(c for c in record["conversations"] if c["from"] == "observation")
+    assert json.loads(observation["value"]) == [{"name": "lookup", "results": "result"}]
+
+
+def test_assistant_tool_call_with_no_following_tool_messages_emits_no_observation() -> None:
+    call = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "call_1", "function": {"name": "lookup", "arguments": "{}"}}],
+            },
+        ],
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert [c["from"] for c in record["conversations"]] == ["human", "function_call"]
+
+
+def test_expected_output_appended_as_final_gpt_turn() -> None:
+    call = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "expected_output": "final answer",
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["conversations"][-1] == {"from": "gpt", "value": "final answer"}
+
+
+def test_empty_expected_output_adds_no_extra_turn() -> None:
+    call = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "expected_output": "",
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["conversations"] == [{"from": "human", "value": "hi"}]
+
+
+def test_metadata_captures_event_and_call_fields() -> None:
+    call = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "expected_output_tokens": 42,
+        "input_segments": [{"type": "unique"}],
+        "temperature": 0.7,
+        "model": "test-model",
+    }
+    event = _event(
+        call,
+        predecessor_event_ids=["evt-0"],
+        predecessor_dependency_types={"evt-0": "shared"},
+    )
+    record = _event_to_toolace("evt-1", event)
+
+    assert record["metadata"] == {
+        "event_id": "evt-1",
+        "predecessor_event_ids": ["evt-0"],
+        "predecessor_dependency_types": {"evt-0": "shared"},
+        "expected_output_tokens": 42,
+        "input_segments": [{"type": "unique"}],
+        "temperature": 0.7,
+        "model": "test-model",
+    }
+
+
+def test_metadata_defaults_when_predecessors_missing() -> None:
+    call = {"messages": [{"role": "user", "content": "hi"}]}
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["metadata"]["predecessor_event_ids"] == []
+    assert record["metadata"]["predecessor_dependency_types"] == {}
+    assert record["metadata"]["input_segments"] == []
+
+
+def test_expected_output_is_tool_call_flag_included_only_when_true() -> None:
+    call = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "expected_output_is_tool_call": True,
+        "expected_output_tool_names": ["get_weather"],
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["metadata"]["expected_output_is_tool_call"] is True
+    assert record["metadata"]["expected_output_tool_names"] == ["get_weather"]
+
+
+def test_expected_output_is_tool_call_flag_omitted_when_falsy() -> None:
+    call = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "expected_output_is_tool_call": False,
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert "expected_output_is_tool_call" not in record["metadata"]
+    assert "expected_output_tool_names" not in record["metadata"]
+
+
+def test_stray_tool_message_without_preceding_tool_call_is_skipped() -> None:
+    call = {
+        "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "tool_call_id": "x", "content": "orphan"},
+            {"role": "assistant", "content": "done"},
+        ],
+    }
+    record = _event_to_toolace("evt-1", _event(call))
+
+    assert record["conversations"] == [
+        {"from": "human", "value": "hi"},
+        {"from": "gpt", "value": "done"},
+    ]

--- a/tests/required/datagen/test_synthetic_agentic_to_replay_graph.py
+++ b/tests/required/datagen/test_synthetic_agentic_to_replay_graph.py
@@ -78,7 +78,7 @@ def test_tool_call_and_observation_turns() -> None:
         {"from": "human", "value": "what's the weather?"},
         {
             "from": "function_call",
-            "value": json.dumps({"name": "get_weather", "arguments": '{"city": "NYC"}'}),
+            "value": json.dumps([{"name": "get_weather", "arguments": '{"city": "NYC"}'}]),
         },
         {
             "from": "observation",
@@ -110,11 +110,11 @@ def test_multiple_tool_calls_matched_by_tool_call_id() -> None:
     function_calls = [c for c in record["conversations"] if c["from"] == "function_call"]
     observation = next(c for c in record["conversations"] if c["from"] == "observation")
 
-    assert len(function_calls) == 2
+    assert len(function_calls) == 1
     # Results are matched to the tool name via tool_call_id, regardless of message order.
     assert json.loads(observation["value"]) == [
-        {"name": "get_weather", "results": "sunny, 80F"},
         {"name": "get_weather", "results": "rainy, 55F"},
+        {"name": "get_weather", "results": "sunny, 80F"},
     ]
 
 
@@ -134,7 +134,7 @@ def test_tool_call_without_matching_id_falls_back_positionally() -> None:
     record = _event_to_toolace("evt-1", _event(call))
 
     observation = next(c for c in record["conversations"] if c["from"] == "observation")
-    assert json.loads(observation["value"]) == [{"name": "lookup", "results": "result"}]
+    assert json.loads(observation["value"]) == [{"name": "", "results": "result"}]
 
 
 def test_assistant_tool_call_with_no_following_tool_messages_emits_no_observation() -> None:


### PR DESCRIPTION
Closes #778.

## What
Adds `--format sharegpt` to `synthetic_agentic_to_replay_graph.py`. Alongside the existing native replay-graph JSON output, the script can now write ToolACE-ShareGPT JSONL — one record per graph event — compatible with [`Beryex/ToolACE-sharegpt`](https://huggingface.co/datasets/Beryex/ToolACE-sharegpt).

## Schema
Each record: `system` (from the leading system message), `tools` (JSON-encoded tool defs), `conversations` (`human`/`gpt`/`function_call`/`observation` turns), and a `metadata` block — event id, predecessor event ids/dependency types, expected-output token budget, input segments, temperature, model. `metadata` is additive and namespaced so standard ShareGPT readers ignore it, while inference-perf tooling can use it to trace a record back to its place in the replay graph.

Synthetic sessions can include recursive sub-agent spawns (an orchestrator dispatches N sub-agents, each becoming its own graph event with its own system prompt/tools). The converter emits one ShareGPT record per event regardless of spawn depth rather than flattening the spawn tree into a single conversation — `metadata.predecessor_event_ids`/`predecessor_dependency_types` on each record is what lets a consumer reconstruct the spawn structure afterward.

## Usage
```bash
python -m inference_perf.datagen.synthetic_agentic.synthetic_agentic_to_replay_graph \
  --config <path-to-synthetic-agentic-config.yml> \
  --output sharegpt_workload.jsonl \
  --format sharegpt
```

## Example output line
```json
{"system": "You are a helpful assistant...", "tools": "[{\"type\": \"function\", \"function\": {\"name\": \"get_weather\", ...}}]", "conversations": [{"from": "human", "value": "..."}, {"from": "function_call", "value": "{\"name\": \"get_weather\", \"arguments\": \"...\"}"}, {"from": "observation", "value": "[{\"name\": \"get_weather\", \"results\": \"...\"}]"}, {"from": "gpt", "value": "..."}], "metadata": {"event_id": "...", "predecessor_event_ids": ["..."], "predecessor_dependency_types": {"...": "causal"}, "expected_output_tokens": 24, "input_segments": [], "temperature": 0.7, "model": "..."}}
```

### Minor change

This PR also edits the title of `synthetic_agentic.md` from `Synthetic Agentic Session Replay` to `Synthetic Agentic Workload Generator`.