### PR TITLE
fix: parse valid SSE line endings and data fields

### DIFF
--- a/inference_perf/apis/streaming_parser.py
+++ b/inference_perf/apis/streaming_parser.py
@@ -20,6 +20,7 @@ LLM APIs, reducing code duplication across different API types.
 """
 
 import json
+import re
 import time
 from typing import Any, Callable, List, Optional, Tuple
 
@@ -80,37 +81,54 @@ async def parse_sse_stream(
     response_chunks: List[str] = []
     server_usage: Optional[dict[str, Any]] = None
 
+    data_lines: List[bytes] = []
+    skip_lf = False
+    done = False
+    line_ending = re.compile(rb"\r\n|\r|\n")
+
     try:
         async for chunk in response.content.iter_any():
             raw_content += chunk
+            if done:
+                continue
             buffer += chunk
-            while b"\n\n" in buffer:
-                message, buffer = buffer.split(b"\n\n", 1)
+            # A CR terminates a line immediately; swallow its optional LF even
+            # when the pair straddles network chunks.
+            if skip_lf and buffer:
+                buffer = buffer.removeprefix(b"\n")
+                skip_lf = False
+            while match := line_ending.search(buffer):
+                line = buffer[: match.start()]
+                skip_lf = match.group() == b"\r" and match.end() == len(buffer)
+                buffer = buffer[match.end() :]
+                if line:
+                    field, separator, value = line.partition(b":")
+                    if field == b"data":
+                        data_lines.append(value.removeprefix(b" ") if separator else b"")
+                    continue
+                if not data_lines:
+                    continue
+                data_str = b"\n".join(data_lines)
+                data_lines.clear()
                 message_time = time.perf_counter()
-                done = False
-                for line in message.split(sep=b"\n"):
-                    if line.startswith(b"data:"):
-                        data_str = line.removeprefix(b"data: ").strip()
-                        if data_str == b"[DONE]":
-                            done = True
-                            break
-                        try:
-                            data = json.loads(data_str)
-                            usage = data.get("usage")
-                            if not isinstance(usage, dict):
-                                message_data = data.get("message")
-                                if isinstance(message_data, dict):
-                                    usage = message_data.get("usage")
-                            if isinstance(usage, dict):
-                                server_usage = {**(server_usage or {}), **usage}
-                            if content := extract_content(data):
-                                output_text += content
-                                chunk_times.append(message_time)
-                                response_chunks.append(data_str.decode("utf-8", errors="ignore"))
-                        except (json.JSONDecodeError, IndexError):
-                            continue
-                if done:
+                if data_str.strip() == b"[DONE]":
+                    done = True
                     break
+                try:
+                    data = json.loads(data_str)
+                    usage = data.get("usage")
+                    if not isinstance(usage, dict):
+                        message_data = data.get("message")
+                        if isinstance(message_data, dict):
+                            usage = message_data.get("usage")
+                    if isinstance(usage, dict):
+                        server_usage = {**(server_usage or {}), **usage}
+                    if content := extract_content(data):
+                        output_text += content
+                        chunk_times.append(message_time)
+                        response_chunks.append(data_str.decode("utf-8", errors="ignore"))
+                except (json.JSONDecodeError, IndexError):
+                    continue
     except Exception as e:
         # The stream broke partway (e.g. a truncated SSE stream, a dropped
         # connection, or a proxy that 200s then sends an error page). Re-raise

--- a/tests/required/apis/test_streaming_parser.py
+++ b/tests/required/apis/test_streaming_parser.py
@@ -136,3 +136,77 @@ async def test_parse_sse_stream_interrupted_preserves_partial_body() -> None:
     # The bytes received before the break are retained, not discarded.
     assert "Hello" in err.raw_content
     assert "world" in err.raw_content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ending", [b"\n", b"\r\n", b"\r"])
+@pytest.mark.parametrize("space", [b"", b" "])
+@pytest.mark.parametrize("chunk_size", [1, 7, 4096])
+async def test_sse_line_endings_and_optional_space(ending: bytes, space: bytes, chunk_size: int) -> None:
+    """Network boundaries must not change valid SSE event framing or UTF-8."""
+    payload = (
+        b": heartbeat"
+        + ending
+        + b"event: message"
+        + ending
+        + b"data:"
+        + space
+        + '{"content": "你好"}'.encode()
+        + ending * 2
+        + b"data:"
+        + space
+        + b'{"usage": {"completion_tokens": 2}}'
+        + ending * 2
+        + b"data:"
+        + space
+        + b"[DONE]"
+        + ending * 2
+    )
+    response = Mock()
+
+    async def chunks() -> AsyncGenerator[bytes, None]:
+        for offset in range(0, len(payload), chunk_size):
+            yield payload[offset : offset + chunk_size]
+
+    response.content.iter_any = chunks
+    output, times, raw, events, usage = await parse_sse_stream(response, lambda data: data.get("content"))
+    assert output == "你好"
+    assert len(times) == len(events) == 1
+    assert raw == payload.decode()
+    assert usage == {"completion_tokens": 2}
+
+
+@pytest.mark.asyncio
+async def test_sse_multiline_data_and_incomplete_event() -> None:
+    response = Mock()
+    payload = b'data: {"content":\ndata: "Hello"}\n\ndata: invalid json\n\ndata: {"content": " discarded"}\n'
+
+    async def chunks() -> AsyncGenerator[bytes, None]:
+        yield payload
+
+    response.content.iter_any = chunks
+    output, times, raw, events, _ = await parse_sse_stream(response, lambda data: data.get("content"))
+    assert output == "Hello"
+    assert len(times) == len(events) == 1
+    assert events == ['{"content":\n"Hello"}']
+    assert raw == payload.decode()
+
+
+@pytest.mark.asyncio
+async def test_sse_done_ignores_later_content_but_preserves_raw_body() -> None:
+    response = Mock()
+    payloads = [
+        b'data: {"content": "Hello"}\n\n',
+        b"data:  [DONE] \n\n",
+        b'data: {"content": " ignored"}\n\n',
+    ]
+
+    async def chunks() -> AsyncGenerator[bytes, None]:
+        for payload in payloads:
+            yield payload
+
+    response.content.iter_any = chunks
+    output, times, raw, events, _ = await parse_sse_stream(response, lambda data: data.get("content"))
+    assert output == "Hello"
+    assert len(times) == len(events) == 1
+    assert raw == b"".join(payloads).decode()


### PR DESCRIPTION
Streaming responses using CRLF line endings or `data:{...}` without a space currently lose every content event, even though both forms are valid SSE. The raw response is retained, but output text, chunk timestamps and server usage are empty.

Parse SSE incrementally using CRLF, LF or CR line endings, including a CRLF pair split across network chunks. Remove the optional single space after `data:`, join multiple data fields into one event, and retain the existing usage aggregation and partial-body error handling.

Regression tests exercise all three line endings, both field forms, one-byte fragmentation (including UTF-8), comments, multiline data, malformed JSON and incomplete final events. Before the fix, 16 of these parser cases fail. The existing interrupted-HTTP-stream integration tests also pass with the fix.

Validation:
- Targeted streaming/parser/integration tests: 31 passed (including whitespace-tolerant [DONE] handling across chunks).
- Full suite: 1383 passed, 7 skipped; the final [DONE] compatibility adjustment was then checked by the 31-test streaming slice.
- Coverage regression check: 77.82% versus 77.80% on the same main commit; both the absolute floor and delta check passed.
- Strict mypy: 260 source files passed.
- Ruff 0.15.20 (matching pdm.lock), formatting and CLI flag documentation sync passed.
- Manual benchmark: real CLI against a local aiohttp SSE endpoint using CRLF and no-space data fields; 4 requests succeeded, each reporting 2 output tokens, 2 content chunks and server usage. No model is needed to reproduce this protocol parsing issue.
