### PR TITLE
docs: point the comparability seed row at load.base_seed

### DIFF
--- a/docs/comparability.md
+++ b/docs/comparability.md
@@ -118,7 +118,7 @@ read from.
 | Generate to the length cap | `server.ignore_eos: true` | `--ignore-eos` | `--extra-inputs ignore_eos:true` |
 | Streaming | `api.streaming` | fixed by the endpoint, no flag | `--streaming` |
 | Tokenizer | `tokenizer.pretrained_model_name_or_path` | `--tokenizer` | `--tokenizer` |
-| Reproducible prompts | `data.seed` | `--seed` (default `0`) | `--random-seed` |
+| Reproducible prompts | `load.base_seed` (default current time) | `--seed` (default `0`) | `--random-seed` |
 | Excluded warmup | no equivalent | no equivalent | `--warmup-request-count`, `--warmup-duration` |
 | Sampling parameters | no equivalent for synthetic data | `--temperature`, `--top-p`, `--top-k`, `--min-p` | `--extra-inputs temperature:0` and similar |
 


### PR DESCRIPTION
In the flag map, the reproducible prompts row references `data.seed`. No such field exists in the config schema, `DataConfig` has no seed and strict validation rejects unknown keys, so a config written from that cell fails to load. The setting that controls this is `load.base_seed`, which seeds the data generators and the per-worker RNGs and is what docs/loadgen.md and docs/config.md already point at. Alongside the vllm column's default annotation, the new cell also says the default is the current time rather than a fixed value, since a run is only reproducible once the seed is set.

Splitting the doc fix noted on #755 out so it lands independently of the converter sequencing.
