### PR TITLE
fix(metrics): use the discovered model in selectors

### DIFF
--- a/inference_perf/client/modelserver/sglang_client.py
+++ b/inference_perf/client/modelserver/sglang_client.py
@@ -54,7 +54,7 @@ class SGlangModelServerClient(openAIModelServerClient):
             request_retries=request_retries,
             request_retry_backoff_sec=request_retry_backoff_sec,
         )
-        self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
+        self.metric_filters = [f"model_name='{self.model_name}'", *additional_filters]
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion, APIType.Chat]

--- a/inference_perf/client/modelserver/vllm_client.py
+++ b/inference_perf/client/modelserver/vllm_client.py
@@ -58,7 +58,7 @@ class vLLMModelServerClient(openAIModelServerClient):
             request_retries=request_retries,
             request_retry_backoff_sec=request_retry_backoff_sec,
         )
-        self.metric_filters = [f"model_name='{model_name}'", *additional_filters]
+        self.metric_filters = [f"model_name='{self.model_name}'", *additional_filters]
 
     def get_supported_apis(self) -> List[APIType]:
         return [APIType.Completion, APIType.Chat, APIType.AnthropicMessages]

--- a/tests/required/client/modelserver/backend_client_suite.py
+++ b/tests/required/client/modelserver/backend_client_suite.py
@@ -370,6 +370,10 @@ class BackendClientSuite:
                 additional_filters=[],
             )
         assert client.model_name == MODEL
+        metadata = client.get_prometheus_metric_metadata()
+        assert metadata.filters == ",".join(self.backend.expected_metric_filters)
+        for _, metric in metadata:
+            assert "None" not in " ".join(metric.get_queries(60, metadata.filters))
         mock_get.assert_called_once_with(f"{BASE_URI}/v1/models")
 
     def test_supported_apis_and_metric_metadata(self) -> None:


### PR DESCRIPTION
When `server.model_name` is omitted, model discovery resolves the name correctly, but vLLM and SGLang metric selectors still interpolate the original `None` argument. Prometheus requests consequently select `model_name='None'` instead of the discovered model.

Build both clients' selectors from `self.model_name`. Extend the existing backend discovery test to validate the resulting metric metadata and queries; TGI's existing filter behavior is preserved.

Validation:
- Regression failed for vLLM and SGLang before the fix and passed afterward.
- Real CLI benchmark against local inference and Prometheus HTTP fixtures: four successful requests; all 141 emitted queries use the discovered model. The same benchmark on main emitted `model_name='None'` and failed the query assertion.
- Full suite: 1364 passed, 7 skipped; related client suite passed.
- Strict mypy, locked Ruff format/lint, CLI documentation sync, license checks passed.
- Coverage: 77.80%, maintained against main; both project coverage gates passed.

The Prometheus fixture records actual HTTP queries; this validation does not require a deployed Prometheus or model server.
