### PR TITLE
fix(config): redact credentials from the logged and saved config

### DIFF
--- a/docs/cli_flags.md
+++ b/docs/cli_flags.md
@@ -397,11 +397,11 @@ Any extra keys in the dict are passed as kwargs to datasets.load_dataset(). |
 | `--server.model_name` | str | Model name sent in each request. Auto-detected from the server if unset. |
 | `--server.base_url` | str | Base URL of the model server, e.g. 'http://localhost:8000'. |
 | `--server.ignore_eos` | boolean | Ask the server to keep generating past the end-of-sequence token so outputs hit the requested length. |
-| `--server.api_key` | str | API key sent as a bearer token with each request. |
+| `--server.api_key` | str | API key sent as a bearer token with each request. Redacted in the logged and saved config. |
 | `--server.cert_path` | str | Path to a client TLS certificate file. |
 | `--server.key_path` | str | Path to the private key for the client TLS certificate. |
 | `--tokenizer.pretrained_model_name_or_path` | str | HuggingFace model name or local path of the tokenizer to load. |
 | `--tokenizer.trust_remote_code` | boolean | Allow the tokenizer to execute code from its repository when loading. |
-| `--tokenizer.token` | str | HuggingFace access token used to download the tokenizer. |
+| `--tokenizer.token` | str | HuggingFace access token used to download the tokenizer. Redacted in the logged and saved config. |
 | `--tokenizer.load_timeout` | float | Deadline in seconds for loading the tokenizer, including any download from Hugging Face Hub. Null disables the deadline. |
 | `--circuit_breakers` | JSON | Circuit breakers that stop the run when observed metrics cross configured thresholds. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,7 @@
    - [Reporting](#reporting)
    - [Storage](#storage)
    - [Tokenizer](#tokenizer)
+   - [Credentials](#credentials)
 3. [Full Configuration Examples](#full-configuration-examples)
 4. [Advanced Use Cases](#advanced-use-cases)
    - [OpenTelemetry Trace Replay](#opentelemetry-trace-replay)
@@ -367,6 +368,16 @@ tokenizer:
 ```
 
 `load_timeout: null` can only be set in a YAML config file; the `--tokenizer.load_timeout` CLI flag parses a float and rejects `null`. The deadline applies to each tokenizer construction independently; a run constructs a tokenizer in several stages (data generation, the model server client, report generation), so the worst-case total wait is a small multiple of `load_timeout`.
+
+### Credentials
+
+A config can carry a credential in three places: `server.api_key`, `tokenizer.token`, and an authentication header under `api.headers`.
+
+A run renders its config twice, to the log at startup and to `config.yaml` in the report bundle. Both copies replace these values with `[REDACTED]`, so pod logs and reports uploaded to GCS or S3 do not carry keys. The requests themselves still use the real values.
+
+Headers are matched by name, ignoring case: `authorization`, `proxy-authorization`, `api-key`, `x-api-key`, `x-goog-api-key`, `x-goog-iam-authorization-token` and `cookie`. Every other header is left as it is, so a rendered config still shows the routing setup the run used.
+
+Because the saved `config.yaml` is redacted, re-running from it needs the credential supplied again.
 
 ## Full Configuration Examples
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -9,7 +9,7 @@ By default, reports are saved in a directory named `reports-YYYYMMDD-HHMMSS/`. T
 - **`summary_lifecycle_metrics.json`**: Aggregated metrics for the entire benchmark run.
 - **`stage_N_lifecycle_metrics.json`**: Metrics for a specific load stage (where N is the stage index).
 - **`per_request_lifecycle_metrics.json`**: Raw data for every single request, including timestamps and token counts.
-- **`config.yaml`**: A copy of the configuration used for the run.
+- **`config.yaml`**: A copy of the configuration used for the run, with credentials redacted (see [Credentials](config.md#credentials)).
 
 ## Understanding the Report Structure
 

--- a/inference_perf/config/client/modelserver/config.py
+++ b/inference_perf/config/client/modelserver/config.py
@@ -15,7 +15,7 @@ from enum import Enum
 from typing import Optional
 
 from inference_perf.config.common import StrictBaseModel
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 
 class ModelServerType(Enum):
@@ -35,6 +35,9 @@ class ModelServerClientConfig(StrictBaseModel):
         default=True,
         description="Ask the server to keep generating past the end-of-sequence token so outputs hit the requested length.",
     )
-    api_key: Optional[str] = Field(default=None, description="API key sent as a bearer token with each request.")
+    api_key: Optional[SecretStr] = Field(
+        default=None,
+        description="API key sent as a bearer token with each request. Redacted in the logged and saved config.",
+    )
     cert_path: Optional[str] = Field(default=None, description="Path to a client TLS certificate file.")
     key_path: Optional[str] = Field(default=None, description="Path to the private key for the client TLS certificate.")

--- a/inference_perf/config/config.py
+++ b/inference_perf/config/config.py
@@ -32,6 +32,7 @@ from inference_perf.config.loadgen import (
     TraceSessionReplayLoadStage,
 )
 from inference_perf.config.metrics import MetricsClientConfig
+from inference_perf.config.redaction import redact
 from inference_perf.config.reportgen import ReportConfig
 from inference_perf.config.utils import CustomTokenizerConfig
 
@@ -133,7 +134,11 @@ def read_config(config_file: Optional[str] = None, cli_overrides: Optional[dict[
                 standard_stages.append(StandardLoadStage(**stage))
             merged_cfg["load"]["stages"] = standard_stages
 
+    # The echoed config is the copy people paste into bug reports, so it goes out
+    # with its credentials masked. merged_cfg itself keeps them, since the run
+    # needs them.
     logger.info(
-        "Benchmarking with the following config:\n\n%s\n", yaml.dump(merged_cfg, sort_keys=False, default_flow_style=False)
+        "Benchmarking with the following config:\n\n%s\n",
+        yaml.dump(redact(merged_cfg, Config), sort_keys=False, default_flow_style=False),
     )
     return Config(**merged_cfg)

--- a/inference_perf/config/redaction.py
+++ b/inference_perf/config/redaction.py
@@ -1,0 +1,161 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Credential masking for the places a config is rendered for someone to read.
+
+A run renders its config twice: once to the log at startup, once into the
+``config.yaml`` of the report bundle. Both copies get shared. Pod logs go to a
+cluster's log store, the report bundle is uploaded to GCS or S3, and the bug
+report template asks for "the entire one printed by the benchmark run". None of
+those places should carry the operator's API key.
+
+Where the credentials are is read off the config schema rather than listed here,
+so a new one is covered by declaring its type:
+
+- a field typed ``SecretStr`` is a credential, and its value never appears.
+- a field named ``headers`` is a request header map, and the values of the
+  headers named in ``CREDENTIAL_HEADER_NAMES`` never appear. That map is
+  free-form so the secret cannot live in its type, but the headers that carry
+  one are well known.
+
+Nothing else is touched. A rendered config still has to be good enough to
+reproduce a run from and to attach to a bug report.
+"""
+
+from copy import deepcopy
+from functools import cache
+from typing import Any, Callable, Mapping, Tuple, Union, get_args, get_origin
+
+from pydantic import BaseModel, SecretStr
+
+REDACTED = "[REDACTED]"
+
+# Request headers whose value is a credential, matched case-insensitively.
+# api.headers is how a run authenticates against a gateway that wants something
+# other than a bearer token, so it carries the same secrets as server.api_key.
+CREDENTIAL_HEADER_NAMES = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "api-key",
+        "x-api-key",
+        "x-goog-api-key",
+        "x-goog-iam-authorization-token",
+        "cookie",
+    }
+)
+
+# Name of the free-form header map on a config model.
+_HEADER_FIELD_NAME = "headers"
+
+_Path = Tuple[str, ...]
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """The annotation with Optional stripped, or the annotation unchanged."""
+    if get_origin(annotation) is Union:
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _nested_models(annotation: Any) -> list[type[BaseModel]]:
+    """Every config model an annotation reaches, through Optional, list and dict."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return [annotation]
+    found: list[type[BaseModel]] = []
+    for arg in get_args(annotation):
+        found.extend(_nested_models(arg))
+    return found
+
+
+def _collect(
+    model: type[BaseModel],
+    prefix: _Path,
+    chain: Tuple[type[BaseModel], ...],
+    secrets: set[_Path],
+    headers: set[_Path],
+) -> None:
+    # A model that can contain itself would recurse forever. Everything below the
+    # repeat was already collected on the way in, so stopping loses nothing.
+    if model in chain:
+        return
+    for name, field in model.model_fields.items():
+        path = prefix + (name,)
+        annotation = _unwrap_optional(field.annotation)
+        if annotation is SecretStr:
+            secrets.add(path)
+            continue
+        if name == _HEADER_FIELD_NAME:
+            headers.add(path)
+        for nested in _nested_models(annotation):
+            _collect(nested, path, chain + (model,), secrets, headers)
+
+
+@cache
+def credential_locations(model: type[BaseModel]) -> Tuple[frozenset[_Path], frozenset[_Path]]:
+    """Where credentials sit in a config model, as (secret fields, header maps).
+
+    Each entry is a path of field names from the root of the model. Derived from
+    the schema on first use and cached, so declaring a field ``SecretStr`` is all
+    it takes for it to be redacted everywhere a config is rendered.
+    """
+    secrets: set[_Path] = set()
+    headers: set[_Path] = set()
+    _collect(model, (), (), secrets, headers)
+    return frozenset(secrets), frozenset(headers)
+
+
+def _apply(node: Any, path: _Path, transform: Callable[[Any], Any]) -> None:
+    """Replace the value at path under node, in place, wherever the path exists.
+
+    Descends into lists so a path through a repeated config section reaches every
+    element of it.
+    """
+    if isinstance(node, list):
+        for item in node:
+            _apply(item, path, transform)
+        return
+    if not isinstance(node, dict) or path[0] not in node:
+        return
+    if len(path) == 1:
+        node[path[0]] = transform(node[path[0]])
+        return
+    _apply(node[path[0]], path[1:], transform)
+
+
+def _mask_credential(value: Any) -> Any:
+    return REDACTED if value is not None else value
+
+
+def _mask_credential_headers(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    return {name: (REDACTED if str(name).lower() in CREDENTIAL_HEADER_NAMES else header) for name, header in value.items()}
+
+
+def redact(data: Mapping[str, Any], model: type[BaseModel]) -> dict[str, Any]:
+    """A copy of a config mapping with every credential replaced by ``REDACTED``.
+
+    Takes a mapping rather than a model so the same masking covers the raw config
+    read from disk, which is logged before it has been validated, and the dump of
+    a validated config. A config that sets no credential renders unchanged.
+    """
+    redacted = deepcopy(dict(data))
+    secrets, headers = credential_locations(model)
+    for path in secrets:
+        _apply(redacted, path, _mask_credential)
+    for path in headers:
+        _apply(redacted, path, _mask_credential_headers)
+    return redacted

--- a/inference_perf/config/utils/config.py
+++ b/inference_perf/config/utils/config.py
@@ -14,7 +14,7 @@
 from typing import Optional
 
 from inference_perf.config.common import StrictBaseModel
-from pydantic import Field
+from pydantic import Field, SecretStr
 
 
 class CustomTokenizerConfig(StrictBaseModel):
@@ -24,7 +24,10 @@ class CustomTokenizerConfig(StrictBaseModel):
     trust_remote_code: Optional[bool] = Field(
         default=None, description="Allow the tokenizer to execute code from its repository when loading."
     )
-    token: Optional[str] = Field(default=None, description="HuggingFace access token used to download the tokenizer.")
+    token: Optional[SecretStr] = Field(
+        default=None,
+        description="HuggingFace access token used to download the tokenizer. Redacted in the logged and saved config.",
+    )
     load_timeout: Optional[float] = Field(
         default=300.0,
         gt=0,

--- a/inference_perf/main.py
+++ b/inference_perf/main.py
@@ -197,6 +197,9 @@ def main_cli() -> None:
     # Define Model Server Client
     model_server_client: ModelServerClient
     if config.server:
+        # Resolved once here, at the boundary between the config and the clients:
+        # the config holds the key as a secret, the client sends it as a header.
+        api_key = config.server.api_key.get_secret_value() if config.server.api_key else None
         if config.server.type == ModelServerType.VLLM:
             model_server_client = vLLMModelServerClient(
                 reportgen.get_metrics_collector(),
@@ -207,7 +210,7 @@ def main_cli() -> None:
                 ignore_eos=config.server.ignore_eos,
                 max_tcp_connections=config.load.worker_max_tcp_connections,
                 additional_filters=config.metrics.prometheus.filters if config.metrics and config.metrics.prometheus else [],
-                api_key=config.server.api_key,
+                api_key=api_key,
                 timeout=config.load.request_timeout,
                 request_retries=config.load.request_retries,
                 request_retry_backoff_sec=config.load.request_retry_backoff_sec,
@@ -227,7 +230,7 @@ def main_cli() -> None:
                 ignore_eos=config.server.ignore_eos,
                 max_tcp_connections=config.load.worker_max_tcp_connections,
                 additional_filters=config.metrics.prometheus.filters if config.metrics and config.metrics.prometheus else [],
-                api_key=config.server.api_key,
+                api_key=api_key,
                 timeout=config.load.request_timeout,
                 request_retries=config.load.request_retries,
                 request_retry_backoff_sec=config.load.request_retry_backoff_sec,
@@ -245,7 +248,7 @@ def main_cli() -> None:
                 ignore_eos=config.server.ignore_eos,
                 max_tcp_connections=config.load.worker_max_tcp_connections,
                 additional_filters=config.metrics.prometheus.filters if config.metrics and config.metrics.prometheus else [],
-                api_key=config.server.api_key,
+                api_key=api_key,
                 timeout=config.load.request_timeout,
                 request_retries=config.load.request_retries,
                 request_retry_backoff_sec=config.load.request_retry_backoff_sec,

--- a/inference_perf/reportgen/base.py
+++ b/inference_perf/reportgen/base.py
@@ -38,6 +38,7 @@ from inference_perf.config import (
     GoodputConfig,
     PerRequestFieldsConfig,
 )
+from inference_perf.config.redaction import redact
 from inference_perf.metrics import SessionMetricsCollector
 from inference_perf.utils import ReportFile
 
@@ -923,11 +924,14 @@ class ReportGenerator:
     def generate_config_report(self) -> ReportFile:
         """
         Generates a report file containing the config.
+
+        Credentials are masked: the report bundle is uploaded to object storage and
+        passed around, so it carries the shape of the run and not the keys it used.
         """
         return ReportFile(
             name="config",
             file_type="yaml",
-            contents=self.config.model_dump(mode="json", by_alias=True),
+            contents=redact(self.config.model_dump(mode="json", by_alias=True), Config),
         )
 
     async def generate_reports(

--- a/inference_perf/utils/cli_parser.py
+++ b/inference_perf/utils/cli_parser.py
@@ -2,7 +2,7 @@ import argparse
 import json
 import typing
 from enum import Enum
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 def unwrap_type(annotation: typing.Any) -> typing.Tuple[typing.Any, bool]:
@@ -87,6 +87,11 @@ def add_pydantic_args(
             choices = [e.value for e in annotation]
             parser.add_argument(arg_name, type=str, choices=choices, help=help_text, default=argparse.SUPPRESS)
             docs.append(f"| `{arg_name}` | Enum ({', '.join(choices)}) | {help_text} |")
+        elif annotation is SecretStr:
+            # A credential. Taken on the command line as a plain string, and masked
+            # by inference_perf.config.redaction wherever the config is rendered.
+            parser.add_argument(arg_name, type=str, help=help_text, default=argparse.SUPPRESS)
+            docs.append(f"| `{arg_name}` | str | {help_text} |")
         elif annotation is bool:
             # We accept "true", "1", "yes" as true, anything else as false
             parser.add_argument(

--- a/inference_perf/utils/custom_tokenizer.py
+++ b/inference_perf/utils/custom_tokenizer.py
@@ -73,10 +73,12 @@ def _load_tokenizer_with_deadline(config: CustomTokenizerConfig) -> PreTrainedTo
     result: dict[str, PreTrainedTokenizerBase] = {}
     error: dict[str, Exception] = {}
 
+    token = config.token.get_secret_value() if config.token else None
+
     def load() -> None:
         try:
             result["tokenizer"] = AutoTokenizer.from_pretrained(
-                config.pretrained_model_name_or_path, token=config.token, trust_remote_code=config.trust_remote_code
+                config.pretrained_model_name_or_path, token=token, trust_remote_code=config.trust_remote_code
             )
         except Exception as e:
             error["error"] = e

--- a/tests/required/config/test_redaction.py
+++ b/tests/required/config/test_redaction.py
@@ -1,0 +1,178 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A run renders its config to the startup log and into the report bundle. Neither
+copy may carry the credentials the run was given.
+
+The leaks pinned here are the ones a benchmark actually hits: server.api_key,
+tokenizer.token and an api.headers authentication header printed verbatim by
+read_config, and the same three written into the config.yaml that is uploaded to
+object storage.
+"""
+
+import logging
+import os
+import tempfile
+from typing import Any, Optional
+
+import pytest
+import yaml
+from pydantic import BaseModel, SecretStr
+from unittest.mock import Mock
+
+from inference_perf.config import Config, read_config
+from inference_perf.config.redaction import (
+    REDACTED,
+    _nested_models,
+    _unwrap_optional,
+    credential_locations,
+    redact,
+)
+from inference_perf.reportgen.base import ReportGenerator
+
+API_KEY = "sk-api-key-that-must-not-be-printed"
+HF_TOKEN = "hf_token_that_must_not_be_printed"
+AUTH_HEADER = "Bearer gateway-token-that-must-not-be-printed"
+
+CREDENTIALS = (API_KEY, HF_TOKEN, AUTH_HEADER)
+
+
+def _config_dict(with_credentials: bool = True) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "api": {"type": "chat", "headers": {"x-routing-strategy": "round-robin"}},
+        "data": {"type": "random"},
+        "load": {"type": "constant", "stages": [{"rate": 1, "duration": 5}]},
+        "server": {"type": "vllm", "base_url": "http://localhost:8000"},
+        "tokenizer": {"pretrained_model_name_or_path": "gpt2"},
+    }
+    if with_credentials:
+        config["api"]["headers"]["Authorization"] = AUTH_HEADER
+        config["server"]["api_key"] = API_KEY
+        config["tokenizer"]["token"] = HF_TOKEN
+    return config
+
+
+def _read(config: dict[str, Any]) -> Config:
+    with tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False) as handle:
+        yaml.safe_dump(config, handle)
+        path = handle.name
+    try:
+        return read_config(path)
+    finally:
+        os.unlink(path)
+
+
+def _saved_config_report(config: Config) -> str:
+    generator = ReportGenerator(metrics_client=None, metrics_collector=Mock(), config=config)
+    return yaml.dump(generator.generate_config_report().get_contents())
+
+
+def _field_paths(
+    model: type[BaseModel],
+    prefix: tuple[str, ...] = (),
+    chain: tuple[type[BaseModel], ...] = (),
+) -> set[tuple[str, ...]]:
+    """Every field path in a config model, for the schema sweep below."""
+    if model in chain:
+        return set()
+    paths: set[tuple[str, ...]] = set()
+    for name, field in model.model_fields.items():
+        path = prefix + (name,)
+        paths.add(path)
+        for nested in _nested_models(_unwrap_optional(field.annotation)):
+            paths |= _field_paths(nested, path, chain + (model,))
+    return paths
+
+
+def test_logged_config_hides_credentials(caplog: pytest.LogCaptureFixture) -> None:
+    """The echoed config is the copy the bug report template asks people to paste."""
+    with caplog.at_level(logging.INFO, logger="inference_perf.config.config"):
+        _read(_config_dict())
+
+    logged = caplog.text
+    assert "Benchmarking with the following config" in logged
+    for credential in CREDENTIALS:
+        assert credential not in logged
+    assert logged.count(REDACTED) == len(CREDENTIALS)
+
+
+def test_saved_config_report_hides_credentials() -> None:
+    """The report bundle is uploaded to GCS or S3 and passed around."""
+    saved = _saved_config_report(_read(_config_dict()))
+
+    for credential in CREDENTIALS:
+        assert credential not in saved
+    assert saved.count(REDACTED) == len(CREDENTIALS)
+
+
+def test_redaction_keeps_the_rest_of_the_headers() -> None:
+    """Routing headers are part of reproducing a run, so only the credential goes."""
+    redacted = redact(_read(_config_dict()).model_dump(mode="json"), Config)
+
+    assert redacted["api"]["headers"] == {"x-routing-strategy": "round-robin", "Authorization": REDACTED}
+
+
+def test_credentials_reach_the_run_intact() -> None:
+    """Masking is for the rendered copies. The run still gets the real values."""
+    config = _read(_config_dict())
+
+    assert config.server is not None and config.server.api_key is not None
+    assert config.server.api_key.get_secret_value() == API_KEY
+    assert config.tokenizer is not None and config.tokenizer.token is not None
+    assert config.tokenizer.token.get_secret_value() == HF_TOKEN
+
+
+def test_config_without_credentials_renders_unchanged() -> None:
+    """The common case has nothing to hide and must render exactly as it did before."""
+    dumped = _read(_config_dict(with_credentials=False)).model_dump(mode="json")
+
+    assert redact(dumped, Config) == dumped
+
+
+def test_every_credential_field_in_the_schema_is_a_secret() -> None:
+    """Catches a credential added to the config as a plain string.
+
+    Redaction follows the type, so a new key declared `str` would be printed like
+    any other setting. The vocabulary below is deliberately narrow: over the whole
+    schema it matches the two credentials and nothing else, so a field it does
+    match is one whose name says it holds a credential.
+    """
+    exact = {"token", "key", "password", "secret"}
+    substrings = ("api_key", "apikey", "secret", "password", "passwd", "credential", "access_token", "auth_token", "bearer")
+
+    paths = _field_paths(Config)
+    # The sweep has to reach nested sections, or it would find nothing and pass.
+    assert ("report", "request_lifecycle", "summary") in paths
+
+    named_like_a_credential = {path for path in paths if path[-1] in exact or any(hint in path[-1] for hint in substrings)}
+    secret_paths, _ = credential_locations(Config)
+
+    assert named_like_a_credential == set(secret_paths), (
+        "A config field named like a credential is not typed SecretStr, so it will be "
+        "printed to the log and written into the report bundle."
+    )
+
+
+def test_redaction_reaches_a_credential_inside_a_list() -> None:
+    """A config section that repeats is masked in every element, not just the first."""
+
+    class Endpoint(BaseModel):
+        name: str
+        api_key: Optional[SecretStr] = None
+
+    class Fleet(BaseModel):
+        endpoints: list[Endpoint] = []
+
+    data = {"endpoints": [{"name": "a", "api_key": "first"}, {"name": "b", "api_key": "second"}]}
+
+    assert redact(data, Fleet) == {"endpoints": [{"name": "a", "api_key": REDACTED}, {"name": "b", "api_key": REDACTED}]}


### PR DESCRIPTION
Fixes #787

## Problem

A run renders its config twice, and both copies carry whatever credentials it was given. `read_config` logs the merged config at INFO, and `generate_config_report` writes the same config into `config.yaml` in the report bundle. `server.api_key`, `tokenizer.token` and an authentication header under `api.headers` all appear in plain text.

Those copies travel: the startup echo is a pod log under the Helm chart, the report bundle is uploaded to GCS or S3, and the bug report template asks for the printed config. The chart already keeps the Hugging Face token in a Kubernetes Secret, and printing it undoes that.


## What this does

Before:

```
server:
  api_key: sk-live-4f9a2b7c
tokenizer:
  token: hf_ABCDEF123456
api:
  headers:
    Authorization: Bearer gw-live-9f2c
    x-routing-strategy: round-robin
```

After:

```
server:
  api_key: '[REDACTED]'
tokenizer:
  token: '[REDACTED]'
api:
  headers:
    Authorization: '[REDACTED]'
    x-routing-strategy: round-robin
```

The requests are unchanged. Masking applies only to the rendered copies. Empty values are not credentials and are left as they are.

A config whose credentials still hold `[REDACTED]`, or the `**********` pydantic writes for a secret, fails validation with an error naming each setting, instead of sending the placeholder to the server. The check is a `Config` validator, so it covers `read_config`, `Config(...)` and `Config.model_validate(...)`. Supplying the credentials again, in the file or on the command line, lets it load. Config validation errors no longer quote input values, since those can be credentials.


## Where the credentials are is read off the schema

`server.api_key` and `tokenizer.token` are now typed `SecretStr`, which is the part of the change that will not go stale. `inference_perf/config/redaction.py` walks the `Config` model and finds them by type, looking through Optional, unions, Annotated, lists and dicts and following recursive models as deep as the config goes. A credential added later is covered by declaring it, with no list to remember to update. `SecretStr` also masks the value in `repr` and in any `model_dump`, so a future rendering path starts out safe.

A test sweeps the whole schema for fields whose name says they hold a credential and asserts each one is `SecretStr`. Over the current 189 fields that vocabulary matches exactly `server.api_key` and `tokenizer.token`, so a plain-string key added later fails CI instead of being printed.

`api.headers` is a `dict[str, str]`, so the secret cannot live in the type. A header is masked when its name contains `auth`, `key`, `token`, `secret` or `cookie`, ignoring case, which covers `Authorization`, `x-api-key`, Kong's `apikey`, `X-Auth-Token` and Azure's `Ocp-Apim-Subscription-Key`. Over-matching only hides a routing value, while a missed header would leak. Every other header is left alone, so a rendered config still shows the routing setup the run used.


## Why redaction and not just SecretStr

The log line renders the merged config before it is validated, so at that point the values are still plain strings and pydantic masking has not applied yet. One helper covers both the raw mapping and the validated dump, which also means both copies use the same marker.


## Breaking changes

- `ModelServerClientConfig.api_key` and `CustomTokenizerConfig.token` are now `Optional[SecretStr]` instead of `Optional[str]`. Python code that reads them from the config models needs `.get_secret_value()`. Formatting the field does not raise: `f"Bearer {config.server.api_key}"` gives `Bearer **********`. `model_dump()` returns a `SecretStr` and `model_dump(mode="json")` returns `"**********"`. A marker annotation on a plain `str` would avoid the break but lose the masking `SecretStr` gives in `repr` and `model_dump`.
- The saved `config.yaml` no longer carries credentials, so re-running from it needs them supplied again.


## What does not change

- YAML configs and the `--server.api_key` and `--tokenizer.token` flags still take a plain string. The flags keep their `str` row in `docs/cli_flags.md`.
- Runs with no credential set, or an empty one, render as they did before. Tests pin both.
- Nothing else in the config is touched, apart from a non-credential header whose name contains one of those fragments. A redacted config is still complete enough to reproduce a run from once the masked values are supplied.


## Tests

`tests/required/config/test_redaction.py`. The two leak repros fail on main and pass here. The rest cover the headers, including gateway header names, the untouched runtime values, the unchanged rendering when no credential is set, and the schema sweep above. A synthetic model checks that the walk and the sweep cover Annotated, `X | None`, lists, dicts and recursive models. A saved config is rejected through both `read_config` and `Config.model_validate`, and so is a `model_dump(mode="json")` dump holding `**********`. The error does not echo the credentials that are set. A saved config loads once its credentials are supplied on the command line, and the check follows the header the client sends when names differ only in case. Empty credentials are neither masked nor rejected.