### PR TITLE
fix: preserve microsecond precision in Azure trace replay

### DIFF
--- a/inference_perf/utils/trace_reader.py
+++ b/inference_perf/utils/trace_reader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
+from itertools import takewhile
 from typing import Iterator, Optional, List, Tuple
 from pathlib import Path
 import csv
@@ -111,8 +112,8 @@ class AzurePublicDatasetReader(TraceReader):
         ts = raw_ts.replace("T", " ").rstrip("Z").strip()
         if "." in ts:
             head, frac = ts.split(".", 1)
-            # Keep only digits in fractional seconds and retain up to microsecond precision
-            frac_digits = "".join(ch for ch in frac if ch.isdigit())
+            # Stop at a suffix so timezone digits cannot enter the fractional seconds.
+            frac_digits = "".join(takewhile(str.isdigit, frac))
             frac6 = frac_digits[:6].ljust(6, "0")
             ts_clean = f"{head}.{frac6}"
         else:

--- a/inference_perf/utils/trace_reader.py
+++ b/inference_perf/utils/trace_reader.py
@@ -107,16 +107,16 @@ class AzurePublicDatasetReader(TraceReader):
         """Parse timestamp from string to float."""
 
         raw_ts = timestamp.strip().strip('"')
-        # Normalize to "YYYY-MM-DD HH:MM:SS.ff" in UTC
+        # Normalize to "YYYY-MM-DD HH:MM:SS.ffffff" in UTC
         ts = raw_ts.replace("T", " ").rstrip("Z").strip()
         if "." in ts:
             head, frac = ts.split(".", 1)
-            # Keep only digits in fractional seconds and coerce to 2 digits
+            # Keep only digits in fractional seconds and retain up to microsecond precision
             frac_digits = "".join(ch for ch in frac if ch.isdigit())
-            frac2 = (frac_digits[:2]).ljust(2, "0")
-            ts_clean = f"{head}.{frac2}"
+            frac6 = frac_digits[:6].ljust(6, "0")
+            ts_clean = f"{head}.{frac6}"
         else:
-            ts_clean = f"{ts}.00"
+            ts_clean = f"{ts}.000000"
         return datetime.strptime(ts_clean, self.timestamp_format).replace(tzinfo=timezone.utc).timestamp()
 
     def has_header(self, file_path: Path) -> bool:

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -177,6 +177,7 @@ class TestAzureTimestampPrecision:
         )
         timer = TraceReplayLoadTimer(AzurePublicDatasetReader(), trace)
         actual = list(timer.start_timer(initial=0.0))
+        # Epoch-sized float64 timestamps have sub-microsecond rounding error.
         assert actual == pytest.approx([0, 0.001, 0.008, 0.010, 0.010123, 1], abs=5e-7)
 
     def test_timestamp_format_compatibility(self) -> None:
@@ -190,6 +191,8 @@ class TestAzureTimestampPrecision:
             (' "2023-01-01T00:00:00.1Z" ', 100000),
             ("2023-01-01 00:00:00.12", 120000),
             ("2023-01-01T00:00:00.123Z", 123000),
+            ("2023-01-01T00:00:00.123+05:30", 123000),
+            ("2023-01-01T00:00:00.123-05:30", 123000),
             ("2023-01-01 00:00:00.123456", 123456),
             ("2023-01-01 00:00:00.123456789", 123456),
         ]:

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -157,3 +157,40 @@ class TestBuildSessionMetricFailureReason:
         assert metric.error is None
         assert metric.num_events_completed == 1
         assert metric.num_events_cancelled == 0
+
+
+class TestAzureTimestampPrecision:
+    def test_submillisecond_replay_timing(self, tmp_path: Path) -> None:
+        import pytest
+        from inference_perf.utils.trace_reader import AzurePublicDatasetReader
+        from inference_perf.loadgen.load_timer import TraceReplayLoadTimer
+
+        trace = tmp_path / "trace.csv"
+        trace.write_text(
+            "TIMESTAMP,ContextTokens,GeneratedTokens\n"
+            "2023-01-01 00:00:00.001,150,200\n"
+            "2023-01-01 00:00:00.002,300,150\n"
+            "2023-01-01 00:00:00.009,250,100\n"
+            "2023-01-01 00:00:00.011,200,300\n"
+            "2023-01-01 00:00:00.011123,200,300\n"
+            "2023-01-01 00:00:01.001,200,300\n"
+        )
+        timer = TraceReplayLoadTimer(AzurePublicDatasetReader(), trace)
+        actual = list(timer.start_timer(initial=0.0))
+        assert actual == pytest.approx([0, 0.001, 0.008, 0.010, 0.010123, 1], abs=5e-7)
+
+    def test_timestamp_format_compatibility(self) -> None:
+        from datetime import datetime, timezone
+        from inference_perf.utils.trace_reader import AzurePublicDatasetReader
+
+        reader = AzurePublicDatasetReader()
+        base = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        for timestamp, microseconds in [
+            ("2023-01-01 00:00:00", 0),
+            (' "2023-01-01T00:00:00.1Z" ', 100000),
+            ("2023-01-01 00:00:00.12", 120000),
+            ("2023-01-01T00:00:00.123Z", 123000),
+            ("2023-01-01 00:00:00.123456", 123456),
+            ("2023-01-01 00:00:00.123456789", 123456),
+        ]:
+            assert reader.parse_timestamp(timestamp) == base.replace(microsecond=microseconds).timestamp()


### PR DESCRIPTION
Azure trace replay truncates fractional timestamps to two digits. Requests at 1, 2, 9 and 11 milliseconds are therefore scheduled at relative offsets `[0, 0, 0, 0.01]`, collapsing distinct arrivals into a burst instead of preserving `[0, 0.001, 0.008, 0.010]`.

Retain up to six fractional digits, matching datetime's microsecond resolution. Keep the existing accepted quoted, UTC `T`/`Z`, whole-second and shorter-fraction formats, and truncate higher precision only at the microsecond boundary.

The regression test loads an actual CSV through AzurePublicDatasetReader and TraceReplayLoadTimer, checking millisecond, microsecond and cross-second offsets. Both new tests fail before the fix and pass afterward.

Validation:
- Trace replay tests: 5 passed.
- Full suite: 1365 passed, 7 skipped, and one analysis test initially failed because the optional matplotlib dependency was absent. After installing the analysis dependency, that test passed (1366 total passing tests).
- Coverage regression check: 77.83% versus 77.80% on the same main commit; both the absolute floor and delta check passed.
- Strict mypy: 260 source files passed.
- Ruff 0.15.20 (matching pdm.lock), formatting and CLI flag documentation sync passed.
- Manual benchmark: real CLI replays a four-row Azure timing trace against a local HTTP completion endpoint; all 4 requests succeed. Exact submillisecond scheduling offsets are asserted in the timer regression test rather than relying on wall-clock network timing.
